### PR TITLE
RUN: Don't use `Redirect Input from` when building

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -236,8 +236,10 @@ object CargoBuildManager {
             "test" -> ParametersListUtil.join("test", "--no-run", *commandArguments.toTypedArray())
             else -> return null
         }
-        // building does not require root privileges anyway
+
+        // building does not require root privileges and redirect input anyway
         buildConfiguration.withSudo = false
+        buildConfiguration.isRedirectInput = false
 
         return buildConfiguration
     }

--- a/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
@@ -21,7 +21,6 @@ import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.fileTree
 import org.rust.ide.actions.RsBuildAction
 import org.rustSlowTests.cargo.runconfig.buildtool.CargoBuildTest
-import java.nio.file.Path
 
 @MinRustcVersion("1.48.0")
 class RsBuildActionTest : CargoBuildTest() {


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/7548.
Fixes https://github.com/intellij-rust/intellij-rust/issues/7723.

changelog: Don't hang on build when an incorrect path is used with `Redirect Input from` option
