### PR TITLE
COMP: reformat completed impl trait items after insertion

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
@@ -518,4 +518,66 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
             fn ty/*caret*/
         }
     """)
+
+    fun `test nested function`() = doSingleCompletion("""
+        fn foo() {
+            trait Trait {
+                fn foo(&self);
+            }
+
+            impl Trait for () {
+                fn fo/*caret*/
+            }
+        }
+    """, """
+        fn foo() {
+            trait Trait {
+                fn foo(&self);
+            }
+
+            impl Trait for () {
+                fn foo(&self) {
+                    todo!()/*caret*/
+                }
+            }
+        }
+    """)
+
+    fun `test nested constant`() = doSingleCompletion("""
+        fn foo() {
+            struct S {
+                attribute1: u32,
+                attribute2: u32,
+                attribute3: u32,
+            }
+
+            trait Trait {
+                const FOO: S;
+            }
+
+            impl Trait for () {
+                const FO/*caret*/
+            }
+        }
+    """, """
+        fn foo() {
+            struct S {
+                attribute1: u32,
+                attribute2: u32,
+                attribute3: u32,
+            }
+
+            trait Trait {
+                const FOO: S;
+            }
+
+            impl Trait for () {
+                const FOO: S = S {
+                    attribute1: 0,
+                    attribute2: 0,
+                    attribute3: 0,
+                }/*caret*/;
+            }
+        }
+    """)
 }


### PR DESCRIPTION
While using the new impl trait item completion, I noticed that it does not generate proper code if a generated constant has multiple lines or if the generated function is nested (i.e. if you impl a trait inside a function). The implement members fix does not have this problem.

Types do not need to be reformatted, as they are generated with `()`.

Before:
![comp-before](https://user-images.githubusercontent.com/4539057/126611407-57750bd7-f8f4-4bab-9996-cd44202142eb.gif)

After:
![comp-after](https://user-images.githubusercontent.com/4539057/126612023-8d6c2239-27ca-4ebc-b4c9-346ac891a010.gif)

changelog: Fix formatting of completed trait items in trait impls.