### PR TITLE
TY: convert primitive types from object to class

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -11,7 +11,6 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.ide.annotator.AnnotatorBase
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.AnnotationSession
-import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.util.Key
 import com.intellij.openapiext.isUnitTestMode
@@ -1033,7 +1032,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             is RsFunction -> {
                 // Check if signature matches `fn(isize, *const *const u8) -> isize`
                 val params = owner.valueParameters
-                if (owner.returnType != TyInteger.ISize) {
+                if (owner.returnType !is TyInteger.ISize) {
                     RsDiagnostic.InvalidStartAttrError.ReturnMismatch(owner.retType?.typeReference ?: owner.identifier)
                         .addToHolder(holder)
                 }
@@ -1044,12 +1043,12 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
                     // with errors
                     return
                 }
-                if (params[0].typeReference?.type != TyInteger.ISize) {
+                if (params[0].typeReference?.type !is TyInteger.ISize) {
                     RsDiagnostic.InvalidStartAttrError.InvalidParam(params[0].typeReference ?: params[0], 0)
                         .addToHolder(holder)
                 }
                 if (params[1].typeReference?.type != TyPointer(
-                        TyPointer(TyInteger.U8, Mutability.IMMUTABLE),
+                        TyPointer(TyInteger.U8.INSTANCE, Mutability.IMMUTABLE),
                         Mutability.IMMUTABLE
                     )
                 ) {
@@ -1531,7 +1530,7 @@ private fun checkEmptyFunctionReturnType(holder: RsAnnotationHolder, fn: RsFunct
 
     val (stmts, expr) = block.expandedStmtsAndTailExpr
     if (stmts.isEmpty() && expr == null) {
-        RsDiagnostic.TypeError(rbrace, returnType, TyUnit).addToHolder(holder)
+        RsDiagnostic.TypeError(rbrace, returnType, TyUnit.INSTANCE).addToHolder(holder)
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -434,7 +434,7 @@ private fun checkParameterTraitMatch(argument: RsFormatMacroArg, parameter: Form
 }
 
 // i32 is allowed because of integers without a specific type
-private val ALLOWED_SPECIFIERS_TYPES = setOf(TyInteger.USize, TyInteger.I32)
+private val ALLOWED_SPECIFIERS_TYPES = setOf(TyInteger.USize.INSTANCE, TyInteger.I32.INSTANCE)
 
 private fun checkSpecifierType(argument: RsFormatMacroArg, parameter: FormatParameter.Specifier): ErrorAnnotation? {
     val expr = argument.expr

--- a/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
@@ -63,7 +63,7 @@ class RsTypeHintsPresentationFactory(
             )
         }
 
-        if (returnType != TyUnit) {
+        if (returnType !is TyUnit) {
             val ret = factory.collapsible(
                 prefix = text(" → "),
                 collapsed = text(PLACEHOLDER),

--- a/src/main/kotlin/org/rust/ide/inspections/RsCastToBoolInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsCastToBoolInspection.kt
@@ -21,9 +21,9 @@ class RsCastToBoolInspection : RsLocalInspectionTool() {
             // It is allowed to cast a bool to a bool, so if the expression's type is of bool, ignore this cast.
             // Casts from non primitive types (and the unit type) emit another error, so we ignore those as well.
             val exprType = castExpr.expr.type
-            if (exprType === TyBool || exprType !is TyPrimitive || exprType === TyUnit) return
+            if (exprType is TyBool || exprType !is TyPrimitive || exprType is TyUnit) return
 
-            if (castExpr.typeReference.type === TyBool) {
+            if (castExpr.typeReference.type is TyBool) {
                 RsDiagnostic.CastAsBoolError(castExpr).addToHolder(holder)
             }
         }

--- a/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
@@ -34,7 +34,7 @@ class RsExtraSemicolonInspection : RsLocalInspectionTool() {
 
 private fun inspect(holder: RsProblemsHolder, fn: RsFunction) {
     val retType = fn.retType?.typeReference ?: return
-    if (retType.type == TyUnit) return
+    if (retType.type is TyUnit) return
     ExitPoint.process(fn) { exitPoint ->
         if (exitPoint is ExitPoint.TailStatement) {
             holder.registerProblem(

--- a/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
@@ -29,7 +29,7 @@ class IntroduceLocalVariableIntention : RsElementBaseIntentionAction<RsExpr>() {
                 parent is RsRetExpr || parent is RsExprStmt || parent is RsBlock && it == parent.expr
             } as? RsExpr
 
-        if (expr?.type == TyUnit) return null
+        if (expr?.type is TyUnit) return null
 
         return expr
     }

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
@@ -39,7 +39,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
                 if (needsTemplate) {
                     return ReturnType(expected, true)
                 }
-                return ReturnType(expected.takeIf { it !is TyUnknown } ?: TyUnit, false)
+                return ReturnType(expected.takeIf { it !is TyUnknown } ?: TyUnit.INSTANCE, false)
             }
         }
     }
@@ -181,7 +181,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
             "p$index: ${expr.type.renderInsertionSafe(useAliasNames = true)}"
         }
 
-        val returnType = ctx.returnType.type.takeIf { it != TyUnknown } ?: TyUnit
+        val returnType = ctx.returnType.type.takeIf { it != TyUnknown } ?: TyUnit.INSTANCE
         val genericConstraints = GenericConstraints.create(callExpr)
             .filterByTypes(arguments.exprList.map { it.type }.plus(returnType))
 

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -270,7 +270,7 @@ open class RsPsiRenderer(
                     val arraySizeExpr = type.expr
                     sb.append("; ")
                     if (arraySizeExpr != null) {
-                        appendConstExpr(sb, arraySizeExpr, TyInteger.USize)
+                        appendConstExpr(sb, arraySizeExpr, TyInteger.USize.INSTANCE)
                     } else {
                         sb.append("{}")
                     }

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -194,7 +194,7 @@ private data class TypeRenderer(
     private fun formatFnLike(fnType: String, paramTypes: List<Ty>, retType: Ty, render: (Ty) -> String): String =
         buildString {
             paramTypes.joinTo(this, ", ", "$fnType(", ")", transform = render)
-            if (retType != TyUnit) {
+            if (retType !is TyUnit) {
                 append(" -> ")
                 append(render(retType))
             }
@@ -211,7 +211,7 @@ private data class TypeRenderer(
             val retType = trait.assoc.entries
                 .find { it.key.name == "Output" }
                 ?.value
-                ?: TyUnit
+                ?: TyUnit.INSTANCE
             append(formatFnLike(name, paramTypes, retType, render))
         } else {
             append(name)

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
@@ -115,7 +115,7 @@ class RsChangeFunctionSignatureConfig private constructor(
     private val originalName: String = function.name.orEmpty()
 
     val returnType: Ty
-        get() = returnTypeDisplay?.type ?: TyUnit
+        get() = returnTypeDisplay?.type ?: TyUnit.INSTANCE
 
     private val parametersText: String
         get() {

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -145,7 +145,7 @@ class RsExtractFunctionConfig private constructor(
         get() = parameters.mapNotNull { it.type }
 
     private val returnType: Ty
-        get() = returnValue?.type ?: TyUnit
+        get() = returnValue?.type ?: TyUnit.INSTANCE
 
     private fun typeParameterBounds(): Map<Ty, Set<Ty>> =
         function.typeParameters.associate { typeParameter ->

--- a/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithIfExpSurrounder.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithIfExpSurrounder.kt
@@ -28,7 +28,7 @@ class RsWithIfExpSurrounder : RsExpressionSurrounderBase<RsIfExpr>() {
         expression.condition!!.expr
 
     override fun isApplicable(expression: RsExpr): Boolean =
-        expression.type == TyBool
+        expression.type is TyBool
 
     override fun doPostprocessAndGetSelectionRange(editor: Editor, expression: PsiElement): TextRange? {
         var block = (expression as? RsIfExpr)?.block ?: return null

--- a/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithNotSurrounder.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithNotSurrounder.kt
@@ -29,7 +29,7 @@ class RsWithNotSurrounder : RsExpressionSurrounderBase<RsUnaryExpr>() {
         (expression.expr as RsParenExpr).expr!!
 
     override fun isApplicable(expression: RsExpr): Boolean =
-        expression.type == TyBool
+        expression.type is TyBool
 
     override fun doPostprocessAndGetSelectionRange(editor: Editor, expression: PsiElement): TextRange {
         val offset = expression.endOffset

--- a/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithWhileExpSurrounder.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithWhileExpSurrounder.kt
@@ -28,7 +28,7 @@ class RsWithWhileExpSurrounder : RsExpressionSurrounderBase<RsWhileExpr>() {
         expression.condition!!.expr
 
     override fun isApplicable(expression: RsExpr): Boolean =
-        expression.type == TyBool
+        expression.type is TyBool
 
     override fun doPostprocessAndGetSelectionRange(editor: Editor, expression: PsiElement): TextRange? {
         var block = (expression as? RsWhileExpr)?.block ?: return null

--- a/src/main/kotlin/org/rust/ide/template/postfix/utils.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/utils.kt
@@ -58,4 +58,4 @@ class RsTypeParentsSelector : PostfixTemplateExpressionSelectorBase(Condition { 
         .toList()
 }
 
-fun RsExpr.isBool() = type == TyBool
+fun RsExpr.isBool() = type is TyBool

--- a/src/main/kotlin/org/rust/ide/utils/BooleanExprSimplifier.kt
+++ b/src/main/kotlin/org/rust/ide/utils/BooleanExprSimplifier.kt
@@ -117,6 +117,6 @@ class BooleanExprSimplifier(val project: Project) {
 
         private fun canBeEvaluated(expr: RsExpr): Boolean = eval(expr) != null
 
-        private fun eval(expr: RsExpr): Boolean? = expr.evaluate(TyBool, resolver = null).asBool()
+        private fun eval(expr: RsExpr): Boolean? = expr.evaluate(TyBool.INSTANCE, resolver = null).asBool()
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsBoolCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsBoolCompletionProvider.kt
@@ -22,7 +22,7 @@ object RsBoolCompletionProvider : RsCompletionProvider() {
     override val elementPattern: ElementPattern<PsiElement> get() = RsPsiPattern.simplePathPattern
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
-        if (parameters.position.safeGetOriginalOrSelf().ancestorOrSelf<RsPathExpr>()?.expectedType == TyBool) {
+        if (parameters.position.safeGetOriginalOrSelf().ancestorOrSelf<RsPathExpr>()?.expectedType is TyBool) {
             for (value in listOf("true", "false")) {
                 result.addElement(LookupElementBuilder.create(value).bold().withPriority(KEYWORD_PRIORITY))
             }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsPrimitiveTypeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsPrimitiveTypeCompletionProvider.kt
@@ -23,9 +23,9 @@ object RsPrimitiveTypeCompletionProvider : RsCompletionProvider() {
     private val primitives: List<String> = buildList {
         addAll(TyInteger.NAMES)
         addAll(TyFloat.NAMES)
-        add(TyBool.name)
-        add(TyStr.name)
-        add(TyChar.name)
+        add(TyBool.INSTANCE.name)
+        add(TyStr.INSTANCE.name)
+        add(TyChar.INSTANCE.name)
     }
 
     override val elementPattern: ElementPattern<PsiElement>

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
@@ -13,4 +13,4 @@ import org.rust.lang.utils.evaluation.evaluate
 
 val RsArrayType.isSlice: Boolean get() = (greenStub as? RsArrayTypeStub)?.isSlice ?: (expr == null)
 
-val RsArrayType.arraySize: Long? get() = expr?.evaluate(TyInteger.USize)?.asLong()
+val RsArrayType.arraySize: Long? get() = expr?.evaluate(TyInteger.USize.INSTANCE)?.asLong()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
@@ -65,4 +65,4 @@ val RsEnumItem.reprType: TyInteger
         .flatMap { it.metaItemArgs?.metaItemList?.asSequence() ?: emptySequence() }
         .mapNotNull { it.name?.let { name -> TyInteger.fromName(name) } }
         .lastOrNull()
-        ?: TyInteger.ISize
+        ?: TyInteger.ISize.INSTANCE

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -102,7 +102,7 @@ val RsFunction.title: String
 
 val RsFunction.returnType: Ty
     get() {
-        val retType = retType ?: return TyUnit
+        val retType = retType ?: return TyUnit.INSTANCE
         return retType.typeReference?.type ?: TyUnknown
     }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -42,64 +42,64 @@ const val DEFAULT_RECURSION_LIMIT = 64
 val HARDCODED_FROM_IMPLS_MAP: Map<TyPrimitive, List<TyPrimitive>> = run {
     val list = listOf(
         // Unsigned -> Unsigned
-        U8 to U16,
-        U8 to U32,
-        U8 to U64,
-        U8 to U128,
-        U8 to USize,
-        U16 to U32,
-        U16 to U64,
-        U16 to U128,
-        U32 to U64,
-        U32 to U128,
-        U64 to U128,
+        U8.INSTANCE to U16.INSTANCE,
+        U8.INSTANCE to U32.INSTANCE,
+        U8.INSTANCE to U64.INSTANCE,
+        U8.INSTANCE to U128.INSTANCE,
+        U8.INSTANCE to USize.INSTANCE,
+        U16.INSTANCE to U32.INSTANCE,
+        U16.INSTANCE to U64.INSTANCE,
+        U16.INSTANCE to U128.INSTANCE,
+        U32.INSTANCE to U64.INSTANCE,
+        U32.INSTANCE to U128.INSTANCE,
+        U64.INSTANCE to U128.INSTANCE,
 
         // Signed -> Signed
-        I8 to I16,
-        I8 to I32,
-        I8 to I64,
-        I8 to I128,
-        I8 to ISize,
-        I16 to I32,
-        I16 to I64,
-        I16 to I128,
-        I32 to I64,
-        I32 to I128,
-        I64 to I128,
+        I8.INSTANCE to I16.INSTANCE,
+        I8.INSTANCE to I32.INSTANCE,
+        I8.INSTANCE to I64.INSTANCE,
+        I8.INSTANCE to I128.INSTANCE,
+        I8.INSTANCE to ISize.INSTANCE,
+        I16.INSTANCE to I32.INSTANCE,
+        I16.INSTANCE to I64.INSTANCE,
+        I16.INSTANCE to I128.INSTANCE,
+        I32.INSTANCE to I64.INSTANCE,
+        I32.INSTANCE to I128.INSTANCE,
+        I64.INSTANCE to I128.INSTANCE,
 
         // Unsigned -> Signed
-        U8 to I16,
-        U8 to I32,
-        U8 to I64,
-        U8 to I128,
-        U16 to I32,
-        U16 to I64,
-        U16 to I128,
-        U32 to I64,
-        U32 to I128,
-        U64 to I128,
+        U8.INSTANCE to I16.INSTANCE,
+        U8.INSTANCE to I32.INSTANCE,
+        U8.INSTANCE to I64.INSTANCE,
+        U8.INSTANCE to I128.INSTANCE,
+        U16.INSTANCE to I32.INSTANCE,
+        U16.INSTANCE to I64.INSTANCE,
+        U16.INSTANCE to I128.INSTANCE,
+        U32.INSTANCE to I64.INSTANCE,
+        U32.INSTANCE to I128.INSTANCE,
+        U64.INSTANCE to I128.INSTANCE,
 
         // https://github.com/rust-lang/rust/pull/49305
-        U16 to USize,
-        U8 to ISize,
-        I16 to ISize,
+        U16.INSTANCE to USize.INSTANCE,
+        U8.INSTANCE to ISize.INSTANCE,
+        I16.INSTANCE to ISize.INSTANCE,
 
         // Signed -> Float
-        I8 to F32,
-        I8 to F64,
-        I16 to F32,
-        I16 to F64,
-        I32 to F64,
+        I8.INSTANCE to F32.INSTANCE,
+        I8.INSTANCE to F64.INSTANCE,
+        I16.INSTANCE to F32.INSTANCE,
+        I16.INSTANCE to F64.INSTANCE,
+        I32.INSTANCE to F64.INSTANCE,
 
         // Unsigned -> Float
-        U8 to F32,
-        U8 to F64,
-        U16 to F32,
-        U16 to F64,
-        U32 to F64,
+        U8.INSTANCE to F32.INSTANCE,
+        U8.INSTANCE to F64.INSTANCE,
+        U16.INSTANCE to F32.INSTANCE,
+        U16.INSTANCE to F64.INSTANCE,
+        U32.INSTANCE to F64.INSTANCE,
 
         // Float -> Float
-        F32 to F64
+        F32.INSTANCE to F64.INSTANCE
     )
     val map = mutableMapOf<TyPrimitive, MutableList<TyPrimitive>>()
     for ((from, to) in list) {
@@ -436,12 +436,12 @@ class ImplLookup(
         HARDCODED_FROM_IMPLS_MAP[ty]?.forEach { from ->
             addImpl(items.From, from)
         }
-        if (ty != TyStr) {
+        if (ty !is TyStr) {
             // Default (libcore/default.rs)
             addImpl(items.Default)
 
             // PatrialEq (libcore/cmp.rs)
-            if (ty != TyNever && ty != TyUnit) {
+            if (ty != TyNever && ty !is TyUnit) {
                 addImpl(items.PartialEq, ty)
             }
 
@@ -451,7 +451,7 @@ class ImplLookup(
             }
 
             // PartialOrd (libcore/cmp.rs)
-            if (ty != TyUnit && ty != TyBool && ty != TyNever) {
+            if (ty !is TyUnit && ty !is TyBool && ty != TyNever) {
                 addImpl(items.PartialOrd, ty)
                 // Ord (libcore/cmp.rs)
                 if (ty !is TyFloat && ty !is TyInfer.FloatVar) {
@@ -768,7 +768,7 @@ class ImplLookup(
             is SelectionCandidate.Closure -> {
                 // TODO hacks hacks hacks
                 val (trait, _, assoc) = ref.trait
-                ctx.combineTypes(assoc[fnOnceOutput] ?: TyUnit, (ref.selfTy as TyFunction).retType)
+                ctx.combineTypes(assoc[fnOnceOutput] ?: TyUnit.INSTANCE, (ref.selfTy as TyFunction).retType)
                 Selection(trait, emptyList())
             }
             is SelectionCandidate.TypeParameter -> {
@@ -992,7 +992,7 @@ class ImplLookup(
             val outputParam = fnOnceOutput ?: return null
             val param = element.typeParamSingle ?: return null
             val argumentTypes = ((subst[param] ?: TyUnknown) as? TyTuple)?.types.orEmpty()
-            val outputType = (assoc[outputParam] ?: TyUnit)
+            val outputType = (assoc[outputParam] ?: TyUnit.INSTANCE)
             return TyFunction(argumentTypes, outputType)
         }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -31,7 +31,7 @@ fun inferTypeReferenceType(type: RsTypeReference, defaultTraitObjectRegion: Regi
         is RsTupleType -> TyTuple(type.typeReferenceList.map { inferTypeReferenceType(it) })
 
         is RsBaseType -> when (val kind = type.kind) {
-            RsBaseTypeKind.Unit -> TyUnit
+            RsBaseTypeKind.Unit -> TyUnit.INSTANCE
             RsBaseTypeKind.Never -> TyNever
             RsBaseTypeKind.Underscore -> TyInfer.TyVar(type)
             is RsBaseTypeKind.Path -> {
@@ -93,14 +93,14 @@ fun inferTypeReferenceType(type: RsTypeReference, defaultTraitObjectRegion: Regi
             if (type.isSlice) {
                 TySlice(componentType)
             } else {
-                val const = type.expr?.evaluate(TyInteger.USize) ?: CtUnknown
+                val const = type.expr?.evaluate(TyInteger.USize.INSTANCE) ?: CtUnknown
                 TyArray(componentType, const)
             }
         }
 
         is RsFnPointerType -> {
             val paramTypes = type.valueParameters.map { it.typeReference?.type ?: TyUnknown }
-            TyFunction(paramTypes, type.retType?.let { it.typeReference?.type ?: TyUnknown } ?: TyUnit)
+            TyFunction(paramTypes, type.retType?.let { it.typeReference?.type ?: TyUnknown } ?: TyUnit.INSTANCE)
         }
 
         is RsTraitType -> {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -156,7 +156,7 @@ private fun inferSlicePatsTypes(
             return CtUnknown
         }
 
-        return ConstExpr.Value.Integer(restSize, TyInteger.USize).toConst()
+        return ConstExpr.Value.Integer(restSize, TyInteger.USize.INSTANCE).toConst()
     }
 
     val (elementType, restType) = when (sliceType) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -195,7 +195,7 @@ class RsInferenceContext(
             else -> {
                 val (retTy, expr) = when (element) {
                     is RsConstant -> element.typeReference?.type to element.expr
-                    is RsArrayType -> TyInteger.USize to element.expr
+                    is RsArrayType -> TyInteger.USize.INSTANCE to element.expr
                     is RsVariantDiscriminant -> {
                         val enum = element.contextStrict<RsEnumItem>()
                         enum?.reprType to element.expr

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -194,8 +194,8 @@ val Ty.isFloat: Boolean
 val Ty.isScalar: Boolean
     get() = isIntegral ||
         isFloat ||
-        this == TyBool ||
-        this == TyChar ||
-        this == TyUnit ||
+        this is TyBool ||
+        this is TyChar ||
+        this is TyUnit ||
         this is TyFunction || // really TyFnDef & TyFnPtr
         this is TyPointer

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -7,10 +7,9 @@ package org.rust.lang.core.types.ty
 
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsPath
-import org.rust.lang.core.psi.ext.hasColonColon
 
 /**
- * These are "atomic" ty (not type constructors, singletons).
+ * These are "atomic" ty.
  *
  * Definition intentionally differs from the reference: we don't treat
  * tuples or arrays as primitive.
@@ -28,39 +27,61 @@ abstract class TyPrimitive : Ty() {
             TyFloat.fromName(name)?.let { return it }
 
             return when (name) {
-                "bool" -> TyBool
-                "char" -> TyChar
-                "str" -> TyStr
+                "bool" -> TyBool.INSTANCE
+                "char" -> TyChar.INSTANCE
+                "str" -> TyStr.INSTANCE
                 else -> null
             }
         }
     }
 }
 
-object TyBool : TyPrimitive() {
-    override val name: String = "bool"
+class TyBool : TyPrimitive() {
+    override val name: String
+        get() = "bool"
+
+    companion object {
+        val INSTANCE: TyBool = TyBool()
+    }
 }
 
-object TyChar : TyPrimitive() {
-    override val name: String = "char"
+class TyChar : TyPrimitive() {
+    override val name: String
+        get() = "char"
+
+    companion object {
+        val INSTANCE: TyChar = TyChar()
+    }
 }
 
-object TyUnit : TyPrimitive() {
-    override val name: String = "unit"
+class TyUnit : TyPrimitive() {
+    override val name: String
+        get() = "unit"
+
+    companion object {
+        val INSTANCE: TyUnit = TyUnit()
+    }
 }
 
 /** The `!` type. E.g. `unimplemented!()` */
 object TyNever : TyPrimitive() {
-    override val name: String = "never"
+    override val name: String
+        get() = "never"
 }
 
-object TyStr : TyPrimitive() {
-    override val name: String = "str"
+class TyStr : TyPrimitive() {
+    override val name: String
+        get() = "str"
+
+    companion object {
+        val INSTANCE: TyStr = TyStr()
+    }
 }
 
 abstract class TyNumeric : TyPrimitive()
 
-sealed class TyInteger(override val name: String, val ordinal: Int) : TyNumeric() {
+sealed class TyInteger : TyNumeric() {
+    abstract val ordinal: Int
 
     // This fixes NPE caused by java classes initialization order. Details:
     // Kotlin `object`s compile into java classes with `INSTANCE` static field
@@ -74,8 +95,8 @@ sealed class TyInteger(override val name: String, val ordinal: Int) : TyNumeric(
     // `TyInteger` class, it will be filled with null value instead of `U8`
     // We fixing it by moving fields from `companion object` an independent object
     private object TyIntegerValuesHolder {
-        val DEFAULT = I32
-        val VALUES = listOf(U8, U16, U32, U64, U128, USize, I8, I16, I32, I64, I128, ISize)
+        val DEFAULT = I32.INSTANCE
+        val VALUES = listOf(U8.INSTANCE, U16.INSTANCE, U32.INSTANCE, U64.INSTANCE, U128.INSTANCE, USize.INSTANCE, I8.INSTANCE, I16.INSTANCE, I32.INSTANCE, I64.INSTANCE, I128.INSTANCE, ISize.INSTANCE)
         val NAMES = VALUES.map { it.name }
     }
 
@@ -94,27 +115,136 @@ sealed class TyInteger(override val name: String, val ordinal: Int) : TyNumeric(
         }
     }
 
-    object U8: TyInteger("u8", 0)
-    object U16: TyInteger("u16", 1)
-    object U32: TyInteger("u32", 2)
-    object U64: TyInteger("u64", 3)
-    object U128: TyInteger("u128", 4)
-    object USize : TyInteger("usize", 5)
+    class U8: TyInteger() {
+        override val name: String
+            get() = "u8"
+        override val ordinal: Int
+            get() = 0
 
-    object I8: TyInteger("i8", 6)
-    object I16: TyInteger("i16", 7)
-    object I32: TyInteger("i32", 8)
-    object I64: TyInteger("i64", 9)
-    object I128: TyInteger("i128", 10)
-    object ISize: TyInteger("isize", 11)
+        companion object {
+            val INSTANCE: U8 = U8()
+        }
+    }
+    class U16: TyInteger() {
+        override val name: String
+            get() = "u16"
+        override val ordinal: Int
+            get() = 1
+
+        companion object {
+            val INSTANCE: U16 = U16()
+        }
+    }
+    class U32: TyInteger() {
+        override val name: String
+            get() = "u32"
+        override val ordinal: Int
+            get() = 2
+
+        companion object {
+            val INSTANCE: U32 = U32()
+        }
+    }
+    class U64: TyInteger() {
+        override val name: String
+            get() = "u64"
+        override val ordinal: Int
+            get() = 3
+
+        companion object {
+            val INSTANCE: U64 = U64()
+        }
+    }
+    class U128: TyInteger() {
+        override val name: String
+            get() = "u128"
+        override val ordinal: Int
+            get() = 4
+
+        companion object {
+            val INSTANCE: U128 = U128()
+        }
+    }
+    class USize : TyInteger() {
+        override val name: String
+            get() = "usize"
+        override val ordinal: Int
+            get() = 5
+
+        companion object {
+            val INSTANCE: USize = USize()
+        }
+    }
+
+    class I8: TyInteger() {
+        override val name: String
+            get() = "i8"
+        override val ordinal: Int
+            get() = 6
+
+        companion object {
+            val INSTANCE: I8 = I8()
+        }
+    }
+    class I16: TyInteger() {
+        override val name: String
+            get() = "i16"
+        override val ordinal: Int
+            get() = 7
+
+        companion object {
+            val INSTANCE: I16 = I16()
+        }
+    }
+    class I32: TyInteger() {
+        override val name: String
+            get() = "i32"
+        override val ordinal: Int
+            get() = 8
+
+        companion object {
+            val INSTANCE: I32 = I32()
+        }
+    }
+    class I64: TyInteger() {
+        override val name: String
+            get() = "i64"
+        override val ordinal: Int
+            get() = 9
+
+        companion object {
+            val INSTANCE: I64 = I64()
+        }
+    }
+    class I128: TyInteger() {
+        override val name: String
+            get() = "i128"
+        override val ordinal: Int
+            get() = 10
+
+        companion object {
+            val INSTANCE: I128 = I128()
+        }
+    }
+    class ISize: TyInteger() {
+        override val name: String
+            get() = "isize"
+        override val ordinal: Int
+            get() = 11
+
+        companion object {
+            val INSTANCE: ISize = ISize()
+        }
+    }
 }
 
-sealed class TyFloat(override val name: String, val ordinal: Int) : TyNumeric() {
+sealed class TyFloat : TyNumeric() {
+    abstract val ordinal: Int
 
     // See TyIntegerValuesHolder
     private object TyFloatValuesHolder {
-        val DEFAULT = F64
-        val VALUES = listOf(F32, F64)
+        val DEFAULT = F64.INSTANCE
+        val VALUES = listOf(F32.INSTANCE, F64.INSTANCE)
         val NAMES = VALUES.map { it.name }
     }
 
@@ -133,6 +263,24 @@ sealed class TyFloat(override val name: String, val ordinal: Int) : TyNumeric() 
         }
     }
 
-    object F32: TyFloat("f32", 0)
-    object F64: TyFloat("f64", 1)
+    class F32: TyFloat() {
+        override val name: String
+            get() = "f32"
+        override val ordinal: Int
+            get() = 0
+
+        companion object {
+            val INSTANCE: F32 = F32()
+        }
+    }
+    class F64: TyFloat() {
+        override val name: String
+            get() = "f64"
+        override val ordinal: Int
+            get() = 1
+
+        companion object {
+            val INSTANCE: F64 = F64()
+        }
+    }
 }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -52,8 +52,8 @@ import org.rust.lang.utils.Severity.*
 import org.rust.stdext.buildList
 import org.rust.stdext.buildMap
 
-private val REF_STR_TY = TyReference(TyStr, Mutability.IMMUTABLE)
-private val MUT_REF_STR_TY = TyReference(TyStr, Mutability.MUTABLE)
+private val REF_STR_TY = TyReference(TyStr.INSTANCE, Mutability.IMMUTABLE)
+private val MUT_REF_STR_TY = TyReference(TyStr.INSTANCE, Mutability.MUTABLE)
 
 sealed class RsDiagnostic(
     val element: PsiElement,
@@ -195,7 +195,7 @@ sealed class RsDiagnostic(
         }
 
         private fun ifActualIsStrGetErrTyOfFromStrImplForTy(ty: Ty, items: KnownItems, lookup: ImplLookup): Ty? {
-            if (lookup.coercionSequence(actualTy).lastOrNull() != TyStr) return null
+            if (lookup.coercionSequence(actualTy).lastOrNull() !is TyStr) return null
             val fromStr = items.FromStr ?: return null
             val result = lookup.selectProjectionStrict(TraitRef(ty, BoundElement(fromStr)),
                 fromStr.findAssociatedType("Err") ?: return null)

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExpr.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExpr.kt
@@ -62,7 +62,7 @@ sealed class ConstExpr<T : Ty>(val flags: TypeFlags = 0) : TypeFoldable<ConstExp
         override fun superVisitWith(visitor: TypeVisitor): Boolean = false
 
         data class Bool(val value: Boolean) : Value<TyBool>() {
-            override val expectedTy: TyBool = TyBool
+            override val expectedTy: TyBool = TyBool.INSTANCE
             override fun toString(): String = value.toString()
         }
 
@@ -75,7 +75,7 @@ sealed class ConstExpr<T : Ty>(val flags: TypeFlags = 0) : TypeFoldable<ConstExp
         }
 
         data class Char(val value: String) : Value<TyChar>() {
-            override val expectedTy: TyChar = TyChar
+            override val expectedTy: TyChar = TyChar.INSTANCE
             override fun toString(): String = value
         }
 

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprBuilder.kt
@@ -27,7 +27,7 @@ fun RsExpr.toConstExpr(
     return builder?.build(this)
 }
 
-private val STR_REF_TYPE: TyReference = TyReference(TyStr, Mutability.IMMUTABLE)
+private val STR_REF_TYPE: TyReference = TyReference(TyStr.INSTANCE, Mutability.IMMUTABLE)
 
 private abstract class ConstExprBuilder<T : Ty, V> {
     protected abstract val expectedTy: T
@@ -108,7 +108,7 @@ private class IntegerConstExprBuilder(
 private class BoolConstExprBuilder(
     override val resolver: PathExprResolver?
 ) : ConstExprBuilder<TyBool, Boolean>() {
-    override val expectedTy: TyBool = TyBool
+    override val expectedTy: TyBool = TyBool.INSTANCE
     override val RsLitExpr.value: Boolean? get() = booleanValue
     override fun Boolean.wrap(): ConstExpr.Value.Bool = ConstExpr.Value.Bool(this)
 
@@ -155,7 +155,7 @@ private class FloatConstExprBuilder(
 private class CharConstExprBuilder(
     override val resolver: PathExprResolver?
 ) : ConstExprBuilder<TyChar, String>() {
-    override val expectedTy: TyChar = TyChar
+    override val expectedTy: TyChar = TyChar.INSTANCE
     override val RsLitExpr.value: String? get() = charValue
     override fun String.wrap(): ConstExpr.Value.Char = ConstExpr.Value.Char(this)
 }

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprEvaluator.kt
@@ -170,16 +170,16 @@ private fun Long.validValueOrNull(ty: TyInteger): Long? = takeIf { it in ty.vali
 // It returns wrong values for large types like `i128` or `usize`, but looks like it's enough for real cases
 private val TyInteger.validValuesRange: LongRange
     get() = when (this) {
-        TyInteger.U8 -> LongRange(0, 1L shl 8)
-        TyInteger.U16 -> LongRange(0, 1L shl 16)
-        TyInteger.U32 -> LongRange(0, 1L shl 32)
-        TyInteger.U64 -> LongRange(0, Long.MAX_VALUE)
-        TyInteger.U128 -> LongRange(0, Long.MAX_VALUE)
-        TyInteger.USize -> LongRange(0, Long.MAX_VALUE)
-        TyInteger.I8 -> LongRange(-(1L shl 7), (1L shl 7) - 1)
-        TyInteger.I16 -> LongRange(-(1L shl 15), (1L shl 15) - 1)
-        TyInteger.I32 -> LongRange(-(1L shl 31), (1L shl 31) - 1)
-        TyInteger.I64 -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
-        TyInteger.I128 -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
-        TyInteger.ISize -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
+        is TyInteger.U8 -> LongRange(0, 1L shl 8)
+        is TyInteger.U16 -> LongRange(0, 1L shl 16)
+        is TyInteger.U32 -> LongRange(0, 1L shl 32)
+        is TyInteger.U64 -> LongRange(0, Long.MAX_VALUE)
+        is TyInteger.U128 -> LongRange(0, Long.MAX_VALUE)
+        is TyInteger.USize -> LongRange(0, Long.MAX_VALUE)
+        is TyInteger.I8 -> LongRange(-(1L shl 7), (1L shl 7) - 1)
+        is TyInteger.I16 -> LongRange(-(1L shl 15), (1L shl 15) - 1)
+        is TyInteger.I32 -> LongRange(-(1L shl 31), (1L shl 31) - 1)
+        is TyInteger.I64 -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
+        is TyInteger.I128 -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
+        is TyInteger.ISize -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
     }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPrimitiveTypeCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPrimitiveTypeCompletionTest.kt
@@ -21,7 +21,7 @@ class RsPrimitiveTypeCompletionTest : RsCompletionTestBase() {
     """)
 
     private fun doTest(@Language("Rust") text: String) {
-        val primitiveTypes = TyInteger.VALUES + TyFloat.VALUES + TyBool + TyStr + TyChar
+        val primitiveTypes = TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyStr.INSTANCE + TyChar.INSTANCE
         for (ty in primitiveTypes) {
             checkContainsCompletion(ty.name, text)
         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsPrimitiveTypeImplsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsPrimitiveTypeImplsTest.kt
@@ -20,16 +20,16 @@ import org.rust.lang.core.types.ty.*
 @ExpandMacros(MacroExpansionScope.ALL, "std")
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsPrimitiveTypeImplsTest : RsTestBase() {
-    fun `test Sized types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit, "Sized")
-    fun `test Clone types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit, "Clone")
-    fun `test Copy types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit, "Copy")
-    fun `test Default types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit, "Default")
-    fun `test Debug types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit + TyStr, "std::fmt::Debug")
-    fun `test PartialEq types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit + TyStr, "PartialEq")
-    fun `test Eq types`() = doTest(TyInteger.VALUES + TyBool + TyChar + TyUnit + TyStr, "Eq")
-    fun `test PartialOrd types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit + TyStr, "PartialOrd")
-    fun `test Ord types`() = doTest(TyInteger.VALUES + TyBool + TyChar + TyUnit + TyStr, "Ord")
-    fun `test Hash types`() = doTest(TyInteger.VALUES + TyBool + TyChar + TyStr, "std::hash::Hash")
+    fun `test Sized types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE, "Sized")
+    fun `test Clone types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE, "Clone")
+    fun `test Copy types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE, "Copy")
+    fun `test Default types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE, "Default")
+    fun `test Debug types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE + TyStr.INSTANCE, "std::fmt::Debug")
+    fun `test PartialEq types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE + TyStr.INSTANCE, "PartialEq")
+    fun `test Eq types`() = doTest(TyInteger.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE + TyStr.INSTANCE, "Eq")
+    fun `test PartialOrd types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE + TyStr.INSTANCE, "PartialOrd")
+    fun `test Ord types`() = doTest(TyInteger.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE + TyStr.INSTANCE, "Ord")
+    fun `test Hash types`() = doTest(TyInteger.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyStr.INSTANCE, "std::hash::Hash")
 
     private fun doTest(primitiveTypes: List<TyPrimitive>, trait: String) {
         InlineFile("""


### PR DESCRIPTION
This is a naive attempt to reduce the usage of `object` in primitive types and convert them to standard classes instead. This is probably needed as a first step to solve https://github.com/intellij-rust/intellij-rust/issues/5080. I didn't change `TyNever` and `TyUnknown`, because we probably don't need aliases to work for them (?).

The ultimate plan is to move `aliasedBy` from `TyAdt` to `Ty`. Which will probably introduce all kinds of scary breakage and problems (especially the description of this PR https://github.com/intellij-rust/intellij-rust/pull/4243 scares me in relation to comparing types :D ).

Sending PR to see what kinds of tests fail.