### PR TITLE
INT: Implement intention to expand inline tables into full ones

### DIFF
--- a/intellij-toml/core/src/main/kotlin/org/toml/ide/intentions/TomlElementBaseIntentionAction.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/ide/intentions/TomlElementBaseIntentionAction.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.intentions
+
+import com.intellij.codeInsight.intention.BaseElementAtCaretIntentionAction
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+
+/**
+ * A base class for implementing intentions: actions available via "light bulb" / `Alt+Enter`.
+ *
+ * The cool thing about intentions is their UX: there is a huge number of intentions,
+ * and they all can be invoked with a single `Alt + Enter` shortcut. This is possible
+ * because at the position of the cursor only small number of intentions is applicable.
+ *
+ * So, intentions consists of two functions: [findApplicableContext] functions determines
+ * if the intention can be applied at the given position, it is used to populate "light bulb" list.
+ * [invoke] is called when the user selects the intention from the list and must apply the changes.
+ *
+ * The context collected by [findApplicableContext] is gathered into [Ctx] object and is passed to
+ * [invoke]. In general, [invoke] should be infallible: if you need to check if some element is not
+ * null, do this in [findApplicableContext] and pass the element via the context.
+ *
+ * [findApplicableContext] is executed under a read action, and [invoke] under a write action.
+ */
+abstract class TomlElementBaseIntentionAction<Ctx> : BaseElementAtCaretIntentionAction() {
+
+    /**
+     * Return `null` if the intention is not applicable, otherwise collect and return
+     * all the necessary info to actually apply the intention.
+     */
+    abstract fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Ctx?
+
+    abstract fun invoke(project: Project, editor: Editor, ctx: Ctx)
+
+    final override fun invoke(project: Project, editor: Editor, element: PsiElement) {
+        val ctx = findApplicableContext(project, editor, element) ?: return
+
+        if (startInWriteAction()) {
+            checkWriteAccessAllowed()
+        }
+
+        invoke(project, editor, ctx)
+    }
+
+    final override fun isAvailable(project: Project, editor: Editor, element: PsiElement): Boolean {
+        checkReadAccessAllowed()
+
+        return findApplicableContext(project, editor, element) != null
+    }
+}
+
+private fun checkWriteAccessAllowed() {
+    check(ApplicationManager.getApplication().isWriteAccessAllowed) {
+        "Needs write action"
+    }
+}
+
+private fun checkReadAccessAllowed() {
+    check(ApplicationManager.getApplication().isReadAccessAllowed) {
+        "Needs read action"
+    }
+}

--- a/intellij-toml/core/src/main/kotlin/org/toml/ide/intentions/TomlExpandInlineTableIntention.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/ide/intentions/TomlExpandInlineTableIntention.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentsOfType
+import com.intellij.refactoring.suggested.endOffset
+import org.toml.lang.psi.*
+
+class TomlExpandInlineTableIntention : TomlElementBaseIntentionAction<TomlExpandInlineTableIntention.Context>() {
+    override fun getText(): String = "Expand into separate table"
+    override fun getFamilyName(): String = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val keyValue = element.parentsOfType<TomlKeyValue>().firstOrNull {
+            val hasInlineTableValue =  it.value is TomlInlineTable
+            val hasTableOrArrayParent = it.parent is TomlKeyValueOwner && it.parent is TomlHeaderOwner
+            val hasTomlFileParent = it.parent is TomlFile
+
+            hasInlineTableValue && (hasTableOrArrayParent || hasTomlFileParent)
+        } ?: return null
+
+        val inlineTable = keyValue.value as TomlInlineTable
+        val parentTable = keyValue.parent as? TomlKeyValueOwner
+        return Context(keyValue, inlineTable, parentTable)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val key = ctx.keyValue.key.text
+        val parentTable = ctx.parentTable
+
+        val newTableKey = if (parentTable != null) {
+            val parentHeader = (parentTable as? TomlHeaderOwner)?.header ?: return
+            val parentTableKey = parentHeader.key?.text ?: return
+            "$parentTableKey.$key"
+        } else {
+            key
+        }
+
+        val newTable = TomlPsiFactory(project).createTable(newTableKey)
+        val psiFactory = TomlPsiFactory(project)
+        for (entry in ctx.inlineTable.entries) {
+            newTable.add(psiFactory.createNewline())
+            newTable.add(entry.copy())
+        }
+
+        val addedTableOffset = if (parentTable != null) {
+            ctx.keyValue.delete()
+
+            val parent = parentTable.parent
+            val addedTable = parent.addAfter(newTable, parentTable)
+
+            parent.addAfter(psiFactory.createWhitespace("\n\n"), parentTable)
+            addedTable.endOffset
+        } else {
+            ctx.keyValue.replace(newTable).endOffset
+        }
+
+        editor.caretModel.moveToOffset(addedTableOffset)
+    }
+
+    class Context(val keyValue: TomlKeyValue, val inlineTable: TomlInlineTable, val parentTable: TomlKeyValueOwner?)
+}

--- a/intellij-toml/core/src/main/kotlin/org/toml/lang/psi/TomlPsiFactory.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/lang/psi/TomlPsiFactory.kt
@@ -8,6 +8,7 @@ package org.toml.lang.psi
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiParserFacade
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.LocalTimeCounter
 
@@ -30,6 +31,11 @@ class TomlPsiFactory(private val project: Project, private val markGenerated: Bo
     // Copied from org.rust.lang.core.psi.ext as it's not available here
     private inline fun <reified T : PsiElement> PsiElement.descendantOfTypeStrict(): T? =
         PsiTreeUtil.findChildOfType(this, T::class.java, /* strict */ true)
+
+    fun createNewline(): PsiElement = createWhitespace("\n")
+
+    fun createWhitespace(ws: String): PsiElement =
+        PsiParserFacade.SERVICE.getInstance(project).createWhiteSpaceFromText(ws)
 
     fun createLiteral(value: String): TomlLiteral =
         // If you're creating a string value, like `serde = "1.0.90"` make sure that the `value` parameter actually

--- a/intellij-toml/core/src/main/resources/META-INF/toml-core.xml
+++ b/intellij-toml/core/src/main/resources/META-INF/toml-core.xml
@@ -41,5 +41,10 @@
                          displayName="Unresolved reference"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.toml.ide.inspections.TomlUnresolvedReferenceInspection"/>
+
+        <intentionAction>
+            <className>org.toml.ide.intentions.TomlExpandInlineTableIntention</className>
+            <category>TOML</category>
+        </intentionAction>
     </extensions>
 </idea-plugin>

--- a/intellij-toml/core/src/main/resources/intentionDescriptions/TomlExpandInlineTableIntention/after.toml.template
+++ b/intellij-toml/core/src/main/resources/intentionDescriptions/TomlExpandInlineTableIntention/after.toml.template
@@ -1,0 +1,3 @@
+[foo.bar]
+baz = 1
+qux = 2

--- a/intellij-toml/core/src/main/resources/intentionDescriptions/TomlExpandInlineTableIntention/before.toml.template
+++ b/intellij-toml/core/src/main/resources/intentionDescriptions/TomlExpandInlineTableIntention/before.toml.template
@@ -1,0 +1,2 @@
+[foo]
+bar = { baz = 1, qux = 2 }

--- a/intellij-toml/core/src/main/resources/intentionDescriptions/TomlExpandInlineTableIntention/description.html
+++ b/intellij-toml/core/src/main/resources/intentionDescriptions/TomlExpandInlineTableIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Expands table property with inline table into separate table.
+</body>
+</html>

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/intentions/TomlExpandInlineTableIntentionTest.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/intentions/TomlExpandInlineTableIntentionTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.intentions
+
+class TomlExpandInlineTableIntentionTest : TomlIntentionTestBase(TomlExpandInlineTableIntention::class) {
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        [dependencies]
+        <selection>foo = { version = "0.1.0", features = ["bar"] }</selection>
+    """)
+
+    fun `test unavailable in keyvalue with literal`() = doUnavailableTest("""
+        [dependencies]
+        foo = "0.1.0"<caret>
+    """)
+
+    fun `test unavailable in keyvalue with inline array`() = doUnavailableTest("""
+        [dependencies]
+        foo = []<caret>
+    """)
+
+    fun `test bare keyvalue`() = doAvailableTest("""
+        foo = { bar = 42 }<caret>
+    """,
+    """
+        [foo]
+        bar = 42<caret>
+    """)
+
+    fun `test replace simple`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.1.0" }<caret>
+    """, """
+        [dependencies]
+
+        [dependencies.foo]
+        version = "0.1.0"<caret>
+    """)
+
+    fun `test replace from name`() = doAvailableTest("""
+        [dependencies]
+        <caret>foo = { version = "0.1.0", features = ["bar"] }
+    """, """
+        [dependencies]
+
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]<caret>
+    """)
+
+    fun `test replace from value`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.1.0", features = ["bar"] }<caret>
+    """, """
+        [dependencies]
+
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]<caret>
+    """)
+
+    fun `test replace from inside keyvalue`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.1.0", features = ["bar"<caret>] }
+    """, """
+        [dependencies]
+
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]<caret>
+    """)
+
+    fun `test replace with platform-specific table`() = doAvailableTest("""
+        [target.'cfg(unix)'.dependencies]
+        foo = { version = "0.1.0", features = ["bar"] }<caret>
+    """, """
+        [target.'cfg(unix)'.dependencies]
+
+        [target.'cfg(unix)'.dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]<caret>
+    """)
+
+    fun `test replace in the middle`() = doAvailableTest("""
+        [dependencies]
+        baz = "0.1.0"
+        foo = { version = "0.1.0", features = ["bar"] }<caret>
+        bar = { version = "0.2.0" }
+    """, """
+        [dependencies]
+        baz = "0.1.0"
+        bar = { version = "0.2.0" }
+
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]<caret>
+    """)
+
+    fun `test replace with another block`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.1.0", features = ["bar"] }<caret>
+
+        [features]
+        something = []
+    """, """
+        [dependencies]
+
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]<caret>
+
+        [features]
+        something = []
+    """)
+
+    fun `test replace in the middle with another block`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.0.1" }
+        bar = { version = "0.0.2" }<caret>
+        baz = { version = "0.0.3" }
+
+        [dependencies.quux]
+        version = "0.0.4"
+    """, """
+        [dependencies]
+        foo = { version = "0.0.1" }
+        baz = { version = "0.0.3" }
+
+        [dependencies.bar]
+        version = "0.0.2"<caret>
+
+        [dependencies.quux]
+        version = "0.0.4"
+    """)
+
+    fun `test with array table`() = doAvailableTest("""
+        [[foo]]
+        bar = { baz = 42 }<caret>
+    """, """
+        [[foo]]
+
+        [foo.bar]
+        baz = 42
+    """)
+
+    fun `test with key segment in table`() = doAvailableTest("""
+        [foo.bar]
+        baz = { qux = 42 }<caret>
+    """, """
+        [foo.bar]
+
+        [foo.bar.baz]
+        qux = 42
+    """)
+
+    fun `test with key segment in key`() = doAvailableTest("""
+        [foo]
+        bar.baz = { qux = 42 }<caret>
+    """, """
+        [foo]
+
+        [foo.bar.baz]
+        qux = 42
+    """)
+
+    fun `test nested inline tables`() = doAvailableTest("""
+        [foo]
+        bar = { baz = { qux = 42 } }<caret>
+    """, """
+        [foo]
+
+        [foo.bar]
+        baz = { qux = 42 }<caret>
+    """)
+}

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/intentions/TomlIntentionTestBase.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/intentions/TomlIntentionTestBase.kt
@@ -1,0 +1,73 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.intentions
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInsight.intention.IntentionActionDelegate
+import com.intellij.openapi.util.TextRange
+import com.intellij.util.ui.UIUtil
+import org.intellij.lang.annotations.Language
+import org.toml.TomlTestBase
+import kotlin.reflect.KClass
+
+abstract class TomlIntentionTestBase(private val intentionClass: KClass<out IntentionAction>): TomlTestBase() {
+    private fun findIntention(): IntentionAction? = myFixture.availableIntentions.firstOrNull {
+        val originalIntention = IntentionActionDelegate.unwrap(it)
+        intentionClass == originalIntention::class
+    }
+
+    protected fun doAvailableTest(
+        @Language("TOML") before: String,
+        @Language("TOML") after: String,
+        filename: String = "example.toml"
+    ) {
+        InlineFile(before.trimIndent(), filename)
+        launchAction()
+        myFixture.checkResult(after.trimIndent())
+    }
+
+    protected fun doUnavailableTest(
+        @Language("TOML") before: String,
+        filename: String = "example.toml"
+    ) {
+        InlineFile(before.trimIndent(), filename)
+
+        val intention = findIntention()
+        check (intention == null) {
+            "\"${intentionClass.simpleName}\" should not be available"
+        }
+    }
+
+    private fun launchAction() {
+        UIUtil.dispatchAllInvocationEvents()
+
+        val intention = findIntention() ?: error("Failed to find ${intentionClass.simpleName} intention")
+        myFixture.launchAction(intention)
+    }
+
+    protected fun checkAvailableInSelectionOnly(@Language("TOML") code: String, filename: String = "example.toml") {
+        InlineFile(code.replace("<selection>", "<selection><caret>"), filename)
+
+        val selections = myFixture.editor.selectionModel.let { model ->
+            model.blockSelectionStarts.zip(model.blockSelectionEnds)
+                .map { TextRange(it.first, it.second + 1) }
+        }
+
+        val intention = findIntention() ?: error("Failed to find ${intentionClass.simpleName} intention")
+        for (pos in myFixture.file.text.indices) {
+            myFixture.editor.caretModel.moveToOffset(pos)
+
+            val expectAvailable = selections.any { it.contains(pos) }
+            val isAvailable = intention.isAvailable(project, myFixture.editor, myFixture.file)
+
+            check(isAvailable == expectAvailable) {
+                "Expect ${if (expectAvailable) "available" else "unavailable"}, " +
+                    "actually ${if (isAvailable) "available" else "unavailable"} " +
+                    "at `${StringBuilder(myFixture.file.text).insert(pos, "<caret>")}`"
+            }
+        }
+    }
+}

--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -11,8 +11,7 @@
     <!-- TODO: create normal change note list -->
     <change-notes><![CDATA[
         <ul>
-            <li>Annotate and provide quick-fix for trailing commas in inline tables</li>
-            <li>Restore missing icon for TOML files</li>
+            <li>Add intention for expanding inline tables into full ones</li>
         </ul>
     ]]>
     </change-notes>

--- a/toml/src/main/kotlin/org/rust/toml/intentions/ExpandDependencySpecificationIntention.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/ExpandDependencySpecificationIntention.kt
@@ -19,7 +19,7 @@ import org.toml.lang.psi.TomlTable
 import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
 
-class ExpandDependencySpecificationIntention : TomlElementBaseIntentionAction<TomlKeyValue>() {
+class ExpandDependencySpecificationIntention : RsTomlElementBaseIntentionAction<TomlKeyValue>() {
     override fun getText() = "Expand dependency specification"
     override fun getFamilyName(): String = text
 

--- a/toml/src/main/kotlin/org/rust/toml/intentions/ExtractDependencySpecificationIntention.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/ExtractDependencySpecificationIntention.kt
@@ -19,7 +19,7 @@ import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlPsiFactory
 import org.toml.lang.psi.TomlTable
 
-class ExtractDependencySpecificationIntention : TomlElementBaseIntentionAction<TomlKeyValue>() {
+class ExtractDependencySpecificationIntention : RsTomlElementBaseIntentionAction<TomlKeyValue>() {
     override fun getText() = "Extract dependency specification"
     override fun getFamilyName(): String = text
 

--- a/toml/src/main/kotlin/org/rust/toml/intentions/RsTomlElementBaseIntentionAction.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/RsTomlElementBaseIntentionAction.kt
@@ -8,10 +8,10 @@ package org.rust.toml.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.toml.tomlPluginIsAbiCompatible
+import org.toml.ide.intentions.TomlElementBaseIntentionAction
 
-abstract class TomlElementBaseIntentionAction<Ctx> : RsElementBaseIntentionAction<Ctx>() {
+abstract class RsTomlElementBaseIntentionAction<Ctx> : TomlElementBaseIntentionAction<Ctx>() {
     final override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Ctx? {
         if (!tomlPluginIsAbiCompatible()) return null
         return findApplicableContextInternal(project, editor, element)

--- a/toml/src/main/kotlin/org/rust/toml/intentions/SimplifyDependencySpecificationIntention.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/SimplifyDependencySpecificationIntention.kt
@@ -17,7 +17,7 @@ import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlTable
 import org.toml.lang.psi.TomlValue
 
-class SimplifyDependencySpecificationIntention : TomlElementBaseIntentionAction<SimplifyDependencySpecificationIntention.Context>() {
+class SimplifyDependencySpecificationIntention : RsTomlElementBaseIntentionAction<SimplifyDependencySpecificationIntention.Context>() {
     override fun getText() = "Simplify dependency specification"
     override fun getFamilyName(): String = text
 


### PR DESCRIPTION
Part of #7180 

Provides an intention for a superset of key-values already covered by `Extract dependency specification` intention for `Cargo.toml`. Also implements a test base for intention actions tests in Toml plugin

<img width="500" src="https://user-images.githubusercontent.com/6342851/128692747-dce49a53-bf14-488b-b33a-75bab51d77ff.gif">

* It can be convenient to create an interface which will include both `TomlKeyValueOwner` and `TomlHeader`
* Maybe we should reduce the intention availability range to `TomlInlineTable` only