### PR TITLE
Highlight exit points when the caret at `fn` or `->` token

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -511,7 +511,8 @@ upper Function ::= async? const? unsafe? ExternAbi?
 {
   pin = 'identifier'
   name = ""
-  implements = [ "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
+  implements = [ "org.rust.lang.core.psi.ext.RsFunctionOrLambda"
+                 "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
                  "org.rust.lang.core.psi.ext.RsGenericDeclaration"
                  "org.rust.lang.core.psi.ext.RsInnerAttributeOwner"
                  "org.rust.lang.core.psi.ext.RsItemElement"
@@ -1150,7 +1151,8 @@ UnaryExpr ::= OuterAttr* (box | '-' | '*' | '!' | '&' [raw (mut | const) | mut])
 }
 
 LambdaExpr ::= OuterAttr* [asyncBlock | static] move? LambdaParameters RetType? <<setStmtMode 'StmtMode.OFF'>> Expr <<resetFlags>> {
-  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsFunctionOrLambda"
+                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunctionOrLambda.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunctionOrLambda.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import org.rust.lang.core.psi.RsRetType
+import org.rust.lang.core.psi.RsValueParameterList
+
+/**
+ * [org.rust.lang.core.psi.RsFunction] or [org.rust.lang.core.psi.RsLambdaExpr]
+ */
+interface RsFunctionOrLambda : RsOuterAttributeOwner {
+    val valueParameterList: RsValueParameterList?
+    val retType: RsRetType?
+}

--- a/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
+++ b/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
@@ -22,6 +22,54 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """, "return 1", "return 0")
 
+    fun `test highlight all returns with caret at fn keyword`() = doTest("""
+        /*caret*/fn main() {
+            if true {
+                return 1;
+            }
+            return 0;
+        }
+    """, "return 1", "return 0")
+
+    fun `test no highlighting with caret at fn keyword in fn pointer type`() = doTest("""
+        fn main() {
+            let _: /*caret*/fn();
+            if true {
+                return 1;
+            }
+            return 0;
+        }
+    """, "fn")
+
+    fun `test highlight all returns with caret at returning type arrow`() = doTest("""
+        fn main() /*caret*/-> i32 {
+            if true {
+                return 1;
+            }
+            return 0;
+        }
+    """, "return 1", "return 0")
+
+    fun `test no highlighting with caret at arrow in a path`() = doTest("""
+        fn main() {
+            let _: Fn() /*caret*/-> i32;
+            if true {
+                return 1;
+            }
+            return 0;
+        }
+    """)
+
+    fun `test no highlighting with caret at arrow in an fn pointer`() = doTest("""
+        fn main() {
+            let _: fn() /*caret*/-> i32;
+            if true {
+                return 1;
+            }
+            return 0;
+        }
+    """)
+
     fun `test highlight try macro as return`() = doTest("""
         fn main() {
             if true {
@@ -154,6 +202,13 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
     fun `test highlight should not highlight outer function`() = doTest("""
         fn main() {
             let one = || { /*caret*/return 1; };
+            return 2;
+        }
+    """, "return 1")
+
+    fun `test highlight should not highlight outer function with caret at lambda return type arrow`() = doTest("""
+        fn main() {
+            let one = || /*caret*/-> i32 { return 1; };
             return 2;
         }
     """, "return 1")


### PR DESCRIPTION
Fixes #6309


https://user-images.githubusercontent.com/3221931/127149231-385c6eb3-b314-463b-a6dc-72c6c98d7149.mp4



changelog: Highlight function or lambda exit points when the caret at `fn` or `->` token