### PR TITLE
TYPE: show autocompletion popup when typing `|`

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/RsTypedHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsTypedHandler.kt
@@ -17,7 +17,7 @@ import org.rust.lang.core.psi.RsDotExpr
 import org.rust.lang.core.psi.RsFile
 
 
-class RsDotTypedHandler : TypedHandlerDelegate() {
+class RsTypedHandler : TypedHandlerDelegate() {
     override fun charTyped(c: Char, project: Project, editor: Editor, file: PsiFile): Result {
         if (file !is RsFile) return Result.CONTINUE
         if (c != '.') return Result.CONTINUE

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -7,15 +7,12 @@ package org.rust.lang.core.completion
 
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionType
-import com.intellij.psi.PsiElement
 import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.RsPsiPattern.declarationPattern
 import org.rust.lang.core.RsPsiPattern.inherentImplDeclarationPattern
 import org.rust.lang.core.completion.lint.RsClippyLintCompletionProvider
 import org.rust.lang.core.completion.lint.RsRustcLintCompletionProvider
 import org.rust.lang.core.or
-import org.rust.lang.core.psi.RsElementTypes.COLON
-import org.rust.lang.core.psi.ext.elementType
 
 class RsCompletionContributor : CompletionContributor() {
 
@@ -45,7 +42,4 @@ class RsCompletionContributor : CompletionContributor() {
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {
         extend(type, provider.elementPattern, provider)
     }
-
-    override fun invokeAutoPopup(position: PsiElement, typeChar: Char): Boolean =
-        typeChar == ':' && position.elementType == COLON
 }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -277,8 +277,8 @@
                       id="RsRawLiteralHashesInserter"/>
         <typedHandler implementation="org.rust.ide.typing.RsAngleBraceTypedHandler"
                       id="RsAngleBraceTypedHandler"/>
-        <typedHandler implementation="org.rust.ide.typing.RsDotTypedHandler"
-                      id="RsDotTypedHandler"/>
+        <typedHandler implementation="org.rust.ide.typing.RsTypedHandler"
+                      id="RsTypedHandler"/>
 
         <backspaceHandlerDelegate implementation="org.rust.ide.typing.RsRawLiteralHashesDeleter"
                                   id="RsRawLiteralHashesDeleter"/>

--- a/src/test/kotlin/org/rust/ide/typing/RsTypedHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RsTypedHandlerTest.kt
@@ -5,7 +5,8 @@
 
 package org.rust.ide.typing
 
-class RsDotTypedHandlerTest : RsTypingTestBase() {
+/** @see org.rust.lang.core.completion.RsCompletionAutoPopupTest */
+class RsTypedHandlerTest : RsTypingTestBase() {
     fun `test autoindent dot in chained call`() = doTestByText("""
         fn main() {
             frobnicate()

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
@@ -31,7 +31,6 @@ class RsCompletionAutoPopupTest : RsCompletionTestBase() {
         """)
         tester.typeWithPauses("::")
 
-        // TODO: find out why this test fails
-//        assertNotNull(tester.lookup)
+        assertNotNull(tester.lookup)
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
@@ -19,6 +19,53 @@ class RsCompletionAutoPopupTest : RsCompletionTestBase() {
         }
     """, "::")
 
+    fun `test lambda argument 1`() = checkPopupIsShownAfterTyping("""
+        fn foo(a: fn()) {}
+        fn main() {
+            foo(/*caret*/);
+        }
+    """, "|")
+
+    fun `test lambda argument 2`() = checkPopupIsShownAfterTyping("""
+        fn foo(a: i32, b: fn()) {}
+        fn main() {
+            foo(0, /*caret*/);
+        }
+    """, "|")
+
+    fun `test lambda argument 3`() = checkPopupIsShownAfterTyping("""
+        fn foo(a: i32, b: fn()) {}
+        fn main() {
+            foo(
+                0,
+                /*caret*/
+            );
+        }
+    """, "|")
+
+    fun `test lambda assignment`() = checkPopupIsShownAfterTyping("""
+        fn main() {
+            let a: fn() = /*caret*/
+        }
+    """, "|")
+
+    fun `test popup is not shown after typing bit OR operator`() = checkPopupIsNotShownAfterTyping("""
+        fn main() {
+            let a = 1;
+            let b = a/*caret*/
+        }
+    """, "|")
+
+    fun `test popup is not shown after typing OR pattern`() = checkPopupIsNotShownAfterTyping("""
+        const C: i32 = 0;
+        fn foo(a: Option<E>) {
+            match a {
+                Some(/*caret*/) => {},
+                _ => {}
+            }
+        }
+    """, "|")
+
     override fun setUp() {
         super.setUp()
         tester = CompletionAutoPopupTester(myFixture)
@@ -33,6 +80,11 @@ class RsCompletionAutoPopupTest : RsCompletionTestBase() {
     private fun checkPopupIsShownAfterTyping(@Language("Rust") code: String, toType: String) {
         configureAndType(code, toType)
         assertNotNull(tester.lookup)
+    }
+
+    private fun checkPopupIsNotShownAfterTyping(@Language("Rust") code: String, toType: String) {
+        configureAndType(code, toType)
+        assertNull(tester.lookup)
     }
 
     private fun configureAndType(code: String, toType: String) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
@@ -7,9 +7,17 @@ package org.rust.lang.core.completion
 
 import com.intellij.testFramework.fixtures.CompletionAutoPopupTester
 import com.intellij.util.ThrowableRunnable
+import org.intellij.lang.annotations.Language
 
 class RsCompletionAutoPopupTest : RsCompletionTestBase() {
     private lateinit var tester: CompletionAutoPopupTester
+
+    fun `test path`() = checkPopupIsShownAfterTyping("""
+        enum Foo { Bar, Baz}
+        fn main() {
+            let _ = Foo/*caret*/
+        }
+    """, "::")
 
     override fun setUp() {
         super.setUp()
@@ -22,15 +30,13 @@ class RsCompletionAutoPopupTest : RsCompletionTestBase() {
 
     override fun runInDispatchThread(): Boolean = false
 
-    fun `test path auto popup`() {
-        myFixture.configureByText("main.rs", """
-            enum Foo { Bar, Baz}
-            fn main() {
-                let _ = Foo<caret>
-            }
-        """)
-        tester.typeWithPauses("::")
-
+    private fun checkPopupIsShownAfterTyping(@Language("Rust") code: String, toType: String) {
+        configureAndType(code, toType)
         assertNotNull(tester.lookup)
+    }
+
+    private fun configureAndType(code: String, toType: String) {
+        InlineFile(code).withCaret()
+        tester.typeWithPauses(toType)
     }
 }


### PR DESCRIPTION
An improvement to #7487 - automatically show completion popup when typing `|`.