### PR TITLE
INSP: Take into account `start` feature in `Main function not found` inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
@@ -7,6 +7,8 @@ package org.rust.ide.inspections
 
 import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
+import org.rust.lang.core.FeatureAvailability
+import org.rust.lang.core.START
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsVisitor
@@ -29,6 +31,7 @@ class RsMainFunctionNotFoundInspection : RsLocalInspectionTool() {
                     if (!file.isCrateRoot) return
 
                     if (file.queryAttributes.hasAttribute("no_main")) return
+                    if (START.availability(file) == FeatureAvailability.AVAILABLE) return
                     if (file.childrenOfType<RsFunction>().lastOrNull { fn -> "main" == fn.name } != null) return
 
                     RsDiagnostic.MainFunctionNotFound(file, crate.presentableName).addToHolder(holder)

--- a/src/test/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections
 
+import org.rust.MockRustcVersion
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
 
@@ -26,6 +27,30 @@ class RsMainFunctionNotFoundInspectionTest : RsInspectionsTestBase(RsMainFunctio
         <error descr="`main` function not found in crate `test-package` [E0601]">
         fn foo() {
             fn bar(<error> </error>{/*caret*/}
+        }
+        </error>
+    """)
+
+    @MockRustcVersion("1.0.0-nightly")
+    fun `test start feature available`() = checkByFileTree("""
+    //- main.rs
+        #![feature(start)]
+
+        #[start]
+        fn start(_argc: isize, _argv: *const *const u8) -> isize {
+            0/*caret*/
+        }
+    """)
+
+    @MockRustcVersion("1.0.0")
+    fun `test start feature not available`() = checkByFileTree("""
+    //- main.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]">
+        #![feature(start)]
+
+        #[start]
+        fn start(_argc: isize, _argv: *const *const u8) -> isize {
+            0/*caret*/
         }
         </error>
     """)


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/7621.

changelog: Take into account `start` feature in `Main function not found` inspection
