### PR TITLE
COMP: don't show popup for let binding starting with a lowercase char

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1191,7 +1191,8 @@ WhileExpr ::= OuterAttr* LabelDecl? while Condition SimpleBlock {
                  "org.rust.lang.core.psi.ext.RsLooplikeExpr" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
-Condition ::= [ let TopPat '=' ] NoStructLitExpr
+Condition ::= IfLetCondition | NoStructLitExpr
+private IfLetCondition ::= let TopPat '=' NoStructLitExpr { pin = 1 }
 
 LoopExpr ::= OuterAttr* LabelDecl? loop SimpleBlock {
   pin = 'loop'

--- a/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
@@ -32,9 +32,9 @@ class RsMissingElseInspection : RsLocalInspectionTool() {
                     .dropWhile { (it is PsiWhiteSpace || it is PsiComment) && '\n' !in it.text }
                     .firstOrNull()
                     .extractIf() ?: return
-                val condition = nextIf.condition ?: return
+                val conditionExpr = nextIf.condition?.expr ?: return
                 val rangeStart = expr.startOffsetInParent + firstIf.textLength
-                val rangeLen = condition.expr.startOffset - firstIf.startOffset - firstIf.textLength
+                val rangeLen = conditionExpr.startOffset - firstIf.startOffset - firstIf.textLength
                 holder.registerProblem(
                     expr.parent,
                     TextRange(rangeStart, rangeStart + rangeLen),

--- a/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
@@ -59,7 +59,13 @@ class RsRedundantElseInspection : RsLocalInspectionTool() {
             }
         private val RsCondition.isRedundant: Boolean
             get() {
-                return patList?.all { pat -> pat.isIrrefutable } ?: (this.expr.evaluate().asBool() ?: false)
+                val patList = patList
+                return if (patList != null) {
+                    patList.all { pat -> pat.isIrrefutable }
+                } else {
+                    val expr = expr ?: return false
+                    expr.evaluate().asBool() == true
+                }
             }
     }
 }

--- a/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt
@@ -103,7 +103,7 @@ class IfLetToMatchIntention : RsElementBaseIntentionAction<IfLetToMatchIntention
         val pat = condition.pat ?: return null
 
         //3) Extract the target
-        val target = condition.expr
+        val target = condition.expr ?: return null
 
         //4) Extract the if body
         val ifBody = iflet.block ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/InvertIfIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/InvertIfIntention.kt
@@ -15,7 +15,7 @@ import org.rust.lang.utils.negate
 class InvertIfIntention : RsElementBaseIntentionAction<InvertIfIntention.Context>() {
     data class Context(
         val ifExpr: RsIfExpr,
-        val condition: RsCondition,
+        val conditionExpr: RsExpr,
         val thenBlock: RsBlock,
         val elseBlock: RsBlock
     )
@@ -25,14 +25,15 @@ class InvertIfIntention : RsElementBaseIntentionAction<InvertIfIntention.Context
         val ifExpr = element.ancestorStrict<RsIfExpr>() ?: return null
         if (element != ifExpr.`if`) return null
         val condition = getSuitableCondition(ifExpr) ?: return null
+        val conditionExpr = condition.expr ?: return null
         val thenBlock = ifExpr.block ?: return null
         val elseBlock = ifExpr.elseBranch?.block ?: return null
 
-        return Context(ifExpr, condition, thenBlock, elseBlock)
+        return Context(ifExpr, conditionExpr, thenBlock, elseBlock)
     }
 
     override fun invoke(project: Project, editor: Editor, ctx: Context) {
-        val negatedCondition = ctx.condition.expr.negate() as? RsExpr ?: return
+        val negatedCondition = ctx.conditionExpr.negate() as? RsExpr ?: return
 
         val newIfExpr = RsPsiFactory(project).createIfElseExpression(negatedCondition, ctx.elseBlock, ctx.thenBlock)
         val replacedIfExpr = ctx.ifExpr.replace(newIfExpr) as RsIfExpr

--- a/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithIfExpSurrounder.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithIfExpSurrounder.kt
@@ -25,7 +25,7 @@ class RsWithIfExpSurrounder : RsExpressionSurrounderBase<RsIfExpr>() {
         RsPsiFactory(project).createExpression("if a {stmt;}") as RsIfExpr
 
     override fun getWrappedExpression(expression: RsIfExpr): RsExpr =
-        expression.condition!!.expr
+        expression.condition!!.expr!!
 
     override fun isApplicable(expression: RsExpr): Boolean =
         expression.type is TyBool

--- a/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithWhileExpSurrounder.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithWhileExpSurrounder.kt
@@ -25,7 +25,7 @@ class RsWithWhileExpSurrounder : RsExpressionSurrounderBase<RsWhileExpr>() {
         RsPsiFactory(project).createExpression("while a {stmt;}") as RsWhileExpr
 
     override fun getWrappedExpression(expression: RsWhileExpr): RsExpr =
-        expression.condition!!.expr
+        expression.condition!!.expr!!
 
     override fun isApplicable(expression: RsExpr): Boolean =
         expression.type is TyBool

--- a/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt
@@ -95,5 +95,5 @@ fun RsExpr.skipParenExprUp(): RsExpr {
  *
  * @return a child expression without parentheses.
  */
-fun RsCondition.skipParenExprDown(): RsExpr =
-    unwrapParenExprs(expr)
+fun RsCondition.skipParenExprDown(): RsExpr? =
+    expr?.let { unwrapParenExprs(it) }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionConfidence.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionConfidence.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionConfidence
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.util.ThreeState
+import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
+import org.rust.lang.core.psi.RsLetDecl
+import org.rust.lang.core.psi.RsPatBinding
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.topLevelPattern
+
+class RsCompletionConfidence : CompletionConfidence() {
+    override fun shouldSkipAutopopup(contextElement: PsiElement, psiFile: PsiFile, offset: Int): ThreeState {
+        // Don't show completion popup when typing a `let binding` identifier starting with a lowercase letter.
+        // If the identifier is uppercase, the user probably wants to type a destructuring pattern
+        // (`let Foo { ... }`), so we show the completion popup in this case
+        if (contextElement.elementType == IDENTIFIER) {
+            val identText = contextElement.node.chars
+            if (identText.firstOrNull()?.isLowerCase() == true && !"mu".startsWith(identText)) {
+                val parent = contextElement.parent
+                if (parent is RsPatBinding && parent.topLevelPattern.parent is RsLetDecl) {
+                    return ThreeState.YES
+                }
+            }
+        }
+        return ThreeState.UNSURE
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
@@ -375,7 +375,7 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
     }
 
     private fun walkCondition(condition: RsCondition) {
-        val init = condition.expr
+        val init = condition.expr ?: return
         walkExpr(init)
         val initCmt = mc.processExpr(init)
         for (pat in condition.patList.orEmpty()) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -935,10 +935,10 @@ class RsTypeInferenceWalker(
             // or
             // while let Some(a) = ... {}
             // while let V1(a) | V2(a) = ... {}
-            val exprTy = resolveTypeVarsWithObligations(expr.inferType())
+            val exprTy = resolveTypeVarsWithObligations(expr?.inferType() ?: TyUnknown)
             pat.extractBindings(exprTy)
         } else {
-            expr.inferType(TyBool.INSTANCE)
+            expr?.inferType(TyBool.INSTANCE)
         }
     }
 

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -241,6 +241,9 @@
 
         <codeCompletionConfigurable instance="org.rust.ide.settings.RsCodeCompletionConfigurable"/>
 
+        <completion.confidence language="Rust"
+                               implementationClass="org.rust.lang.core.completion.RsCompletionConfidence"/>
+
         <completion.contributor language="Rust"
                                 implementationClass="org.rust.lang.core.completion.RsKeywordCompletionContributor"
                                 id="RsKeywordCompletionContributor"

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
@@ -66,6 +66,76 @@ class RsCompletionAutoPopupTest : RsCompletionTestBase() {
         }
     """, "|")
 
+    fun `test popup is not shown when typing lowercase let binding`() = checkPopupIsNotShownAfterTyping("""
+        struct a1 { f: i32 }
+        const a2: i32 = 1;
+        fn main() {
+            let /*caret*/
+        }
+    """, "a")
+
+    fun `test popup is not shown when typing nested lowercase let binding`() = checkPopupIsNotShownAfterTyping("""
+        struct a1 { f: i32 }
+        const a2: i32 = 1;
+        fn main() {
+            let (a, /*caret*/)
+        }
+    """, "a")
+
+    fun `test popup is shown when typing uppercase let binding`() = checkPopupIsShownAfterTyping("""
+        struct A1 { f: i32 }
+        const A2: i32 = 1;
+        fn main() {
+            let /*caret*/
+        }
+    """, "A")
+
+    fun `test popup is shown when typing if let binding`() = checkPopupIsShownAfterTyping("""
+        struct a1 { f: i32 }
+        const a2: i32 = 1;
+        fn main() {
+            if let /*caret*/
+        }
+    """, "a")
+
+    fun `test popup is shown when typing while let binding`() = checkPopupIsShownAfterTyping("""
+        struct a1 { f: i32 }
+        const a2: i32 = 1;
+        fn main() {
+            while let /*caret*/
+        }
+    """, "a")
+
+    fun `test popup is shown when typing binding in match arm`() = checkPopupIsShownAfterTyping("""
+        struct a1 { f: i32 }
+        const a2: i32 = 1;
+        fn main() {
+            match 1 {
+                /*caret*/
+            }
+        }
+    """, "a")
+
+    fun `test popup is shown when typing let mut 1`() = checkPopupIsShownAfterTyping("""
+        fn main() {
+            let /*caret*/
+        }
+    """, "m")
+
+    fun `test popup is shown when typing let mut 2`() = checkPopupIsShownAfterTyping("""
+        fn main() {
+            let m/*caret*/
+        }
+    """, "u")
+
+    fun `test popup is not shown when typing lowercase let mut binding`() = checkPopupIsNotShownAfterTyping("""
+        struct a1 { f: i32 }
+        const a2: i32 = 1;
+        fn main() {
+            let mut /*caret*/
+        }
+    """, "a")
+
     override fun setUp() {
         super.setUp()
         tester = CompletionAutoPopupTester(myFixture)

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/exprs.rs
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/exprs.rs
@@ -31,4 +31,7 @@ fn foo() {
     fn a() {}
     foo11(
     fn a() {}
+
+    if let ;
+    while let ;
 }

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/exprs.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/exprs.txt
@@ -318,5 +318,27 @@ FILE
         RsBlockImpl(BLOCK)
           PsiElement({)('{')
           PsiElement(})('}')
+      PsiWhiteSpace('\n\n    ')
+      RsExprStmtImpl(EXPR_STMT)
+        RsIfExprImpl(IF_EXPR)
+          PsiElement(if)('if')
+          PsiWhiteSpace(' ')
+          RsConditionImpl(CONDITION)
+            PsiElement(let)('let')
+            PsiErrorElement:<pattern> expected, got ';'
+              <empty list>
+        PsiWhiteSpace(' ')
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n    ')
+      RsExprStmtImpl(EXPR_STMT)
+        RsWhileExprImpl(WHILE_EXPR)
+          PsiElement(while)('while')
+          PsiWhiteSpace(' ')
+          RsConditionImpl(CONDITION)
+            PsiElement(let)('let')
+            PsiErrorElement:<pattern> expected, got ';'
+              <empty list>
+        PsiWhiteSpace(' ')
+        PsiElement(;)(';')
       PsiWhiteSpace('\n')
       PsiElement(})('}')


### PR DESCRIPTION
Fixes #7249

Don't show a completion popup automatically when typing a `let binding` identifier starting with a lowercase letter. You still can invoke the completion explicitly (using `ctrl`+`enter`, for example).

https://user-images.githubusercontent.com/3221931/127017258-40e10085-f531-4dc7-a615-7243c28e2906.mp4

If the identifier is uppercase, the user probably wants to type a destructuring pattern (`let Foo { ... }`), so we show the completion popup in this case. In `match`, `if let` and `while let` constructions completion popup is shown as before.

changelog: Don't show a completion popup automatically when typing a `let binding` identifier starting from a lowercase letter. You still can invoke the completion explicitly (using `ctrl`+`enter`, for example).
