### PR TITLE
T: Optimize `RsPromoteModuleToDirectoryActionTest`

### DIFF
--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -100,8 +100,13 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
             Target("$contentRoot/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
             Target("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB), edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
             Target("$contentRoot/bin/a.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/bin/a/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/tests/a.rs", name, TargetKind.Test, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/tests/a/main.rs", name, TargetKind.Test, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
             Target("$contentRoot/bench/a.rs", name, TargetKind.Bench, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/bench/a/main.rs", name, TargetKind.Bench, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
             Target("$contentRoot/example/a.rs", name, TargetKind.ExampleBin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/example/a/main.rs", name, TargetKind.ExampleBin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
             Target("$contentRoot/example-lib/a.rs", name, TargetKind.ExampleLib(EnumSet.of(LibKind.LIB)), edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
             Target("$contentRoot/build.rs", "build_script_build", TargetKind.CustomBuild, edition = Edition.EDITION_2015, doctest = false, requiredFeatures = emptyList())
         ),


### PR DESCRIPTION
Made `RsPromoteModuleToDirectoryActionTest` usual test (without toolchain), because tests with toolchain are very slow. Thanks @vlad20012 for pointing this out