### PR TITLE
INSP&COMP: Add completion and quick-fix for `crate_type` attribute

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
@@ -34,6 +34,6 @@ class RsUnknownCrateTypesInspection : RsLintInspection() {
         }
 
     companion object {
-        private val KNOWN_CRATE_TYPES = listOf("bin", "lib", "dylib", "staticlib", "cdylib", "rlib", "proc-macro")
+        val KNOWN_CRATE_TYPES = listOf("bin", "lib", "dylib", "staticlib", "cdylib", "rlib", "proc-macro")
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -197,6 +197,11 @@ object RsPsiPattern {
                 eq?.elementType == EQ && feature?.textMatches("feature") == true
             }
 
+    val insideCrateTypeAttrValue: PsiElementPattern.Capture<RsLitExpr> = psiElement<RsLitExpr>().withParent(
+            rootMetaItem("crate_type")
+                .with("innerAttribute") { _, context -> context?.get(META_ITEM_ATTR) is RsInnerAttr }
+        )
+
     private object VisibilityOwnerField : PatternCondition<RsFieldDecl>("visibilityOwnerField") {
         override fun accepts(field: RsFieldDecl, context: ProcessingContext?): Boolean {
             return field.owner !is RsEnumVariant && field.vis == null

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -38,6 +38,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, RsPsiPattern.fieldVisibility, RsVisibilityCompletionProvider())
         extend(CompletionType.BASIC, declarationPattern() or inherentImplDeclarationPattern(), RsVisibilityCompletionProvider())
         extend(CompletionType.BASIC, RsReprCompletionProvider)
+        extend(CompletionType.BASIC, RsCrateTypeAttrCompletionProvider)
     }
 
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCrateTypeAttrCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCrateTypeAttrCompletionProvider.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.ide.inspections.lints.RsUnknownCrateTypesInspection
+import org.rust.lang.core.RsPsiPattern
+import org.rust.lang.core.psi.RsElementTypes.STRING_LITERAL
+
+object RsCrateTypeAttrCompletionProvider : RsCompletionProvider() {
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        result.addAllElements(RsUnknownCrateTypesInspection.KNOWN_CRATE_TYPES.map { LookupElementBuilder.create(it) })
+    }
+
+    override val elementPattern: ElementPattern<out PsiElement>
+        get() = psiElement(STRING_LITERAL).withParent(RsPsiPattern.insideCrateTypeAttrValue)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspectionTest.kt
@@ -12,6 +12,10 @@ class RsUnknownCrateTypesInspectionTest : RsInspectionsTestBase(RsUnknownCrateTy
         #![crate_type = <error descr="Invalid `crate_type` value">"foo"</error>]
     """)
 
+    fun `test as argument in configuration`() = checkWarnings("""
+        #![cfg_attr(unix, crate_type = <error descr="Invalid `crate_type` value">"foo"</error>)]
+    """)
+
     fun `test correct crate type`() = checkWarnings("""
         #![crate_type = "cdylib"]
     """)
@@ -33,5 +37,11 @@ class RsUnknownCrateTypesInspectionTest : RsInspectionsTestBase(RsUnknownCrateTy
     fun `test allow unknown_crate_types`() = checkWarnings("""
         #![allow(unknown_crate_types)]
         #![crate_type = "foo"]
+    """)
+
+    fun `test typo quick-fix unknown_crate_types`() = checkFixByText("Change to `dylib`", """
+        #![crate_type = <error descr="Invalid `crate_type` value">"d_ylib<caret>"</error>]
+    """, """
+        #![crate_type = "dylib<caret>"]
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCrateTypeAttrCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCrateTypeAttrCompletionProviderTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+class RsCrateTypeAttrCompletionProviderTest : RsCompletionTestBase() {
+    fun `test basic completion`() = doSingleCompletion("""
+        #![crate_type = "pro<caret>"]
+    """, """
+        #![crate_type = "proc-macro<caret>"]
+    """)
+
+    fun `test has popular types`() = checkContainsCompletion(listOf("bin", "lib"), """
+        #![crate_type = "<caret>"]
+    """)
+
+    fun `test completion when argument in configuration`() = doSingleCompletion("""
+        #![cfg_attr(unix, crate_type = "bi<caret>")]
+    """, """
+        #![cfg_attr(unix, crate_type = "bin<caret>")]
+    """)
+
+    fun `test no completion when outer`() = checkNoCompletion("""
+        #[crate_type = "<caret>"]
+        fn foo() {}
+    """)
+
+    fun `test no completion when not root`() = checkNoCompletion("""
+        #![not(crate_type = "<caret>")]
+    """)
+
+    fun `test no completion when wrong key`() = checkNoCompletion("""
+        #![something_type = "<caret>"]
+    """)
+}


### PR DESCRIPTION
<img width="500" src="https://user-images.githubusercontent.com/6342851/125989465-caaabe30-9710-46b3-aeab-47269164b124.png">
<img width="600" src="https://user-images.githubusercontent.com/6342851/125989536-5901d520-96d7-40d7-9aec-905b39de7dea.png">

changelog: `crate_type` attribute now has completion and quick-fix for typos
