### PR TITLE
INSP: Implement property redefinition inspection in TOML

### DIFF
--- a/intellij-toml/core/src/main/kotlin/org/toml/ide/inspections/TomlPropertyRedefinitionInspection.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/ide/inspections/TomlPropertyRedefinitionInspection.kt
@@ -1,0 +1,46 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.inspections
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.toml.lang.psi.*
+
+class TomlPropertyRedefinitionInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        val elements = hashSetOf<List<String>>()
+
+        return object : TomlVisitor() {
+            override fun visitElement(element: TomlElement) {
+                if (element !is TomlKey) return
+
+                val path = element.path
+                if (path in elements) {
+                    holder.registerProblem(element, "Property redefinition is not allowed")
+                } else {
+                    elements.add(path)
+                }
+            }
+        }
+    }
+}
+
+val TomlElement.path: List<String>
+    get() {
+        var current = when (this) {
+            is TomlKeyValue -> this.key.segments.map { it.text }
+            is TomlTable -> this.header.key?.segments?.map { it.text }
+            else -> null
+        } ?: emptyList()
+
+        if (this.parent !is TomlFile) {
+            val parentPath = (this.parent as TomlElement).path
+            current = parentPath + current
+        }
+
+        return current
+    }

--- a/intellij-toml/core/src/main/resources/META-INF/toml-core.xml
+++ b/intellij-toml/core/src/main/resources/META-INF/toml-core.xml
@@ -41,5 +41,11 @@
                          displayName="Unresolved reference"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.toml.ide.inspections.TomlUnresolvedReferenceInspection"/>
+
+        <localInspection language="TOML"
+                         groupName="TOML"
+                         displayName="Property redefinition"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.toml.ide.inspections.TomlPropertyRedefinitionInspection"/>
     </extensions>
 </idea-plugin>

--- a/intellij-toml/core/src/main/resources/inspectionDescriptions/TomlPropertyRedefinition.html
+++ b/intellij-toml/core/src/main/resources/inspectionDescriptions/TomlPropertyRedefinition.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Reports property redefinitions in TOML files.
+</body>
+</html>

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/annotator/TomlAnnotationTestBase.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/annotator/TomlAnnotationTestBase.kt
@@ -11,7 +11,7 @@ import org.toml.TomlTestBase
 
 abstract class TomlAnnotationTestBase : TomlTestBase() {
 
-    private lateinit var annotationFixture: TomlAnnotationTestFixture
+    protected lateinit var annotationFixture: TomlAnnotationTestFixture
 
     override fun setUp() {
         super.setUp()

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/inspections/TomlInspectionsTestBase.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/inspections/TomlInspectionsTestBase.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.inspections
+
+import com.intellij.codeInspection.InspectionProfileEntry
+import org.toml.ide.annotator.TomlAnnotationTestBase
+import org.toml.ide.annotator.TomlAnnotationTestFixture
+import kotlin.reflect.KClass
+
+abstract class TomlInspectionsTestBase(
+    private val inspectionClass: KClass<out InspectionProfileEntry>
+) : TomlAnnotationTestBase() {
+
+    override fun createAnnotationFixture(): TomlAnnotationTestFixture =
+        TomlAnnotationTestFixture(this, myFixture, inspectionClasses = listOf(inspectionClass))
+
+    private lateinit var inspection: InspectionProfileEntry
+
+    override fun setUp() {
+        super.setUp()
+        inspection = annotationFixture.enabledInspections[0]
+    }
+}

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/inspections/TomlPropertyRedefinitionInspectionTest.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/inspections/TomlPropertyRedefinitionInspectionTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.inspections
+
+class TomlPropertyRedefinitionInspectionTest : TomlInspectionsTestBase(TomlPropertyRedefinitionInspection::class) {
+    fun `test in keys`() = checkByText("""
+        foo = "bar"
+        <error descr="Property redefinition is not allowed">foo</error> = "baz"
+    """)
+
+    fun `test in table`() = checkByText("""
+        foo.bar = 1
+
+        [foo]
+        <error descr="Property redefinition is not allowed">bar</error> = 2
+    """)
+
+    fun `test in inline table`() = checkByText("""
+        foo.bar = 1
+        foo = { <error descr="Property redefinition is not allowed">bar</error> = "" }
+    """)
+}

--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -11,8 +11,7 @@
     <!-- TODO: create normal change note list -->
     <change-notes><![CDATA[
         <ul>
-            <li>Annotate and provide quick-fix for trailing commas in inline tables</li>
-            <li>Restore missing icon for TOML files</li>
+            <li>Highlight property redefinitions as errors</li>
         </ul>
     ]]>
     </change-notes>


### PR DESCRIPTION
As TOML doesn't allow redefinition of properties, it should be useful to highlight such problems inside TOML files.

<img width="400" src="https://user-images.githubusercontent.com/6342851/127324260-ec3da14c-2a7b-4909-8440-2de6cfa52a79.png">