### PR TITLE
REF: Ignore trailing semicolon and colon when extracting expression

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.siblings
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.refactoring.RsFunctionSignatureConfig
+import org.rust.ide.utils.findElementAtIgnoreWhitespaceAfter
 import org.rust.ide.utils.findStatementsOrExprInRange
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -222,6 +223,17 @@ class RsExtractFunctionConfig private constructor(
 
     companion object {
         fun create(file: PsiFile, start: Int, end: Int): RsExtractFunctionConfig? {
+            doCreate(file, start, end)?.let { return it }
+
+            file.findElementAtIgnoreWhitespaceAfter(end - 1)?.let { lastElement ->
+                if (lastElement.elementType in listOf(RsElementTypes.COMMA, RsElementTypes.SEMICOLON)) {
+                    return create(file, start, lastElement.startOffset)
+                }
+            }
+            return null
+        }
+
+        fun doCreate(file: PsiFile, start: Int, end: Int): RsExtractFunctionConfig? {
             val elements = findStatementsOrExprInRange(file, start, end).asList()
             if (elements.isEmpty()) return null
             val first = elements.first()

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -919,6 +919,54 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """, "bar", noSelected = listOf("a"))
 
+    fun `test extract expr with trailing semicolon`() = doTest("""
+        fn main() {
+            let a = <selection>42;</selection>
+        }
+    """, """
+        fn main() {
+            let a = bar();
+        }
+
+        fn bar() -> i32 {
+            42
+        }
+    """, "bar")
+
+    fun `test extract expr with trailing semicolon and whitespace`() = doTest("""
+        fn main() {
+            let a = <selection>42; </selection> //
+        }
+    """, """
+        fn main() {
+            let a = bar();  //
+        }
+
+        fn bar() -> i32 {
+            42
+        }
+    """, "bar")
+
+    fun `test extract expr with trailing comma`() = doTest("""
+        fn main() {
+            let s = S {
+                a: <selection>42,</selection>
+                b: 0,
+            };
+        }
+    """, """
+        fn main() {
+            let s = S {
+                a: bar(),
+                b: 0,
+            };
+        }
+
+        fn bar() -> i32 {
+            42
+        }
+    """, "bar")
+
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extract async function with await`() = doTest("""
         #[lang = "core::future::future::Future"]


### PR DESCRIPTION
Fixes #7232

It should be useful when applying "Extract function" refactoring to e.g. multiline expression

changelog: "Extract function" refactoring now can be applied when trailing semicolon is selected together with expression
