### PR TITLE
Change useAliasNames and skipUnchangedDefaultTypeArguments defaults to true in type rendering and import helper

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -433,7 +433,7 @@ private fun checkParameterTraitMatch(argument: RsFormatMacroArg, parameter: Form
         !expr.implLookup.canSelectWithDeref(TraitRef(expr.type, requiredTrait.withSubst()))) {
         return ErrorAnnotation(
             argument.textRange,
-            "`${expr.type.render(useAliasNames = true)}` doesn't implement `${requiredTrait.name}`" +
+            "`${expr.type.render()}` doesn't implement `${requiredTrait.name}`" +
                 " (required by ${parameter.matchInfo.text})",
             isTraitError = true
         )

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFix.kt
@@ -235,11 +235,7 @@ private fun suffix(number: Int): String {
 }
 
 private fun renderType(ty: Ty): String =
-    ty.renderInsertionSafe(
-        skipUnchangedDefaultTypeArguments = true,
-        useAliasNames = true,
-        includeLifetimeArguments = true
-    )
+    ty.renderInsertionSafe(includeLifetimeArguments = true)
 
 private fun getExistingParameterNames(usedNames: MutableSet<String>, function: RsFunction) {
     val visitor = object : RsRecursiveVisitor() {

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
@@ -25,7 +25,6 @@ import org.rust.lang.core.types.ty.TyUnit
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
 
-
 class ChangeReturnTypeFix(
     element: RsElement,
     private val actualTy: Ty
@@ -44,15 +43,14 @@ class ChangeReturnTypeFix(
         }
 
         val useQualifiedName = if (callable != null) {
-            getTypeReferencesInfoFromTys(callable, actualTy, useAliases = true).toQualify
+            getTypeReferencesInfoFromTys(callable, actualTy).toQualify
         } else {
             emptySet()
         }
 
         val rendered = actualTy.render(
             context = element,
-            useQualifiedName = useQualifiedName,
-            useAliasNames = true
+            useQualifiedName = useQualifiedName
         )
         "Change return type$item$name to '$rendered'"
     }
@@ -76,12 +74,11 @@ class ChangeReturnTypeFix(
         }
 
         val oldTy = oldRetType?.typeReference?.type ?: TyUnknown
-        val (_, useQualifiedName) = getTypeReferencesInfoFromTys(owner, actualTy, oldTy, useAliases = true)
+        val (_, useQualifiedName) = getTypeReferencesInfoFromTys(owner, actualTy, oldTy)
         val text = actualTy.renderInsertionSafe(
             context = startElement as? RsElement,
             useQualifiedName = useQualifiedName,
-            includeLifetimeArguments = true,
-            useAliasNames = true
+            includeLifetimeArguments = true
         )
         val retType = RsPsiFactory(project).createRetType(text)
 
@@ -91,7 +88,7 @@ class ChangeReturnTypeFix(
             owner.addAfter(retType, owner.valueParameterList)
         }
 
-        importTypeReferencesFromTy(owner, actualTy, useAliases = true)
+        importTypeReferencesFromTy(owner, actualTy)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertLetDeclTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertLetDeclTypeFix.kt
@@ -35,7 +35,7 @@ class ConvertLetDeclTypeFix(
     ) {
         val decl = startElement as? RsLetDecl ?: return
         val factory = RsPsiFactory(project)
-        val type = factory.tryCreateType(ty.renderInsertionSafe(useAliasNames = true)) ?: return
+        val type = factory.tryCreateType(ty.renderInsertionSafe()) ?: return
 
         decl.typeReference?.replace(type)
     }

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyFix.kt
@@ -17,7 +17,7 @@ abstract class ConvertToTyFix(
 ) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
 
     constructor(expr: RsExpr, ty: Ty, convertSubject: String) :
-        this(expr, ty.render(skipUnchangedDefaultTypeArguments = true), convertSubject)
+        this(expr, ty.render(), convertSubject)
 
     override fun getFamilyName(): String = "Convert to type"
     override fun getText(): String = "Convert to $tyName using $convertSubject"

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -88,7 +88,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
 
     private fun generateDoc(element: RsPatBinding, buffer: StringBuilder) {
         val presentationInfo = element.presentationInfo ?: return
-        val type = element.type.render(useAliasNames = true).escaped
+        val type = element.type.render().escaped
         buffer += presentationInfo.type
         buffer += " "
         buffer.b { it += presentationInfo.name }

--- a/src/main/kotlin/org/rust/ide/hints/type/RsExpressionTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsExpressionTypeProvider.kt
@@ -37,7 +37,7 @@ class RsExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
 
     override fun getInformationHint(element: PsiElement): String {
         val type = getType(element)
-        return type.render(useAliasNames = true).escaped
+        return type.render(skipUnchangedDefaultTypeArguments = false).escaped
     }
 
     private fun getType(element: PsiElement): Ty = when (element) {

--- a/src/main/kotlin/org/rust/ide/intentions/DestructureIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/DestructureIntention.kt
@@ -65,7 +65,7 @@ class DestructureIntention : RsElementBaseIntentionAction<DestructureIntention.C
         val (newPat, replaceContext) = createDestructuredPat(ctx, factory, toRename, bindings)
 
         if (ctx is Context.Struct) {
-            importTypeReferencesFromTy(newPat, ctx.type, true)
+            importTypeReferencesFromTy(newPat, ctx.type)
         }
 
         when (replaceContext) {
@@ -94,7 +94,7 @@ class DestructureIntention : RsElementBaseIntentionAction<DestructureIntention.C
     ): Pair<RsElement, ReplaceContext> {
         return when (ctx) {
             is Context.Struct -> {
-                val typeName = ctx.type.render(includeTypeArguments = false, useAliasNames = true)
+                val typeName = ctx.type.render(includeTypeArguments = false)
                 val struct = ctx.struct
 
                 if (struct.isTupleStruct) {

--- a/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
@@ -55,11 +55,11 @@ class SpecifyTypeExplicitlyIntention : RsElementBaseIntentionAction<SpecifyTypeE
 
     override fun invoke(project: Project, editor: Editor, ctx: Context) {
         val factory = RsPsiFactory(project)
-        val createdType = factory.createType(ctx.type.renderInsertionSafe(useAliasNames = true))
+        val createdType = factory.createType(ctx.type.renderInsertionSafe())
         val letDecl = ctx.letDecl
         val colon = letDecl.addAfter(factory.createColon(), letDecl.pat)
         letDecl.addAfter(createdType, colon)
-        importTypeReferencesFromTy(ctx.letDecl, ctx.type, useAliases = true)
+        importTypeReferencesFromTy(ctx.letDecl, ctx.type)
     }
 
 

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
@@ -160,7 +160,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
             parameters.add(0, "&self")
         }
         val returnType = if (config.returnType !is TyUnit) {
-            " -> ${config.returnType.renderInsertionSafe(useAliasNames = true)}"
+            " -> ${config.returnType.renderInsertionSafe()}"
         } else ""
         val paramsText = parameters.joinToString(", ")
 
@@ -178,7 +178,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
         val arguments = ctx.arguments
 
         val parameters = arguments.exprList.mapIndexed { index, expr ->
-            "p$index: ${expr.type.renderInsertionSafe(useAliasNames = true)}"
+            "p$index: ${expr.type.renderInsertionSafe()}"
         }
 
         val returnType = ctx.returnType.type.takeIf { it != TyUnknown } ?: TyUnit.INSTANCE

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -40,8 +40,8 @@ fun Ty.render(
     useQualifiedName: Set<RsQualifiedNamedElement> = emptySet(),
     includeTypeArguments: Boolean = true,
     includeLifetimeArguments: Boolean = false,
-    useAliasNames: Boolean = false,
-    skipUnchangedDefaultTypeArguments: Boolean = false
+    useAliasNames: Boolean = true,
+    skipUnchangedDefaultTypeArguments: Boolean = true
 ): String = TypeRenderer(
     context = context,
     unknown = unknown,
@@ -63,8 +63,8 @@ fun Ty.renderInsertionSafe(
     useQualifiedName: Set<RsQualifiedNamedElement> = emptySet(),
     includeTypeArguments: Boolean = true,
     includeLifetimeArguments: Boolean = false,
-    useAliasNames: Boolean = false,
-    skipUnchangedDefaultTypeArguments: Boolean = false
+    useAliasNames: Boolean = true,
+    skipUnchangedDefaultTypeArguments: Boolean = true
 ): String = TypeRenderer(
     context = context,
     unknown = "_",
@@ -82,7 +82,7 @@ fun Ty.renderInsertionSafe(
 
 val Ty.shortPresentableText: String
     get() = generateSequence(1) { it + 1 }
-        .map { render(level = it, unknown = "?", useAliasNames = true) }
+        .map { render(level = it, unknown = "?") }
         .withPrevious()
         .takeWhile { (cur, prev) ->
             cur != prev && (prev == null || cur.length <= MAX_SHORT_TYPE_LEN)

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
@@ -80,7 +80,7 @@ fun processFunction(
     changeUnsafe(factory, function, config)
 
     for (type in config.additionalTypesToImport) {
-        RsImportHelper.importTypeReferencesFromTy(function, type, useAliases = true)
+        RsImportHelper.importTypeReferencesFromTy(function, type)
     }
 }
 
@@ -122,8 +122,7 @@ private fun changeReturnType(factory: RsPsiFactory, function: RsFunction, config
         if (config.returnType !is TyUnit) {
             val ret = factory.createRetType(config.returnTypeReference.text)
             function.addAfter(ret, function.valueParameterList) as RsRetType
-            RsImportHelper.importTypeReferencesFromTy(function, config.returnType,
-                useAliases = true, skipUnchangedDefaultTypeArguments = true)
+            RsImportHelper.importTypeReferencesFromTy(function, config.returnType)
         }
     }
 }
@@ -141,8 +140,7 @@ private fun changeArguments(
     }
     for (parameter in config.parameters) {
         val defaultValue = parameter.defaultValue.item ?: continue
-        RsImportHelper.importTypeReferencesFromElements(arguments, setOf(defaultValue),
-            useAliases = true, skipUnchangedDefaultTypeArguments = true)
+        RsImportHelper.importTypeReferencesFromElements(arguments, setOf(defaultValue))
     }
     val argumentsCopy = arguments.copy() as RsValueArgumentList
     val argumentsList = argumentsCopy.exprList
@@ -283,8 +281,7 @@ private fun PsiElement.collectSurroundingWhiteSpaceAndComments(): List<PsiElemen
 
 private fun importParameterTypes(descriptors: List<Parameter>, context: RsElement) {
     for (descriptor in descriptors) {
-        RsImportHelper.importTypeReferencesFromElements(context, setOf(descriptor.typeReference),
-            useAliases = true, skipUnchangedDefaultTypeArguments = true)
+        RsImportHelper.importTypeReferencesFromElements(context, setOf(descriptor.typeReference))
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -58,7 +58,7 @@ class Parameter private constructor(
         } else {
             ""
         }
-    private val typeText: String = type?.renderInsertionSafe(useAliasNames = true, skipUnchangedDefaultTypeArguments = true).orEmpty()
+    private val typeText: String = type?.renderInsertionSafe().orEmpty()
 
     val originalParameterText: String
         get() = if (type != null) "$mutText$originalName: $referenceText$typeText" else originalName
@@ -183,7 +183,7 @@ class RsExtractFunctionConfig private constructor(
         }
         append("fn $name$typeParametersText(${if (isOriginal) originalParametersText else parametersText})")
         if (returnValue != null && returnValue.type !is TyUnit) {
-            append(" -> ${returnValue.type.renderInsertionSafe(useAliasNames = true, skipUnchangedDefaultTypeArguments = true)}")
+            append(" -> ${returnValue.type.renderInsertionSafe()}")
         }
         append(whereClausesText)
     }

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
@@ -46,7 +46,7 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
             val parameters = config.valueParameters.filter { it.isSelected }
             renameFunctionParameters(extractedFunction, parameters.map { it.name })
             val types = (parameters.map { it.type } + config.returnValue?.type).filterNotNull()
-            importTypeReferencesFromTys(extractedFunction, types, useAliases = true, skipUnchangedDefaultTypeArguments = true)
+            importTypeReferencesFromTys(extractedFunction, types)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/utils/CallInfo.kt
+++ b/src/main/kotlin/org/rust/ide/utils/CallInfo.kt
@@ -23,11 +23,7 @@ class CallInfo private constructor(
     class Parameter(val typeRef: RsTypeReference?, val pattern: String? = null, val type: Ty? = null) {
         fun renderType(): String {
             return if (type != null && type !is TyUnknown) {
-                type.render(
-                    includeLifetimeArguments = true,
-                    useAliasNames = true,
-                    skipUnchangedDefaultTypeArguments = true
-                )
+                type.render(includeLifetimeArguments = true)
             } else {
                 typeRef?.substAndGetText(emptySubstitution) ?: "_"
             }

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -23,8 +23,8 @@ object RsImportHelper {
         context: RsElement,
         elements: Collection<RsElement>,
         subst: Substitution = emptySubstitution,
-        useAliases: Boolean = false,
-        skipUnchangedDefaultTypeArguments: Boolean = false
+        useAliases: Boolean = true,
+        skipUnchangedDefaultTypeArguments: Boolean = true
     ) {
         val (toImport, _) = getTypeReferencesInfoFromElements(context, elements, subst, useAliases, skipUnchangedDefaultTypeArguments)
         importElements(context, toImport)
@@ -33,8 +33,8 @@ object RsImportHelper {
     fun importTypeReferencesFromTys(
         context: RsElement,
         tys: Collection<Ty>,
-        useAliases: Boolean = false,
-        skipUnchangedDefaultTypeArguments: Boolean = false
+        useAliases: Boolean = true,
+        skipUnchangedDefaultTypeArguments: Boolean = true
     ) {
         val (toImport, _) = getTypeReferencesInfoFromTys(
             context,
@@ -48,8 +48,8 @@ object RsImportHelper {
     fun importTypeReferencesFromTy(
         context: RsElement,
         ty: Ty,
-        useAliases: Boolean = false,
-        skipUnchangedDefaultTypeArguments: Boolean = false
+        useAliases: Boolean = true,
+        skipUnchangedDefaultTypeArguments: Boolean = true
     ) {
         importTypeReferencesFromTys(context, listOf(ty), useAliases, skipUnchangedDefaultTypeArguments)
     }
@@ -97,8 +97,8 @@ object RsImportHelper {
     fun getTypeReferencesInfoFromTys(
         context: RsElement,
         vararg elemTys: Ty,
-        useAliases: Boolean = false,
-        skipUnchangedDefaultTypeArguments: Boolean = false
+        useAliases: Boolean = true,
+        skipUnchangedDefaultTypeArguments: Boolean = true
     ): TypeReferencesInfo = getTypeReferencesInfo(context, elemTys.toList()) { ty, result ->
         collectImportSubjectsFromTy(ty, emptySubstitution, result, useAliases, skipUnchangedDefaultTypeArguments)
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -350,7 +350,7 @@ class RsPsiFactory(
     }
 
     fun createConstant(name: String, expr: RsExpr): RsConstant =
-        createFromText("const $name: ${expr.type.renderInsertionSafe(useAliasNames = true, includeLifetimeArguments = true)} = ${expr.text};")
+        createFromText("const $name: ${expr.type.renderInsertionSafe(includeLifetimeArguments = true)} = ${expr.text};")
             ?: error("Failed to create constant $name from ${expr.text} ")
 
     private inline fun <reified T : RsElement> createFromText(code: CharSequence): T? =
@@ -570,11 +570,7 @@ fun RsTypeReference.substAndGetText(subst: Substitution): String =
     getStubOnlyText(subst)
 
 fun Ty.substAndGetText(subst: Substitution): String =
-    substitute(subst).renderInsertionSafe(
-        includeLifetimeArguments = true,
-        useAliasNames = true,
-        skipUnchangedDefaultTypeArguments = true
-    )
+    substitute(subst).renderInsertionSafe(includeLifetimeArguments = true)
 
 private fun mutsToRefs(mutability: List<Mutability>): String =
     mutability.joinToString("", "", "") {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -48,7 +48,7 @@ abstract class Ty(override val flags: TypeFlags = 0) : Kind, TypeFoldable<Ty> {
     /**
      * User visible string representation of a type
      */
-    final override fun toString(): String = render()
+    final override fun toString(): String = render(useAliasNames = false, skipUnchangedDefaultTypeArguments = false)
 }
 
 enum class Mutability {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -98,7 +98,7 @@ sealed class RsDiagnostic(
                         val pat = parent.pat
                         if (pat is RsPatIdent &&
                             !actualTy.containsTyOfClass(TyUnknown::class.java, TyAnon::class.java)) {
-                            val text = "Change type of `${pat.patBinding.identifier.text ?: "?"}` to `${actualTy.renderInsertionSafe(useAliasNames = true)}`"
+                            val text = "Change type of `${pat.patBinding.identifier.text ?: "?"}` to `${actualTy.renderInsertionSafe()}`"
                             add(ConvertLetDeclTypeFix(parent, text, actualTy))
                         }
                     }
@@ -1524,12 +1524,12 @@ private val RsSelfParameter.canonicalDecl: String
     }
 
 private fun Ty.rendered(useQualifiedName: Set<RsQualifiedNamedElement> = emptySet()): String =
-    render(useQualifiedName = useQualifiedName, useAliasNames = true)
+    render(useQualifiedName = useQualifiedName)
 
 private fun getConflictingNames(element: PsiElement, vararg tys: Ty): Set<RsQualifiedNamedElement> {
     val context = element.ancestorOrSelf<RsElement>()
     return if (context != null) {
-        getTypeReferencesInfoFromTys(context, *tys, useAliases = true).toQualify
+        getTypeReferencesInfoFromTys(context, *tys).toQualify
     } else {
         emptySet()
     }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddTypeFixTest.kt
@@ -33,6 +33,30 @@ class AddTypeFixTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
         const CONST: (_, _)/*caret*/ = (S, S);
     """)
 
+    fun `test alias`() = checkFixByText("Add type Foo", """
+        type Foo = u32;
+
+        const fn foo() -> Foo { 0 }
+
+        <error>const CONST/*caret*/ = foo();</error>
+    """, """
+        type Foo = u32;
+
+        const fn foo() -> Foo { 0 }
+
+        const CONST: Foo/*caret*/ = foo();
+    """)
+
+    fun `test skip default type argument`() = checkFixByText("Add type Foo", """
+        struct Foo<T = u32>(T);
+
+        <error>const CONST/*caret*/ = Foo(0u32);</error>
+    """, """
+        struct Foo<T = u32>(T);
+
+        const CONST: Foo = Foo(0u32);
+    """)
+
     fun `test missing expr`() = checkFixIsUnavailable("Add type", """
         <error>const CONST/*caret*/;</error>
     """)

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
@@ -159,6 +159,42 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         }
     """)
 
+    fun `test add aliased type`() = checkFixByText("Add `Foo` as `1st` parameter to function `foo`", """
+        fn foo() {}
+
+        type Foo = u32;
+
+        fn bar(f: Foo) {
+            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>f/*caret*/</error>)</error>;
+        }
+    """, """
+        fn foo(f: Foo) {}
+
+        type Foo = u32;
+
+        fn bar(f: Foo) {
+            foo(f);
+        }
+    """)
+
+    fun `test add type with default type argument`() = checkFixByText("Add `Foo` as `1st` parameter to function `foo`", """
+        fn foo() {}
+
+        struct Foo<T = u32>(T);
+
+        fn bar(f: Foo) {
+            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>f/*caret*/</error>)</error>;
+        }
+    """, """
+        fn foo(f: Foo) {}
+
+        struct Foo<T = u32>(T);
+
+        fn bar(f: Foo) {
+            foo(f);
+        }
+    """)
+
     fun `test import argument type`() = checkFixByText("Add `S` as `1st` parameter to function `bar`", """
         mod foo {
             pub fn bar() {}

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntentionTest.kt
@@ -86,4 +86,32 @@ class ConvertClosureToFunctionIntentionTest : RsIntentionTestBase(ConvertClosure
             fn foo(x: i32) -> i32 { x + 1 }/*caret*/
         }
     """)
+
+    fun `test keep aliases`() = doAvailableTest("""
+        type Foo = (u32, u32);
+
+        fn main() {
+            let foo = |x: Foo/*caret*/| { x };
+        }
+    """, """
+        type Foo = (u32, u32);
+
+        fn main() {
+            fn foo(x: Foo) -> Foo { x }/*caret*/
+        }
+    """)
+
+    fun `test skip default type argument`() = doAvailableTest("""
+        struct S<T = u32>(T);
+
+        fn main() {
+            let foo = |s: S/*caret*/| { s };
+        }
+    """, """
+        struct S<T = u32>(T);
+
+        fn main() {
+            fn foo(s: S) -> S { s }/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ConvertMethodCallToUFCSTest : RsIntentionTestBase(ConvertMethodCallToUFCSIntention::class) {
+class ConvertMethodCallToUFCSIntentionTest : RsIntentionTestBase(ConvertMethodCallToUFCSIntention::class) {
     fun `test unavailable on function call`() = doUnavailableTest("""
         fn foo() {}
         fn bar() {
@@ -419,6 +419,60 @@ class ConvertMethodCallToUFCSTest : RsIntentionTestBase(ConvertMethodCallToUFCSI
 
         fn foo(foo: &[u8]) {
             <[u8]>::foo(foo);
+        }
+    """)
+
+    fun `test aliased type`() = doAvailableTest("""
+        struct Foo;
+        impl Foo {
+            fn foo(self) {}
+        }
+
+        type Bar = Foo;
+
+        fn foo(foo: Bar) {
+            foo./*caret*/foo();
+        }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn foo(self) {}
+        }
+
+        type Bar = Foo;
+
+        fn foo(foo: Bar) {
+            Bar::foo(foo);
+        }
+    """)
+
+    fun `test import aliased type`() = doAvailableTest("""
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                pub fn foo(self) {}
+            }
+
+            pub type Bar = Foo;
+        }
+
+        fn bar(x: foo::Bar) {
+            x./*caret*/foo();
+        }
+    """, """
+        use foo::Bar;
+
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                pub fn foo(self) {}
+            }
+
+            pub type Bar = Foo;
+        }
+
+        fn bar(x: foo::Bar) {
+            Bar::foo(x);
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertUFCSToMethodCallIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertUFCSToMethodCallIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ConvertUFCSToMethodCallTest : RsIntentionTestBase(ConvertUFCSToMethodCallIntention::class) {
+class ConvertUFCSToMethodCallIntentionTest : RsIntentionTestBase(ConvertUFCSToMethodCallIntention::class) {
     fun `test not available for methods`() = doUnavailableTest("""
         struct S;
         impl S {

--- a/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
@@ -128,4 +128,40 @@ class CreateStructIntentionTest : RsIntentionTestBase(CreateStructIntention::cla
             }
         }
     """)
+
+    fun `test field with aliased type`() = doAvailableTest("""
+        type Bar = u32;
+
+        fn foo(bar: Bar) {
+            Foo/*caret*/ { a: bar };
+        }
+    """, """
+        type Bar = u32;
+
+        struct Foo {
+            a: Bar
+        }
+
+        fn foo(bar: Bar) {
+            Foo { a: bar };
+        }
+    """)
+
+    fun `test field with default type argument`() = doAvailableTest("""
+        struct S<T = u32>(T);
+
+        fn foo(bar: S<u32>) {
+            Foo/*caret*/ { a: bar };
+        }
+    """, """
+        struct S<T = u32>(T);
+
+        struct Foo {
+            a: S
+        }
+
+        fn foo(bar: S<u32>) {
+            Foo { a: bar };
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
@@ -111,4 +111,36 @@ class CreateTupleStructIntentionTest : RsIntentionTestBase(CreateTupleStructInte
             }
         }
     """)
+
+    fun `test aliased parameter`() = doAvailableTest("""
+        type Bar = u32;
+
+        fn foo(bar: Bar) {
+            Foo/*caret*/(bar);
+        }
+    """, """
+        type Bar = u32;
+
+        struct Foo(Bar);
+
+        fn foo(bar: Bar) {
+            Foo(bar);
+        }
+    """)
+
+    fun `test type with default type argument`() = doAvailableTest("""
+        struct S<T = u32>(T);
+
+        fn foo(bar: S) {
+            Foo/*caret*/(bar);
+        }
+    """, """
+        struct S<T = u32>(T);
+
+        struct Foo(S);
+
+        fn foo(bar: S) {
+            Foo(bar);
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
@@ -32,7 +32,6 @@ Cannot change signature of function with cfg-disabled parameters""")
         }
     """, "The caret should be positioned at a function or method")
 
-
     fun `test unavailable on unresolved function call`() = checkError("""
         fn bar(a: u32) {}
         fn baz() {
@@ -1228,6 +1227,34 @@ Cannot change signature of function with cfg-disabled parameters""")
         val vec = findElementInEditor<RsTypeReference>()
         parameters.add(parameter("a", vec))
         returnTypeDisplay = vec
+    }
+
+    fun `test import aliased type`() = doTest("""
+        mod foo {
+            pub struct S;
+            pub type Foo = S;
+
+            fn bar(t: Foo) {}
+                      //^
+        }
+
+        fn bar/*caret*/() {}
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct S;
+            pub type Foo = S;
+
+            fn bar(t: Foo) {}
+                      //^
+        }
+
+        fn bar(a: Foo) -> Foo {}
+    """) {
+        val foo = findElementInEditor<RsTypeReference>()
+        parameters.add(parameter("a", foo))
+        returnTypeDisplay = foo
     }
 
     private fun RsChangeFunctionSignatureConfig.swapParameters(a: Int, b: Int) {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceParameterTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceParameterTest.kt
@@ -272,6 +272,42 @@ class RsIntroduceParameterTest : RsTestBase() {
         }
     """)
 
+    fun `test aliased type`() = doTest("""
+        type Foo = u32;
+
+        fn bar() -> Foo { 0 }
+
+        fn hello() {
+            foo(/*caret*/bar());
+        }
+    """, listOf("bar()", "foo(bar())"), 0, 0, """
+        type Foo = u32;
+
+        fn bar() -> Foo { 0 }
+
+        fn hello(/*caret*/i: Foo) {
+            foo(i);
+        }
+    """)
+
+    fun `test type with default type argument`() = doTest("""
+        struct S<T = u32>(T);
+
+        fn bar() -> S { S(0) }
+
+        fn hello() {
+            foo(/*caret*/bar());
+        }
+    """, listOf("bar()", "foo(bar())"), 0, 0, """
+        struct S<T = u32>(T);
+
+        fn bar() -> S { S(0) }
+
+        fn hello(/*caret*/s: S) {
+            foo(s);
+        }
+    """)
+
     private fun doTest(
         @Language("Rust") before: String,
         expressions: List<String>,

--- a/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
@@ -280,7 +280,6 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
             s;
           //^ S<1, i32, 1, u32, 1, u32>
         }
-
     """)
 
     fun `test const argument that looks like a type argument`() = stubOnlyTypeInfer("""

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -518,9 +518,9 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
 
         val ty = typeAtCaret.type
         val renderedTy = when (renderMode) {
-            DEFAULT -> ty.toString()
-            WITH_LIFETIMES -> ty.renderInsertionSafe(includeLifetimeArguments = true)
-            WITH_ALIAS_NAMES -> ty.render(useAliasNames = true)
+            DEFAULT -> ty.render(useAliasNames = false, skipUnchangedDefaultTypeArguments = false)
+            WITH_LIFETIMES -> ty.renderInsertionSafe(includeLifetimeArguments = true, skipUnchangedDefaultTypeArguments = false)
+            WITH_ALIAS_NAMES -> ty.render(useAliasNames = true, skipUnchangedDefaultTypeArguments = false)
         }
         check(renderedTy == expectedType) {
             "$renderedTy != $expectedType"

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
@@ -9,6 +9,7 @@ import com.intellij.openapiext.Testmark
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
+import org.rust.ide.presentation.render
 import org.rust.lang.core.macros.expandedFrom
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsMacroCall
@@ -52,7 +53,7 @@ abstract class RsTypificationTestBase : RsTestBase() {
         val (expr, data) = findElementAndDataInEditor<RsExpr>()
         val expectedTypes = data.split("|").map(String::trim)
 
-        val type = expr.type.toString()
+        val type = expr.type.render(skipUnchangedDefaultTypeArguments = false, useAliasNames = false)
         check(type in expectedTypes) {
             "Type mismatch. Expected one of $expectedTypes, found: $type. $description"
         }


### PR DESCRIPTION
I think that it's long overdue to change `skipUnchangedDefaultTypeArguments` to true by default. In addition, since aliases are now much better supported (both in PSI and in type system and expression usage), I think that allowing aliases by default is also useful.

This affects several intentions (at least, `ConvertClosureToFunctionIntention`, `ConvertMethodCallToUFCS`, `ConvertUFCSToMethodCall`, `CreateTupleStructIntention`, `SpecifyTypeExplicitlyIntention`), refactorings (at least, `RsChangeSignature`, `RsExtractFunction`, `RsIntroduceParameter`) and quick fixes (at least, `AddTypeFix`, `ChangeFunctionSignatureFix`, `ChangeReturnTypeFix`), and also changes how types are rendered in error annotations.

changelog: Take into account type aliases in most of [intention actions, quick fixes](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-code-generation.html#intention-actions), and [refactorings](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-refactorings.html)