### PR TITLE
ANN: add quick fix to implement missing supertrait(s)

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFix.kt
@@ -1,0 +1,127 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.presentation.ImportingPsiRenderer
+import org.rust.ide.presentation.PsiRenderingOptions
+import org.rust.ide.presentation.renderTraitRef
+import org.rust.ide.presentation.renderTypeReference
+import org.rust.ide.refactoring.implementMembers.generateMissingTraitMembers
+import org.rust.ide.utils.GenericConstraints
+import org.rust.ide.utils.import.import
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.descendantsOfType
+import org.rust.lang.core.psi.ext.resolveToBoundTrait
+import org.rust.lang.core.resolve.ref.pathPsiSubst
+import org.rust.lang.core.types.*
+import org.rust.lang.core.types.infer.substitute
+
+/**
+ * Implements missing supertrait(s) for a type in an impl item.
+ *
+ * ```
+ * trait A {}
+ * trait B: A {}
+ *
+ * struct S;
+ *
+ * impl B/*caret*/ for S {}
+ *
+ * // fix adds
+ * impl A for S {}
+ * ```
+ */
+class AddMissingSupertraitImplFix(implItem: RsImplItem) : LocalQuickFixAndIntentionActionOnPsiElement(implItem) {
+    override fun getText(): String = "Implement missing supertrait(s)"
+    override fun getFamilyName(): String = text
+
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        val impl = startElement as? RsImplItem ?: return
+        val traitRef = impl.traitRef ?: return
+        val trait = impl.implementedTrait ?: return
+
+        val typeRef = impl.typeReference ?: return
+        val type = typeRef.type
+        val implLookup = impl.implLookup
+
+        val traits = mutableListOf<Pair<BoundElement<RsTraitItem>, RsTraitRef>>()
+        val substitutions = mutableListOf(pathPsiSubst(traitRef.path, trait.element))
+        collectSuperTraits(trait, traitRef, substitutions, traits, mutableSetOf())
+
+        for ((superTrait, ref) in traits) {
+            if (!implLookup.canSelect(TraitRef(type, superTrait))) {
+                implementTrait(impl, ref, typeRef, trait, substitutions)
+            }
+        }
+    }
+}
+
+private fun implementTrait(
+    context: RsImplItem,
+    superTraitRef: RsTraitRef,
+    typeReference: RsTypeReference,
+    trait: BoundElement<RsTraitItem>,
+    substitutions: List<RsPsiSubstitution>
+) {
+    val renderer = ImportingPsiRenderer(
+        PsiRenderingOptions(),
+        substitutions,
+        context,
+    )
+
+    val factory = RsPsiFactory(context.project)
+
+    val typeReferences = superTraitRef.descendantsOfType<RsTypeReference>() + typeReference.descendantsOfType()
+    val types = typeReferences.map { it.type.substitute(trait.subst) }
+    val constraints = GenericConstraints.create(context).filterByTypes(types)
+
+    val typeParameters = constraints.buildTypeParameters()
+    val traitText = renderer.renderTraitRef(superTraitRef)
+    val typeText = renderer.renderTypeReference(typeReference)
+    val whereClause = constraints.buildWhereClause()
+
+    val text = "impl$typeParameters $traitText for $typeText $whereClause{}"
+    val impl = factory.tryCreateImplItem(text) ?: return
+
+    val inserted = context.parent.addBefore(impl, context) as RsImplItem
+    for (importCandidate in renderer.itemsToImport) {
+        importCandidate.import(inserted)
+    }
+    generateMissingTraitMembers(inserted)
+}
+
+private fun collectSuperTraits(
+    trait: BoundElement<RsTraitItem>,
+    ref: RsTraitRef,
+    substitutions: MutableList<RsPsiSubstitution>,
+    ordered: MutableList<Pair<BoundElement<RsTraitItem>, RsTraitRef>>,
+    visited: MutableSet<BoundElement<RsTraitItem>>
+) {
+    if (trait !in visited) {
+        visited.add(trait)
+        ordered.add(Pair(trait, ref))
+    } else {
+        return
+    }
+
+    trait.element.typeParamBounds?.polyboundList?.forEach {
+        val traitRef = it.bound.traitRef ?: return@forEach
+        val superTrait = traitRef.resolveToBoundTrait() ?: return@forEach
+        substitutions.add(pathPsiSubst(traitRef.path, superTrait.element))
+        collectSuperTraits(superTrait.substitute(trait.subst), traitRef, substitutions, ordered, visited)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -194,7 +194,7 @@ class MembersGenerator(
 ) {
     private val renderer = ImportingPsiRenderer(
         PsiRenderingOptions(shortPaths = false),
-        pathPsiSubst(impl.traitRef!!.path, trait.element),
+        listOf(pathPsiSubst(impl.traitRef!!.path, trait.element)),
         impl.members!!
     )
     val itemsToImport: Set<ImportCandidate> get() = renderer.itemsToImport

--- a/src/main/kotlin/org/rust/ide/utils/ExtractUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/ExtractUtils.kt
@@ -29,7 +29,7 @@ import org.rust.lang.core.types.type
  * Holds type parameters, lifetimes, const parameters and where clauses.
  * It serves as a combination of several `RsGenericDeclaration`s.
  *
- * Can be filtered by a set of types/type references to only returns parameters/constraints that are needed by these
+ * Can be filtered by a set of types/type references to only return parameters/constraints that are needed by these
  * given types/type references.
  */
 data class GenericConstraints(

--- a/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
@@ -157,7 +157,7 @@ private fun completeFunction(
     memberGenerator: MembersGenerator,
     keyword: PsiElement?
 ): LookupElementBuilder {
-    val shortRenderer = PsiSubstitutingPsiRenderer(PsiRenderingOptions(renderGenericsAndWhere = false), substitution)
+    val shortRenderer = PsiSubstitutingPsiRenderer(PsiRenderingOptions(renderGenericsAndWhere = false), listOf(substitution))
     val shortSignature = removePrefix(shortRenderer.renderFunctionSignature(target), keyword)
     val text = removePrefix(memberGenerator.renderAbstractable(target), keyword)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -254,6 +254,8 @@ class RsPsiFactory(
         return createFromText("impl T for S {$text}") ?: error("Failed to create members from text: `$text`")
     }
 
+    fun tryCreateImplItem(text: String): RsImplItem? = createFromText(text)
+
     fun createInherentImplItem(
         name: String,
         typeParameterList: RsTypeParameterList? = null,

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -336,7 +336,7 @@ private fun pathTypeParameters(path: RsPath): RsPsiPathParameters? {
             val assoc = mutableListOf<RsAssocTypeBinding>()
             for (child in inAngles.stubChildrenOfType<RsElement>()) {
                 when (child) {
-                    is RsTypeReference, is RsExpr -> typeOrConstArgs.add(child as RsElement)
+                    is RsTypeReference, is RsExpr -> typeOrConstArgs.add(child)
                     is RsLifetime -> lifetimeArgs += child
                     is RsAssocTypeBinding -> assoc += child
                 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1539,7 +1539,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         struct S;
 
-        impl <error descr="the trait bound `S: A` is not satisfied [E0277]">B</error> for S {}
+        <error>impl <error descr="the trait bound `S: A` is not satisfied [E0277]">B</error> for S</error> {}
     """)
 
     fun `test supertrait is not implemented E0277 multiple traits`() = checkErrors("""
@@ -1550,7 +1550,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         struct S;
 
-        impl <error descr="the trait bound `S: B` is not satisfied [E0277]"><error descr="the trait bound `S: A` is not satisfied [E0277]">C</error></error> for S {}
+        <error>impl <error descr="the trait bound `S: A` is not satisfied [E0277]"><error descr="the trait bound `S: B` is not satisfied [E0277]">C</error></error> for S</error> {}
     """)
 
     fun `test supertrait is not implemented E0277 generic supertrait`() = checkErrors("""
@@ -1559,11 +1559,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         trait C<T>: A<T> {}
 
         struct S1;
-        impl <error descr="the trait bound `S1: A<u32>` is not satisfied [E0277]">B</error> for S1 {}
+        <error>impl <error descr="the trait bound `S1: A<u32>` is not satisfied [E0277]">B</error> for S1</error> {}
 
         struct S2;
         impl A<bool> for S2 {}
-        impl <error descr="the trait bound `S2: A<u32>` is not satisfied [E0277]">B</error> for S2 {}
+        <error>impl <error descr="the trait bound `S2: A<u32>` is not satisfied [E0277]">B</error> for S2</error> {}
 
         struct S3;
         impl A<bool> for S3 {}
@@ -1571,11 +1571,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl B for S3 {}
 
         struct S4;
-        impl<T> <error descr="the trait bound `S4: A<T>` is not satisfied [E0277]">C<T></error> for S4 {}
+        <error>impl<T> <error descr="the trait bound `S4: A<T>` is not satisfied [E0277]">C<T></error> for S4</error> {}
 
         struct S5;
         impl A<u32> for S5 {}
-        impl<T> <error descr="the trait bound `S5: A<T>` is not satisfied [E0277]">C<T></error> for S5 {}
+        <error>impl<T> <error descr="the trait bound `S5: A<T>` is not satisfied [E0277]">C<T></error> for S5</error> {}
 
         struct S6;
         impl<T> A<T> for S6 {}
@@ -1587,7 +1587,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         struct S8;
         impl A<bool> for S8 {}
-        impl <error descr="the trait bound `S8: A<u32>` is not satisfied [E0277]">C<u32></error> for S8 {}
+        <error>impl <error descr="the trait bound `S8: A<u32>` is not satisfied [E0277]">C<u32></error> for S8</error> {}
 
         struct S9;
         impl A<u32> for S9 {}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
@@ -1,0 +1,361 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
+
+class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test empty supertrait`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A {}
+        trait B: A {}
+
+        struct S;
+
+        <error>impl <error>B/*caret*/</error> for S</error> {}
+    """, """
+        trait A {}
+        trait B: A {}
+
+        struct S;
+
+        impl A for S {}
+
+        impl B/*caret*/ for S {}
+    """)
+
+    fun `test supertrait with items`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A {
+            type FOO;
+            const BAR: u32;
+            fn foo(&self);
+        }
+        trait B: A {}
+
+        struct S;
+
+        <error>impl <error>B/*caret*/</error> for S</error> {}
+    """, """
+        trait A {
+            type FOO;
+            const BAR: u32;
+            fn foo(&self);
+        }
+        trait B: A {}
+
+        struct S;
+
+        impl A for S {
+            type FOO = ();
+            const BAR: u32 = 0;
+
+            fn foo(&self) {
+                todo!()
+            }
+        }
+
+        impl B/*caret*/ for S {}
+    """)
+
+    fun `test multiple supertraits`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A {}
+        trait B {}
+        trait C: A + B {}
+
+        struct S;
+
+        <error>impl <error>C/*caret*/</error> for S</error> {}
+    """, """
+        trait A {}
+        trait B {}
+        trait C: A + B {}
+
+        struct S;
+
+        impl A for S {}
+
+        impl B for S {}
+
+        impl C/*caret*/ for S {}
+    """)
+
+    fun `test grandparent supertrait`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A {}
+        trait B: A {}
+        trait C: B {}
+
+        struct S;
+
+        <error>impl <error>C/*caret*/</error> for S</error> {}
+    """, """
+        trait A {}
+        trait B: A {}
+        trait C: B {}
+
+        struct S;
+
+        impl B for S {}
+
+        impl A for S {}
+
+        impl C/*caret*/ for S {}
+    """)
+
+    fun `test do not implement supertrait multiple times`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A {}
+        trait B: A {}
+        trait C: B + A {}
+
+        struct S;
+
+        <error>impl <error>C/*caret*/</error> for S</error> {}
+    """, """
+        trait A {}
+        trait B: A {}
+        trait C: B + A {}
+
+        struct S;
+
+        impl B for S {}
+
+        impl A for S {}
+
+        impl C/*caret*/ for S {}
+    """)
+
+    fun `test implement supertrait multiple times with different generic arguments`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A<T> {}
+        trait B: A<u32> {}
+        trait C: B + A<bool> {}
+
+        struct S;
+
+        <error>impl <error>C/*caret*/</error> for S</error> {}
+    """, """
+        trait A<T> {}
+        trait B: A<u32> {}
+        trait C: B + A<bool> {}
+
+        struct S;
+
+        impl B for S {}
+
+        impl A<u32> for S {}
+
+        impl A<bool> for S {}
+
+        impl C/*caret*/ for S {}
+    """)
+
+    fun `test already implemented trait`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A {}
+        trait B {}
+        trait C: A + B {}
+
+        struct S;
+
+        impl B for S {}
+
+        <error>impl <error>C/*caret*/</error> for S</error> {}
+    """, """
+        trait A {}
+        trait B {}
+        trait C: A + B {}
+
+        struct S;
+
+        impl B for S {}
+
+        impl A for S {}
+
+        impl C/*caret*/ for S {}
+    """)
+
+    fun `test implemented trait for specific generic argument`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A<T> {
+            fn foo(&self) -> T;
+        }
+        trait C<T>: A<T> {}
+
+        struct S;
+
+        <error>impl <error>C<u32>/*caret*/</error> for S</error> {}
+    """, """
+        trait A<T> {
+            fn foo(&self) -> T;
+        }
+        trait C<T>: A<T> {}
+
+        struct S;
+
+        impl A<u32> for S {
+            fn foo(&self) -> u32 {
+                todo!()
+            }
+        }
+
+        impl C<u32>/*caret*/ for S {}
+    """)
+
+    fun `test trait partially implemented for specific type`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A<T> {}
+        trait C<T>: A<T> {}
+
+        struct S;
+
+        impl A<u32> for S {}
+
+        <error>impl <R> <error>C<R>/*caret*/</error> for S</error> {}
+    """, """
+        trait A<T> {}
+        trait C<T>: A<T> {}
+
+        struct S;
+
+        impl A<u32> for S {}
+
+        impl<R> A<R> for S {}
+
+        impl <R> C<R>/*caret*/ for S {}
+    """)
+
+    fun `test generic type generic type argument`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A<T> {}
+        trait B<T>: A<T> {}
+
+        struct S<T>(T);
+
+        <error>impl <R> <error>B<u32>/*caret*/</error> for S<R></error> {}
+    """, """
+        trait A<T> {}
+        trait B<T>: A<T> {}
+
+        struct S<T>(T);
+
+        impl<R> A<u32> for S<R> {}
+
+        impl <R> B<u32> for S<R> {}
+    """)
+
+    fun `test generic type specific type argument`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A<T> {}
+        trait B<T>: A<T> {}
+
+        struct S<T>(T);
+
+        <error>impl <error>B<u32>/*caret*/</error> for S<bool></error> {}
+    """, """
+        trait A<T> {}
+        trait B<T>: A<T> {}
+
+        struct S<T>(T);
+
+        impl A<u32> for S<bool> {}
+
+        impl B<u32> for S<bool> {}
+    """)
+
+    // TODO: psiSubst merging?
+    fun `test recursive generics`() = checkFixByText("Implement missing supertrait(s)", """
+        trait T1<A> {}
+        trait T2<B>: T1<B> {}
+        trait T3<D>: T2<D> {}
+        trait T4<R>: T3<R> {}
+        trait T5<C>: T4<C> {}
+        trait T6<D>: T5<D> {}
+        trait T7<E>: T6<E> {}
+
+        struct S<T>(T);
+
+        <error>impl <R> <error>T7<R>/*caret*/</error> for S<R></error> {}
+    """, """
+        trait T1<A> {}
+        trait T2<B>: T1<B> {}
+        trait T3<D>: T2<D> {}
+        trait T4<R>: T3<R> {}
+        trait T5<C>: T4<C> {}
+        trait T6<D>: T5<D> {}
+        trait T7<E>: T6<E> {}
+
+        struct S<T>(T);
+
+        impl<R> T6<R> for S<R> {}
+
+        impl<R> T5<R> for S<R> {}
+
+        impl<R> T4<R> for S<R> {}
+
+        impl<R> T3<R> for S<R> {}
+
+        impl<R> T2<R> for S<R> {}
+
+        impl<R> T1<R> for S<R> {}
+
+        impl <R> T7<R> for S<R> {}
+    """)
+
+    fun `test filter unused type parameters`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A {}
+        trait B<T>: A {}
+
+        struct S<T>(T);
+
+        <error>impl <R> <error>B<R>/*caret*/</error> for S<u32></error> {}
+    """, """
+        trait A {}
+        trait B<T>: A {}
+
+        struct S<T>(T);
+
+        impl A for S<u32> {}
+
+        impl <R> B<R> for S<u32> {}
+    """)
+
+    fun `test filter unused where clause`() = checkFixByText("Implement missing supertrait(s)", """
+        trait A {}
+        trait B<T>: A {}
+
+        struct S<T>(T);
+
+        <error>impl <R> <error>B<R>/*caret*/</error> for S<u32></error> where R: A {}
+    """, """
+        trait A {}
+        trait B<T>: A {}
+
+        struct S<T>(T);
+
+        impl A for S<u32> {}
+
+        impl <R> B<R> for S<u32> where R: A {}
+    """)
+
+    fun `test import trait`() = checkFixByText("Implement missing supertrait(s)", """
+        mod foo {
+            pub trait A {}
+            pub trait B: A {}
+        }
+
+        struct S;
+
+        <error>impl <error>foo::B/*caret*/</error> for S</error> {}
+    """, """
+        use foo::A;
+
+        mod foo {
+            pub trait A {}
+            pub trait B: A {}
+        }
+
+        struct S;
+
+        impl A for S {}
+
+        impl foo::B/*caret*/ for S {}
+    """)
+}
+
+// TODO: all kinds of bounds and generics


### PR DESCRIPTION
This PR implements the second part of https://github.com/intellij-rust/intellij-rust/pull/5339 by creating a quick fix to implement missing supertrait(s).

![implement-supertrait](https://user-images.githubusercontent.com/4539057/125782468-93993473-1e4e-49aa-8c66-6a6dd2691d36.gif)

I wasn't sure how to solve deep type parameter replacing (see `test recursive generics`). When using normal `Substitution`, the type parameters are replaced correctly, but then we lose type alias information and rendering the resulting trait type will add `dyn`, which we don't want. We can fix the first problem with https://github.com/intellij-rust/intellij-rust/pull/7521 and the second by parametrizing the renderer, but I wonder if there's a way of doing this with `RsPsiSubstitution` instead.

Currently I do use `RsPsiSubstitution`, but it doesn't use recursive type substitution, since I suppose it's not implemented? I wasn't sure how to do it properly, probably it would require something like `TypeFoldable`,  but for type references?

changelog: Add quick fix to implement missing supertrait(s) for a trait impl block.