### PR TITLE
Enable js module for 2021.2 builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ val compileNativeCodeTaskName = "compileNativeCode"
 plugins {
     idea
     kotlin("jvm") version "1.5.20"
-    id("org.jetbrains.intellij") version "1.1.2"
+    id("org.jetbrains.intellij") version "1.1.3"
     id("org.jetbrains.grammarkit") version "2021.1.3"
     id("net.saliman.properties") version "1.5.1"
     id("org.gradle.test-retry") version "1.2.0"
@@ -264,9 +264,7 @@ project(":plugin") {
         implementation(project(":intelliLang"))
         implementation(project(":duplicates"))
         implementation(project(":grazie"))
-        if (platformVersion < 212) {
-            implementation(project(":js"))
-        }
+        implementation(project(":js"))
         implementation(project(":ml-completion"))
     }
 
@@ -515,17 +513,15 @@ project(":grazie") {
     }
 }
 
-if (platformVersion < 212) {
-    project(":js") {
-        intellij {
-            plugins.set(listOf(javaScriptPlugin))
-        }
-        dependencies {
-            implementation(project(":"))
-            implementation(project(":common"))
-            testImplementation(project(":", "testOutput"))
-            testImplementation(project(":common", "testOutput"))
-        }
+project(":js") {
+    intellij {
+        plugins.set(listOf(javaScriptPlugin))
+    }
+    dependencies {
+        implementation(project(":"))
+        implementation(project(":common"))
+        testImplementation(project(":", "testOutput"))
+        testImplementation(project(":common", "testOutput"))
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,16 +12,11 @@ include(
     "intelliLang",
     "duplicates",
     "grazie",
+    "js",
     "ml-completion",
     "intellij-toml",
     "intellij-toml:core"
 )
-
-val platformVersion: String by extra
-
-if (platformVersion.toInt() < 212) {
-    include("js")
-}
 
 // Configure Gradle Build Cache. It is enabled in `gradle.properties` via `org.gradle.caching`.
 // Also, `gradle clean` task is configured to delete `build-cache` directory.


### PR DESCRIPTION
Previously, the corresponding module was excluded from 2021.2 builds because of https://github.com/JetBrains/gradle-intellij-plugin/issues/674 that was fixed in 1.1.3

changelog: Enable [Go to generated declaration](https://plugins.jetbrains.com/plugin/8182-rust/docs/wasm-projects-support.html#goto-wasm-bindgen) line marker in WASM projects for 2021.2 platform
