### PR TITLE
COMP: don't offer live templates in patterns

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/RsContextType.kt
+++ b/src/main/kotlin/org/rust/ide/template/RsContextType.kt
@@ -95,7 +95,7 @@ sealed class RsContextType(
 
     companion object {
         private fun owner(element: PsiElement): PsiElement? = PsiTreeUtil.findFirstParent(element) {
-            it is RsBlock || it is RsItemElement || it is RsAttr || it is PsiFile
+            it is RsBlock || it is RsPat || it is RsItemElement || it is RsAttr || it is PsiFile
                 || it is RsMacro || it is RsMacroCall
         }
     }

--- a/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
@@ -85,6 +85,12 @@ class RsLiveTemplatesTest : RsTestBase() {
         }
     """)
 
+    fun `test pattern binding`() = noSnippet("""
+        fn main() {
+            let p/*caret*/
+        }
+    """)
+
     fun `test macro definition 1`() = noSnippet("""
         macro_rules! foo {
             (impl/*caret*/) => {};


### PR DESCRIPTION
changelog: don't offer live templates (like `p` that inserts `println!()`) in patterns