### PR TITLE
The Rust 2021 Edition Autocompletion

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -50,6 +50,7 @@ Guillaume Eveillard
 harrisjt
 HeyLey
 himikof
+HTG-YT
 HybridEidolon
 ice1000
 idubrov

--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
@@ -21,7 +21,7 @@ class CargoTomlCompletionContributor : CompletionContributor() {
     init {
         if (tomlPluginIsAbiCompatible()) {
             extend(BASIC, inKey, CargoTomlKeysCompletionProvider())
-            extend(BASIC, inValueWithKey("edition"), CargoTomlKnownValuesCompletionProvider(listOf("2015", "2018")))
+            extend(BASIC, inValueWithKey("edition"), CargoTomlKnownValuesCompletionProvider(listOf("2015", "2018", "2021")))
             extend(BASIC, inFeatureDependencyArray, CargoTomlFeatureDependencyCompletionProvider())
             extend(BASIC, inDependencyPackageFeatureArray, CargoTomlDependencyFeaturesCompletionProvider())
 


### PR DESCRIPTION
This commit further implements Rust 2021 Edition support for IntelliJ Rust.

Part of: #6902

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

Tasks:
- [x] add the value `2021` for autocompletion in the `edition` field of `Cargo.toml`

changelog: add the value `2021` for autocompletion in the `edition` field of `Cargo.toml`