### PR TITLE
REF: Don't offer to move file to same directory

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesDialog.kt
@@ -50,6 +50,10 @@ class RsMoveFilesOrDirectoriesDialog(
         try {
             for (element in filesOrDirectoriesToMove) {
                 if (element is RsFile) {
+                    if (element.parent == targetDirectory) {
+                        showError("Please choose target directory different from current")
+                        return
+                    }
                     CopyFilesOrDirectoriesHandler.checkFileExist(targetDirectory, null, element, element.name, "Move")
                 }
                 MoveFilesOrDirectoriesUtil.checkMove(element, targetDirectory)
@@ -63,8 +67,7 @@ class RsMoveFilesOrDirectoriesDialog(
             if (e !is IncorrectOperationException) {
                 logger<RsMoveFilesOrDirectoriesDialog>().error(e)
             }
-            val title = RefactoringBundle.message("error.title")
-            CommonRefactoringUtil.showErrorMessage(title, e.message, "refactoring.moveFile", project)
+            showError(e.message)
         }
     }
 
@@ -116,6 +119,11 @@ class RsMoveFilesOrDirectoriesDialog(
             project = project
         )
         return result == Messages.OK
+    }
+
+    private fun showError(message: String?) {
+        val title = RefactoringBundle.message("error.title")
+        CommonRefactoringUtil.showErrorMessage(title, message, "refactoring.moveFile", project)
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesHandler.kt
@@ -66,6 +66,11 @@ class RsMoveFilesOrDirectoriesHandler : MoveFilesOrDirectoriesHandler() {
         if (files.mapToSet { it.`super` }.size != 1) return false
 
         val adjustedTargetContainer = adjustTargetForMove(null, targetContainer)
+        if (files.any { it.parent == adjustedTargetContainer }) {
+            // Can't move file to same directory
+            return false
+        }
+
         return super.canMove(elements, adjustedTargetContainer, reference)
     }
 


### PR DESCRIPTION
Previously you can use drag-and-drop to move file to same directory, and receive error "File with same name already exists". This PR prevents moving file to same directory using drag-and-drop, and a bit improves error message (in case user tries to move file to same directory using shortcut)

Fixes #7712

cc @neonaot 

changelog: Don't offer to move file to same directory in file tree
