### PR TITLE
MACRO: expand macro 2.0

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1363,12 +1363,8 @@ YieldExpr ::= OuterAttr* yield AnyExpr? {
 upper Macro ::= "macro_rules" '!' identifier ShallowMacroBody <<macroSemicolon>> {
   pin = 2
   name = ""
-  implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
-                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
-                 "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
-                 "org.rust.lang.core.psi.ext.RsMacroDefinitionBase"
-                 "org.rust.lang.core.macros.RsExpandedElement"
-                 "org.rust.lang.core.psi.ext.RsModificationTrackerOwner" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsMacroDefinitionBase"
+                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   extends = "org.rust.lang.core.psi.ext.RsMacroImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsMacroStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
@@ -1416,10 +1412,8 @@ MacroExpansionGroupSeparator ::= <<macroBindingGroupSeparatorToken>>
 upper Macro2 ::= MACRO_KW identifier ( Macro2FunctionLikeBody | Macro2MatchLikeBody ) {
   pin = 1
   name = ""
-  implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
-                 "org.rust.lang.core.psi.ext.RsItemElement"
-                 "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
-                 "org.rust.lang.core.psi.ext.RsMacroDefinitionBase" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsMacroDefinitionBase"
+                 "org.rust.lang.core.psi.ext.RsItemElement" ]
   extends = "org.rust.lang.core.psi.ext.RsMacro2ImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsMacro2Stub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroData.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroData.kt
@@ -7,15 +7,14 @@ package org.rust.lang.core.macros
 
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.lang.core.macros.builtin.BuiltinMacroExpander
-import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroBody
-import org.rust.lang.core.psi.ext.macroBodyStubbed
+import org.rust.lang.core.psi.ext.RsMacroDefinitionBase
 import org.rust.stdext.HashCode
 
 sealed class RsMacroData
 
 class RsDeclMacroData(val macroBody: Lazy<RsMacroBody?>): RsMacroData() {
-    constructor(def: RsMacro) : this(lazy(LazyThreadSafetyMode.PUBLICATION) { def.macroBodyStubbed })
+    constructor(def: RsMacroDefinitionBase) : this(lazy(LazyThreadSafetyMode.PUBLICATION) { def.macroBodyStubbed })
 }
 
 data class RsProcMacroData(val name: String, val artifact: CargoWorkspaceData.ProcMacroArtifact): RsMacroData()

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
@@ -30,6 +30,7 @@ import org.rust.lang.core.macros.macroExpansionManagerIfCreated
 import org.rust.lang.core.psi.RsPsiManager.Companion.isIgnorePsiEvents
 import org.rust.lang.core.psi.RsPsiTreeChangeEvent.*
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsMacroDefinitionBase
 import org.rust.lang.core.psi.ext.findModificationTrackerOwner
 import org.rust.lang.core.psi.ext.isTopLevelExpansion
 
@@ -193,7 +194,7 @@ class RsPsiManagerImpl(val project: Project) : RsPsiManager, Disposable {
         // Whitespace/comment changes are meaningful for macros only
         // (b/c they affect range mappings and body hashes)
         if (isWhitespaceOrComment) {
-            if (owner !is RsMacroCall && owner !is RsMacro && !RsProcMacroPsiUtil.canBeInProcMacroCallBody(psi)) return
+            if (owner !is RsMacroCall && owner !is RsMacroDefinitionBase && !RsProcMacroPsiUtil.canBeInProcMacroCallBody(psi)) return
         }
 
         val isStructureModification = owner == null || !owner.incModificationCount(psi)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro2.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro2.kt
@@ -6,13 +6,16 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
+import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
-import org.rust.lang.core.psi.RsMacro2
-import org.rust.lang.core.psi.RsPsiImplUtil
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsMacro2Stub
+import org.rust.stdext.HashCode
 import javax.swing.Icon
 
 abstract class RsMacro2ImplMixin : RsStubbedNamedElementImpl<RsMacro2Stub>,
@@ -26,5 +29,51 @@ abstract class RsMacro2ImplMixin : RsStubbedNamedElementImpl<RsMacro2Stub>,
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 
+    override val modificationTracker: SimpleModificationTracker =
+        SimpleModificationTracker()
+
+    override fun incModificationCount(element: PsiElement): Boolean {
+        modificationTracker.incModificationCount()
+        return false // force rustStructureModificationTracker to be incremented
+    }
+
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    override val macroBodyStubbed: RsMacroBody?
+        get() {
+            return CachedValuesManager.getCachedValue(this) {
+                val text = stub?.macroBody ?: prepareMacroBody()
+                CachedValueProvider.Result.create(
+                    RsPsiFactory(project, markGenerated = false).createMacroBody(text),
+                    modificationTracker
+                )
+            }
+        }
+
+    override val bodyHash: HashCode?
+        get() {
+            val stub = greenStub
+            if (stub !== null) return stub.bodyHash
+            return CachedValuesManager.getCachedValue(this) {
+                val body = prepareMacroBody()
+                val hash = HashCode.compute(body)
+                CachedValueProvider.Result.create(hash, modificationTracker)
+            }
+        }
+
+    override val hasRustcBuiltinMacro: Boolean
+        get() = MACRO2_HAS_RUSTC_BUILTIN_MACRO_PROP.getByPsi(this)
+}
+
+val MACRO2_HAS_RUSTC_BUILTIN_MACRO_PROP: StubbedAttributeProperty<RsMacro2, RsMacro2Stub> =
+    StubbedAttributeProperty(QueryAttributes<*>::hasRustcBuiltinMacro, RsMacro2Stub::mayHaveRustcBuiltinMacro)
+
+fun RsMacro2.prepareMacroBody(): String {
+    val macroPatternContents = macroPatternContents
+    val macroExpansionContents = macroExpansionContents
+    return if (macroPatternContents != null && macroExpansionContents != null) {
+        "{(${macroPatternContents.text}) => {${macroExpansionContents.text}}}"
+    } else {
+        macroCaseList.joinToString(prefix = "{", postfix = "}") { it.text }
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinitionBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinitionBase.kt
@@ -5,7 +5,18 @@
 
 package org.rust.lang.core.psi.ext
 
+import org.rust.lang.core.macros.RsExpandedElement
+import org.rust.lang.core.psi.RsMacroBody
+import org.rust.stdext.HashCode
+
 /**
  * [org.rust.lang.core.psi.RsMacro] or [org.rust.lang.core.psi.RsMacro2]
  */
-interface RsMacroDefinitionBase : RsElement
+interface RsMacroDefinitionBase : RsNameIdentifierOwner,
+                                  RsQualifiedNamedElement,
+                                  RsExpandedElement,
+                                  RsModificationTrackerOwner {
+    val macroBodyStubbed: RsMacroBody?
+    val bodyHash: HashCode?
+    val hasRustcBuiltinMacro: Boolean
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -404,7 +404,17 @@ class DeclMacroDefInfo(
 class DeclMacro2DefInfo(
     override val crate: CratePersistentId,
     override val path: ModPath,
-) : MacroDefInfo()
+    private val bodyText: String,
+    val bodyHash: HashCode,
+    val hasRustcBuiltinMacro: Boolean,
+    project: Project,
+) : MacroDefInfo() {
+    /** Lazy because usually it should not be used (thanks to macro expansion cache) */
+    val body: Lazy<RsMacroBody?> = lazy(LazyThreadSafetyMode.PUBLICATION) {
+        val psiFactory = RsPsiFactory(project, markGenerated = false)
+        psiFactory.createMacroBody(bodyText)
+    }
+}
 
 class ProcMacroDefInfo(
     override val crate: CratePersistentId,

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -340,7 +340,11 @@ private class ModCollector(
         // save macro body for later use
         modData.macros2[def.name] = DeclMacro2DefInfo(
             crate = modData.crate,
-            path = modData.path.append(def.name)
+            path = modData.path.append(def.name),
+            def.body,
+            def.bodyHash,
+            def.hasRustcBuiltinMacro,
+            project
         )
 
         // add macro to scope

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -208,6 +208,9 @@ class ModCollectorBase private constructor(
         val defLight = Macro2DefLight(
             name = def.name ?: return,
             visibility = VisibilityLight.from(def),
+            body = def.macroBody,
+            bodyHash = def.bodyHash,
+            hasRustcBuiltinMacro = MACRO2_HAS_RUSTC_BUILTIN_MACRO_PROP.getByStub(def, crate),
         )
         visitor.collectMacro2Def(defLight)
     }
@@ -501,11 +504,16 @@ data class MacroDefLight(
 data class Macro2DefLight(
     val name: String,
     val visibility: VisibilityLight,
+    val body: String,
+    val bodyHash: HashCode,
+    val hasRustcBuiltinMacro: Boolean,
 ) : Writeable {
 
     override fun writeTo(data: DataOutput) {
         IOUtil.writeUTF(data, name)
         visibility.writeTo(data)
+        data.writeHashCode(bodyHash)
+        data.writeBoolean(hasRustcBuiltinMacro)
     }
 }
 

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacro2ExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacro2ExpansionTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.decl
+
+import org.rust.MinRustcVersion
+import org.rust.ProjectDescriptor
+import org.rust.UseNewResolve
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.macros.RsMacroExpansionTestBase
+
+@UseNewResolve
+class RsMacro2ExpansionTest : RsMacroExpansionTestBase() {
+    fun `test function-like body`() = doTest("""
+        macro foo ($ i:ident) {
+            fn $ i() {}
+        }
+        foo! { bar }
+    """, """
+        fn bar() {}
+    """)
+
+    fun `test macro_rules-like body`() = doTest("""
+        macro foo {
+            ($ i:ident) => {
+                fn $ i() {}
+            }
+        }
+        foo! { bar }
+    """, """
+        fn bar() {}
+    """)
+
+    fun `test stmt context`() = checkSingleMacro("""
+       macro foo {
+            ($ i:ident, $ j:ident) => {
+                struct $ i;
+                let $ j = 0;
+                ($ i, $ j)
+            }
+        }
+
+        fn main() {
+            foo!(S, a);
+        } //^
+    """, """
+        struct S;
+        let a = 0;
+        (S, a)
+    """)
+
+    fun `test expr context`() = checkSingleMacro("""
+       macro foo {
+            ($ e:expr) => {
+                $ e + 3
+            }
+        }
+
+        fn main() {
+            let _ = foo!(1 + 2);
+        }          //^
+    """, """
+        (1 + 2) + 3
+    """)
+
+    @MinRustcVersion("1.52.0")
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test std addr_of`() = checkSingleMacro("""
+       fn main() {
+           let a = 1;
+           let _ = std::ptr::addr_of!(a);
+       }                   //^
+    """, """
+        &raw const a
+    """)
+}

--- a/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
@@ -149,6 +149,10 @@ class RsRustStructureModificationTrackerTest : RsTestBase() {
         macro_rules! foo { () => { /*caret*/ } }
     """)
 
+    fun `test macro2`() = doTest(INC, """
+        macro foo { () => { /*caret*/ } }
+    """)
+
     fun `test macro call (old engine)`() = checkModCount(INC, """
         foo! { /*caret*/ }
     """, "a")

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
@@ -345,6 +345,43 @@ class RsDefMapUpdateChangeSingleFileTest : RsDefMapUpdateTestBase() {
         macro foo() {}
     """)
 
+    fun `test add rustc_builtin_macro attr to macro 2 def`() = doTestChanged("""
+        macro foo() {}
+    """, """
+        #[rustc_builtin_macro]
+        macro foo() {}
+    """)
+
+    fun `test change macro 2 def content 1`() = doTestChanged("""
+        macro foo {
+            () => {}
+        }
+    """, """
+        macro foo {
+            () => { fn func() {} }
+        }
+    """)
+
+    fun `test change macro 2 def content 2`() = doTestChanged("""
+        macro foo() {
+
+        }
+    """, """
+        macro foo() {
+            fn func() {}
+        }
+    """)
+
+    fun `test change macro 2 def content 3`() = doTestChanged("""
+        macro foo() {
+
+        }
+    """, """
+        macro foo($ i:ident) {
+
+        }
+    """)
+
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test add file level cfg attribute`() = doTestChanged("""
     """, """


### PR DESCRIPTION
Related to #2419

changelog: Provide initial support for `macro 2.0` (like `std::ptr::addr_of`)
