### PR TITLE
ANN: fix auto-import popup rendering on 212

### DIFF
--- a/src/211/main/kotlin/org/rust/ide/inspections/import/RsImportCandidateCellRenderer.kt
+++ b/src/211/main/kotlin/org/rust/ide/inspections/import/RsImportCandidateCellRenderer.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.import
+
+import com.intellij.util.ui.UIUtil
+import java.awt.Component
+import javax.swing.BorderFactory
+import javax.swing.DefaultListCellRenderer
+import javax.swing.JList
+import javax.swing.SwingConstants
+
+class RsImportCandidateCellRenderer : RsImportCandidateCellRendererBase() {
+
+    private val rightRender: LibraryCellRender = LibraryCellRender()
+
+    override fun getRightCellRenderer(value: Any?): DefaultListCellRenderer = rightRender
+
+    private inner class LibraryCellRender : DefaultListCellRenderer() {
+        override fun getListCellRendererComponent(
+            list: JList<*>,
+            value: Any?,
+            index: Int,
+            isSelected: Boolean,
+            cellHasFocus: Boolean
+        ): Component {
+            val component = super.getListCellRendererComponent(list, null, index, isSelected, cellHasFocus)
+            val textWithIcon = textWithIcon(value)
+            if (textWithIcon != null) {
+                text = textWithIcon.first
+                icon = textWithIcon.second
+            }
+
+            border = BorderFactory.createEmptyBorder(0, 0, 0, 2)
+            horizontalTextPosition = SwingConstants.LEFT
+            background = UIUtil.getListBackground(isSelected, cellHasFocus)
+            foreground = UIUtil.getListForeground(isSelected, cellHasFocus)
+            return component
+        }
+    }
+}

--- a/src/212/main/kotlin/org/rust/ide/inspections/import/RsImportCandidateCellRenderer.kt
+++ b/src/212/main/kotlin/org/rust/ide/inspections/import/RsImportCandidateCellRenderer.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.import
+
+import com.intellij.util.TextWithIcon
+
+class RsImportCandidateCellRenderer : RsImportCandidateCellRendererBase() {
+    override fun getItemLocation(value: Any?): TextWithIcon? {
+        val (text, icon) = textWithIcon(value) ?: return null
+        return TextWithIcon(text, icon)
+    }
+}


### PR DESCRIPTION
Previously, item renderer had a state that kept an instance of `ImportCandidate` for the corresponding psi element. And when `PsiElementListCellRenderer` became asynchronous, it was broken.
Now, we wrap `ImportCandidate` into `FakePsiElement` and get rid of state in psi renderer

Fixes #7609

changelog: Fix item rendering by popup of `Import` quick-fix on 2021.2 IDEs
