### PR TITLE
INSP: Disable unused import inspection in doctests

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.parentOfType
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.fixes.RemoveImportFix
+import org.rust.lang.core.crate.impl.DoctestCrate
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve2.NamedItem
@@ -29,6 +30,9 @@ class RsUnusedImportInspection : RsLintInspection() {
                 it is RsModItem || it is RsModDeclItem
             }
             if (item.parentOfType<RsFunction>() == null && hasChildMods) return
+
+            // It's common to include more imports than needed in doctest sample code
+            if (item.containingCrate is DoctestCrate) return
 
             val owner = item.parent as? RsItemsOwner ?: return
             val usage = owner.pathUsage

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -740,4 +740,12 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
             }
         }
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test disabled in doctests`() = checkByText("""
+        /// ```
+        /// use test_project::func;
+        /// ```
+        pub fn func() {}
+    """)
 }


### PR DESCRIPTION
It's common to include more imports than needed in doctest sample code, so I think it makes sense to disable inspection there