### PR TITLE
INSP: add support for multiple spans in external linter check inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
@@ -197,26 +197,28 @@ fun AnnotationHolder.createAnnotationsForFile(
         // We can't control what messages cargo generates, so we can't test them well.
         // Let's use special message for tests to distinguish annotation from external linter
         val annotationMessage = if (isUnitTestMode) TEST_MESSAGE else message.message
-        val annotationBuilder = newAnnotation(message.severity, annotationMessage)
-            .tooltip(message.htmlTooltip)
-            .range(message.textRange)
-            .problemGroup(object : SuppressableProblemGroup {
-                override fun getProblemName(): String = RUST_EXTERNAL_LINTER_ID
-                override fun getSuppressActions(element: PsiElement?): Array<SuppressIntentionAction> {
-                    if (element == null || message.lint == null) return emptyArray()
-                    return convertBatchToSuppressIntentionActions(createSuppressFixes(element, message.lint))
+        for (range in message.textRanges) {
+            val annotationBuilder = newAnnotation(message.severity, annotationMessage)
+                .tooltip(message.htmlTooltip)
+                .range(range)
+                .problemGroup(object : SuppressableProblemGroup {
+                    override fun getProblemName(): String = RUST_EXTERNAL_LINTER_ID
+                    override fun getSuppressActions(element: PsiElement?): Array<SuppressIntentionAction> {
+                        if (element == null || message.lint == null) return emptyArray()
+                        return convertBatchToSuppressIntentionActions(createSuppressFixes(element, message.lint))
+                    }
+                })
+                .needsUpdateOnTyping(true)
+
+            message.quickFixes
+                .singleOrNull { it.applicability <= minApplicability }
+                ?.let { f ->
+                    val key = HighlightDisplayKey.findOrRegister(RUST_EXTERNAL_LINTER_ID, "Rust external linter")
+                    annotationBuilder.newFix(f).key(key).registerFix()
                 }
-            })
-            .needsUpdateOnTyping(true)
 
-        message.quickFixes
-            .singleOrNull { it.applicability <= minApplicability }
-            ?.let { f ->
-                val key = HighlightDisplayKey.findOrRegister(RUST_EXTERNAL_LINTER_ID, "Rust external linter")
-                annotationBuilder.newFix(f).key(key).registerFix()
-            }
-
-        annotationBuilder.create()
+            annotationBuilder.create()
+        }
     }
 }
 
@@ -236,7 +238,7 @@ class RsExternalLinterResult(commandOutput: List<String>, val executionTime: Lon
 
 private data class RsExternalLinterFilteredMessage(
     val severity: HighlightSeverity,
-    val textRange: TextRange,
+    val textRanges: List<TextRange>,
     val message: String,
     val htmlTooltip: String,
     val lint: RsLint.ExternalLinterLint?,
@@ -266,7 +268,8 @@ private data class RsExternalLinterFilteredMessage(
             val spanFilePath = PathUtil.toSystemIndependentName(span.file_name)
             if (!file.virtualFile.path.endsWith(spanFilePath)) return null
 
-            val textRange = span.toTextRange(document) ?: return null
+            val textRanges = message.spans.mapNotNull { it.toTextRange(document) }
+            if (textRanges.isEmpty()) return null
 
             val tooltip = buildString {
                 append(formatMessage(StringEscapeUtils.escapeHtml(message.message)).escapeUrls())
@@ -291,7 +294,7 @@ private data class RsExternalLinterFilteredMessage(
 
             return RsExternalLinterFilteredMessage(
                 severity,
-                textRange,
+                textRanges,
                 message.message.capitalized(),
                 tooltip,
                 message.code?.code?.let { RsLint.ExternalLinterLint(it) },

--- a/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
@@ -31,7 +31,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
     fun `test highlights type errors`() = doTest("""
         struct X; struct Y;
         fn main() {
-            let _: X = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">Y</error>;
+            let _: <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">X</error> = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">Y</error>;
         }
     """)
 
@@ -39,9 +39,9 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
     fun `test highlights errors from macro`() = doTest("""
         fn main() {
             let mut x = 42;
-            let r = &mut x;
-            <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">dbg!(x)</error>;
-            dbg!(r);
+            let r = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">&mut x</error>;
+            dbg!(x);
+            dbg!(<error descr="${RsExternalLinterUtils.TEST_MESSAGE}">r</error>);
         }
     """)
 
@@ -50,7 +50,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
 
         #[test]
         fn test() {
-            let x: i32 = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">0.0</error>;
+            let x: <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">i32</error> = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">0.0</error>;
         }
     """)
 
@@ -65,7 +65,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
 
         #[cfg(feature = "enabled_feature")]
         fn foo() {
-            let x: i32 = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">0.0</error>;
+            let x: <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">i32</error> = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">0.0</error>;
         }
 
         #[cfg(feature = "disabled_feature")]
@@ -260,7 +260,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
         }.create()
         myFixture.openFileInEditor(cargoProjectDirectory.findFileByRelativePath("src/main.rs")!!)
         val highlight = myFixture.doHighlighting(HighlightSeverity.WEAK_WARNING)
-            .single { it.description == RsExternalLinterUtils.TEST_MESSAGE }
+            .first { it.description == RsExternalLinterUtils.TEST_MESSAGE }
         assertEquals(tooltip.trimIndent().replace("\n", "<br>"), highlight.toolTip)
     }
 }


### PR DESCRIPTION
@mchernyavsky Is this the correct way forward to display multiple spans per linter message?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7508