### PR TITLE
ANN: do not import default type arguments in ChangeFunctionSignatureFix and ChangeReturnTypeFix

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
@@ -50,7 +50,8 @@ class ChangeReturnTypeFix(
         val rendered = actualTy.render(
             context = element,
             useQualifiedName = useQualifiedName,
-            useAliasNames = true
+            useAliasNames = true,
+            skipUnchangedDefaultTypeArguments = true
         )
         "Change return type$item$name to '$rendered'"
     }
@@ -79,7 +80,8 @@ class ChangeReturnTypeFix(
             context = startElement as? RsElement,
             useQualifiedName = useQualifiedName,
             includeLifetimeArguments = true,
-            useAliasNames = true
+            useAliasNames = true,
+            skipUnchangedDefaultTypeArguments = true
         )
         val retType = RsPsiFactory(project).createRetType(text)
 
@@ -89,7 +91,7 @@ class ChangeReturnTypeFix(
             owner.addAfter(retType, owner.valueParameters)
         }
 
-        importTypeReferencesFromTy(owner, actualTy, useAliases = true)
+        importTypeReferencesFromTy(owner, actualTy, useAliases = true, skipUnchangedDefaultTypeArguments = true)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
@@ -80,7 +80,7 @@ fun processFunction(
     changeUnsafe(factory, function, config)
 
     for (type in config.additionalTypesToImport) {
-        RsImportHelper.importTypeReferencesFromTy(function, type, useAliases = true)
+        RsImportHelper.importTypeReferencesFromTy(function, type, useAliases = true, skipUnchangedDefaultTypeArguments = true)
     }
 }
 
@@ -122,8 +122,10 @@ private fun changeReturnType(factory: RsPsiFactory, function: RsFunction, config
         if (config.returnType !is TyUnit) {
             val ret = factory.createRetType(config.returnTypeReference.text)
             function.addAfter(ret, function.valueParameterList) as RsRetType
-            RsImportHelper.importTypeReferencesFromTy(function, config.returnType,
-                useAliases = true, skipUnchangedDefaultTypeArguments = true)
+            RsImportHelper.importTypeReferencesFromTy(
+                function, config.returnType,
+                useAliases = true, skipUnchangedDefaultTypeArguments = true
+            )
         }
     }
 }
@@ -141,8 +143,10 @@ private fun changeArguments(
     }
     for (parameter in config.parameters) {
         val defaultValue = parameter.defaultValue.item ?: continue
-        RsImportHelper.importTypeReferencesFromElements(arguments, setOf(defaultValue),
-            useAliases = true, skipUnchangedDefaultTypeArguments = true)
+        RsImportHelper.importTypeReferencesFromElements(
+            arguments, setOf(defaultValue),
+            useAliases = true, skipUnchangedDefaultTypeArguments = true
+        )
     }
     val argumentsCopy = arguments.copy() as RsValueArgumentList
     val argumentsList = argumentsCopy.exprList
@@ -283,8 +287,10 @@ private fun PsiElement.collectSurroundingWhiteSpaceAndComments(): List<PsiElemen
 
 private fun importParameterTypes(descriptors: List<Parameter>, context: RsElement) {
     for (descriptor in descriptors) {
-        RsImportHelper.importTypeReferencesFromElements(context, setOf(descriptor.typeReference),
-            useAliases = true, skipUnchangedDefaultTypeArguments = true)
+        RsImportHelper.importTypeReferencesFromElements(
+            context, setOf(descriptor.typeReference),
+            useAliases = true, skipUnchangedDefaultTypeArguments = true
+        )
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
@@ -185,6 +185,34 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         }
     """)
 
+    fun `test do not import default type parameter or argument type`() = checkFixByText("Add `S` as `1st` parameter to function `bar`", """
+        mod foo {
+            pub fn bar() {}
+        }
+
+        pub struct R;
+        pub struct S<T=R>(T);
+
+        fn main() {
+            let s = S(R);
+            foo::bar<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>s/*caret*/</error>)</error>;
+        }
+    """, """
+        mod foo {
+            use S;
+
+            pub fn bar(s: S) {}
+        }
+
+        pub struct R;
+        pub struct S<T=R>(T);
+
+        fn main() {
+            let s = S(R);
+            foo::bar(s);
+        }
+    """)
+
     fun `test do not offer on tuple struct constructors`() = checkFixIsUnavailable("Add", """
         struct S(u32);
 

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
@@ -166,6 +166,32 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
         }
     """)
 
+    fun `test do not import default type parameter of unresolved type`() = checkFixByText("Change return type of function 'foo' to 'S'", """
+        use a::bar;
+
+        mod a {
+            pub struct R;
+            pub struct S<T=R>(T);
+            pub fn bar() -> S { S(R) }
+        }
+
+        fn foo() {
+            <error>bar()<caret></error>
+        }
+    """, """
+        use a::{bar, S};
+
+        mod a {
+            pub struct R;
+            pub struct S<T=R>(T);
+            pub fn bar() -> S { S(R) }
+        }
+
+        fn foo() -> S {
+            bar()
+        }
+    """)
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test do not offer fix in closure without an explicit return type passed to a function`() = checkFixIsUnavailable("Change return type of closure", """
         fn foo<F>(f: F) -> i32


### PR DESCRIPTION
I noticed that some quick fixes (change function signature and change return type) still import default type arguments, which causes problems (https://github.com/intellij-rust/intellij-rust/issues/7077).

I would like to propose to change the `skipUnchangedDefaultTypeArguments` parameter default value to true, because I'm sure that it also causes issues at other places. We should do this at least in `RsImportHelper`, but I think that it would be also nice to have it in `TypeRendering`.

changelog: Do not import unnecessary default type parameters in change function signature and change return type quick fixes.