### PR TITLE
IDE: Ignore cfg-disabled imports when removing unused imports

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -93,6 +93,7 @@ class RsUnusedImportInspection : RsLintInspection() {
         fun isApplicableForUseItem(item: RsUseItem): Boolean {
             if (!item.project.isNewResolveEnabled) return false
             if (item.isReexport) return false
+            if (!item.isEnabledByCfg) return false
 
             // Do not check uses if there is a child mod inside the current mod
             val parentMod = item.containingMod

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -178,6 +178,19 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test cfg-disabled import and usage`() = checkByText("""
+        mod foo {
+            pub struct S {}
+        }
+
+        mod bar {
+            #[cfg(not(intellij_rust))]
+            use crate::foo::S;
+        }
+    """)
+
     fun `test used trait method`() = checkByText("""
         mod foo {
             pub trait Trait {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
 import org.rust.*
+import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.lints.RsUnusedImportInspection
 
 @WithEnabledInspections(RsUnusedImportInspection::class)
@@ -636,6 +637,20 @@ class RsImportOptimizerTest: RsTestBase() {
         struct S2;
 
         mod foo {}
+    """)
+
+    @UseNewResolve
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test do not remove cfg-disabled import`() = checkNotChanged("""
+        mod foo {
+            pub struct S {}
+        }
+
+        mod bar {
+            #[cfg(not(intellij_rust))]
+            use crate::foo::S;
+        }
     """)
 
     private fun doTest(@Language("Rust") code: String, @Language("Rust") excepted: String) =


### PR DESCRIPTION
Fixes that cfg-disabled import can be removed even if there is cfg-disabled usage

changelog: Ignore cfg-disabled imports when removing unused imports
