### PR TITLE
FIX: add impl support to AddUnsafeFix

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -404,7 +404,8 @@ sealed class RsDiagnostic(
         override fun prepare() = PreparedAnnotation(
             ERROR,
             E0200,
-            errorText()
+            errorText(),
+            fixes = listOfNotNull(AddUnsafeFix.create(element))
         )
 
         private fun errorText(): String {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFixTest.kt
@@ -5,10 +5,14 @@
 
 package org.rust.ide.annotator.fixes
 
-import org.rust.ide.annotator.RsAnnotatorTestBase
-import org.rust.ide.annotator.RsUnsafeExpressionAnnotator
+import org.rust.ide.annotator.*
 
-class AddUnsafeFixTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class) {
+class AddUnsafeFixTest : RsAnnotationTestBase() {
+    override fun createAnnotationFixture(): RsAnnotationTestFixture<Unit> {
+        val annotatorClasses = listOf(RsUnsafeExpressionAnnotator::class, RsErrorAnnotator::class)
+        return RsAnnotationTestFixture(this, myFixture, annotatorClasses = annotatorClasses)
+    }
+
     fun `test add unsafe to function`() = checkFixByText("Add unsafe to function", """
         unsafe fn foo() {}
 
@@ -251,5 +255,15 @@ class AddUnsafeFixTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class)
         fn test() {
             unsafe { *foo() = 5; }
         }
+    """)
+
+    fun `test add unsafe to impl`() = checkFixByText("Add unsafe to impl", """
+        unsafe trait Trait {}
+
+        impl <error>Trait/*caret*/</error> for () {}
+    """, """
+        unsafe trait Trait {}
+
+        unsafe impl Trait/*caret*/ for () {}
     """)
 }


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7590

changelog: "Add unsafe" quick fix now also supports `impl` items. 