### PR TITLE
RUN: Fix macros and generated items support for WSL toolchains

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/RustcMessage.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/RustcMessage.kt
@@ -145,6 +145,8 @@ sealed class CompilerMessage {
     @Suppress("PropertyName")
     abstract val package_id: PackageId
 
+    abstract fun convertPaths(converter: PathConverter): CompilerMessage
+
     companion object {
         fun fromJson(json: JsonObject): CompilerMessage? {
             val reason = json.getAsJsonPrimitive("reason")?.asString ?: return null
@@ -169,6 +171,11 @@ data class BuildScriptMessage(
     val env: List<List<String>>,
     val out_dir: String?
 ) : CompilerMessage() {
+
+    override fun convertPaths(converter: PathConverter): BuildScriptMessage = copy(
+        out_dir = out_dir?.let(converter)
+    )
+
     companion object {
         const val REASON: String = "build-script-executed"
     }
@@ -201,6 +208,12 @@ data class CompilerArtifactMessage(
                 filenames.filter { !it.endsWith(".dSYM") && !it.endsWith(".pdb") }
             }
         }
+
+    override fun convertPaths(converter: PathConverter): CompilerArtifactMessage = copy(
+        target = target.convertPaths(converter),
+        filenames = filenames.map(converter),
+        executable = executable?.let(converter)
+    )
 
     companion object {
         const val REASON: String = "compiler-artifact"

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -48,6 +48,7 @@ import org.rust.cargo.toolchain.impl.CargoMetadata
 import org.rust.cargo.toolchain.impl.CargoMetadata.replacePaths
 import org.rust.cargo.toolchain.impl.CompilerMessage
 import org.rust.cargo.toolchain.tools.Rustup.Companion.checkNeedInstallClippy
+import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.ide.actions.InstallBinaryCrateAction
 import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.notifications.showBalloon
@@ -194,7 +195,7 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
     ): BuildMessages? {
         if (!isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)) return null
         val additionalArgs = listOf("--message-format", "json")
-        val nativeHelper = RsPathManager.nativeHelper()
+        val nativeHelper = RsPathManager.nativeHelper(toolchain is RsWslToolchain)
         val envs = if (nativeHelper != null && Registry.`is`("org.rust.cargo.evaluate.build.scripts.wrapper")) {
             EnvironmentVariablesData.create(mapOf(RUSTC_WRAPPER to nativeHelper.toString()), true)
         } else {
@@ -214,7 +215,9 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
 
         for (line in processOutput.stdoutLines) {
             val jsonObject = tryParseJsonObject(line) ?: continue
-            CompilerMessage.fromJson(jsonObject)?.let { messages.getOrPut(it.package_id) { mutableListOf() } += it }
+            CompilerMessage.fromJson(jsonObject)
+                ?.convertPaths(toolchain::toLocalPath)
+                ?.let { messages.getOrPut(it.package_id) { mutableListOf() } += it }
         }
         return BuildMessages(messages)
     }

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroApplicationService.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroApplicationService.kt
@@ -6,26 +6,63 @@
 package org.rust.lang.core.macros.proc
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ProjectManagerListener
+import com.intellij.openapi.util.Disposer
+import org.rust.cargo.project.settings.RustProjectSettingsService
+import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.toolchain.RsToolchainBase
+import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.ide.experiments.RsExperiments
 import org.rust.openapiext.isFeatureEnabled
 
 @Service
 class ProcMacroApplicationService : Disposable {
+    private val servers: MutableMap<String, ProcMacroServerPool?> = hashMapOf()
 
-    private var sharedServer: ProcMacroServerPool? = null
+    init {
+        val connect = ApplicationManager.getApplication().messageBus.connect(this)
+
+        connect.subscribe(RustProjectSettingsService.RUST_SETTINGS_TOPIC, object : RustProjectSettingsService.RustSettingsListener {
+            override fun rustSettingsChanged(e: RustProjectSettingsService.RustSettingsChangedEvent) {
+                if (e.oldState.toolchain?.distributionId != e.newState.toolchain?.distributionId) {
+                    removeUnusableSevers()
+                }
+            }
+        })
+
+        connect.subscribe(ProjectManager.TOPIC, object : ProjectManagerListener {
+            override fun projectClosed(project: Project) {
+                removeUnusableSevers()
+            }
+        })
+    }
 
     @Synchronized
-    fun getServer(): ProcMacroServerPool? {
+    fun getServer(toolchain: RsToolchainBase): ProcMacroServerPool? {
         if (!isEnabled()) return null
 
-        var server = sharedServer
+        val id = toolchain.distributionId
+        var server = servers[id]
         if (server == null) {
-            server = ProcMacroServerPool.tryCreate(this)
-            sharedServer = server
+            server = ProcMacroServerPool.tryCreate(toolchain, this)
+            servers[id] = server
         }
         return server
+    }
+
+    @Synchronized
+    private fun removeUnusableSevers() {
+        val distributionIds = ProjectManager.getInstance().openProjects
+            .mapNotNull { it.rustSettings.toolchain?.distributionId }
+        servers.keys
+            .filterNot { it in distributionIds }
+            .mapNotNull { servers.remove(it) }
+            .forEach { Disposer.dispose(it) }
     }
 
     override fun dispose() {}
@@ -34,5 +71,8 @@ class ProcMacroApplicationService : Disposable {
         fun getInstance(): ProcMacroApplicationService = service()
         fun isEnabled(): Boolean = isFeatureEnabled(RsExperiments.PROC_MACROS)
             && isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)
+
+        private val RsToolchainBase.distributionId: String
+            get() = if (this is RsWslToolchain) wslPath.distributionId else "Local"
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -7,6 +7,8 @@ package org.rust.lang.core.macros.proc
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.toolchain.RsToolchainBase
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.macros.errors.ProcMacroExpansionError
 import org.rust.lang.core.macros.errors.ProcMacroExpansionError.ExecutableNotFound
@@ -25,7 +27,8 @@ import java.util.concurrent.TimeoutException
 
 class ProcMacroExpander(
     private val project: Project,
-    private val server: ProcMacroServerPool? = ProcMacroApplicationService.getInstance().getServer(),
+    private val toolchain: RsToolchainBase? = project.toolchain,
+    private val server: ProcMacroServerPool? = toolchain?.let { ProcMacroApplicationService.getInstance().getServer(it) },
     private val timeout: Long = Registry.get("org.rust.macros.proc.timeout").asInteger().toLong(),
 ) : MacroExpander<RsProcMacroData, ProcMacroExpansionError>() {
     private val isEnabled: Boolean = if (server != null) true else ProcMacroApplicationService.isEnabled()
@@ -52,10 +55,11 @@ class ProcMacroExpander(
         lib: String,
         env: Map<String, String> = emptyMap()
     ): RsResult<TokenTree.Subtree, ProcMacroExpansionError> {
+        val remoteLib = toolchain?.toRemotePath(lib) ?: lib
         val server = server ?: return Err(if (isEnabled) ExecutableNotFound else ProcMacroExpansionIsDisabled)
-        val envList = env.map { listOf(it.key, it.value) }
+        val envList = env.map { listOf(it.key, toolchain?.toRemotePath(it.value) ?: it.value) }
         val response = try {
-            server.send(Request.ExpansionMacro(macroCallBody, macroName, null, lib, envList), timeout)
+            server.send(Request.ExpansionMacro(macroCallBody, macroName, null, remoteLib, envList), timeout)
         } catch (ignored: TimeoutException) {
             return Err(ProcMacroExpansionError.Timeout(timeout))
         } catch (e: ProcessCreationException) {

--- a/src/main/kotlin/org/rust/openapiext/RsPathManager.kt
+++ b/src/main/kotlin/org/rust/openapiext/RsPathManager.kt
@@ -18,9 +18,9 @@ object RsPathManager {
     fun prettyPrintersDir(): Path = pluginDir().resolve("prettyPrinters")
     private fun pluginDir(): Path = plugin().pluginPath
 
-    fun nativeHelper(): Path? {
+    fun nativeHelper(isWslToolchain: Boolean): Path? {
         val (os, binaryName) = when {
-            SystemInfo.isLinux -> "linux" to INTELLIJ_RUST_NATIVE_HELPER
+            SystemInfo.isLinux || isWslToolchain -> "linux" to INTELLIJ_RUST_NATIVE_HELPER
             SystemInfo.isMac -> "macos" to INTELLIJ_RUST_NATIVE_HELPER
             SystemInfo.isWindows -> "windows" to "$INTELLIJ_RUST_NATIVE_HELPER.exe"
             else -> return null

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -35,6 +35,7 @@ import org.rust.cargo.toolchain.tools.Rustup
 import org.rust.cargo.toolchain.tools.cargo
 import org.rust.cargo.toolchain.tools.rustc
 import org.rust.cargo.toolchain.tools.rustup
+import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.cargo.util.DownloadResult
 import org.rust.ide.experiments.RsExperiments
 import org.rust.openapiext.RsPathManager
@@ -221,7 +222,8 @@ open class WithProcMacros(
             if (toolchain == null) {
                 return "No toolchain"
             }
-            if (RsPathManager.nativeHelper() == null && System.getenv("CI") == null) {
+            if (RsPathManager.nativeHelper(toolchain is RsWslToolchain) == null &&
+                System.getenv("CI") == null) {
                 return "no native-helper executable"
             }
             return delegate.skipTestReason

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
@@ -7,7 +7,9 @@ package org.rust.lang.core.completion
 
 import com.intellij.openapi.util.SystemInfo
 import org.rust.*
+import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.lang.core.macros.MacroExpansionScope
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
@@ -92,7 +94,7 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
     @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test complete items from 'os' module unix`() {
-        if (!SystemInfo.isUnix) return
+        if (!SystemInfo.isUnix && project.toolchain !is RsWslToolchain) return
         doSingleCompletion("""
             use std::os::uni/*caret*/
         """, """
@@ -103,7 +105,7 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
     @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test complete items from 'os' module windows`() {
-        if (!SystemInfo.isWindows) return
+        if (!SystemInfo.isWindows || project.toolchain is RsWslToolchain) return
         doSingleCompletion("""
             use std::os::win/*caret*/
         """, """

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -7,6 +7,8 @@ package org.rust.lang.core.resolve
 
 import com.intellij.openapi.util.SystemInfo
 import org.rust.*
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 import org.rust.stdext.BothEditions
@@ -717,7 +719,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test resolve in os module unix`() {
-        if (!SystemInfo.isUnix) return
+        if (!SystemInfo.isUnix && project.toolchain !is RsWslToolchain) return
         stubOnlyResolve("""
             //- main.rs
             use std::os::unix;
@@ -729,7 +731,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test resolve in os module windows`() {
-        if (!SystemInfo.isWindows) return
+        if (!SystemInfo.isWindows || project.toolchain is RsWslToolchain) return
         stubOnlyResolve("""
             //- main.rs
             use std::os::windows;

--- a/src/test/kotlin/org/rustSlowTests/console/RsEvcxrTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/console/RsEvcxrTest.kt
@@ -7,7 +7,6 @@ package org.rustSlowTests.console
 
 import com.intellij.util.ThrowableRunnable
 import org.rust.cargo.RsWithToolchainTestBase
-import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.tools.Cargo
 import org.rust.cargo.toolchain.tools.evcxr
 import org.rust.ide.console.RsConsoleCommunication
@@ -58,7 +57,7 @@ class RsEvcxrTest : RsWithToolchainTestBase() {
 
     private fun createProcess(): Process {
         val workingDirectory = cargoProjectDirectory.pathAsPath.toFile()
-        val commandLine = project.toolchain!!.evcxr()!!.createCommandLine(workingDirectory)
+        val commandLine = rustupFixture.toolchain!!.evcxr()!!.createCommandLine(workingDirectory)
         return commandLine.createProcess()
     }
 

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
@@ -272,6 +272,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }.create(project, libraryDir)
 
         val libraryPath = FileUtil.toSystemIndependentName(library.root.path)
+            .let { rustupFixture.toolchain?.toRemotePath(it) }
 
         buildProject {
             toml("Cargo.toml", """
@@ -338,6 +339,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }.create(project, libraryDir)
 
         val libraryPath = FileUtil.toSystemIndependentName(library.root.path)
+            .let { rustupFixture.toolchain?.toRemotePath(it) }
 
         buildProject {
             toml("Cargo.toml", """
@@ -404,6 +406,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }.create(project, libraryDir)
 
         val libraryPath = FileUtil.toSystemIndependentName(library.root.path)
+            .let { rustupFixture.toolchain?.toRemotePath(it) }
 
         buildProject {
             toml("Cargo.toml", """
@@ -470,6 +473,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }.create(project, libraryDir)
 
         val libraryPath = FileUtil.toSystemIndependentName(library.root.path)
+            .let { rustupFixture.toolchain?.toRemotePath(it) }
 
         buildProject {
             toml("Cargo.toml", """
@@ -536,6 +540,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }.create(project, libraryDir)
 
         val libraryPath = FileUtil.toSystemIndependentName(library.root.path)
+            .let { rustupFixture.toolchain?.toRemotePath(it) }
 
         buildProject {
             toml("Cargo.toml", """

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
@@ -17,6 +17,7 @@ import org.rust.*
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.impl.testCargoProjects
+import org.rust.cargo.project.settings.toolchain
 import org.rust.lang.core.crate.impl.CrateGraphTestmarks
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.resolve.NameResolutionTestmarks
@@ -578,6 +579,7 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
         }.create(project, libraryDir)
 
         val libraryPath = FileUtil.toSystemIndependentName(library.root.pathAsPath.resolve("cargo").toString())
+            .let { rustupFixture.toolchain?.toRemotePath(it) }
         val testProject = buildProject {
             toml("Cargo.toml", """
                 [package]

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/RsProcMacroExpansionResolveIntegrationTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/RsProcMacroExpansionResolveIntegrationTest.kt
@@ -10,6 +10,7 @@ import org.rust.ExpandMacros
 import org.rust.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.impl.testCargoProjects
+import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.fileTree
 import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.macros.MacroExpansionScope
@@ -119,7 +120,8 @@ class RsProcMacroExpansionResolveIntegrationTest : RsWithToolchainTestBase() {
     }
 
     override fun runTestRunnable(testRunnable: ThrowableRunnable<Throwable>) {
-        if (RsPathManager.nativeHelper() == null && System.getenv("CI") == null) {
+        if (RsPathManager.nativeHelper(rustupFixture.toolchain is RsWslToolchain) == null &&
+            System.getenv("CI") == null) {
             System.err.println("SKIP \"$name\": no native-helper executable")
             return
         }


### PR DESCRIPTION
changelog: Fix macros and generated items support for WSL toolchains

Fixes
```
2021-07-11 21:11:39,418 [71319350]   WARN - st.cargo.toolchain.tools.Cargo - Execution failed (exit code 101).
C:\WINDOWS\system32\wsl.exe --distribution Ubuntu --exec /bin/sh -c "export PATH=\"/home/misha/.cargo/bin:$PATH\" && export RUST_BACKTRACE=short && export RUSTC_WRAPPER=/mnt/c/Users/Mikhail/IdeaProjects/intellij-rust/plugin/build/clion-sandbox-212/plugins/intellij-rust/bin/windows/x86-64/intellij-rust-native-helper.exe && export TERM=ansi && cd /mnt/c/Users/Mikhail/CLionProjects/untitled8 && /home/misha/.cargo/bin/cargo check --message-format json"
stdout : error: failed to join search paths together
Does $LD_LIBRARY_PATH have an unterminated quote character?

Caused by:
  failed to join path array: ["/mnt/c/Users/Mikhail/CLionProjects/untitled8/target/debug/deps", "C:\\Users\\Mikhail\\.rustup\\toolchains\\nightly-2020-10-04-x86_64-pc-windows-msvc/lib", "/home/misha/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib"]

Caused by:
  path segment contains separator `:`

stderr :  
com.intellij.execution.ExecutionException: Execution failed (exit code 101).
C:\WINDOWS\system32\wsl.exe --distribution Ubuntu --exec /bin/sh -c "export PATH=\"/home/misha/.cargo/bin:$PATH\" && export RUST_BACKTRACE=short && export RUSTC_WRAPPER=/mnt/c/Users/Mikhail/IdeaProjects/intellij-rust/plugin/build/clion-sandbox-212/plugins/intellij-rust/bin/windows/x86-64/intellij-rust-native-helper.exe && export TERM=ansi && cd /mnt/c/Users/Mikhail/CLionProjects/untitled8 && /home/misha/.cargo/bin/cargo check --message-format json"
stdout : error: failed to join search paths together
Does $LD_LIBRARY_PATH have an unterminated quote character?

Caused by:
  failed to join path array: ["/mnt/c/Users/Mikhail/CLionProjects/untitled8/target/debug/deps", "C:\\Users\\Mikhail\\.rustup\\toolchains\\nightly-2020-10-04-x86_64-pc-windows-msvc/lib", "/home/misha/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib"]

Caused by:
  path segment contains separator `:`

stderr : 
	at org.rust.openapiext.CommandLineExtKt.execute(CommandLineExt.kt:108)
	at org.rust.cargo.toolchain.tools.Cargo.execute(Cargo.kt:412)
	at org.rust.cargo.toolchain.tools.Cargo.execute$default(Cargo.kt:406)
	at org.rust.cargo.toolchain.tools.Cargo.fetchBuildScriptsInfo(Cargo.kt:204)
	at org.rust.cargo.toolchain.tools.Cargo.fullProjectDescription(Cargo.kt:134)
	at org.rust.cargo.project.model.impl.CargoSyncTaskKt$fetchCargoWorkspace$1.invoke(CargoSyncTask.kt:316)
	at org.rust.cargo.project.model.impl.CargoSyncTaskKt$fetchCargoWorkspace$1.invoke(CargoSyncTask.kt:306)
	at org.rust.cargo.project.model.impl.CargoSyncTaskKt.runWithChildProgress(CargoSyncTask.kt:409)
	at org.rust.cargo.project.model.impl.CargoSyncTaskKt.access$runWithChildProgress(CargoSyncTask.kt:1)
	at org.rust.cargo.project.model.impl.CargoSyncTask$SyncContext.runWithChildProgress(CargoSyncTask.kt:178)
	at org.rust.cargo.project.model.impl.CargoSyncTaskKt.fetchCargoWorkspace(CargoSyncTask.kt:306)
	at org.rust.cargo.project.model.impl.CargoSyncTaskKt.access$fetchCargoWorkspace(CargoSyncTask.kt:1)
	at org.rust.cargo.project.model.impl.CargoSyncTask$doRun$refreshedProjects$1$2.invoke(CargoSyncTask.kt:118)
	at org.rust.cargo.project.model.impl.CargoSyncTask$doRun$refreshedProjects$1$2.invoke(CargoSyncTask.kt:109)
	at org.rust.cargo.project.model.impl.CargoSyncTaskKt.runWithChildProgress(CargoSyncTask.kt:409)
	at org.rust.cargo.project.model.impl.CargoSyncTaskKt.runWithChildProgress$default(CargoSyncTask.kt:400)
	at org.rust.cargo.project.model.impl.CargoSyncTask.doRun(CargoSyncTask.kt:106)
	at org.rust.cargo.project.model.impl.CargoSyncTask.run(CargoSyncTask.kt:74)
	at com.intellij.openapi.progress.impl.CoreProgressManager.startTask(CoreProgressManager.java:450)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.startTask(ProgressManagerImpl.java:117)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsync$5(CoreProgressManager.java:510)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:243)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:183)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:705)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:647)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:170)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:243)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	at java.base/java.lang.Thread.run(Thread.java:829)
```