### PR TITLE
PERF: Optimize search scope for files with child modules

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
@@ -74,6 +74,7 @@ private fun buildDefMapContainingExplicitItems(
         fileId = crateRoot.virtualFile.fileId,
         fileRelativePath = "",
         ownedDirectoryId = crateRootOwnedDirectory.fileId,
+        hasPathAttribute = false,
         hasMacroUse = false,
         crateDescription = crateDescription
     )

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeMetaInfo.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeMetaInfo.kt
@@ -5,6 +5,8 @@
 
 package org.rust.lang.core.resolve2
 
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
 import com.intellij.util.containers.map2Array
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.RsNamedElement
@@ -31,3 +33,13 @@ private fun PerNs.allVisItems(): Array<Pair<VisItem, Namespace>> =
     types.map2Array { it to Namespace.Types } +
         values.map2Array { it to Namespace.Values } +
         macros.map2Array { it to Namespace.Macros }
+
+/**
+ * In most cases returns [RsMod.getOwnedDirectory],
+ * or some its parent directory if there is complex `include!` or mod declaration with ```#[path]``` attribute.
+ * Note that this directory may not contain [this]
+ */
+fun RsMod.getDirectoryContainedAllChildFiles(): VirtualFile? {
+    val (_, _, modData) = getModInfo(this) as? RsModInfo ?: return null
+    return PersistentFS.getInstance().findFileById(modData.directoryContainedAllChildFiles)
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -199,6 +199,9 @@ private class ModCollector(
             modData.addLegacyMacros(childModLegacyMacros)
             legacyMacros += childModLegacyMacros
         }
+        if (childModData.isRsFile && childModData.hasPathAttributeRelativeToParentFile) {
+            modData.recordChildFileInUnusualLocation(childModData.fileId)
+        }
         return childModData
     }
 
@@ -225,6 +228,7 @@ private class ModCollector(
             fileId = fileId,
             fileRelativePath = fileRelativePath,
             ownedDirectoryId = childMod.getOwnedDirectory(modData, pathAttribute)?.fileId,
+            hasPathAttribute = pathAttribute != null,
             hasMacroUse = childMod.hasMacroUse,
             crateDescription = defMap.crateDescription
         )
@@ -267,6 +271,7 @@ private class ModCollector(
             fileId = modData.fileId,
             fileRelativePath = "${modData.fileRelativePath}::$enumName",
             ownedDirectoryId = modData.ownedDirectoryId,  // actually can use any value here
+            hasPathAttribute = modData.hasPathAttribute,
             isEnum = true,
             hasMacroUse = false,
             crateDescription = defMap.crateDescription

--- a/src/test/kotlin/org/rust/FileTree.kt
+++ b/src/test/kotlin/org/rust/FileTree.kt
@@ -75,6 +75,7 @@ interface FileTreeBuilder {
 
 class FileTree(val rootDirectory: Entry.Directory) {
     fun create(project: Project, directory: VirtualFile): TestProject {
+        val files: MutableList<String> = mutableListOf()
         val filesWithCaret: MutableList<String> = mutableListOf()
         val filesWithSelection: MutableList<String> = mutableListOf()
 
@@ -85,11 +86,13 @@ class FileTree(val rootDirectory: Entry.Directory) {
                     is Entry.File -> {
                         val vFile = root.findChild(name) ?: root.createChildData(root, name)
                         VfsUtil.saveText(vFile, replaceCaretMarker(entry.text))
+                        val filePath = components.joinToString(separator = "/")
+                        files += filePath
                         if (hasCaretMarker(entry.text) || "//^" in entry.text || "#^" in entry.text) {
-                            filesWithCaret += components.joinToString(separator = "/")
+                            filesWithCaret += filePath
                         }
                         if (hasSelectionMarker(entry.text)) {
-                            filesWithSelection += components.joinToString(separator = "/")
+                            filesWithSelection += filePath
                         }
                         Unit
                     }
@@ -112,7 +115,7 @@ class FileTree(val rootDirectory: Entry.Directory) {
             fullyRefreshDirectory(directory)
         }
 
-        return TestProject(project, directory, filesWithCaret, filesWithSelection)
+        return TestProject(project, directory, files, filesWithCaret, filesWithSelection)
     }
 
     fun assertEquals(baseDir: VirtualFile) {
@@ -170,6 +173,7 @@ fun FileTree.createAndOpenFileWithCaretMarker(fixture: CodeInsightTestFixture): 
 class TestProject(
     private val project: Project,
     val root: VirtualFile,
+    val files: List<String>,
     private val filesWithCaret: List<String>,
     private val filesWithSelection: List<String>
 ) {


### PR DESCRIPTION
This is also needed for #7550

changelog: Slightly optimize "Find usage" inside files with child modules