### PR TITLE
INSP: move `Unused import` inspection into `Rust/Lints` inspection group

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -608,7 +608,7 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.lints.RsUnknownCrateTypesInspection"/>
 
-        <localInspection language="Rust" groupName="Rust"
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Unused import"
                          enabledByDefault="false" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsUnusedImportInspection"/>


### PR DESCRIPTION
changelog: move `Unused import` inspection into `Rust/Lints` inspection group in settings
