### PR TITLE
IDE: add imports after pasting code

### DIFF
--- a/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
@@ -27,6 +27,10 @@ class RsAutoImportOptions : UiDslUnnamedConfigurable.Simple(), AutoImportOptions
                     .bindSelected(settings::importOutOfScopeItems)
             }
             row {
+                checkBox(RsBundle.message("settings.rust.auto.import.on.paste"))
+                    .bindSelected(settings::importOnPaste)
+            }
+            row {
                 checkBox(ApplicationBundle.message("checkbox.add.unambiguous.imports.on.the.fly"))
                     .bindSelected(settings::addUnambiguousImportsOnTheFly)
                     .gap(RightGap.SMALL)

--- a/src/main/kotlin/org/rust/ide/settings/RsCodeInsightSettings.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsCodeInsightSettings.kt
@@ -18,6 +18,7 @@ class RsCodeInsightSettings : PersistentStateComponent<RsCodeInsightSettings> {
     var importOutOfScopeItems: Boolean = true
     var suggestOutOfScopeItems: Boolean = true
     var addUnambiguousImportsOnTheFly: Boolean = false
+    var importOnPaste: Boolean = true
 
     override fun getState(): RsCodeInsightSettings = this
 

--- a/src/main/kotlin/org/rust/ide/typing/paste/RsImportCopyPasteProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/typing/paste/RsImportCopyPasteProcessor.kt
@@ -1,0 +1,223 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.typing.paste
+
+import com.intellij.codeInsight.daemon.impl.CollectHighlightsUtil
+import com.intellij.codeInsight.editorActions.CopyPastePostProcessor
+import com.intellij.codeInsight.editorActions.TextBlockTransferableData
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Ref
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.source.tree.injected.changesHandler.range
+import org.rust.ide.inspections.import.AutoImportFix
+import org.rust.ide.settings.RsCodeInsightSettings
+import org.rust.ide.utils.import.ImportCandidate
+import org.rust.ide.utils.import.import
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsQualifiedNamedElement
+import org.rust.lang.core.psi.ext.qualifiedName
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.lang.core.types.inference
+import org.rust.openapiext.toPsiFile
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+
+data class ImportMap(private val offsetToFqnMap: Map<Int, String>) {
+    fun elementToFqn(element: PsiElement, range: TextRange): String? {
+        val offset = toRelativeOffset(element, range)
+        return offsetToFqnMap[offset]
+    }
+}
+
+class RsTextBlockTransferableData(val importMap: ImportMap) : TextBlockTransferableData {
+    override fun getFlavor(): DataFlavor? = RsImportCopyPasteProcessor.dataFlavor
+
+    override fun getOffsetCount(): Int = 0
+
+    override fun getOffsets(offsets: IntArray?, index: Int): Int = index
+    override fun setOffsets(offsets: IntArray?, index: Int): Int = index
+}
+
+class RsImportCopyPasteProcessor : CopyPastePostProcessor<RsTextBlockTransferableData>() {
+    override fun collectTransferableData(
+        file: PsiFile,
+        editor: Editor,
+        startOffsets: IntArray,
+        endOffsets: IntArray
+    ): List<RsTextBlockTransferableData> {
+        if (file !is RsFile || DumbService.getInstance(file.getProject()).isDumb) return emptyList()
+        if (!RsCodeInsightSettings.getInstance().importOnPaste) return emptyList()
+
+        val startOffset = startOffsets.singleOrNull() ?: return emptyList()
+        val endOffset = endOffsets.singleOrNull() ?: return emptyList()
+        val range = TextRange(startOffset, endOffset)
+
+        // If the whole file is copied, it's not useful to add imports
+        if (range == file.textRange) return emptyList()
+
+        val map = createFqnMap(file, range)
+
+        return listOf(RsTextBlockTransferableData(map))
+    }
+
+    override fun extractTransferableData(content: Transferable): List<RsTextBlockTransferableData> {
+        try {
+            val data = content.getTransferData(dataFlavor) as? RsTextBlockTransferableData ?: return emptyList()
+            return listOf(data)
+        } catch (e: Throwable) {
+            return emptyList()
+        }
+    }
+
+    override fun processTransferableData(
+        project: Project,
+        editor: Editor,
+        bounds: RangeMarker,
+        caretOffset: Int,
+        indented: Ref<in Boolean>,
+        values: List<RsTextBlockTransferableData>
+    ) {
+        if (!RsCodeInsightSettings.getInstance().importOnPaste) return
+
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+
+        val data = values.getOrNull(0) ?: return
+        val file = editor.document.toPsiFile(project) as? RsFile ?: return
+        val range = bounds.range
+
+        val elements = gatherElements(file, range)
+        val importCtx = elements.firstOrNull { it is RsElement } as? RsElement ?: return
+
+        val visitor = ImportingVisitor(range, data.importMap)
+
+        runWriteAction {
+            for (element in elements) {
+                element.accept(visitor)
+            }
+            // We need to import the candidates after visiting all elements, otherwise the relative offsets could be
+            // invalidated after an import has been added
+            for (candidate in visitor.importCandidates) {
+                candidate.import(importCtx)
+            }
+        }
+    }
+
+    companion object {
+        val dataFlavor: DataFlavor? by lazy {
+            try {
+                val dataClass = RsReferenceData::class.java
+                DataFlavor(
+                    DataFlavor.javaJVMLocalObjectMimeType + ";class=" + dataClass.name,
+                    "RsReferenceData",
+                    dataClass.classLoader
+                )
+            } catch (e: NoClassDefFoundError) {
+                null
+            } catch (e: IllegalArgumentException) {
+                null
+            }
+        }
+    }
+}
+
+private class RsReferenceData
+
+private class ImportingVisitor(private val range: TextRange, private val importMap: ImportMap) : RsRecursiveVisitor() {
+    private val candidates: MutableList<ImportCandidate> = mutableListOf()
+
+    val importCandidates: List<ImportCandidate> = candidates
+
+    override fun visitPath(path: RsPath) {
+        val ctx = AutoImportFix.findApplicableContext(path)
+        handleContext(path, ctx)
+        super.visitPath(path)
+    }
+
+    override fun visitMethodCall(methodCall: RsMethodCall) {
+        val ctx = AutoImportFix.findApplicableContext(methodCall)
+        handleContext(methodCall, ctx)
+        super.visitMethodCall(methodCall)
+    }
+
+    override fun visitPatBinding(binding: RsPatBinding) {
+        if (importMap.elementToFqn(binding, range) != null) {
+            val ctx = AutoImportFix.findApplicableContext(binding)
+            handleContext(binding, ctx)
+        }
+        super.visitPatBinding(binding)
+    }
+
+    private fun handleContext(element: PsiElement, ctx: AutoImportFix.Context?) {
+        if (ctx != null) {
+            val candidate = ctx.candidates.find {
+                val fqn = importMap.elementToFqn(element, range)
+                fqn == it.qualifiedNamedItem.item.qualifiedName
+            }
+            if (candidate != null) {
+                candidates.add(candidate)
+            }
+        }
+    }
+}
+
+/**
+ * Records mapping between offsets (relative to copy/paste content range) and fully qualified names of resolved items
+ * from paths and method calls.
+ */
+private fun createFqnMap(file: RsFile, range: TextRange): ImportMap {
+    val elements = gatherElements(file, range)
+    val fqnMap = hashMapOf<Int, String>()
+
+    val visitor = object : RsRecursiveVisitor() {
+        override fun visitPath(path: RsPath) {
+            val target = (path.reference?.resolve() as? RsQualifiedNamedElement)?.qualifiedName
+            if (target != null) {
+                fqnMap[toRelativeOffset(path, range)] = target
+            }
+
+            super.visitPath(path)
+        }
+
+        override fun visitMethodCall(methodCall: RsMethodCall) {
+            val methods = methodCall.inference?.getResolvedMethod(methodCall)
+            val target = methods?.firstNotNullOfOrNull {
+                it.source.implementedTrait?.element?.qualifiedName
+            }
+
+            if (target != null) {
+                fqnMap[toRelativeOffset(methodCall, range)] = target
+            }
+
+            super.visitMethodCall(methodCall)
+        }
+
+        override fun visitPatBinding(binding: RsPatBinding) {
+            val target = (binding.reference.resolve() as? RsQualifiedNamedElement)?.qualifiedName
+            if (target != null) {
+                fqnMap[toRelativeOffset(binding, range)] = target
+            }
+            super.visitPatBinding(binding)
+        }
+    }
+    for (element in elements) {
+        element.accept(visitor)
+    }
+
+    return ImportMap(fqnMap)
+}
+
+private fun gatherElements(file: RsFile, range: TextRange): List<PsiElement> =
+    CollectHighlightsUtil.getElementsInRange(file, range.startOffset, range.endOffset)
+
+private fun toRelativeOffset(element: PsiElement, range: TextRange): Int = element.startOffset - range.startOffset

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -138,6 +138,7 @@
 
         <!-- Copy paste processors -->
         <copyPastePostProcessor implementation="org.rust.ide.typing.paste.RsConvertJsonToStructCopyPasteProcessor"/>
+        <copyPastePostProcessor implementation="org.rust.ide.typing.paste.RsImportCopyPasteProcessor"/>
 
         <!-- Imports -->
 

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -105,6 +105,7 @@ run.target.rustc.executable.version.label=Rustc version:
 
 settings.rust.auto.import.on.completion=Import out-of-scope items on completion
 settings.rust.auto.import.show.popup=Show import popup
+settings.rust.auto.import.on.paste=Insert imports on paste
 settings.rust.auto.import.title=Rust
 
 settings.rust.cargo.auto.update.project.label=Update project automatically when Cargo.toml changes

--- a/src/test/kotlin/org/rust/FileTree.kt
+++ b/src/test/kotlin/org/rust/FileTree.kt
@@ -223,7 +223,9 @@ class TestProject(
             else -> error("More than one file with carets found: $filesWithCaret")
         }
 
-    val fileWithCaretOrSelection: String get() = filesWithCaret.singleOrNull() ?: filesWithSelection.single()
+    val fileWithCaretOrSelection: String get() = filesWithCaret.singleOrNull() ?: fileWithSelection
+
+    val fileWithSelection: String get() = filesWithSelection.single()
 
     inline fun <reified T : PsiElement> findElementInFile(path: String): T {
         return doFindElementInFile(path, T::class.java)

--- a/src/test/kotlin/org/rust/ide/typing/paste/RsAddImportOnCopyPasteTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/paste/RsAddImportOnCopyPasteTest.kt
@@ -1,0 +1,625 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.typing.paste
+
+import com.intellij.openapi.actionSystem.IdeActions
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.fileTreeFromText
+
+class RsAddImportOnCopyPasteTest : RsTestBase() {
+    fun `test type reference`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo::S;
+
+            <selection>fn fun(_: S) {}</selection>
+        }
+
+        mod baz {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo::S;
+
+            fn fun(_: S) {}
+        }
+
+        mod baz {
+            use crate::foo::S;
+
+            fn fun(_: S) {}
+        }
+    """)
+
+    fun `test expression context`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub struct S;
+
+            impl S {
+                pub fn new() -> Self { S }
+            }
+        }
+
+        mod bar {
+            use crate::foo::S;
+
+            <selection>fn fun() {
+                let _ = S::new();
+            }</selection>
+        }
+
+        mod baz {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub struct S;
+
+            impl S {
+                pub fn new() -> Self { S }
+            }
+        }
+
+        mod bar {
+            use crate::foo::S;
+
+            fn fun() {
+                let _ = S::new();
+            }
+        }
+
+        mod baz {
+            use crate::foo::S;
+
+            fn fun() {
+                let _ = S::new();
+            }
+        }
+    """)
+
+    fun `test method call import trait`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub trait Trait {
+                fn foo(&self) {}
+            }
+
+            impl Trait for () {
+                fn foo(&self) {}
+            }
+        }
+
+        mod bar {
+            use crate::foo::Trait;
+
+            <selection>fn fun() {
+                ().foo();
+            }</selection>
+        }
+
+        mod baz {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub trait Trait {
+                fn foo(&self) {}
+            }
+
+            impl Trait for () {
+                fn foo(&self) {}
+            }
+        }
+
+        mod bar {
+            use crate::foo::Trait;
+
+            fn fun() {
+                ().foo();
+            }
+        }
+
+        mod baz {
+            use crate::foo::Trait;
+
+            fn fun() {
+                ().foo();
+            }
+        }
+    """)
+
+    fun `test import from multiple elements`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub struct S1;
+            pub struct S2;
+            pub struct S3;
+        }
+
+        mod bar {
+            use crate::foo::S1;
+            use crate::foo::S2;
+            use crate::foo::S3;
+
+            <selection>fn fun1(_: S1) {}
+            fn fun2(_: S2) {}
+            fn fun3(_: S3) {}</selection>
+        }
+
+        mod baz {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub struct S1;
+            pub struct S2;
+            pub struct S3;
+        }
+
+        mod bar {
+            use crate::foo::S1;
+            use crate::foo::S2;
+            use crate::foo::S3;
+
+            fn fun1(_: S1) {}
+            fn fun2(_: S2) {}
+            fn fun3(_: S3) {}
+        }
+
+        mod baz {
+            use crate::foo::{S1, S2, S3};
+
+            fn fun1(_: S1) {}
+            fn fun2(_: S2) {}
+            fn fun3(_: S3) {}
+        }
+    """)
+
+    fun `test import from other file`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo;
+        mod bar;
+
+        //- foo.rs
+        pub struct S;
+
+        <selection>fn fun(_: S) {}</selection>
+
+        //- bar.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        mod foo;
+        mod bar;
+
+        //- foo.rs
+        pub struct S;
+
+        fn fun(_: S) {}
+
+        //- bar.rs
+        use crate::foo::S;
+
+        fn fun(_: S) {}
+    """)
+
+    fun `test ambiguous import 1`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo1 {
+            pub struct S;
+        }
+        mod foo2 {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo1::S;
+
+            <selection>fn fun(_: S) {}</selection>
+        }
+
+        mod baz {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo1 {
+            pub struct S;
+        }
+        mod foo2 {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo1::S;
+
+            fn fun(_: S) {}
+        }
+
+        mod baz {
+            use crate::foo1::S;
+
+            fn fun(_: S) {}
+        }
+    """)
+
+    fun `test ambiguous import 2`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo1 {
+            pub struct S;
+        }
+        mod foo2 {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo2::S;
+
+            <selection>fn fun(_: S) {}</selection>
+        }
+
+        mod baz {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo1 {
+            pub struct S;
+        }
+        mod foo2 {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo2::S;
+
+            fn fun(_: S) {}
+        }
+
+        mod baz {
+            use crate::foo2::S;
+
+            fn fun(_: S) {}
+        }
+    """)
+
+    fun `test ambiguous trait import 1`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub trait Trait1 {
+                fn foo(&self) {}
+            }
+            impl Trait1 for () {
+                fn foo(&self) {}
+            }
+
+            pub trait Trait2 {
+                fn foo(&self) {}
+            }
+            impl Trait2 for () {
+                fn foo(&self) {}
+            }
+        }
+
+        mod bar {
+            use crate::foo::Trait1;
+
+            <selection>fn fun() {
+                ().foo();
+            }</selection>
+        }
+
+        mod baz {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub trait Trait1 {
+                fn foo(&self) {}
+            }
+            impl Trait1 for () {
+                fn foo(&self) {}
+            }
+
+            pub trait Trait2 {
+                fn foo(&self) {}
+            }
+            impl Trait2 for () {
+                fn foo(&self) {}
+            }
+        }
+
+        mod bar {
+            use crate::foo::Trait1;
+
+            fn fun() {
+                ().foo();
+            }
+        }
+
+        mod baz {
+            use crate::foo::Trait1;
+
+            fn fun() {
+                ().foo();
+            }
+        }
+    """)
+
+    fun `test ambiguous trait import 2`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub trait Trait1 {
+                fn foo(&self) {}
+            }
+            impl Trait1 for () {
+                fn foo(&self) {}
+            }
+
+            pub trait Trait2 {
+                fn foo(&self) {}
+            }
+            impl Trait2 for () {
+                fn foo(&self) {}
+            }
+        }
+
+        mod bar {
+            use crate::foo::Trait2;
+
+            <selection>fn fun() {
+                ().foo();
+            }</selection>
+        }
+
+        mod baz {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub trait Trait1 {
+                fn foo(&self) {}
+            }
+            impl Trait1 for () {
+                fn foo(&self) {}
+            }
+
+            pub trait Trait2 {
+                fn foo(&self) {}
+            }
+            impl Trait2 for () {
+                fn foo(&self) {}
+            }
+        }
+
+        mod bar {
+            use crate::foo::Trait2;
+
+            fn fun() {
+                ().foo();
+            }
+        }
+
+        mod baz {
+            use crate::foo::Trait2;
+
+            fn fun() {
+                ().foo();
+            }
+        }
+    """)
+
+    fun `test do not import private item`() = doCopyPasteTest("""
+        //- lib.rs
+        mod a {
+            pub struct S;
+            pub fn foo1() -> S { S }
+        }
+
+        mod b {
+            struct S;
+            <selection>fn foo2() -> S { S }</selection>
+        }
+
+        /*caret*/
+    """, """
+        //- lib.rs
+        mod a {
+            pub struct S;
+            pub fn foo1() -> S { S }
+        }
+
+        mod b {
+            struct S;
+            fn foo2() -> S { S }
+        }
+
+        fn foo2() -> S { S }
+    """)
+
+    fun `test copy paste same location`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo::S;
+
+            <selection>fn fun(_: S) {}</selection>
+            fn fun2() {}
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo::S;
+
+            fn fun(_: S) {}
+            fn fun2() {}
+            fn fun(_: S) {}
+        }
+    """)
+
+    fun `test pat qualified path`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub mod consts {
+                pub const CONST: u32 = 1;
+            }
+
+            fn bar(a: u32) -> u32 {
+                <selection>match a {
+                    consts::CONST => 1,
+                    _ => 2
+                }</selection>
+            }
+        }
+
+        mod baz {
+            fn bar(a: u32) -> u32 {
+                /*caret*/
+            }
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub mod consts {
+                pub const CONST: u32 = 1;
+            }
+
+            fn bar(a: u32) -> u32 {
+                match a {
+                    consts::CONST => 1,
+                    _ => 2
+                }
+            }
+        }
+
+        mod baz {
+            use crate::foo::consts;
+
+            fn bar(a: u32) -> u32 {
+                match a {
+                    consts::CONST => 1,
+                    _ => 2
+                }
+            }
+        }
+    """)
+
+    fun `test pat binding`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub const CONST: u32 = 1;
+
+            fn bar(a: u32) -> u32 {
+                <selection>match a {
+                    CONST => 1,
+                    _ => 2
+                }</selection>
+            }
+        }
+
+        mod baz {
+            fn bar(a: u32) -> u32 {
+                /*caret*/
+            }
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub const CONST: u32 = 1;
+
+            fn bar(a: u32) -> u32 {
+                match a {
+                    CONST => 1,
+                    _ => 2
+                }
+            }
+        }
+
+        mod baz {
+            use crate::foo::CONST;
+
+            fn bar(a: u32) -> u32 {
+                match a {
+                    CONST => 1,
+                    _ => 2
+                }
+            }
+        }
+    """)
+
+    fun `test copy with whitespace`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo::S;<selection>
+
+            fn fun(_: S) {}</selection>
+        }
+
+        mod baz {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            use crate::foo::S;
+
+            fn fun(_: S) {}
+        }
+
+        mod baz {
+            use crate::foo::S;
+
+            fn fun(_: S) {}
+        }
+    """)
+
+    private fun doCopyPasteTest(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String
+    ) {
+        val testProject = fileTreeFromText(before).create()
+        myFixture.configureFromTempProjectFile(testProject.fileWithSelection)
+        myFixture.performEditorAction(IdeActions.ACTION_COPY)
+
+        myFixture.configureFromTempProjectFile(testProject.fileWithCaret)
+        myFixture.performEditorAction(IdeActions.ACTION_PASTE)
+
+        fileTreeFromText(after).assertEquals(myFixture.findFileInTempDir("."))
+    }
+}


### PR DESCRIPTION
This PR adds a copy/paste postprocessor that tries to import unresolved items from the pasted code. There is also some crude support for selecting between ambiguous imports.

I took inspiration from the Kotlin plugin, mainly with the data flavor thing, I'm not sure how that's supposed to work.

![auto-import](https://user-images.githubusercontent.com/4539057/127229710-9b4ec896-e4dc-41ac-ab7e-b91d59670498.gif)

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7241

changelog: Automatically import unresolved items after copy/pasting Rust code.