### PR TITLE
COMP: improve completion inside impl trait

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -233,6 +233,15 @@ object RsPsiPattern {
         psiElement()
             .withParent(or(psiElement<RsPath>(), psiElement<RsModItem>(), psiElement<RsFile>()))
 
+    fun baseTraitOrImplDeclaration(): PsiElementPattern.Capture<PsiElement> {
+        return psiElement().withParent(
+            or(
+                psiElement<RsMembers>(),
+                psiElement().withParent(RsMembers::class.java)
+            )
+        )
+    }
+
     fun baseInherentImplDeclarationPattern(): PsiElementPattern.Capture<PsiElement> {
         val membersInInherentImpl = psiElement<RsMembers>().withParent(
             psiElement<RsImplItem>().with("InherentImpl") { e -> e.traitRef == null }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.completion
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.editor.Editor
 import com.intellij.patterns.ElementPattern
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.parentOfType
@@ -17,13 +18,15 @@ import org.rust.ide.presentation.PsiSubstitutingPsiRenderer
 import org.rust.ide.presentation.renderFunctionSignature
 import org.rust.ide.refactoring.implementMembers.MembersGenerator
 import org.rust.ide.utils.import.import
+import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsAbstractable
+import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.block
 import org.rust.lang.core.psi.ext.expandedMembers
 import org.rust.lang.core.resolve.ref.pathPsiSubst
 import org.rust.lang.core.types.RsPsiSubstitution
-import org.rust.openapiext.selectElement
+import org.rust.openapiext.createSmartPointer
 
 object RsImplTraitMemberCompletionProvider : RsCompletionProvider() {
     override val elementPattern: ElementPattern<PsiElement>
@@ -90,7 +93,7 @@ private fun completeConstant(
                 importCandidate.import(impl)
             }
             val expr = element.expr ?: return@withInsertHandler
-            selectElement(expr, context.editor)
+            runTemplate(expr, context.editor)
         }
 }
 
@@ -101,7 +104,7 @@ private fun completeType(target: RsTypeAlias, memberGenerator: MembersGenerator)
         .withInsertHandler { context, _ ->
             val element = context.getElementOfType<RsTypeAlias>() ?: return@withInsertHandler
             val typeReference = element.typeReference ?: return@withInsertHandler
-            selectElement(typeReference, context.editor)
+            runTemplate(typeReference, context.editor)
         }
 }
 
@@ -123,7 +126,11 @@ private fun completeFunction(
                 importCandidate.import(impl)
             }
             val body = element.block?.expr ?: return@withInsertHandler
-            selectElement(body, context.editor)
+            runTemplate(body, context.editor)
         }
         .withPresentableText("$shortSignature { ... }")
+}
+
+private fun runTemplate(element: RsElement, editor: Editor) {
+    editor.buildAndRunTemplate(element.parent, listOf(element.createSmartPointer()))
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
@@ -384,4 +384,138 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
             const FOO: Alias = 0/*caret*/;
         }
     """)
+
+    fun `test complete after fn keyword`() = doFirstCompletion("""
+        trait Trait {
+            fn foo(&self);
+        }
+
+        impl Trait for () {
+            fn /*caret*/
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+
+        impl Trait for () {
+            fn foo(&self) {
+                todo!()/*caret*/
+            }
+        }
+    """)
+
+    fun `test complete in function name`() = doFirstCompletion("""
+        trait Trait {
+            fn foo(&self);
+        }
+
+        impl Trait for () {
+            fn fo/*caret*/
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+
+        impl Trait for () {
+            fn foo(&self) {
+                todo!()/*caret*/
+            }
+        }
+    """)
+
+    fun `test complete after const keyword`() = doFirstCompletion("""
+        trait Trait {
+            const FOO: u32;
+        }
+
+        impl Trait for () {
+            const /*caret*/
+        }
+    """, """
+        trait Trait {
+            const FOO: u32;
+        }
+
+        impl Trait for () {
+            const FOO: u32 = 0/*caret*/;
+        }
+    """)
+
+    fun `test complete in constant name`() = doFirstCompletion("""
+        trait Trait {
+            const FOO: u32;
+        }
+
+        impl Trait for () {
+            const FO/*caret*/
+        }
+    """, """
+        trait Trait {
+            const FOO: u32;
+        }
+
+        impl Trait for () {
+            const FOO: u32 = 0/*caret*/;
+        }
+    """)
+
+    fun `test complete after type keyword`() = doFirstCompletion("""
+        trait Trait {
+            type FOO;
+        }
+
+        impl Trait for () {
+            type /*caret*/
+        }
+    """, """
+        trait Trait {
+            type FOO;
+        }
+
+        impl Trait for () {
+            type FOO = ()/*caret*/;
+        }
+    """)
+
+    fun `test complete in type name`() = doFirstCompletion("""
+        trait Trait {
+            type FOO;
+        }
+
+        impl Trait for () {
+            type FO/*caret*/
+        }
+    """, """
+        trait Trait {
+            type FOO;
+        }
+
+        impl Trait for () {
+            type FOO = ()/*caret*/;
+        }
+    """)
+
+    fun `test filter items after keyword 1`() = checkNoCompletion("""
+        trait Trait {
+            fn foo(&self);
+            type BAR;
+        }
+
+        impl Trait for () {
+            fn BA/*caret*/
+        }
+    """)
+
+    fun `test filter items after keyword 2`() = checkNoCompletion("""
+        trait Trait {
+            fn foo(&self);
+            type BAR;
+        }
+
+        impl Trait for () {
+            fn ty/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
@@ -23,7 +23,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
         }
 
         impl Foo for () {
-            const FOO: u32 = <selection>/*caret*/0</selection>;
+            const FOO: u32 = 0/*caret*/;
         }
     """)
 
@@ -45,7 +45,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
         }
 
         impl<X> Foo<X> for () {
-            const FOO: S<X> = <selection>/*caret*/S(())</selection>;
+            const FOO: S<X> = S(())/*caret*/;
         }
     """)
 
@@ -63,7 +63,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
         }
 
         impl Foo for () {
-            type FOO = <selection>/*caret*/()</selection>;
+            type FOO = ()/*caret*/;
         }
     """)
 
@@ -82,7 +82,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
 
         impl Foo for () {
             fn foo(&self, a: u32, b: u32) -> u32 {
-                <selection>/*caret*/todo!()</selection>
+                todo!()/*caret*/
             }
         }
     """)
@@ -201,7 +201,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
         }
 
         impl foo::Foo for () {
-            const FOO: S = <selection>/*caret*/S</selection>;
+            const FOO: S = S/*caret*/;
         }
     """)
 
@@ -229,7 +229,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
         }
 
         impl foo::Foo for () {
-            const FOO: ALIAS = <selection>/*caret*/0</selection>;
+            const FOO: ALIAS = 0/*caret*/;
         }
     """)
 
@@ -260,7 +260,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
 
         impl foo::Foo for () {
             fn foo(s: S) -> T {
-                <selection>/*caret*/todo!()</selection>
+                todo!()/*caret*/
             }
         }
     """)
@@ -292,7 +292,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
 
         impl foo::Foo for () {
             fn foo(s: ALIAS1) -> ALIAS2 {
-                <selection>/*caret*/todo!()</selection>
+                todo!()/*caret*/
             }
         }
     """)
@@ -314,7 +314,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
 
         impl T2 for () {
             fn foo<T>() -> T where T: T1 {
-                <selection>/*caret*/todo!()</selection>
+                todo!()/*caret*/
             }
         }
     """)
@@ -334,7 +334,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
 
         impl T2<u32> for () {
             fn foo() -> u32 {
-                <selection>/*caret*/todo!()</selection>
+                todo!()/*caret*/
             }
         }
     """)
@@ -358,7 +358,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
 
         impl T2<Alias> for () {
             fn foo() -> Alias {
-                <selection>/*caret*/todo!()</selection>
+                todo!()/*caret*/
             }
         }
     """)
@@ -381,7 +381,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
         type Alias = u32;
 
         impl T2<Alias> for () {
-            const FOO: Alias = <selection>/*caret*/0</selection>;
+            const FOO: Alias = 0/*caret*/;
         }
     """)
 }


### PR DESCRIPTION
This PR improves the UX of completion inside impl trait.

![impl-trait](https://user-images.githubusercontent.com/4539057/125956865-cacb4360-8397-48de-9e6d-daa0522fb989.gif)

1) Template builder is used instead of just selecting the generated element. Therefore you can change the generated item and if you click on Enter after the completion, the element will remain (before it would delete it and create a newline, which was weird).
2) Complete items that are after an abstractable keyword (`fn`, `const`, `type`). Also use the keyword to filter the corresponding items (i.e. after `fn`, only functions will be suggested).

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7533

changelog: Improve completion of items inside impl trait.