### PR TITLE
Fix rendering tuples of size 1

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
@@ -91,10 +91,16 @@ class RsTypeHintsPresentationFactory(
         factory.collapsible(
             prefix = text("("),
             collapsed = text(PLACEHOLDER),
-            expanded = { parametersHint(type.types, level + 1) },
+            expanded = { tupleTypesHint(type.types, level + 1) },
             suffix = text(")"),
             startWithPlaceholder = checkSize(level, type.types.size)
         )
+
+    private fun tupleTypesHint(types: List<Ty>, level: Int): InlayPresentation = if (types.size == 1) {
+        factory.seq(hint(types.single(), level), text(","))
+    } else {
+        types.map { hint(it, level) }.join(", ")
+    }
 
     private fun adtTypeHint(type: TyAdt, level: Int): InlayPresentation {
         val adtName = type.item.name

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -239,10 +239,16 @@ open class RsPsiRenderer(
 
     open fun appendTypeReference(sb: StringBuilder, ref: RsTypeReference) {
         when (val type = ref.skipParens()) {
-            is RsTupleType ->
-                type.typeReferenceList.joinToWithBuffer(sb, ", ", "(", ")") {
-                    appendTypeReference(it, this)
+            is RsTupleType -> {
+                val types = type.typeReferenceList
+                if (types.size == 1) {
+                    sb.append("(")
+                    appendTypeReference(sb, types.single())
+                    sb.append(",)")
+                } else {
+                    types.joinToWithBuffer(sb, ", ", "(", ")") { appendTypeReference(it, this) }
                 }
+            }
 
             is RsBaseType -> when (val kind = type.kind) {
                 RsBaseTypeKind.Unit -> sb.append("()")

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -134,7 +134,11 @@ private data class TypeRenderer(
             is TyFunction -> formatFnLike("fn", ty.paramTypes, ty.retType, render)
             is TySlice -> "[${render(ty.elementType)}]"
 
-            is TyTuple -> ty.types.joinToString(", ", "(", ")", transform = render)
+            is TyTuple -> if (ty.types.size == 1) {
+                "(${render(ty.types.single())},)"
+            } else {
+                ty.types.joinToString(", ", "(", ")", transform = render)
+            }
             is TyArray -> "[${render(ty.base)}; ${render(ty.const)}]"
             is TyReference -> buildString {
                 append('&')

--- a/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
@@ -475,4 +475,12 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
 //            let xs/*hint text="[:  [impl  [Iterator [< [Item = i32] >]] ]]"*/ = vec![1,2,3].into_iter();
 //        }
 //    """)
+
+    fun `test tuple type`() = checkByText("""
+        fn main() {
+            let a/*hint text="[:  [( [i32 ,] )]]"*/ = (1,);
+            let b/*hint text="[:  [( [i32 ,  i32] )]]"*/ = (1, 2);
+            let c/*hint text="[:  [( … )]]"*/ = (1, 2, 3);
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -745,6 +745,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
             fn f3(u32, u64);
             fn f4() -> bool;
             fn f5(a: f64, b: bool) -> (i8, u8);
+            fn f6(a: (i32,)) -> (i8,);
         }
         struct S;
         impl T for S {/*caret*/}
@@ -753,7 +754,8 @@ class ImplementMembersHandlerTest : RsTestBase() {
         ImplementMemberSelection("f2(a: (i32, u32))", true),
         ImplementMemberSelection("f3(u32, u64)", true),
         ImplementMemberSelection("f4() -> bool", true),
-        ImplementMemberSelection("f5(a: f64, b: bool) -> (i8, u8)", true)
+        ImplementMemberSelection("f5(a: f64, b: bool) -> (i8, u8)", true),
+        ImplementMemberSelection("f6(a: (i32,)) -> (i8,)", true),
     ), """
         trait T {
             fn f1(a: i8, b: i16, c: i32, d: i64);
@@ -761,6 +763,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
             fn f3(u32, u64);
             fn f4() -> bool;
             fn f5(a: f64, b: bool) -> (i8, u8);
+            fn f6(a: (i32,)) -> (i8,);
         }
         struct S;
         impl T for S {
@@ -781,6 +784,10 @@ class ImplementMembersHandlerTest : RsTestBase() {
             }
 
             fn f5(a: f64, b: bool) -> (i8, u8) {
+                todo!()
+            }
+
+            fn f6(a: (i32, )) -> (i8, ) {
                 todo!()
             }
         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -38,6 +38,14 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test tuple of size 1`() = testType("""
+        struct S;
+        fn main() {
+            let _: (S,) = (S,);
+                 //^ (S,)
+        }
+    """)
+
     fun `test type in parens`() = testType("""
         struct S;
         fn main() {


### PR DESCRIPTION
Fixes PSI rendering, Ty rendering, and type hints
Fixes #7642


changelog: Fix code generation and type hints related to tuples of size 1 (for example `(i32,)`)