### PR TITLE
INSP: Support declarative macros in unused import inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsPathUsageAnalysis.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsPathUsageAnalysis.kt
@@ -9,7 +9,10 @@ import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.*
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsItemsOwner
+import org.rust.lang.core.psi.ext.isEnabledByCfg
+import org.rust.lang.core.psi.ext.qualifier
 import org.rust.lang.core.types.infer.ResolvedPath
 import org.rust.lang.core.types.inference
 import org.rust.openapiext.processElementsWithMacros
@@ -75,6 +78,12 @@ private fun handleElement(
                         addItem(name, it)
                     }
                 }
+            }
+            true
+        }
+        is RsMacroCall -> {
+            processElementsWithMacros(element.path) {
+                handleElement(it, directUsages, traitUsages)
             }
             true
         }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -79,11 +79,6 @@ private fun isUseSpeckUsed(useSpeck: RsUseSpeck, usage: PathUsageMap): Boolean {
         items.filterIsInstance<RsNamedElement>().map { NamedItem(name, it) }
     }
 
-    // TODO: remove after macros are supported in RsPathUsageAnalysis.kt
-    if (items.any { (_, item) -> item is RsMacro }) {
-        return true
-    }
-
     return items.any { (name, item) ->
         item in usage.pathUsages[name].orEmpty()
             || item in usage.traitUsages

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -530,14 +530,14 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
 
         mod bar {
+            use crate::mac;
             fn baz() {
-                use crate::mac;
                 mac!();
             }
         }
     """)
 
-    /*fun `test unused macro`() = checkByText("""
+    fun `test unused macro`() = checkByText("""
         mod foo {
             #[macro_export]
             macro_rules! mac { () => {} }
@@ -548,7 +548,25 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
                 <warning descr="Unused import: `crate::mac`">use crate::mac;</warning>
             }
         }
-    """)*/
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test used qualified macro`() = checkByText("""
+        mod foo {
+            #[macro_export]
+            macro_rules! gen_ {
+                () => {};
+            }
+            pub use gen_ as gen;
+        }
+
+        mod bar {
+            use crate::foo;
+            fn main() {
+                foo::gen!();
+            }
+        }
+    """)
 
     fun `test unresolved use`() = checkByText("""
         mod bar {


### PR DESCRIPTION
Take into account macro paths when traversing modules in `PathUsageAnalysis`. Previously macros were intentionally ignored in inspection because of this

changelog: Support declarative macros in unused import inspection
