### PR TITLE
REF: use aliases in Extract function refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -58,7 +58,7 @@ class Parameter private constructor(
         } else {
             ""
         }
-    private val typeText: String = type?.renderInsertionSafe(skipUnchangedDefaultTypeArguments = true).orEmpty()
+    private val typeText: String = type?.renderInsertionSafe(useAliasNames = true, skipUnchangedDefaultTypeArguments = true).orEmpty()
 
     val originalParameterText: String
         get() = if (type != null) "$mutText$originalName: $referenceText$typeText" else originalName
@@ -183,7 +183,7 @@ class RsExtractFunctionConfig private constructor(
         }
         append("fn $name$typeParametersText(${if (isOriginal) originalParametersText else parametersText})")
         if (returnValue != null && returnValue.type !is TyUnit) {
-            append(" -> ${returnValue.type.renderInsertionSafe(skipUnchangedDefaultTypeArguments = true)}")
+            append(" -> ${returnValue.type.renderInsertionSafe(useAliasNames = true, skipUnchangedDefaultTypeArguments = true)}")
         }
         append(whereClausesText)
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1373,6 +1373,46 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """, "bar")
 
+    fun `test respect aliases in extracted function`() = doTest("""
+        struct S;
+        struct R<T>(T);
+
+        type Type1 = S;
+        type Type2 = u32;
+        type Type3 = R<u32>;
+
+        fn foo() -> Type3 {
+            let a: Type1 = S;
+            let b: Type3 = R(0);
+            let e: Type2 = 0;
+
+            <selection>let c = a;
+            let d = b;
+            (d, e)</selection>
+        }
+    """, """
+        struct S;
+        struct R<T>(T);
+
+        type Type1 = S;
+        type Type2 = u32;
+        type Type3 = R<u32>;
+
+        fn foo() -> Type3 {
+            let a: Type1 = S;
+            let b: Type3 = R(0);
+            let e: Type2 = 0;
+
+            bar(a, b, e)
+        }
+
+        fn bar(a: Type1, b: Type3, e: Type2) -> (Type3, Type2) {
+            let c = a;
+            let d = b;
+            (d, e)
+        }
+    """, "bar")
+
     private fun doTest(
         @Language("Rust") code: String,
         @Language("Rust") excepted: String,


### PR DESCRIPTION
This PR modifies the Extract function refactoring so that it respects aliases. Same as with [`skipUnchangedDefaultTypeArguments`](https://github.com/intellij-rust/intellij-rust/pull/7570), I think that `useAliasNames` should default to `true`.

changelog: Respect type aliases in Extract function refactoring.