### PR TITLE
T: fix build tests

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildContext.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildContext.kt
@@ -32,7 +32,7 @@ class CargoBuildContext(
     val progressTitle: String,
     val isTestBuild: Boolean
 ) {
-    val buildId: Any = if (isUnitTestMode) CargoBuildManager.testBuildId ?: Any() else Any()
+    val buildId: Any = Any()
 
     val project: Project get() = cargoProject.project
     val workingDirectory: Path get() = cargoProject.workingDirectory

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -96,12 +96,7 @@ object CargoBuildManager {
             progressTitle = "Building...",
             isTestBuild = state.commandLine.command == "test"
         )) {
-            val buildProgressListener = if (isUnitTestMode) {
-                mockBuildProgressListener ?: EmptyBuildProgressListener
-            } else {
-                ServiceManager.getService(project, BuildViewManager::class.java)
-            }
-
+            val buildProgressListener = ServiceManager.getService(project, BuildViewManager::class.java)
             if (!isHeadlessEnvironment) {
                 @Suppress("UsePropertyAccessSyntax")
                 val buildToolWindow = BuildContentManager.getInstance(project).getOrCreateToolWindow()
@@ -309,10 +304,6 @@ object CargoBuildManager {
     @TestOnly
     @Volatile
     var testBuildId: Any? = null
-
-    @TestOnly
-    @Volatile
-    var mockBuildProgressListener: MockBuildProgressListener? = null
 
     @TestOnly
     @Volatile

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -303,10 +303,6 @@ object CargoBuildManager {
 
     @TestOnly
     @Volatile
-    var testBuildId: Any? = null
-
-    @TestOnly
-    @Volatile
     var mockProgressIndicator: MockProgressIndicator? = null
 
     @TestOnly

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/Utils.kt
@@ -7,20 +7,13 @@
 
 package org.rust.cargo.runconfig.buildtool
 
-import com.intellij.build.BuildProgressListener
-import com.intellij.build.events.BuildEvent
-import com.intellij.build.events.FinishBuildEvent
 import com.intellij.execution.ExecutionListener
 import com.intellij.execution.ExecutionManager
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.util.Key
-import com.intellij.util.ConcurrencyUtil
-import com.intellij.util.ui.UIUtil
 import org.rust.cargo.toolchain.CargoCommandLine
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 typealias CargoPatch = (CargoCommandLine) -> CargoCommandLine
 
@@ -66,31 +59,5 @@ class MockProgressIndicator : EmptyProgressIndicator() {
     override fun setText2(text: String?) {
         super.setText2(text)
         _textHistory += text
-    }
-}
-
-object EmptyBuildProgressListener : BuildProgressListener {
-    override fun onEvent(buildId: Any, event: BuildEvent) = Unit
-}
-
-@Suppress("UnstableApiUsage")
-class MockBuildProgressListener(buildsCount: Int = 1) : BuildProgressListener {
-    private val latch: CountDownLatch = CountDownLatch(buildsCount)
-    private val _eventHistory: MutableList<BuildEvent> = mutableListOf()
-    val eventHistory: List<BuildEvent> get() = _eventHistory
-
-    override fun onEvent(buildId: Any, event: BuildEvent) {
-        _eventHistory.add(event)
-        if (event is FinishBuildEvent) {
-            latch.countDown()
-        }
-    }
-
-    @Throws(InterruptedException::class)
-    fun waitFinished(timeoutMs: Long = 5000) {
-        for (i in 1..timeoutMs / ConcurrencyUtil.DEFAULT_TIMEOUT_MS) {
-            UIUtil.dispatchAllInvocationEvents()
-            if (latch.await(ConcurrencyUtil.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) break
-        }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/Utils.kt
@@ -16,6 +16,8 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.util.Key
+import com.intellij.util.ConcurrencyUtil
+import com.intellij.util.ui.UIUtil
 import org.rust.cargo.toolchain.CargoCommandLine
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -85,7 +87,10 @@ class MockBuildProgressListener(buildsCount: Int = 1) : BuildProgressListener {
     }
 
     @Throws(InterruptedException::class)
-    fun waitFinished(timeout: Long = 1, unit: TimeUnit = TimeUnit.MINUTES) {
-        latch.await(timeout, unit)
+    fun waitFinished(timeoutMs: Long = 1000) {
+        for (i in 1..timeoutMs / ConcurrencyUtil.DEFAULT_TIMEOUT_MS) {
+            UIUtil.dispatchAllInvocationEvents()
+            if (latch.await(ConcurrencyUtil.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) break
+        }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/Utils.kt
@@ -87,7 +87,7 @@ class MockBuildProgressListener(buildsCount: Int = 1) : BuildProgressListener {
     }
 
     @Throws(InterruptedException::class)
-    fun waitFinished(timeoutMs: Long = 1000) {
+    fun waitFinished(timeoutMs: Long = 5000) {
         for (i in 1..timeoutMs / ConcurrencyUtil.DEFAULT_TIMEOUT_MS) {
             UIUtil.dispatchAllInvocationEvents()
             if (latch.await(ConcurrencyUtil.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) break

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/CargoBuildManagerTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/CargoBuildManagerTest.kt
@@ -12,13 +12,7 @@ import com.intellij.build.events.impl.FailureResultImpl
 import com.intellij.build.events.impl.SuccessResultImpl
 import org.rust.MinRustcVersion
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.mockProgressIndicator
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.testBuildId
 import org.rust.fileTree
-import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest.Companion.MyFinishBuildEvent
-import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest.Companion.MyFinishEvent
-import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest.Companion.MyMessageEvent
-import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest.Companion.MyStartBuildEvent
-import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest.Companion.MyStartEvent
 
 @MinRustcVersion("1.48.0")
 class CargoBuildManagerTest : CargoBuildTest() {
@@ -49,27 +43,23 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0"
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling project v0.1.0")
+                finishEvent(
+                    message = "Compiling project v0.1.0",
+                    result = SuccessResultImpl()
+                )
+            }
+            finishBuildEvent(
                 message = "Build successful",
                 result = SuccessResultImpl()
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -104,32 +94,27 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0"
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Function is never used: `foo`",
-                kind = MessageEvent.Kind.WARNING
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling project v0.1.0")
+                messageEvent(
+                    message = "Function is never used: `foo`",
+                    kind = MessageEvent.Kind.WARNING
+                )
+                finishEvent(
+                    message = "Compiling project v0.1.0",
+                    result = SuccessResultImpl()
+                )
+            }
+            finishBuildEvent(
                 message = "Build successful",
                 result = SuccessResultImpl()
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -164,32 +149,27 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0"
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Mismatched types",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0",
-                result = FailureResultImpl(null as Throwable?)
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling project v0.1.0")
+                messageEvent(
+                    message = "Mismatched types",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                finishEvent(
+                    message = "Compiling project v0.1.0",
+                    result = FailureResultImpl(null as Throwable?)
+                )
+            }
+            finishBuildEvent(
                 message = "Build failed",
                 result = FailureResultImpl(null as Throwable?)
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -228,42 +208,35 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0"
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Cannot add `&str` to `{integer}`",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Cannot add `&str` to `{integer}`",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Cannot add `&str` to `{integer}`",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0",
-                result = FailureResultImpl(null as Throwable?)
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling project v0.1.0")
+                messageEvent(
+                    message = "Cannot add `&str` to `{integer}`",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                messageEvent(
+                    message = "Cannot add `&str` to `{integer}`",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                messageEvent(
+                    message = "Cannot add `&str` to `{integer}`",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                finishEvent(
+                    message = "Compiling project v0.1.0",
+                    result = FailureResultImpl(null as Throwable?)
+                )
+            }
+            finishBuildEvent(
                 message = "Build failed",
                 result = FailureResultImpl(null as Throwable?)
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -299,7 +272,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = true
         )
 
-        checkEvents()
+        checkEvents {}
 
         checkProgressIndicator(
             "Building...",
@@ -340,37 +313,31 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0"
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Mismatched types",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Mismatched types",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0",
-                result = FailureResultImpl(null as Throwable?)
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling project v0.1.0")
+                messageEvent(
+                    message = "Mismatched types",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                messageEvent(
+                    message = "Mismatched types",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                finishEvent(
+                    message = "Compiling project v0.1.0",
+                    result = FailureResultImpl(null as Throwable?)
+                )
+            }
+            finishBuildEvent(
                 message = "Build failed",
                 result = FailureResultImpl(null as Throwable?)
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -408,27 +375,23 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0"
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling project v0.1.0")
+                finishEvent(
+                    message = "Compiling project v0.1.0",
+                    result = SuccessResultImpl()
+                )
+            }
+            finishBuildEvent(
                 message = "Build successful",
                 result = SuccessResultImpl()
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -467,32 +430,27 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0"
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Mismatched types",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0",
-                result = FailureResultImpl(null as Throwable?)
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling project v0.1.0")
+                messageEvent(
+                    message = "Mismatched types",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                finishEvent(
+                    message = "Compiling project v0.1.0",
+                    result = FailureResultImpl(null as Throwable?)
+                )
+            }
+            finishBuildEvent(
                 message = "Build failed",
                 result = FailureResultImpl(null as Throwable?)
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -531,32 +489,27 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0"
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Mismatched types",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling project v0.1.0",
-                result = FailureResultImpl(null as Throwable?)
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling project v0.1.0")
+                messageEvent(
+                    message = "Mismatched types",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                finishEvent(
+                    message = "Compiling project v0.1.0",
+                    result = FailureResultImpl(null as Throwable?)
+                )
+            }
+            finishBuildEvent(
                 message = "Build failed",
                 result = FailureResultImpl(null as Throwable?)
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -619,38 +572,32 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0"
-            ),
-            MyStartEvent(
-                id = "second 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling second v0.1.0"
-            ),
-            MyFinishEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishEvent(
-                id = "second 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling second v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishBuildEvent(
+            )
+            unordered {
+                eventTree {
+                    startEvent(message = "Compiling first v0.1.0")
+                    finishEvent(
+                        message = "Compiling first v0.1.0",
+                        result = SuccessResultImpl()
+                    )
+                }
+                eventTree {
+                    startEvent(message = "Compiling second v0.1.0")
+                    finishEvent(
+                        message = "Compiling second v0.1.0",
+                        result = SuccessResultImpl()
+                    )
+                }
+            }
+            finishBuildEvent(
                 message = "Build successful",
                 result = SuccessResultImpl()
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -715,43 +662,34 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0"
-            ),
-            MyStartEvent(
-                id = "second 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling second v0.1.0"
-            ),
-            MyFinishEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyMessageEvent(
-                parentId = "second 0.1.0",
-                message = "Mismatched types",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyFinishEvent(
-                id = "second 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling second v0.1.0",
-                result = FailureResultImpl(null as Throwable?)
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling first v0.1.0")
+                finishEvent(
+                    message = "Compiling first v0.1.0",
+                    result = SuccessResultImpl()
+                )
+            }
+            eventTree {
+                startEvent(message = "Compiling second v0.1.0")
+                messageEvent(
+                    message = "Mismatched types",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                finishEvent(
+                    message = "Compiling second v0.1.0",
+                    result = FailureResultImpl(null as Throwable?)
+                )
+            }
+            finishBuildEvent(
                 message = "Build failed",
                 result = FailureResultImpl(null as Throwable?)
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -816,32 +754,27 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0"
-            ),
-            MyMessageEvent(
-                parentId = "first 0.1.0",
-                message = "Mismatched types",
-                kind = MessageEvent.Kind.ERROR
-            ),
-            MyFinishEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0",
-                result = FailureResultImpl(null as Throwable?)
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling first v0.1.0")
+                messageEvent(
+                    message = "Mismatched types",
+                    kind = MessageEvent.Kind.ERROR
+                )
+                finishEvent(
+                    message = "Compiling first v0.1.0",
+                    result = FailureResultImpl(null as Throwable?)
+                )
+            }
+            finishBuildEvent(
                 message = "Build failed",
                 result = FailureResultImpl(null as Throwable?)
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -876,32 +809,27 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Checking project v0.1.0"
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "Function is never used: `foo`",
-                kind = MessageEvent.Kind.WARNING
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Checking project v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Checking project v0.1.0")
+                messageEvent(
+                    message = "Function is never used: `foo`",
+                    kind = MessageEvent.Kind.WARNING
+                )
+                finishEvent(
+                    message = "Checking project v0.1.0",
+                    result = SuccessResultImpl()
+                )
+            }
+            finishBuildEvent(
                 message = "Build successful",
                 result = SuccessResultImpl()
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",
@@ -936,32 +864,27 @@ class CargoBuildManagerTest : CargoBuildTest() {
             canceled = false
         )
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Checking project v0.1.0"
-            ),
-            MyMessageEvent(
-                parentId = "project 0.1.0",
-                message = "This lifetime isn't used in the function definition",
-                kind = MessageEvent.Kind.WARNING
-            ),
-            MyFinishEvent(
-                id = "project 0.1.0",
-                parentId = testBuildId,
-                message = "Checking project v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Checking project v0.1.0")
+                messageEvent(
+                    message = "This lifetime isn't used in the function definition",
+                    kind = MessageEvent.Kind.WARNING
+                )
+                finishEvent(
+                    message = "Checking project v0.1.0",
+                    result = SuccessResultImpl()
+                )
+            }
+            finishBuildEvent(
                 message = "Build successful",
                 result = SuccessResultImpl()
             )
-        )
+        }
 
         checkProgressIndicator(
             "Building...",

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/CargoBuildManagerTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/CargoBuildManagerTest.kt
@@ -52,7 +52,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",
@@ -107,7 +107,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",
@@ -167,7 +167,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",
@@ -231,7 +231,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",
@@ -343,7 +343,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",
@@ -411,7 +411,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",
@@ -470,7 +470,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",
@@ -534,7 +534,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",
@@ -622,7 +622,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "first 0.1.0",
@@ -718,7 +718,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "first 0.1.0",
@@ -819,7 +819,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "first 0.1.0",
@@ -879,7 +879,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",
@@ -939,7 +939,7 @@ class CargoBuildManagerTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "project 0.1.0",

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/CargoBuildTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/CargoBuildTest.kt
@@ -21,6 +21,7 @@ import org.rust.cargo.runconfig.buildtool.RsBuildEventsConverter.Companion.RUSTC
 import org.rustSlowTests.cargo.runconfig.RunConfigurationTestBase
 import org.rustSlowTests.cargo.runconfig.buildtool.TestBuildViewManager.*
 
+@Suppress("EqualsOrHashCode")
 abstract class CargoBuildTest : RunConfigurationTestBase() {
 
     protected lateinit var testBuildViewManager: TestBuildViewManager
@@ -49,7 +50,6 @@ abstract class CargoBuildTest : RunConfigurationTestBase() {
         assertEquals(expectedEventTree, testBuildViewManager.rootNode)
     }
 
-    @Suppress("EqualsOrHashCode")
     companion object {
 
         @JvmStatic
@@ -92,115 +92,115 @@ abstract class CargoBuildTest : RunConfigurationTestBase() {
                 }
             assertEquals(expectedTexts.toList(), actualTexts)
         }
+    }
 
-        protected abstract class MyBuildEvent(
-            private val id: Any,
-            private val parentId: Any?,
-            private val message: String
-        ) : BuildEvent {
-            override fun getId(): Any = id
-            override fun getParentId(): Any? = parentId
-            override fun getMessage(): String = message
-            override fun getEventTime(): Long = 0
-            override fun getDescription(): String? = null
-            override fun getHint(): String? = null
+    private abstract class MyBuildEvent(
+        private val id: Any,
+        private val parentId: Any?,
+        private val message: String
+    ) : BuildEvent {
+        override fun getId(): Any = id
+        override fun getParentId(): Any? = parentId
+        override fun getMessage(): String = message
+        override fun getEventTime(): Long = 0
+        override fun getDescription(): String? = null
+        override fun getHint(): String? = null
 
-            override fun equals(other: Any?): Boolean = when {
-                this === other -> true
-                other !is BuildEvent -> false
-                message != other.message -> false
-                else -> true
-            }
-
-            override fun toString(): String = "MyBuildEvent(id=$id, parentId=$parentId, message='$message')"
+        override fun equals(other: Any?): Boolean = when {
+            this === other -> true
+            other !is BuildEvent -> false
+            message != other.message -> false
+            else -> true
         }
 
-        protected open class MyStartEvent(
-            id: Any,
-            parentId: Any?,
-            message: String
-        ) : MyBuildEvent(id, parentId, message), StartEvent {
-            override fun equals(other: Any?): Boolean = when {
-                !super.equals(other) -> false
-                other !is StartEvent -> false
-                else -> true
-            }
+        override fun toString(): String = "MyBuildEvent(id=$id, parentId=$parentId, message='$message')"
+    }
 
-            override fun toString(): String = "MyStartEvent(${super.toString()})"
+    private open class MyStartEvent(
+        id: Any,
+        parentId: Any?,
+        message: String
+    ) : MyBuildEvent(id, parentId, message), StartEvent {
+        override fun equals(other: Any?): Boolean = when {
+            !super.equals(other) -> false
+            other !is StartEvent -> false
+            else -> true
         }
 
-        protected open class MyFinishEvent(
-            id: Any,
-            parentId: Any?,
-            message: String,
-            private val result: EventResult
-        ) : MyBuildEvent(id, parentId, message), FinishEvent {
-            override fun getResult(): EventResult = result
+        override fun toString(): String = "MyStartEvent(${super.toString()})"
+    }
 
-            override fun equals(other: Any?): Boolean = when {
-                !super.equals(other) -> false
-                other !is FinishEvent -> false
-                result.javaClass != other.result.javaClass -> false
-                else -> true
-            }
+    private open class MyFinishEvent(
+        id: Any,
+        parentId: Any?,
+        message: String,
+        private val result: EventResult
+    ) : MyBuildEvent(id, parentId, message), FinishEvent {
+        override fun getResult(): EventResult = result
 
-            override fun toString(): String = "MyFinishEvent(${super.toString()}, result=$result)"
+        override fun equals(other: Any?): Boolean = when {
+            !super.equals(other) -> false
+            other !is FinishEvent -> false
+            result.javaClass != other.result.javaClass -> false
+            else -> true
         }
 
-        protected class MyStartBuildEvent(
-            id: Any,
-            message: String,
-            val buildTitle: String
-        ) : MyStartEvent(id, null, message), StartBuildEvent {
+        override fun toString(): String = "MyFinishEvent(${super.toString()}, result=$result)"
+    }
 
-            override fun getBuildDescriptor(): BuildDescriptor =
-                DefaultBuildDescriptor(Any(), "", "", 0)
+    private class MyStartBuildEvent(
+        id: Any,
+        message: String,
+        val buildTitle: String
+    ) : MyStartEvent(id, null, message), StartBuildEvent {
 
-            override fun equals(other: Any?): Boolean = when {
-                !super.equals(other) -> false
-                other !is StartBuildEvent -> false
-                buildTitle != other.buildDescriptor.title -> false
-                else -> true
-            }
+        override fun getBuildDescriptor(): BuildDescriptor =
+            DefaultBuildDescriptor(Any(), "", "", 0)
 
-            override fun toString(): String = "MyStartBuildEvent(${super.toString()}, buildTitle='$buildTitle')"
+        override fun equals(other: Any?): Boolean = when {
+            !super.equals(other) -> false
+            other !is StartBuildEvent -> false
+            buildTitle != other.buildDescriptor.title -> false
+            else -> true
         }
 
-        protected class MyFinishBuildEvent(
-            id: Any,
-            message: String,
-            result: EventResult
-        ) : MyFinishEvent(id, null, message, result), FinishBuildEvent {
-            override fun equals(other: Any?): Boolean = when {
-                !super.equals(other) -> false
-                other !is FinishBuildEvent -> false
-                else -> true
-            }
+        override fun toString(): String = "MyStartBuildEvent(${super.toString()}, buildTitle='$buildTitle')"
+    }
 
-            override fun toString(): String = "MyFinishBuildEvent(${super.toString()})"
+    private class MyFinishBuildEvent(
+        id: Any,
+        message: String,
+        result: EventResult
+    ) : MyFinishEvent(id, null, message, result), FinishBuildEvent {
+        override fun equals(other: Any?): Boolean = when {
+            !super.equals(other) -> false
+            other !is FinishBuildEvent -> false
+            else -> true
         }
 
-        protected open class MyMessageEvent(
-            id: Any,
-            parentId: Any,
-            message: String,
-            private val kind: MessageEvent.Kind
-        ) : MyBuildEvent(id, parentId, message), MessageEvent {
-            override fun getGroup(): String = RUSTC_MESSAGE_GROUP
-            override fun getKind(): MessageEvent.Kind = kind
-            override fun getNavigatable(project: Project): Navigatable? = null
-            override fun getResult(): MessageEventResult = MessageEventResult { kind }
+        override fun toString(): String = "MyFinishBuildEvent(${super.toString()})"
+    }
 
-            override fun equals(other: Any?): Boolean = when {
-                !super.equals(other) -> false
-                other !is MessageEvent -> false
-                kind != other.kind -> false
-                kind != other.result.kind -> false
-                else -> true
-            }
+    private open class MyMessageEvent(
+        id: Any,
+        parentId: Any,
+        message: String,
+        private val kind: MessageEvent.Kind
+    ) : MyBuildEvent(id, parentId, message), MessageEvent {
+        override fun getGroup(): String = RUSTC_MESSAGE_GROUP
+        override fun getKind(): MessageEvent.Kind = kind
+        override fun getNavigatable(project: Project): Navigatable? = null
+        override fun getResult(): MessageEventResult = MessageEventResult { kind }
 
-            override fun toString(): String = "MyMessageEvent(${super.toString()}, kind=$kind)"
+        override fun equals(other: Any?): Boolean = when {
+            !super.equals(other) -> false
+            other !is MessageEvent -> false
+            kind != other.kind -> false
+            kind != other.result.kind -> false
+            else -> true
         }
+
+        override fun toString(): String = "MyMessageEvent(${super.toString()}, kind=$kind)"
     }
 
     protected data class EventTreeBuilder(

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/CargoBuildTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/CargoBuildTest.kt
@@ -26,8 +26,6 @@ abstract class CargoBuildTest : RunConfigurationTestBase() {
 
     protected lateinit var testBuildViewManager: TestBuildViewManager
 
-    override fun shouldRunTest(): Boolean = System.getenv("CI") == null
-
     override fun setUp() {
         super.setUp()
         testBuildViewManager = TestBuildViewManager(project)

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/TestBuildViewManager.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/TestBuildViewManager.kt
@@ -8,20 +8,41 @@ package org.rustSlowTests.cargo.runconfig.buildtool
 import com.intellij.build.BuildViewManager
 import com.intellij.build.events.BuildEvent
 import com.intellij.build.events.FinishBuildEvent
+import com.intellij.build.events.OutputBuildEvent
+import com.intellij.build.events.StartBuildEvent
 import com.intellij.openapi.project.Project
 import com.intellij.util.ConcurrencyUtil
 import com.intellij.util.ui.UIUtil
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-class TestBuildViewManager(project: Project, buildsCount: Int = 1) : BuildViewManager(project) {
-    private val latch: CountDownLatch = CountDownLatch(buildsCount)
-    private val _eventHistory: MutableList<BuildEvent> = mutableListOf()
-    val eventHistory: List<BuildEvent> get() = _eventHistory
+class TestBuildViewManager(project: Project) : BuildViewManager(project) {
+    private val latch: CountDownLatch = CountDownLatch(1)
+
+    var rootNode: EventTreeNode? = null
+
+    private val events = mutableMapOf<Any, MutableList<EventTreeNode>>()
 
     override fun onEvent(buildId: Any, event: BuildEvent) {
         super.onEvent(buildId, event)
-        _eventHistory.add(event)
+
+        if (event is OutputBuildEvent) return
+
+        if (event.id !in events) {
+            val childrenEvents = mutableListOf<EventTreeNode>()
+            events[event.id] = childrenEvents
+            val parentId = event.parentId
+            val parentNode = ParentEventNode(childrenEvents)
+            if (parentId != null) {
+                events.getValue(parentId).add(parentNode)
+            }
+            if (event is StartBuildEvent) {
+                rootNode = parentNode
+            }
+        }
+
+        events.getValue(event.id) += SingleEventNode(event)
+
         if (event is FinishBuildEvent) {
             latch.countDown()
         }
@@ -32,6 +53,88 @@ class TestBuildViewManager(project: Project, buildsCount: Int = 1) : BuildViewMa
         for (i in 1..timeoutMs / ConcurrencyUtil.DEFAULT_TIMEOUT_MS) {
             UIUtil.dispatchAllInvocationEvents()
             if (latch.await(ConcurrencyUtil.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) break
+        }
+    }
+
+    sealed class EventTreeNode(val unorderedGroupId: Int) {
+
+        abstract val firstMessage: String
+        abstract fun treeRepresentation(builder: StringBuilder, level: Int)
+
+        override fun toString(): String {
+            val builder = StringBuilder()
+            treeRepresentation(builder, 0)
+            return builder.toString()
+        }
+    }
+
+    @Suppress("EqualsOrHashCode")
+    class SingleEventNode(val event: BuildEvent, unorderedGroupId: Int = -1) : EventTreeNode(unorderedGroupId) {
+
+        override val firstMessage: String get() = event.message
+
+        override fun treeRepresentation(builder: StringBuilder, level: Int) {
+            builder.append(" ".repeat(level))
+            builder.append(event.toString())
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as SingleEventNode
+
+            if (event != other.event) return false
+
+            return true
+        }
+    }
+
+    @Suppress("EqualsOrHashCode")
+    class ParentEventNode(
+        val children: List<EventTreeNode>,
+        unorderedGroupId: Int = -1
+    ) : EventTreeNode(unorderedGroupId) {
+
+        override val firstMessage: String get() = children.first().firstMessage
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as ParentEventNode
+
+            if (children.size != other.children.size) return false
+
+            var index = 0
+            while (index < children.size) {
+                val node = children[index]
+                val unorderedGroupId = node.unorderedGroupId
+
+                fun List<EventTreeNode>.sortIfNeeded(): List<EventTreeNode> {
+                    return if (unorderedGroupId != -1) sortedBy { it.firstMessage } else this
+                }
+
+                val startIndex = index
+                while (index < children.size && children[index].unorderedGroupId == unorderedGroupId) {
+                    index++
+                }
+
+                val subChildren = children.subList(startIndex, index).sortIfNeeded()
+                val otherSubChildren = other.children.subList(startIndex, index).sortIfNeeded()
+                if (subChildren != otherSubChildren) return false
+            }
+
+            return true
+        }
+
+        override fun treeRepresentation(builder: StringBuilder, level: Int) {
+            for (child in children) {
+                when (child) {
+                    is ParentEventNode -> child.treeRepresentation(builder, level + 2)
+                    is SingleEventNode -> child.treeRepresentation(builder, level)
+                }
+            }
         }
     }
 }

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/TestBuildViewManager.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/TestBuildViewManager.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests.cargo.runconfig.buildtool
+
+import com.intellij.build.BuildViewManager
+import com.intellij.build.events.BuildEvent
+import com.intellij.build.events.FinishBuildEvent
+import com.intellij.openapi.project.Project
+import com.intellij.util.ConcurrencyUtil
+import com.intellij.util.ui.UIUtil
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class TestBuildViewManager(project: Project, buildsCount: Int = 1) : BuildViewManager(project) {
+    private val latch: CountDownLatch = CountDownLatch(buildsCount)
+    private val _eventHistory: MutableList<BuildEvent> = mutableListOf()
+    val eventHistory: List<BuildEvent> get() = _eventHistory
+
+    override fun onEvent(buildId: Any, event: BuildEvent) {
+        super.onEvent(buildId, event)
+        _eventHistory.add(event)
+        if (event is FinishBuildEvent) {
+            latch.countDown()
+        }
+    }
+
+    @Throws(InterruptedException::class)
+    fun waitFinished(timeoutMs: Long = 5000) {
+        for (i in 1..timeoutMs / ConcurrencyUtil.DEFAULT_TIMEOUT_MS) {
+            UIUtil.dispatchAllInvocationEvents()
+            if (latch.await(ConcurrencyUtil.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) break
+        }
+    }
+}

--- a/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
@@ -88,7 +88,7 @@ class RsBuildActionTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "first 0.1.0",
@@ -165,7 +165,7 @@ class RsBuildActionTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "second 0.1.0",
@@ -244,7 +244,7 @@ class RsBuildActionTest : CargoBuildTest() {
         checkEvents(
             MyStartBuildEvent(
                 message = "Build running...",
-                buildTitle = "Run Cargo command"
+                buildTitle = "Run Cargo Command"
             ),
             MyStartEvent(
                 id = "first 0.1.0",

--- a/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
@@ -15,17 +15,12 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.testFramework.TestDataProvider
 import org.rust.MinRustcVersion
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.lastBuildCommandLine
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.testBuildId
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.CompositeCargoRunConfigurationProducer
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.fileTree
 import org.rust.ide.actions.RsBuildAction
 import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest
-import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest.Companion.MyFinishBuildEvent
-import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest.Companion.MyFinishEvent
-import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest.Companion.MyStartBuildEvent
-import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest.Companion.MyStartEvent
 
 @MinRustcVersion("1.48.0")
 class RsBuildActionTest : CargoBuildTest() {
@@ -84,27 +79,23 @@ class RsBuildActionTest : CargoBuildTest() {
         )
         assertEquals(expectedCommandLine, actualCommandLine)
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0"
-            ),
-            MyFinishEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling first v0.1.0")
+                finishEvent(
+                    message = "Compiling first v0.1.0",
+                    result = SuccessResultImpl()
+                )
+            }
+            finishBuildEvent(
                 message = "Build successful",
                 result = SuccessResultImpl()
             )
-        )
+        }
     }
 
     fun `test build second action`() {
@@ -161,27 +152,23 @@ class RsBuildActionTest : CargoBuildTest() {
         )
         assertEquals(expectedCommandLine, actualCommandLine)
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "second 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling second v0.1.0"
-            ),
-            MyFinishEvent(
-                id = "second 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling second v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishBuildEvent(
+            )
+            eventTree {
+                startEvent(message = "Compiling second v0.1.0")
+                finishEvent(
+                    message = "Compiling second v0.1.0",
+                    result = SuccessResultImpl()
+                )
+            }
+            finishBuildEvent(
                 message = "Build successful",
                 result = SuccessResultImpl()
             )
-        )
+        }
     }
 
     fun `test build all action`() {
@@ -240,38 +227,32 @@ class RsBuildActionTest : CargoBuildTest() {
         )
         assertEquals(expectedCommandLine, actualCommandLine)
 
-        checkEvents(
-            MyStartBuildEvent(
+        checkEvents {
+            startBuildEvent(
                 message = "Build running...",
                 buildTitle = "Run Cargo Command"
-            ),
-            MyStartEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0"
-            ),
-            MyStartEvent(
-                id = "second 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling second v0.1.0"
-            ),
-            MyFinishEvent(
-                id = "first 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling first v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishEvent(
-                id = "second 0.1.0",
-                parentId = testBuildId,
-                message = "Compiling second v0.1.0",
-                result = SuccessResultImpl()
-            ),
-            MyFinishBuildEvent(
+            )
+            unordered {
+                eventTree {
+                    startEvent(message = "Compiling first v0.1.0")
+                    finishEvent(
+                        message = "Compiling first v0.1.0",
+                        result = SuccessResultImpl()
+                    )
+                }
+                eventTree {
+                    startEvent(message = "Compiling second v0.1.0")
+                    finishEvent(
+                        message = "Compiling second v0.1.0",
+                        result = SuccessResultImpl()
+                    )
+                }
+            }
+            finishBuildEvent(
                 message = "Build successful",
                 result = SuccessResultImpl()
             )
-        )
+        }
     }
 
     fun `test build does not use root privileges`() {

--- a/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
@@ -15,7 +15,6 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.testFramework.TestDataProvider
 import org.rust.MinRustcVersion
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.lastBuildCommandLine
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.mockBuildProgressListener
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.testBuildId
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.CompositeCargoRunConfigurationProducer
@@ -74,7 +73,7 @@ class RsBuildActionTest : CargoBuildTest() {
 
         setUpSelectedConfigurationFromContext(testProject.fileWithCaret)
         performBuildAction()
-        mockBuildProgressListener!!.waitFinished()
+        testBuildViewManager.waitFinished()
 
         val actualCommandLine = lastBuildCommandLine!!
         val expectedCommandLine = CargoCommandLine(
@@ -151,7 +150,7 @@ class RsBuildActionTest : CargoBuildTest() {
 
         setUpSelectedConfigurationFromContext(testProject.fileWithCaret)
         performBuildAction()
-        mockBuildProgressListener!!.waitFinished()
+        testBuildViewManager.waitFinished()
 
         val actualCommandLine = lastBuildCommandLine!!
         val expectedCommandLine = CargoCommandLine(
@@ -230,7 +229,7 @@ class RsBuildActionTest : CargoBuildTest() {
         }.create()
 
         performBuildAction()
-        mockBuildProgressListener!!.waitFinished()
+        testBuildViewManager.waitFinished()
 
         val actualCommandLine = lastBuildCommandLine!!
         val expectedCommandLine = CargoCommandLine(
@@ -292,7 +291,7 @@ class RsBuildActionTest : CargoBuildTest() {
 
         setUpSelectedConfigurationFromContext(testProject.fileWithCaret, withSudo = true)
         performBuildAction()
-        mockBuildProgressListener!!.waitFinished()
+        testBuildViewManager.waitFinished()
 
         val actualCommandLine = lastBuildCommandLine!!
         assertFalse(actualCommandLine.withSudo)


### PR DESCRIPTION
These changes:
- fix deadlock introduced in #7432
- get rid of some hack in `CargoBuildManager` made for tests like `CargoBuildManager.testBuildId` and `CargoBuildManager. mockBuildProgressListener`
- introduce dsl to check build event hierarchy, including a way to mark some events as unordered. Note, now we don't take into account events id in tests
- enable the corresponding tests on CI

Closes #6532