### PR TITLE
ANN: disable Grazie proofreading for Rust language in 2021.2 IDEs

### DIFF
--- a/grazie/src/211/main/resources/META-INF/platform-grazie-only.xml
+++ b/grazie/src/211/main/resources/META-INF/platform-grazie-only.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/grazie/src/211/test/kotlin/org/rust/grazie/compatUtils.kt
+++ b/grazie/src/211/test/kotlin/org/rust/grazie/compatUtils.kt
@@ -1,0 +1,10 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.grazie
+
+import com.intellij.grazie.config.CheckingContext
+
+fun CheckingContext.withRsLanguageEnabled(): CheckingContext = this

--- a/grazie/src/212/main/resources/META-INF/platform-grazie-only.xml
+++ b/grazie/src/212/main/resources/META-INF/platform-grazie-only.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij.grazie">
+        <disableChecking language="Rust"/>
+    </extensions>
+</idea-plugin>

--- a/grazie/src/212/test/kotlin/org/rust/grazie/compatUtils.kt
+++ b/grazie/src/212/test/kotlin/org/rust/grazie/compatUtils.kt
@@ -1,0 +1,11 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.grazie
+
+import com.intellij.grazie.config.CheckingContext
+import org.rust.lang.RsLanguage
+
+fun CheckingContext.withRsLanguageEnabled(): CheckingContext = copy(enabledLanguages = enabledLanguages + RsLanguage.id)

--- a/grazie/src/main/resources/META-INF/grazie-only.xml
+++ b/grazie/src/main/resources/META-INF/grazie-only.xml
@@ -1,5 +1,8 @@
-<idea-plugin>
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
     <depends>tanvd.grazi</depends>
+
+    <xi:include href="/META-INF/platform-grazie-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
     <extensions defaultExtensionNs="com.intellij.grazie">
         <grammar.strategy language="Rust" implementationClass="org.rust.grazie.RsGrammarCheckingStrategy"/>
     </extensions>

--- a/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
+++ b/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
@@ -31,7 +31,8 @@ class RsGrammarCheckingTest : RsInspectionsTestBase(GrazieInspection::class) {
             updateSettings { state ->
                 state.copy(
                     enabledGrammarStrategies = state.enabledGrammarStrategies + strategy.getID(),
-                    enabledLanguages = enabledLanguages
+                    enabledLanguages = enabledLanguages,
+                    checkingContext = state.checkingContext.withRsLanguageEnabled()
                 )
             }
         }


### PR DESCRIPTION
Grazie plugin enables proofreading inspection for all languages by default in 2021.2 release. Since we actually haven't checked it properly yet (Grazie plugin was significantly changed recently).
So we decided to disable it for now, check properly, fix potential bugs and enable it by default again

changelog: Temporarily disable proofreading checks from [Grazie plugin](https://plugins.jetbrains.com/plugin/12175-grazie) for Rust language in 2021.2 IDEs
