### PR TITLE
TY: lift aliasedBy from TyAdt to Ty

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -149,13 +149,15 @@ object RsImportHelper {
     ) {
         ty.substitute(subst).visitWith(object : TypeVisitor {
             override fun visitTy(ty: Ty): Boolean {
+                val alias = ty.aliasedBy?.element.takeIf { useAliases } as? RsQualifiedNamedElement
+                if (alias != null) {
+                    result += alias
+                    return true
+                }
+
                 when (ty) {
                     is TyAdt -> {
-                        val alias = ty.aliasedBy?.element.takeIf { useAliases } as? RsQualifiedNamedElement
-                        result += alias ?: ty.item
-                        if (alias != null) {
-                            return true
-                        }
+                        result += ty.item
 
                         if (skipUnchangedDefaultTypeArguments) {
                             val filteredTypeArguments = ty.typeArguments

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -61,7 +61,7 @@ fun inferTypeReferenceType(type: RsTypeReference, defaultTraitObjectRegion: Regi
                     target is RsTypeDeclarationElement -> {
                         val ty = target.declaredType
                             .substituteWithTraitObjectRegion(subst, defaultTraitObjectRegion ?: ReStatic)
-                        if (ty is TyAdt && ty.item != target && target is RsTypeAlias) {
+                        if (target is RsTypeAlias) {
                             ty.withAlias(boundElement.downcast()!!)
                         } else {
                             ty

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -465,7 +465,7 @@ class RsInferenceContext(
     fun combineTypesNoVars(ty1: Ty, ty2: Ty): CoerceResult =
         when {
             ty1 === ty2 -> CoerceResult.Ok
-            ty1 is TyPrimitive && ty2 is TyPrimitive && ty1 == ty2 -> CoerceResult.Ok
+            ty1 is TyPrimitive && ty2 is TyPrimitive && ty1.javaClass == ty2.javaClass -> CoerceResult.Ok
             ty1 is TyTypeParameter && ty2 is TyTypeParameter && ty1 == ty2 -> CoerceResult.Ok
             ty1 is TyProjection && ty2 is TyProjection && ty1.target == ty2.target && combineBoundElements(ty1.trait, ty2.trait) -> {
                 combineTypes(ty1.type, ty2.type)

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.types.ty
 
 import org.rust.ide.presentation.render
 import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.ext.fields
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.knownItems
@@ -34,6 +35,10 @@ abstract class Ty(override val flags: TypeFlags = 0) : Kind, TypeFoldable<Ty> {
     override fun visitWith(visitor: TypeVisitor): Boolean = visitor.visitTy(this)
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean = false
+
+    open val aliasedBy: BoundElement<RsTypeAlias>? = null
+
+    open fun withAlias(aliasedBy: BoundElement<RsTypeAlias>) = this
 
     /**
      * Bindings between formal type parameters and actual type arguments.

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt
@@ -34,7 +34,7 @@ data class TyAdt private constructor(
     val typeArguments: List<Ty>,
     val regionArguments: List<Region>,
     val constArguments: List<Const>,
-    val aliasedBy: BoundElement<RsTypeAlias>?
+    override val aliasedBy: BoundElement<RsTypeAlias>?
 ) : Ty(mergeFlags(typeArguments) or mergeFlags(regionArguments) or mergeFlags(constArguments)) {
 
     // This method is rarely called (in comparison with folding), so we can implement it in a such inefficient way.
@@ -66,7 +66,7 @@ data class TyAdt private constructor(
             regionArguments.any { it.visitWith(visitor) } ||
             constArguments.any { it.visitWith(visitor) }
 
-    fun withAlias(aliasedBy: BoundElement<RsTypeAlias>?): TyAdt =
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): TyAdt =
         copy(aliasedBy = aliasedBy)
 
     companion object {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
@@ -5,17 +5,25 @@
 
 package org.rust.lang.core.types.ty
 
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.asLong
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 
-data class TyArray(val base: Ty, val const: Const) : Ty(base.flags or const.flags) {
+data class TyArray(
+    val base: Ty,
+    val const: Const,
+    override val aliasedBy: BoundElement<RsTypeAlias>? = null
+) : Ty(base.flags or const.flags) {
     val size: Long? get() = const.asLong()
 
     override fun superFoldWith(folder: TypeFolder): Ty =
-        TyArray(base.foldWith(folder), const.foldWith(folder))
+        TyArray(base.foldWith(folder), const.foldWith(folder), aliasedBy?.foldWith(folder))
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean =
         base.visitWith(visitor) || const.visitWith(visitor)
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = copy(aliasedBy = aliasedBy)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
@@ -5,15 +5,23 @@
 
 package org.rust.lang.core.types.ty
 
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.mergeFlags
 
-data class TyFunction(val paramTypes: List<Ty>, val retType: Ty) : Ty(mergeFlags(paramTypes) or retType.flags) {
+data class TyFunction(
+    val paramTypes: List<Ty>,
+    val retType: Ty,
+    override val aliasedBy: BoundElement<RsTypeAlias>? = null
+) : Ty(mergeFlags(paramTypes) or retType.flags) {
 
     override fun superFoldWith(folder: TypeFolder): Ty =
-        TyFunction(paramTypes.map { it.foldWith(folder) }, retType.foldWith(folder))
+        TyFunction(paramTypes.map { it.foldWith(folder) }, retType.foldWith(folder), aliasedBy?.foldWith(folder))
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean =
         paramTypes.any { it.visitWith(visitor) } || retType.visitWith(visitor)
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = copy(aliasedBy = aliasedBy)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
@@ -5,14 +5,22 @@
 
 package org.rust.lang.core.types.ty
 
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 
-data class TyPointer(val referenced: Ty, val mutability: Mutability) : Ty(referenced.flags) {
+data class TyPointer(
+    val referenced: Ty,
+    val mutability: Mutability,
+    override val aliasedBy: BoundElement<RsTypeAlias>? = null
+) : Ty(referenced.flags) {
 
     override fun superFoldWith(folder: TypeFolder): Ty =
-        TyPointer(referenced.foldWith(folder), mutability)
+        TyPointer(referenced.foldWith(folder), mutability, aliasedBy?.foldWith(folder))
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean =
         referenced.visitWith(visitor)
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = copy(aliasedBy = aliasedBy)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -7,6 +7,9 @@ package org.rust.lang.core.types.ty
 
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.infer.TypeFolder
 
 /**
  * These are "atomic" ty.
@@ -15,8 +18,16 @@ import org.rust.lang.core.psi.RsPath
  * tuples or arrays as primitive.
  */
 abstract class TyPrimitive : Ty() {
-
     abstract val name: String
+
+    override fun superFoldWith(folder: TypeFolder): Ty {
+        val alias = aliasedBy
+        return if (alias == null) {
+            this
+        } else {
+            withAlias(alias.foldWith(folder))
+        }
+    }
 
     companion object {
         fun fromPath(path: RsPath): TyPrimitive? {
@@ -36,27 +47,33 @@ abstract class TyPrimitive : Ty() {
     }
 }
 
-class TyBool : TyPrimitive() {
+class TyBool(override val aliasedBy: BoundElement<RsTypeAlias>? = null) : TyPrimitive() {
     override val name: String
         get() = "bool"
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = TyBool(aliasedBy)
 
     companion object {
         val INSTANCE: TyBool = TyBool()
     }
 }
 
-class TyChar : TyPrimitive() {
+class TyChar(override val aliasedBy: BoundElement<RsTypeAlias>? = null) : TyPrimitive() {
     override val name: String
         get() = "char"
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = TyChar(aliasedBy)
 
     companion object {
         val INSTANCE: TyChar = TyChar()
     }
 }
 
-class TyUnit : TyPrimitive() {
+class TyUnit(override val aliasedBy: BoundElement<RsTypeAlias>? = null) : TyPrimitive() {
     override val name: String
         get() = "unit"
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = TyUnit(aliasedBy)
 
     companion object {
         val INSTANCE: TyUnit = TyUnit()
@@ -69,9 +86,11 @@ object TyNever : TyPrimitive() {
         get() = "never"
 }
 
-class TyStr : TyPrimitive() {
+class TyStr(override val aliasedBy: BoundElement<RsTypeAlias>? = null) : TyPrimitive() {
     override val name: String
         get() = "str"
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = TyStr(aliasedBy)
 
     companion object {
         val INSTANCE: TyStr = TyStr()
@@ -115,122 +134,146 @@ sealed class TyInteger : TyNumeric() {
         }
     }
 
-    class U8: TyInteger() {
+    class U8(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "u8"
         override val ordinal: Int
             get() = 0
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = U8(aliasedBy)
+
         companion object {
             val INSTANCE: U8 = U8()
         }
     }
-    class U16: TyInteger() {
+    class U16(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "u16"
         override val ordinal: Int
             get() = 1
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = U16(aliasedBy)
+
         companion object {
             val INSTANCE: U16 = U16()
         }
     }
-    class U32: TyInteger() {
+    class U32(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "u32"
         override val ordinal: Int
             get() = 2
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = U32(aliasedBy)
+
         companion object {
             val INSTANCE: U32 = U32()
         }
     }
-    class U64: TyInteger() {
+    class U64(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "u64"
         override val ordinal: Int
             get() = 3
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = U64(aliasedBy)
+
         companion object {
             val INSTANCE: U64 = U64()
         }
     }
-    class U128: TyInteger() {
+    class U128(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "u128"
         override val ordinal: Int
             get() = 4
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = U128(aliasedBy)
+
         companion object {
             val INSTANCE: U128 = U128()
         }
     }
-    class USize : TyInteger() {
+    class USize(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "usize"
         override val ordinal: Int
             get() = 5
+
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = USize(aliasedBy)
 
         companion object {
             val INSTANCE: USize = USize()
         }
     }
 
-    class I8: TyInteger() {
+    class I8(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "i8"
         override val ordinal: Int
             get() = 6
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = I8(aliasedBy)
+
         companion object {
             val INSTANCE: I8 = I8()
         }
     }
-    class I16: TyInteger() {
+    class I16(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "i16"
         override val ordinal: Int
             get() = 7
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = I16(aliasedBy)
+
         companion object {
             val INSTANCE: I16 = I16()
         }
     }
-    class I32: TyInteger() {
+    class I32(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "i32"
         override val ordinal: Int
             get() = 8
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = I32(aliasedBy)
+
         companion object {
             val INSTANCE: I32 = I32()
         }
     }
-    class I64: TyInteger() {
+    class I64(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "i64"
         override val ordinal: Int
             get() = 9
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = I64(aliasedBy)
+
         companion object {
             val INSTANCE: I64 = I64()
         }
     }
-    class I128: TyInteger() {
+    class I128(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "i128"
         override val ordinal: Int
             get() = 10
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = I128(aliasedBy)
+
         companion object {
             val INSTANCE: I128 = I128()
         }
     }
-    class ISize: TyInteger() {
+    class ISize(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyInteger() {
         override val name: String
             get() = "isize"
         override val ordinal: Int
             get() = 11
+
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = ISize(aliasedBy)
 
         companion object {
             val INSTANCE: ISize = ISize()
@@ -263,21 +306,25 @@ sealed class TyFloat : TyNumeric() {
         }
     }
 
-    class F32: TyFloat() {
+    class F32(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyFloat() {
         override val name: String
             get() = "f32"
         override val ordinal: Int
             get() = 0
 
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = F32(aliasedBy)
+
         companion object {
             val INSTANCE: F32 = F32()
         }
     }
-    class F64: TyFloat() {
+    class F64(override val aliasedBy: BoundElement<RsTypeAlias>? = null): TyFloat() {
         override val name: String
             get() = "f64"
         override val ordinal: Int
             get() = 1
+
+        override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = F64(aliasedBy)
 
         companion object {
             val INSTANCE: F64 = F64()

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
@@ -5,6 +5,8 @@
 
 package org.rust.lang.core.types.ty
 
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.regions.ReUnknown
@@ -13,14 +15,17 @@ import org.rust.lang.core.types.regions.Region
 data class TyReference(
     val referenced: Ty,
     val mutability: Mutability,
-    val region: Region = ReUnknown
+    val region: Region = ReUnknown,
+    override val aliasedBy: BoundElement<RsTypeAlias>? = null
 ) : Ty(referenced.flags or region.flags) {
 
     override fun superFoldWith(folder: TypeFolder): Ty =
-        TyReference(referenced.foldWith(folder), mutability, region.foldWith(folder))
+        TyReference(referenced.foldWith(folder), mutability, region.foldWith(folder), aliasedBy?.foldWith(folder))
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean =
         referenced.visitWith(visitor) || region.visitWith(visitor)
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = copy(aliasedBy = aliasedBy)
 
     /**
      * We ignore lifetimes when comparing because we don't yet know how to compare them.

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
@@ -5,14 +5,21 @@
 
 package org.rust.lang.core.types.ty
 
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 
-data class TySlice(val elementType: Ty) : Ty(elementType.flags) {
+data class TySlice(
+    val elementType: Ty,
+    override val aliasedBy: BoundElement<RsTypeAlias>? = null
+) : Ty(elementType.flags) {
 
     override fun superFoldWith(folder: TypeFolder): Ty =
-        TySlice(elementType.foldWith(folder))
+        TySlice(elementType.foldWith(folder), aliasedBy?.foldWith(folder))
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean =
         elementType.visitWith(visitor)
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = copy(aliasedBy = aliasedBy)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
@@ -5,15 +5,22 @@
 
 package org.rust.lang.core.types.ty
 
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.mergeFlags
 
-data class TyTuple(val types: List<Ty>) : Ty(mergeFlags(types)) {
+data class TyTuple(
+    val types: List<Ty>,
+    override val aliasedBy: BoundElement<RsTypeAlias>? = null
+) : Ty(mergeFlags(types)) {
 
     override fun superFoldWith(folder: TypeFolder): Ty =
-        TyTuple(types.map { it.foldWith(folder) })
+        TyTuple(types.map { it.foldWith(folder) }, aliasedBy?.foldWith(folder))
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean =
         types.any { it.visitWith(visitor) }
+
+    override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): TyTuple = copy(aliasedBy = aliasedBy)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -978,4 +978,22 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
         async fn baz(a: u32) {}
     """)
+
+    fun `test aliased argument type`() = doAvailableTest("""
+        type Alias = (u32, u32);
+
+        fn foo(a: Alias) {
+            bar/*caret*/(a);
+        }
+    """, """
+        type Alias = (u32, u32);
+
+        fn foo(a: Alias) {
+            bar(a);
+        }
+
+        fn bar(p0: Alias) {
+            todo!()
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsShortTypeRenderingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsShortTypeRenderingTest.kt
@@ -38,7 +38,7 @@ class RsShortTypeRenderingTest : RsTestBase() {
                 .wrap(|x: i32| x)
                 .wrap(|x: i32| x);
             foo;
-            //^ S<fn(i32) -> i32, S<fn(i32) -> i32, S<…, …>>>
+            //^ S<fn(i32) -> i32, S<fn(…) -> …, S<…, …>>>
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -416,6 +416,81 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
                  //^ Foo
     """, WITH_ALIAS_NAMES)
 
+    fun `test render alias name tuple`() = testType("""
+        struct S;
+        type Foo = (S, S);
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias name function`() = testType("""
+        type Foo = fn(u32) -> u32;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias name trait object`() = testType("""
+        trait T {}
+
+        type Foo = dyn T;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias name reference`() = testType("""
+        type Foo = &'static u32;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias name pointer`() = testType("""
+        type Foo = *const u32;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias array`() = testType("""
+        type Foo = [u32; 3];
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias slice`() = testType("""
+        type Foo = [u32];
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias char`() = testType("""
+        type Foo = char;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias str`() = testType("""
+        type Foo = str;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias bool`() = testType("""
+        type Foo = bool;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias integer`() = testType("""
+        type Foo = u32;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
+    fun `test render alias float`() = testType("""
+        type Foo = f32;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
     fun `test render alias name with generics`() = testType("""
         struct S<A, B>(A, B);
         type Foo<T> = S<T, u8>;
@@ -448,4 +523,3 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         DEFAULT, WITH_LIFETIMES, WITH_ALIAS_NAMES
     }
 }
-


### PR DESCRIPTION
This is an attempt to implement `aliasedBy` for (almost) all types, attempt number 2.

I wanted `aliasedBy` to be optional, so that you can first create a type without it and then "bolt" it onto the type later. This makes implementing `inferTypeReferenceType` much simpler, because the alias can be added "from the outside".

There are probably two ways of implementing the attribute itself:
1) Create an `aliasedBy` field directly inside `Ty`
    - (meh) each type will need to implement a `copy` method so that it can re-create itself with an alias
    - (bad) it's not really possible to pass the `aliasedBy` field from child constructor of data classes to `Ty`. So you couldn't create these classes directly with an alias. So e.g. in `superFoldWith` you would need to create the folded type and then create it again with an added alias (which is not very nice).
    - (bad) even types that do not care about aliases (like `TyUnknown`) will need to keep an unnecessary reference (set to `null`)
2) Create an `aliasedBy` property inside `Ty`, defaulting to `null`
    - (meh) each type will need to implement a `copy with alias` method so that it can re-create itself with an alias
    - (meh) each type that cares about aliases will need to implement the property, by creating its own backing field

1x meh + 2x bad seemed worse than 2x meh, so I chose the second one. So basically each type that wants to "participate" in aliases needs to implement `withAlias` + include the alias in `superFoldWith`.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5080