### PR TITLE
T: improve run configuration tests

### DIFF
--- a/coverage/src/test/kotlin/org/rust/coverage/RsCoverageTest.kt
+++ b/coverage/src/test/kotlin/org/rust/coverage/RsCoverageTest.kt
@@ -6,11 +6,8 @@
 package org.rust.coverage
 
 import com.intellij.coverage.CoverageDataManager
-import com.intellij.coverage.CoverageExecutor
 import com.intellij.coverage.CoverageRunnerData
-import com.intellij.execution.ExecutorRegistry
 import com.intellij.execution.configurations.RunConfiguration
-import com.intellij.execution.runners.ExecutionEnvironmentBuilder
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VfsUtil
@@ -21,8 +18,6 @@ import org.rust.FileTreeBuilder
 import org.rust.lang.core.psi.isRustFile
 import org.rust.openapiext.toPsiFile
 import org.rustSlowTests.cargo.runconfig.RunConfigurationTestBase
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
 
 class RsCoverageTest : RunConfigurationTestBase() {
     private val coverageData: ProjectData?
@@ -248,14 +243,8 @@ class RsCoverageTest : RunConfigurationTestBase() {
     }
 
     private fun executeWithCoverage(configuration: RunConfiguration): RunContentDescriptor {
-        val future = CompletableFuture<RunContentDescriptor>()
-        val executor = ExecutorRegistry.getInstance().getExecutorById(CoverageExecutor.EXECUTOR_ID)!!
-        val environment = ExecutionEnvironmentBuilder
-            .create(executor, configuration)
-            .runnerSettings(CoverageRunnerData())
-            .build { future.complete(it) }
-        environment.runner.execute(environment)
-        return future.get(10, TimeUnit.SECONDS)!!
+        val result = execute(configuration) { runnerSettings(CoverageRunnerData()) }
+        return result.descriptor ?: error("Failed to get `RunContentDescriptor` object")
     }
 
     private fun hitsFrom(text: String): Set<Hits> =

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
@@ -17,6 +17,7 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.showRunContent
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.application.invokeLater
+import com.intellij.openapiext.isUnitTestMode
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
@@ -60,7 +61,7 @@ class CargoTestCommandRunner : AsyncProgramRunner<RunnerSettings>() {
             }
             val exitCode = AsyncPromise<Int?>()
 
-            if (environment.isActivateToolWindowBeforeRun) {
+            if (environment.isActivateToolWindowBeforeRun && !isUnitTestMode) {
                 RunContentExecutor(environment.project, buildProcessHandler)
                     .apply { createFilters(state.cargoProject).forEach { withFilter(it) } }
                     .withAfterCompletion { exitCode.setResult(buildProcessHandler.exitCode) }

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RunConfigurationTestBase.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RunConfigurationTestBase.kt
@@ -79,13 +79,17 @@ abstract class RunConfigurationTestBase : RsWithToolchainTestBase() {
             ?: error("Can't create run configuration settings")
     }
 
-    protected fun execute(configuration: RunConfiguration): TestExecutionResult {
+    protected fun execute(
+        configuration: RunConfiguration,
+        customizeExecutionEnv: ExecutionEnvironmentBuilder.() -> ExecutionEnvironmentBuilder = { this }
+    ): TestExecutionResult {
         val connection = project.messageBus.connect(testRootDisposable)
         val executionListener = TestExecutionListener(testRootDisposable, configuration)
         connection.subscribe(ExecutionManager.EXECUTION_TOPIC, executionListener)
 
         ExecutionEnvironmentBuilder.create(DefaultRunExecutor.getRunExecutorInstance(), configuration)
             .activeTarget()
+            .customizeExecutionEnv()
             .buildAndExecute()
         return executionListener.waitFinished() ?: error("Process not finished")
     }

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/TestBuildViewManager.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/buildtool/TestBuildViewManager.kt
@@ -11,10 +11,8 @@ import com.intellij.build.events.FinishBuildEvent
 import com.intellij.build.events.OutputBuildEvent
 import com.intellij.build.events.StartBuildEvent
 import com.intellij.openapi.project.Project
-import com.intellij.util.ConcurrencyUtil
-import com.intellij.util.ui.UIUtil
+import org.rustSlowTests.cargo.runconfig.waitFinished
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 class TestBuildViewManager(project: Project) : BuildViewManager(project) {
     private val latch: CountDownLatch = CountDownLatch(1)
@@ -50,10 +48,7 @@ class TestBuildViewManager(project: Project) : BuildViewManager(project) {
 
     @Throws(InterruptedException::class)
     fun waitFinished(timeoutMs: Long = 5000) {
-        for (i in 1..timeoutMs / ConcurrencyUtil.DEFAULT_TIMEOUT_MS) {
-            UIUtil.dispatchAllInvocationEvents()
-            if (latch.await(ConcurrencyUtil.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) break
-        }
+        latch.waitFinished(timeoutMs)
     }
 
     sealed class EventTreeNode(val unorderedGroupId: Int) {

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/test/CargoTestNodeInfoTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/test/CargoTestNodeInfoTest.kt
@@ -103,7 +103,6 @@ class CargoTestNodeInfoTest : CargoTestRunnerTestBase() {
         configuration.command += " --unknown"
         val root = executeAndGetTestRoot(configuration)
         assertTrue("Testing started" in root.output)
-        assertTrue("Compiling sandbox" in root.output)
         assertTrue("warning: unused variable: `x`" in root.output)
         assertTrue("Finished" in root.output)
         assertTrue("Running" in root.output)

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/test/CargoTestRunnerTestBase.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/test/CargoTestRunnerTestBase.kt
@@ -9,8 +9,7 @@ import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.testframework.TestProxyRoot
 import com.intellij.execution.testframework.sm.runner.SMTestProxy
 import com.intellij.execution.testframework.sm.runner.ui.SMTRunnerConsoleView
-import com.intellij.openapi.util.Disposer
-import com.intellij.util.ui.UIUtil
+import com.intellij.testFramework.PlatformTestUtil
 import org.rust.stdext.removeLast
 import org.rustSlowTests.cargo.runconfig.RunConfigurationTestBase
 
@@ -18,15 +17,10 @@ abstract class CargoTestRunnerTestBase : RunConfigurationTestBase() {
 
     protected fun executeAndGetTestRoot(configuration: RunConfiguration): SMTestProxy.SMRootTestProxy {
         val result = execute(configuration)
-        val executionConsole = result.executionConsole as SMTRunnerConsoleView
-        val testsRootNode = executionConsole.resultsViewer.testsRootNode
-        with(result.processHandler) {
-            startNotify()
-            waitFor()
-        }
-        UIUtil.dispatchAllInvocationEvents()
-        Disposer.register(project, executionConsole)
-        return testsRootNode
+        PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
+        val executionConsole = result.descriptor?.executionConsole as? SMTRunnerConsoleView
+            ?: error("Failed to get test execution console")
+        return executionConsole.resultsViewer.testsRootNode
     }
 
     protected fun SMTestProxy.SMRootTestProxy.findTestByName(testFullName: String): SMTestProxy {

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/utils.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/utils.kt
@@ -1,0 +1,118 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests.cargo.runconfig
+
+import com.intellij.execution.ExecutionListener
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.impl.ExecutionManagerImpl
+import com.intellij.execution.process.*
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.ui.RunContentDescriptor
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.Key
+import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.util.ConcurrencyUtil
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@Throws(InterruptedException::class)
+fun CountDownLatch.waitFinished(timeoutMs: Long): Boolean {
+    for (i in 1..timeoutMs / ConcurrencyUtil.DEFAULT_TIMEOUT_MS) {
+        PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        if (await(ConcurrencyUtil.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) return true
+    }
+    return false
+}
+
+/**
+ * Capturing adapter that removes ANSI escape codes from the output
+ */
+class AnsiAwareCapturingProcessAdapter : ProcessAdapter(), AnsiEscapeDecoder.ColoredTextAcceptor {
+    val output = ProcessOutput()
+
+    private val decoder = object : AnsiEscapeDecoder() {
+        override fun getCurrentOutputAttributes(outputType: Key<*>) = outputType
+    }
+
+    override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) =
+        decoder.escapeText(event.text, outputType, this)
+
+    private fun addToOutput(text: String, outputType: Key<*>) {
+        if (outputType === ProcessOutputTypes.STDERR) {
+            output.appendStderr(text)
+        } else {
+            output.appendStdout(text)
+        }
+    }
+
+    override fun processTerminated(event: ProcessEvent) {
+        output.exitCode = event.exitCode
+    }
+
+    override fun coloredTextAvailable(text: String, attributes: Key<*>) =
+        addToOutput(text, attributes)
+}
+
+class TestExecutionListener(
+    private val parentDisposable: Disposable,
+    private val configuration: RunConfiguration
+) : ExecutionListener {
+
+    private val latch = CountDownLatch(1)
+    private val processListener = AnsiAwareCapturingProcessAdapter()
+
+    private var isProcessStarted = false
+    private var notStartedCause: Throwable? = null
+    private var descriptor: RunContentDescriptor? = null
+
+    // BACKCOMPAT: 2021.1.
+    // Use com.intellij.execution.ExecutionListener.processNotStarted(java.lang.String, com.intellij.execution.runners.ExecutionEnvironment, java.lang.Throwable)
+    // And set `cause` to `notStartedCause`
+    override fun processNotStarted(executorId: String, env: ExecutionEnvironment) {
+        checkAndExecute(env) {
+            latch.countDown()
+        }
+    }
+
+    override fun processStarting(executorId: String, env: ExecutionEnvironment, handler: ProcessHandler) {
+        checkAndExecute(env) {
+            isProcessStarted = true
+            handler.addProcessListener(processListener)
+            Disposer.register(parentDisposable) {
+                ExecutionManagerImpl.stopProcess(handler)
+            }
+        }
+    }
+
+    override fun processTerminated(executorId: String, env: ExecutionEnvironment, handler: ProcessHandler, exitCode: Int) {
+        checkAndExecute(env) {
+            descriptor = env.contentToReuse?.also {
+                Disposer.register(parentDisposable, it)
+            }
+            latch.countDown()
+        }
+    }
+
+    private fun checkAndExecute(env: ExecutionEnvironment, action: () -> Unit) {
+        if (env.runProfile == configuration) {
+            action()
+        }
+    }
+
+    @Throws(InterruptedException::class)
+    fun waitFinished(timeoutMs: Long = 5000): TestExecutionResult? {
+        if (!latch.waitFinished(timeoutMs)) return null
+        val output = if (isProcessStarted) processListener.output else null
+        return TestExecutionResult(output, descriptor, notStartedCause)
+    }
+}
+
+data class TestExecutionResult(
+    val output: ProcessOutput?,
+    val descriptor: RunContentDescriptor?,
+    val notStartedCause: Throwable?
+)


### PR DESCRIPTION
In the beginning (before `Build View`), there wasn't a significant difference between the previous implementation and the current one.
But `Build View` introduced a separate build task that should be executed before the actual running of run configuration. Found out that build task wasn't launched in run configuration tests because of two reasons:
- `RunProfileState.execute` doesn't invoke build tasks at all
- `ExecutionManagerImpl` doesn't run build tasks in tests if `ExecutionManagerImpl.forceCompilationInTests` is `false`

So now we set `ExecutionManagerImpl.forceCompilationInTests` to true and use `ProgramRunner.execute()` (actually, `ExecutionEnvironmentBuilder.buildAndExecute()` but it calls `ProgramRunner.execute()` under the hood)

Note, I've also started to use new approach in coverage tests as well, but they still don't work