### PR TITLE
INT: add intention to add an alias to an import

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsPathUsageAnalysis.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsPathUsageAnalysis.kt
@@ -31,24 +31,34 @@ val RsItemsOwner.pathUsage: PathUsageMap
         CachedValueProvider.Result.create(usages, PsiModificationTracker.MODIFICATION_COUNT)
     }
 
+sealed class PathUsageBase {
+    data class PathUsage(val name: String, val target: RsElement, val source: PsiElement?) : PathUsageBase()
+    data class TraitUsage(val trait: RsTraitItem) : PathUsageBase()
+}
+
+fun traversePathUsages(owner: RsItemsOwner, processor: (PathUsageBase) -> Unit) {
+    for (child in owner.children) {
+        handleSubtree(child, processor)
+    }
+}
+
 private fun calculatePathUsages(owner: RsItemsOwner): PathUsageMap {
     val directUsages = hashMapOf<String, MutableSet<RsElement>>()
     val traitUsages = hashSetOf<RsTraitItem>()
 
-    for (child in owner.children) {
-        handleSubtree(child, directUsages, traitUsages)
+    traversePathUsages(owner) { usage ->
+        when (usage) {
+            is PathUsageBase.PathUsage -> directUsages.getOrPut(usage.name) { hashSetOf() }.add(usage.target)
+            is PathUsageBase.TraitUsage -> traitUsages.add(usage.trait)
+        }
     }
 
     return PathUsageMap(directUsages, traitUsages)
 }
 
-private fun handleSubtree(
-    root: PsiElement,
-    directUsages: MutableMap<String, MutableSet<RsElement>>,
-    traitUsages: MutableSet<RsTraitItem>
-) {
+private fun handleSubtree(root: PsiElement, processor: (PathUsageBase) -> Unit) {
     processElementsWithMacros(root) { element ->
-        if (handleElement(element, directUsages, traitUsages)) {
+        if (handleElement(element, processor)) {
             TreeStatus.VISIT_CHILDREN
         } else {
             TreeStatus.SKIP_CHILDREN
@@ -56,15 +66,7 @@ private fun handleSubtree(
     }
 }
 
-private fun handleElement(
-    element: PsiElement,
-    directUsages: MutableMap<String, MutableSet<RsElement>>,
-    traitUsages: MutableSet<RsTraitItem>
-): Boolean {
-    fun addItem(name: String, item: RsElement) {
-        directUsages.getOrPut(name) { hashSetOf() }.add(item)
-    }
-
+private fun handleElement(element: PsiElement, processor: (PathUsageBase) -> Unit): Boolean {
     if (!element.isEnabledByCfg) return false
 
     return when (element) {
@@ -73,14 +75,16 @@ private fun handleElement(
             val name = element.patBinding.referenceName
             val targets = element.patBinding.reference.multiResolve()
             targets.forEach {
-                addItem(name, it)
+                processor(PathUsageBase.PathUsage(name, it, element.patBinding.referenceNameElement))
             }
             true
         }
         is RsPath -> {
             if (element.qualifier != null) {
                 val requiredTraits = getAssociatedItemRequiredTraits(element).orEmpty()
-                traitUsages.addAll(requiredTraits)
+                requiredTraits.forEach {
+                    processor(PathUsageBase.TraitUsage(it))
+                }
             } else {
                 val useSpeck = element.parentOfType<RsUseSpeck>()
                 if (useSpeck == null || useSpeck.isTopLevel) {
@@ -88,19 +92,21 @@ private fun handleElement(
                     if (name in IGNORED_USE_PATHS) return true
                     val targets = element.reference?.multiResolve().orEmpty()
                     targets.forEach {
-                        addItem(name, it)
+                        processor(PathUsageBase.PathUsage(name, it, element.referenceNameElement))
                     }
                 }
             }
             true
         }
         is RsMacroCall -> {
-            handleSubtree(element.path, directUsages, traitUsages)
+            handleSubtree(element.path, processor)
             true
         }
         is RsMethodCall -> {
             val requiredTraits = getMethodRequiredTraits(element).orEmpty()
-            traitUsages.addAll(requiredTraits)
+            requiredTraits.forEach {
+                processor(PathUsageBase.TraitUsage(it))
+            }
             true
         }
         else -> true

--- a/src/main/kotlin/org/rust/ide/intentions/AddImportAliasIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImportAliasIntention.kt
@@ -1,0 +1,84 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.lints.PathUsageBase
+import org.rust.ide.inspections.lints.RsUnusedImportInspection
+import org.rust.ide.inspections.lints.traversePathUsages
+import org.rust.ide.refactoring.isValidRustVariableIdentifier
+import org.rust.ide.utils.template.newTemplateBuilder
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsUseItem
+import org.rust.lang.core.psi.RsUseSpeck
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.createSmartPointer
+
+class AddImportAliasIntention : RsElementBaseIntentionAction<AddImportAliasIntention.Context>() {
+    override fun getText(): String = "Add import alias"
+    override fun getFamilyName() = text
+
+    data class Context(val speck: RsUseSpeck, val name: String)
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val speck = element.ancestorStrict<RsUseSpeck>() ?: return null
+        if (speck.useGroup != null || speck.alias != null || speck.isStarImport) return null
+
+        val name = speck.path?.referenceName ?: return null
+        if (!isValidRustVariableIdentifier(name)) return null
+
+        val useItem = speck.ancestorStrict<RsUseItem>() ?: return null
+        if (!RsUnusedImportInspection.isApplicableForUseItem(useItem)) return null
+
+        return Context(speck, name)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val speck = ctx.speck
+        val name = ctx.name
+
+        val targets = speck.path?.reference?.multiResolve()?.toSet() ?: return
+
+        // Original elements have to be gathered before the alias is introduced
+        val toReplace = getElementsToReplace(name, speck, targets).map { it.createSmartPointer() }
+
+        val factory = RsPsiFactory(project)
+        val speckWithAlias = factory.createUseSpeck("${speck.text} as T")
+
+        val inserted = speck.replace(speckWithAlias) as RsUseSpeck
+
+        val template = editor.newTemplateBuilder(inserted.containingMod) ?: return
+        val alias = inserted.alias?.identifier ?: return
+
+        template.introduceVariable(alias, "").apply {
+            toReplace.forEach {
+                replaceElementWithVariable(it.element ?: return@forEach)
+            }
+        }
+        template.runInline()
+    }
+}
+
+private fun getElementsToReplace(name: String, speck: RsUseSpeck, targets: Set<RsElement>): Set<PsiElement> {
+    val owner = speck.ancestorStrict<RsItemsOwner>() ?: return emptySet()
+    val elements = HashSet<PsiElement>()
+
+    traversePathUsages(owner) { usage ->
+        if (
+            usage is PathUsageBase.PathUsage &&
+            usage.name == name &&
+            usage.target in targets &&
+            usage.source != null &&
+            speck !in usage.source.ancestors
+        ) {
+            elements.add(usage.source)
+        }
+    }
+
+    return elements
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
@@ -11,6 +11,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.inspections.lints.RsUnusedImportInspection
+import org.rust.ide.inspections.lints.isUsed
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 
@@ -52,16 +54,37 @@ class RsImportOptimizer : ImportOptimizer {
 
         /** Returns false if [useSpeck] is empty and should be removed */
         fun optimizeUseSpeck(psiFactory: RsPsiFactory, useSpeck: RsUseSpeck): Boolean {
-            val useGroup = useSpeck.useGroup ?: return true
-            useGroup.useSpeckList.forEach { optimizeUseSpeck(psiFactory, it) }
-            if (removeUseSpeckIfEmpty(useSpeck)) return false
-            if (removeCurlyBracesIfPossible(psiFactory, useSpeck)) return true
+            val item = useSpeck.ancestorStrict<RsUseItem>() ?: return true
+            val checkUnusedImports = RsUnusedImportInspection.isApplicableForUseItem(item)
+            return optimizeUseSpeck(psiFactory, useSpeck, checkUnusedImports)
+        }
 
-            val sortedList = useGroup.useSpeckList
-                .sortedWith(compareBy<RsUseSpeck> { it.path?.self == null }.thenBy { it.pathText })
-                .map { it.copy() }
-            useGroup.useSpeckList.zip(sortedList).forEach { it.first.replace(it.second) }
-            return true
+        private fun optimizeUseSpeck(
+            psiFactory: RsPsiFactory,
+            useSpeck: RsUseSpeck,
+            checkUnusedImports: Boolean
+        ): Boolean {
+            val useGroup = useSpeck.useGroup
+            if (useGroup == null) {
+                if (!checkUnusedImports) return true
+
+                return if (!useSpeck.isUsed()) {
+                    useSpeck.deleteWithSurroundingComma()
+                    false
+                } else {
+                    true
+                }
+            } else {
+                useGroup.useSpeckList.forEach { optimizeUseSpeck(psiFactory, it, checkUnusedImports) }
+                if (removeUseSpeckIfEmpty(useSpeck)) return false
+                if (removeCurlyBracesIfPossible(psiFactory, useSpeck)) return true
+
+                val sortedList = useGroup.useSpeckList
+                    .sortedWith(compareBy<RsUseSpeck> { it.path?.self == null }.thenBy { it.pathText })
+                    .map { it.copy() }
+                useGroup.useSpeckList.zip(sortedList).forEach { it.first.replace(it.second) }
+                return true
+            }
         }
 
         /** Returns true if successfully removed, e.g. `use aaa::{bbb};` -> `use aaa::bbb;` */

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -922,6 +922,10 @@
             <className>org.rust.ide.intentions.AddImplTraitIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.AddImportAliasIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/AddImportAliasIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/AddImportAliasIntention/after.rs.template
@@ -1,0 +1,9 @@
+mod foo {
+    pub struct S;
+}
+
+use foo::S as T;
+
+fn main() {
+    let _: T;
+}

--- a/src/main/resources/intentionDescriptions/AddImportAliasIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/AddImportAliasIntention/before.rs.template
@@ -1,0 +1,9 @@
+mod foo {
+    pub struct S;
+}
+
+use foo::<spot>S</spot>;
+
+fn main() {
+    let _: S;
+}

--- a/src/main/resources/intentionDescriptions/AddImportAliasIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddImportAliasIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention adds an alias to an import.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/AddImportAliasIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImportAliasIntentionTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.rust.MockEdition
+import org.rust.UseNewResolve
+import org.rust.cargo.project.workspace.CargoWorkspace
+
+@UseNewResolve
+class AddImportAliasIntentionTest : RsIntentionTestBase(AddImportAliasIntention::class) {
+    fun `test not available with use group`() = doUnavailableTest("""
+        use foo::/*caret*/{Foo};
+    """)
+
+    fun `test not available with alias`() = doUnavailableTest("""
+        use foo::/*caret*/Foo as Bar;
+    """)
+
+    fun `test not available for star import`() = doUnavailableTest("""
+        use foo::*/*caret*/;
+    """)
+
+    fun `test not available for crate`() = doUnavailableTest("""
+        use crate/*caret*/;
+    """)
+
+    fun `test not available for super`() = doUnavailableTest("""
+        use crate::{super/*caret*/};
+    """)
+
+    fun `test not available for self`() = doUnavailableTest("""
+        use crate::{self/*caret*/};
+    """)
+
+    fun `test simple`() = doAvailableTestWithLiveTemplate("""
+        use foo::/*caret*/Foo;
+    """, "T\t", """
+        use foo::Foo as T/*caret*/;
+    """)
+
+    fun `test nested`() = doAvailableTestWithLiveTemplate("""
+        use foo::{Foo, Bar/*caret*/};
+    """, "T\t", """
+        use foo::{Foo, Bar as T/*caret*/};
+    """)
+
+    fun `test qualified`() = doAvailableTestWithLiveTemplate("""
+        use foo::{Foo, bar::Bar/*caret*/};
+    """, "T\t", """
+        use foo::{Foo, bar::Bar as T/*caret*/};
+    """)
+
+    fun `test replace type usage`() = doAvailableTestWithLiveTemplate("""
+        mod foo {
+            pub struct S;
+        }
+        mod bar {
+            use crate::foo::S/*caret*/;
+
+            fn baz(_: S) {}
+        }
+    """, "T\t", """
+        mod foo {
+            pub struct S;
+        }
+        mod bar {
+            use crate::foo::S as T/*caret*/;
+
+            fn baz(_: T) {}
+        }
+    """)
+
+    fun `test replace expression usage`() = doAvailableTestWithLiveTemplate("""
+        mod foo {
+            pub struct S<T>(T);
+
+            impl <T> S<T> {
+                pub fn new() -> Self { todo!() }
+            }
+        }
+        mod bar {
+            use crate::foo::S/*caret*/;
+
+            fn baz() {
+                let _ = S::<u32>::new();
+            }
+        }
+    """, "T\t", """
+        mod foo {
+            pub struct S<T>(T);
+
+            impl <T> S<T> {
+                pub fn new() -> Self { todo!() }
+            }
+        }
+        mod bar {
+            use crate::foo::S as T/*caret*/;
+
+            fn baz() {
+                let _ = T::<u32>::new();
+            }
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test replace usage in use speck`() = doAvailableTestWithLiveTemplate("""
+        mod foo {
+            pub mod bar {
+                pub struct S;
+            }
+        }
+        mod baz {
+            use crate::foo::bar/*caret*/;
+            use bar::S;
+
+            fn fun(_: S) {}
+        }
+    """, "T\t", """
+        mod foo {
+            pub mod bar {
+                pub struct S;
+            }
+        }
+        mod baz {
+            use crate::foo::bar as T/*caret*/;
+            use T::S;
+
+            fn fun(_: S) {}
+        }
+    """)
+
+    fun `test trait import`() = doAvailableTestWithLiveTemplate("""
+        mod foo {
+            pub trait Trait {
+                fn foo(&self);
+            }
+            impl Trait for () {
+                fn foo(&self) {}
+            }
+        }
+        mod bar {
+            use crate::foo::Trait/*caret*/;
+
+            fn baz() {
+                ().foo();
+            }
+        }
+    """, "T\t", """
+        mod foo {
+            pub trait Trait {
+                fn foo(&self);
+            }
+            impl Trait for () {
+                fn foo(&self) {}
+            }
+        }
+        mod bar {
+            use crate::foo::Trait as T/*caret*/;
+
+            fn baz() {
+                ().foo();
+            }
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileVisibilityTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileVisibilityTest.kt
@@ -360,6 +360,8 @@ class RsMoveFileVisibilityTest : RsMoveFileTestBase() {
         mod foo;
         mod bar {
             use super::foo;
+
+            fn baz(_: foo::S) {}
         }
     //- mod2/mod.rs
     //- mod1/foo.rs
@@ -371,6 +373,8 @@ class RsMoveFileVisibilityTest : RsMoveFileTestBase() {
     //- mod1/mod.rs
         mod bar {
             use crate::mod2::foo;
+
+            fn baz(_: foo::S) {}
         }
     //- mod2/mod.rs
         pub mod foo;
@@ -388,6 +392,8 @@ class RsMoveFileVisibilityTest : RsMoveFileTestBase() {
         mod foo;
         mod bar {
             use super::foo;
+
+            fn baz(_: foo::S) {}
         }
     //- mod1/foo.rs
         fn func() {}
@@ -398,6 +404,8 @@ class RsMoveFileVisibilityTest : RsMoveFileTestBase() {
     //- mod1/mod.rs
         mod bar {
             use crate::foo;
+
+            fn baz(_: foo::S) {}
         }
     //- foo.rs
         fn func() {}

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -924,6 +924,10 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
                 bar::bar_func();
                 let _ = BarStruct {};
             }
+            fn foo2() {
+                bar::bar_func();
+                let _ = BarStruct {};
+            }
         }
         mod mod2/*target*/ {}
         mod bar {
@@ -935,6 +939,11 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod1 {
             use crate::bar;
             use crate::bar::BarStruct;
+
+            fn foo2() {
+                bar::bar_func();
+                let _ = BarStruct {};
+            }
         }
         mod mod2 {
             use crate::bar;
@@ -1023,9 +1032,7 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """, """
     //- lib.rs
-        mod mod1 {
-            use crate::bar::Bar;
-        }
+        mod mod1 {}
         mod mod2 {
             use crate::bar::Bar;
 
@@ -1380,9 +1387,7 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod2/*target*/ {}
     """, """
     //- lib.rs
-        mod mod1 {
-            use std::fs;
-        }
+        mod mod1 {}
         mod mod2 {
             use std::fs;
 
@@ -1402,9 +1407,7 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod2/*target*/ {}
     """, """
     //- lib.rs
-        mod mod1 {
-            use std::sync::Arc;
-        }
+        mod mod1 {}
         mod mod2 {
             use std::sync::Arc;
 
@@ -1522,13 +1525,12 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod1 {}
         mod mod2 {
             mod foo1 {
-                use crate::{mod1, mod2};
+                use crate::mod2;
 
                 fn test() { mod2::bar1(); }
             }
 
             mod foo2 {
-                use crate::mod1::*;
                 use crate::mod2::bar2;
 
                 fn test() { bar2(); }
@@ -1566,7 +1568,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
             }
 
             mod foo2 {
-                use crate::mod1::*;
                 use crate::mod2::Bar2;
 
                 fn test() { let _ = Bar2 {}; }
@@ -1584,7 +1585,12 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
             mod foo/*caret*/ {
                 mod test {
                     use super::*;
+
+                    fn baz() {
+                        bar();
+                    }
                 }
+                fn bar() {}
             }
         }
         mod mod2/*target*/ {}
@@ -1595,7 +1601,12 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
             mod foo {
                 mod test {
                     use super::*;
+
+                    fn baz() {
+                        bar();
+                    }
                 }
+                fn bar() {}
             }
         }
     """)
@@ -1878,7 +1889,7 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
 
         mod usage {
-            use crate::{mod1, mod2};
+            use crate::mod2;
 
             fn test() {
                 mod2::foo1();
@@ -1921,7 +1932,7 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
 
         mod usage {
-            use crate::{inner1, inner2};
+            use crate::inner2;
 
             fn test() {
                 inner2::mod2::foo1();
@@ -2309,6 +2320,12 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod2/*target*/ {}
         mod usage {
             use crate::mod1::{foo1, foo2, bar};
+
+            fn foo() {
+                foo1();
+                foo2();
+                bar();
+            }
         }
     """, """
     //- lib.rs
@@ -2323,6 +2340,12 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod usage {
             use crate::mod1::bar;
             use crate::mod2::{foo1, foo2};
+
+            fn foo() {
+                foo1();
+                foo2();
+                bar();
+            }
         }
     """)
 
@@ -2345,6 +2368,12 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
                 foo1::{foo1_func, foo1_inner::foo1_inner_func},
                 foo2::foo2_func,
             };
+
+            fn foo() {
+                foo1_func();
+                foo1_inner_func();
+                foo2_func();
+            }
         }
     """, """
     //- lib.rs
@@ -2364,6 +2393,12 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod usage1 {
             use crate::mod2::foo1::{foo1_func, foo1_inner::foo1_inner_func};
             use crate::mod2::foo2::foo2_func;
+
+            fn foo() {
+                foo1_func();
+                foo1_inner_func();
+                foo2_func();
+            }
         }
     """)
 
@@ -2623,9 +2658,7 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod foo {
             pub struct Foo {}
         }
-        mod mod1 {
-            use crate::foo::Foo as Bar;
-        }
+        mod mod1 {}
         mod mod2 {
             use crate::foo::Foo as Bar;
 


### PR DESCRIPTION
This PR adds an intention that introduces an alias to an import, inspired by the corresponding intention in the Kotlin plugin. It depends on the new unused imports inspection infrastructure.

![import-alias](https://user-images.githubusercontent.com/4539057/126074143-69148140-f5dd-4f4a-ba49-282843c18d25.gif)

Depends on: https://github.com/intellij-rust/intellij-rust/pull/7495

changelog: Add intention to introduce an alias to a use item.