### PR TITLE
INSP: Support usages in derive proc macros in unused imports inspection

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructOrEnumItemElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructOrEnumItemElement.kt
@@ -25,7 +25,7 @@ val RsStructOrEnumItemElement.derivedTraitsToMetaItems: Map<RsTraitItem, RsMetaI
         .mapNotNull { meta -> (meta.resolveToDerivedTrait())?.let { it to meta } }
         .toMap()
 
-private val RsStructOrEnumItemElement.deriveMetaItems: Sequence<RsMetaItem>
+val RsStructOrEnumItemElement.deriveMetaItems: Sequence<RsMetaItem>
     get() = queryAttributes.deriveMetaItems
 
 val QueryAttributes<RsMetaItem>.deriveMetaItems: Sequence<RsMetaItem>


### PR DESCRIPTION
changelog: Support usages in derive proc macros in unused imports inspection
