### PR TITLE
INSP: Handle unresolved method calls in unused imports inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -119,7 +119,10 @@ private fun isUseSpeckUsed(useSpeck: RsUseSpeck, usage: PathUsageMap): Boolean {
     }
 
     return items.any { (name, item) ->
-        item in usage.pathUsages[name].orEmpty()
+        val used = item in usage.pathUsages[name].orEmpty()
             || item in usage.traitUsages
+        val probablyUsed = name in usage.unresolvedPaths
+            || (item as? RsTraitItem)?.expandedMembers.orEmpty().any { it.name in usage.unresolvedMethods }
+        used || probablyUsed
     }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -764,4 +764,48 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         /// ```
         pub fn func() {}
     """)
+
+    // emulates situation when method is unresolved because of some bug
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test ignore trait import when there is unresolved related method 1`() = checkByText("""
+        mod foo {
+            pub trait T {
+                fn func(&self) {}
+            }
+        }
+        mod bar {
+            use crate::foo::T;
+            fn test() {
+                ().func();
+            }
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test ignore trait import when there is unresolved related method 2`() = checkByText("""
+        mod foo {
+            pub trait T {
+                fn func(&self) {}
+            }
+        }
+        mod bar {
+            use crate::foo::T as _;
+            fn test() {
+                ().func();
+            }
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test ignore import when there is unresolved related path`() = checkByText("""
+        mod foo {
+            pub mod inner {}
+        }
+        mod bar {
+            use crate::foo::inner;
+            fn test() {
+                let x = inner;
+            }
+        }
+    """)
 }


### PR DESCRIPTION
Fixes false-positives related to unresolved method calls - if method call is unresolved, then we consider import of trait which has method with same name as used

changelog: Fix false-positives related to unresolved method calls in unused imports inspection
