### PR TITLE
COMP: fix autoimport-aware completion after completion at empty place

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -12,6 +12,7 @@ import com.intellij.codeInsight.lookup.LookupElementDecorator
 import com.intellij.openapiext.Testmark
 import com.intellij.patterns.ElementPattern
 import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.StandardPatterns
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.PsiTreeUtil
@@ -174,7 +175,10 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
             val positionInMacroArgument = parameters.position.findElementExpandedFrom()
             val originalPosition = if (positionInMacroArgument != null) positionInMacroArgument.safeGetOriginalElement() else parameters.originalPosition
             // We use the position in the original file in order not to process empty paths
-            if (originalPosition == null || originalPosition.elementType != RsElementTypes.IDENTIFIER) return
+            if (originalPosition == null || originalPosition.elementType != RsElementTypes.IDENTIFIER) {
+                result.restartCompletionOnPrefixChange(StandardPatterns.string().withLength(1))
+                return
+            }
             val actualPosition = if (positionInMacroArgument != null) parameters.position else originalPosition
             // Checks that macro call and expanded element are located in the same modules
             if (positionInMacroArgument != null && !isInSameRustMod(positionInMacroArgument, actualPosition)) {


### PR DESCRIPTION
The bug was explained @Kobzol in [the comment](https://github.com/intellij-rust/intellij-rust/pull/7480#issuecomment-878633497)

![completion](https://user-images.githubusercontent.com/4539057/125358280-ff0bcf00-e368-11eb-995c-a437b88132c5.gif)

The full completion list isn't shown when completing in an empty place because unfiltered completion (without a prefix) would be quite slow. But the bug is that the full completion list isn't loaded after typing the first letter.
