### PR TITLE
COMP: add postfix template for wrapping a type with another type

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
@@ -46,7 +46,8 @@ class RsPostfixTemplateProvider : PostfixTemplateProvider {
         DbgrPostfixTemplate(this),
         OkPostfixTemplate(this),
         SomePostfixTemplate(this),
-        ErrPostfixTemplate(this)
+        ErrPostfixTemplate(this),
+        WrapTypePathPostfixTemplate(this)
     )
 
     override fun getTemplates(): Set<PostfixTemplate> = templates

--- a/src/main/kotlin/org/rust/ide/template/postfix/WrapTypePathPostfixTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/WrapTypePathPostfixTemplate.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix
+
+import com.intellij.codeInsight.template.TemplateResultListener
+import com.intellij.codeInsight.template.impl.MacroCallNode
+import com.intellij.codeInsight.template.macro.CompleteMacro
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateWithExpressionSelector
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
+import org.rust.ide.utils.template.newTemplateBuilder
+import org.rust.lang.core.parser.RustParserUtil
+import org.rust.lang.core.psi.RsBaseType
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsTypeReference
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.openapiext.createSmartPointer
+
+class WrapTypePathPostfixTemplate(provider: RsPostfixTemplateProvider)
+    : PostfixTemplateWithExpressionSelector(null, "wrap", "\$wrapper$<path>", RsTypeParentsSelector(), provider) {
+    override fun expandForChooseExpression(element: PsiElement, editor: Editor) {
+        val typeRef = element as? RsTypeReference ?: return
+
+        val factory = RsPsiFactory(typeRef.project)
+        val path = factory.tryCreatePath("Wrapper<${typeRef.text}>", RustParserUtil.PathParsingMode.TYPE) ?: return
+        val newTypeRef = factory.tryCreateType(path.text) ?: return
+        val inserted = typeRef.replace(newTypeRef) as? RsBaseType ?: return
+        val ptr = inserted.createSmartPointer()
+
+        val template = editor.newTemplateBuilder(inserted) ?: return
+        val name = ptr.element?.path?.referenceNameElement ?: return
+        template.replaceElement(name, MacroCallNode(CompleteMacro()))
+        template.withResultListener {
+            // For some reason, the result is set to BrokenOff sometimes, even on successful template confirmation
+            if (it != TemplateResultListener.TemplateResult.Canceled) {
+                // Move caret after the inserted wrapper type
+                val end = ptr.element?.path?.typeArgumentList?.gt
+                if (end != null) {
+                    editor.caretModel.moveToOffset(end.startOffset + 1)
+                }
+            }
+        }
+        template.runInline()
+    }
+}

--- a/src/main/kotlin/org/rust/ide/template/postfix/utils.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/utils.kt
@@ -11,9 +11,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.Condition
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.RsBlock
-import org.rust.lang.core.psi.RsExpr
-import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestors
 import org.rust.lang.core.types.ty.TyBool
 import org.rust.lang.core.types.type
@@ -46,6 +44,17 @@ class RsExprParentsSelector(pred: (RsExpr) -> Boolean = { true })
         .ancestors
         .takeWhile { it !is RsBlock }
         .filter { it is RsExpr }
+        .toList()
+}
+
+class RsTypeParentsSelector : PostfixTemplateExpressionSelectorBase(Condition { it is RsTypeReference }) {
+    override fun getNonFilteredExpressions(
+        context: PsiElement,
+        document: Document,
+        offset: Int
+    ): List<PsiElement> = context
+        .ancestors
+        .filter { it is RsTypeReference }
         .toList()
 }
 

--- a/src/main/resources/postfixTemplates/WrapTypePathPostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/WrapTypePathPostfixTemplate/after.rs.template
@@ -1,0 +1,3 @@
+fn foo(number: Mutex<i32>) {
+
+}

--- a/src/main/resources/postfixTemplates/WrapTypePathPostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/WrapTypePathPostfixTemplate/before.rs.template
@@ -1,0 +1,3 @@
+fn foo(number: <spot>i32</spot>.wrap) {
+
+}

--- a/src/main/resources/postfixTemplates/WrapTypePathPostfixTemplate/description.html
+++ b/src/main/resources/postfixTemplates/WrapTypePathPostfixTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Surrounds a type with a wrapper type.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.template.postfix
 
+import com.intellij.codeInsight.template.impl.TemplateManagerImpl
 import com.intellij.codeInsight.template.postfix.templates.LanguagePostfixTemplate
 import com.intellij.codeInsight.template.postfix.templates.PostfixLiveTemplate
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
@@ -38,10 +39,32 @@ abstract class RsPostfixTemplateTest(private val postfixTemplate: PostfixTemplat
         @Language("Rust") before: String,
         @Language("Rust") after: String,
         checkSyntaxErrors: Boolean = true
+    ) = doTestWithAction(before, after, checkSyntaxErrors)
+
+    protected fun doTestWithLiveTemplate(
+        @Language("Rust") before: String,
+        toType: String,
+        @Language("Rust") after: String,
+        checkSyntaxErrors: Boolean = true
+    ) {
+        TemplateManagerImpl.setTemplateTesting(testRootDisposable)
+        doTestWithAction(before, after, checkSyntaxErrors) {
+            assertNotNull(TemplateManagerImpl.getTemplateState(myFixture.editor))
+            myFixture.type(toType)
+            assertNull(TemplateManagerImpl.getTemplateState(myFixture.editor))
+        }
+    }
+
+    private fun doTestWithAction(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        checkSyntaxErrors: Boolean = true,
+        action: () -> Unit = {}
     ) {
         InlineFile(before.trimIndent()).withCaret()
         checkApplicability(before.trimIndent(), true)
         myFixture.type('\t')
+        action()
         if (checkSyntaxErrors) myFixture.checkHighlighting(false, false, false)
 
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))

--- a/src/test/kotlin/org/rust/ide/template/postfix/WrapTypePathPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/WrapTypePathPostfixTemplateTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix
+
+class WrapTypePathPostfixTemplateTest : RsPostfixTemplateTest(WrapTypePathPostfixTemplate(RsPostfixTemplateProvider())) {
+    fun `test ignore path expression`() = doTestNotApplicable("""
+        struct S;
+
+        fn main() {
+            let a = S.wrap/*caret*/
+        }
+    """)
+
+    fun `test simple path`() = doTestWithLiveTemplate("""
+        fn foo(a: u32.wrap/*caret*/) {}
+    """, "Wrapper\t", """
+        fn foo(a: Wrapper<u32>/*caret*/) {}
+    """)
+
+    fun `test path with type arguments`() = doTestWithLiveTemplate("""
+        struct S<T>(T);
+
+        fn foo(a: S<u32>.wrap/*caret*/) {}
+    """, "Wrapper\t", """
+        struct S<T>(T);
+
+        fn foo(a: Wrapper<S<u32>>/*caret*/) {}
+    """)
+
+    fun `test qualified path`() = doTestWithLiveTemplate("""
+        mod bar {
+            pub struct S;
+        }
+
+        fn foo(a: bar::S.wrap/*caret*/) {}
+    """, "Wrapper\t", """
+        mod bar {
+            pub struct S;
+        }
+
+        fn foo(a: Wrapper<bar::S>/*caret*/) {}
+    """)
+
+    fun `test nested path`() = doTestWithLiveTemplate("""
+        struct S<T>(T);
+
+        fn foo(a: S<u32.wrap/*caret*/>) {}
+    """, "Wrapper\t", """
+        struct S<T>(T);
+
+        fn foo(a: S<Wrapper<u32>/*caret*/>) {}
+    """)
+
+    fun `test tuple type`() = doTestWithLiveTemplate("""
+        fn foo(a: (u32, u32).wrap/*caret*/) {}
+    """, "Wrapper\t", """
+        fn foo(a: Wrapper<(u32, u32)>/*caret*/) {}
+    """)
+}


### PR DESCRIPTION
Recently I needed to wrap several types inside `Mutex` and I thought that a postfix template that wraps a type in another type could be nice.

![wrap](https://user-images.githubusercontent.com/4539057/125466875-ba882a95-21e4-4701-9f16-ec6e4174aa04.gif)

To make it practical for repeated wrapping, it would be nice if the caret moved to the end of the wrapped type, instead of moving after its name. But I didn't find how to do this with the `Template` API. I could probably override and completely re-implement `expandForChooseExpression` to use a template builder, but I'm not sure if that's the right way to do it.

For some reason autoimport in the template used by the postfix completion doesn't work in tests. It works in the IDE though.

changelog: Add postfix template named `.wrap` that wraps an existing type with another type.