### PR TITLE
QDOC: Display implied shortcut reference links in quick documentation

### DIFF
--- a/src/test/kotlin/org/rust/ide/docs/RsRenderedDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsRenderedDocumentationTest.kt
@@ -141,6 +141,46 @@ class RsRenderedDocumentationTest : RsDocumentationProviderTest() {
         """<p><a href="psi_element://Long::Path::For::MyType">my link</a></p>"""
     )
 
+    fun `test implied shortcut reference link`() = doTest("""
+        fn foo() {}
+        /// [foo]
+        fn main() {}
+           //^
+    """,
+        """<p><a href="psi_element://foo">foo</a></p>"""
+    )
+
+    fun `test implied shortcut reference link with backticks`() = doTest("""
+        /// [`Iterator`]
+        fn main() {}
+           //^
+    """,
+        """<p><a href="psi_element://Iterator"><code>Iterator</code></a></p>"""
+    )
+
+    fun `test implied shortcut reference link, ignore non-valid rust identifier or path`() {
+        val badVariants = listOf("some.web.site", "foo bar w spaces", "some/path")
+        for (s in badVariants) {
+            doTest("""
+                    /// [${s}]
+                    fn main() {}
+                       //^
+                """, """<p>[${s}]</p>"""
+            )
+        }
+    }
+
+    fun `test implied shortcut reference link with reference, reference has higher priority`() = doTest("""
+        fn foo() {}
+        /// [foo]
+        ///
+        /// [foo]: Path::For::Smth
+        fn main() {}
+           //^
+    """,
+        """<p><a href="psi_element://Path::For::Smth">foo</a></p>"""
+    )
+
     private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String?) {
         doTest(code, expected) { originalItem, _ ->
             (originalItem as? RsDocAndAttributeOwner)


### PR DESCRIPTION
Info about that type of links can be found [there](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html#implied-shortcut-reference-links). In short, string `[ABC]` should be rendered as `<a html="psi_element://ABC">ABC</a>` if there are no references (such as `[ABC]: www.github.com`) and `ABC` looks like valid Rust identifier or path. So it's essentially the same as `[ABC](ABC)` but a little bit shorter.
As far as I know it's not a part of any markdown standard, but it's extensively used in rust docs and worth implementing I think.
Below is one example before/after. The links are clickable
![image](https://user-images.githubusercontent.com/8329446/127268760-b9303dc5-23ee-4a44-a1af-43c0ae5930b4.png)
![image](https://user-images.githubusercontent.com/8329446/127268768-0dff789a-d7b5-4a36-9f32-5add26b516a1.png)


changelog: Display implied shortcut reference links in quick documentation
