### PR TITLE
FIX: Take into account const generics in `Move type constraint to parameter list` quickfix

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntention.kt
@@ -8,10 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.RsBaseType
-import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.RsTypeParameter
-import org.rust.lang.core.psi.RsWhereClause
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 
 class MoveTypeConstraintToParameterListIntention : RsElementBaseIntentionAction<RsWhereClause>() {
@@ -38,27 +35,44 @@ class MoveTypeConstraintToParameterListIntention : RsElementBaseIntentionAction<
         val declaration = ctx.ancestorStrict<RsGenericDeclaration>() ?: return
 
         val typeParameterList = declaration.typeParameterList ?: return
-        val lifetimes = typeParameterList.lifetimeParameterList.mapNotNull { typeParameterText(it, it.bounds) }
-        val types = typeParameterList.typeParameterList.mapNotNull { typeParameterText(it, it.bounds) }
+        val generics = typeParameterList.genericParameterList
+            .filter { it.name != null }
+            .map { param ->
+                when (param) {
+                    is RsTypeParameter -> typeParameterText(param)
+                    is RsLifetimeParameter -> lifetimeParameterText(param)
+                    is RsConstParameter -> constParameterText(param)
+                    else -> error("unreachable")
+                }
+            }
 
-        val newElement = RsPsiFactory(project).createTypeParameterList(lifetimes + types)
+        val newElement = RsPsiFactory(project).createTypeParameterList(generics)
         val offset = typeParameterList.startOffset + newElement.textLength
         typeParameterList.replace(newElement)
         ctx.delete()
         editor.caretModel.moveToOffset(offset)
     }
 
-    private fun typeParameterText(param: RsNamedElement, bounds: List<RsElement>): String? {
-        val name = param.name ?: return null
-        val bs = bounds.distinctBy { it.text }
-        return buildString {
-            append(name)
-            if (bs.isNotEmpty()) {
-                append(bs.joinToString(separator = "+", prefix = ":") { it.text })
-            }
-            val default = (param as? RsTypeParameter)?.typeReference?.text
-            if (default != null) append("=$default")
+    private fun typeParameterText(param: RsTypeParameter): String = buildString {
+        append(param.name)
+        val bounds = param.bounds.distinctBy { it.text }
+        if (bounds.isNotEmpty()) {
+            bounds.joinTo(this, separator = "+", prefix = ":") { it.text }
+        }
+        param.typeReference?.let { append("=${it.text}") }
+    }
+
+    private fun lifetimeParameterText(param: RsLifetimeParameter): String = buildString {
+        append(param.name)
+        val bounds = param.bounds.distinctBy { it.text }
+        if (bounds.isNotEmpty()) {
+            bounds.joinTo(this, separator = "+", prefix = ":") { it.text }
         }
     }
 
+    private fun constParameterText(param: RsConstParameter): String = buildString {
+        append("const ")
+        append(param.name)
+        param.typeReference?.let { append(": ${it.text}") }
+    }
 }

--- a/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntentionTest.kt
@@ -12,6 +12,11 @@ class MoveTypeConstraintToParameterListIntentionTest : RsIntentionTestBase(MoveT
         """ fn foo<'a, 'b: 'a, 'c: 'a, T: Clone, U: Copy>/*caret*/() {} """
     )
 
+    fun `test const generics and traits`() = doAvailableTest(
+        """ fn foo<const N: usize, T, U, const M: usize>() /*caret*/where T: Clone, U: Copy {} """,
+        """ fn foo<const N: usize, T: Clone, U: Copy, const M: usize>/*caret*/() {} """
+    )
+
     fun `test multiple bounds`() = doAvailableTest(
         """ fn foo<'a, 'b, 'c, 'd, T, U>() where /*caret*/'c: 'a + 'b, 'd: 'a + 'b, T: Clone + Copy, U: Copy + Debug {} """,
         """ fn foo<'a, 'b, 'c: 'a + 'b, 'd: 'a + 'b, T: Clone + Copy, U: Copy + Debug>/*caret*/() {} """

--- a/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntentionTest.kt
@@ -16,6 +16,11 @@ class MoveTypeConstraintToWhereClauseIntentionTest : RsIntentionTestBase(MoveTyp
         """ fn foo<'a, 'b, T, F>(t: &'a T, f: &'b F) where 'b: 'a, T: Send, F: Sync/*caret*/ { } """
     )
 
+    fun `test const generics and traits`() = doAvailableTest(
+        """ fn foo<const N: usize, T: Send,/*caret*/ F: Sync, const M: usize>(t: T, f: F) { } """,
+        """ fn foo<const N: usize, T, F, const M: usize>(t: T, f: F) where T: Send, F: Sync/*caret*/ { } """
+    )
+
     fun `test multiple bounds`() = doAvailableTest(
         """ fn foo<T: /*caret*/Send + Sync>(t: T, f: F) { } """,
         """ fn foo<T>(t: T, f: F) where T: Send + Sync/*caret*/ { } """


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/7586.

changelog: Take into account const generics in `Move type constraint to parameter list` quick fix
