### PR TITLE
minor typo & style fixes

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
@@ -69,7 +69,7 @@ data class StandardLibrary(
                 val rustcVersion = rustcInfo?.version
                 val semverVersion = rustcVersion?.semver
                 if (semverVersion == null) {
-                    LOG.warn("Toolchain version is unknown. Hardcoded stdlib struture will be used")
+                    LOG.warn("Toolchain version is unknown. Hardcoded stdlib structure will be used")
                     fetchHardcodedStdlib(srcDir)
                 } else {
                     val result = fetchActualStdlib(project, srcDir, rustcVersion)

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildContext.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildContext.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageType
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.UserDataHolderEx
-import com.intellij.openapiext.isUnitTestMode
 import com.intellij.util.concurrency.FutureResult
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.runconfig.RsExecutableRunner.Companion.artifact

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddTypeArguments.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddTypeArguments.kt
@@ -15,7 +15,6 @@ import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.COMMA
 import org.rust.lang.core.psi.RsElementTypes.LT
-import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.getNextNonCommentSibling

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/setter/GenerateSetterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/setter/GenerateSetterHandler.kt
@@ -7,16 +7,12 @@ package org.rust.ide.refactoring.generate.setter
 
 
 import com.intellij.openapi.editor.Editor
-import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.refactoring.generate.BaseGenerateAction
 import org.rust.ide.refactoring.generate.BaseGenerateHandler
 import org.rust.ide.refactoring.generate.GenerateAccessorHandler
 import org.rust.ide.refactoring.generate.StructMember
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.types.Substitution
-import org.rust.lang.core.types.infer.substitute
-import org.rust.lang.core.types.ty.TyUnit
-import org.rust.lang.core.types.type
 import org.rust.openapiext.checkWriteAccessAllowed
 
 class GenerateSetterAction : BaseGenerateAction() {

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -276,7 +276,7 @@ class MacroExpansionManagerImpl(
 
     override fun setUnitTestExpansionModeAndDirectory(mode: MacroExpansionScope, cacheDirectory: String): Disposable {
         check(isUnitTestMode)
-        val dir = updateDirs(if (cacheDirectory.isNotEmpty()) cacheDirectory else null)
+        val dir = updateDirs(cacheDirectory.ifEmpty { null })
         val impl = MacroExpansionServiceBuilder.prepare(dir).buildInReadAction(project)
         this.dirs = dir
         this.inner = impl

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -440,7 +440,7 @@ class ImplLookup(
             // Default (libcore/default.rs)
             addImpl(items.Default)
 
-            // PatrialEq (libcore/cmp.rs)
+            // PartialEq (libcore/cmp.rs)
             if (ty != TyNever && ty !is TyUnit) {
                 addImpl(items.PartialEq, ty)
             }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -691,9 +691,7 @@ class RsTypeInferenceWalker(
             traitToCallee.keys.filterInScope(context).forEach {
                 filtered += traitToCallee.getValue(it)
             }
-            if (filtered.isNotEmpty()) {
-                filtered
-            } else {
+            filtered.ifEmpty {
                 TypeInferenceMarks.methodPickTraitsOutOfScope.hit()
                 list
             }

--- a/src/main/kotlin/org/rust/lang/doc/psi/impl/RsDocCommentImpl.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/impl/RsDocCommentImpl.kt
@@ -32,7 +32,7 @@ class RsDocCommentImpl(type: IElementType, text: CharSequence?) : LazyParseableP
 
     // Needed for RsFoldingBuilder
     override fun accept(visitor: PsiElementVisitor) {
-        visitor.visitComment(this);
+        visitor.visitComment(this)
     }
 
     override fun toString(): String {

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -42,7 +42,7 @@ import kotlin.reflect.full.createInstance
 
 abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
 
-    // Needed for assertion that the directory doesn't acidentally renamed during the test
+    // Needed for assertion that the directory doesn't accidentally renamed during the test
     private var tempDirRootUrl: String? = null
     private var tempDirRoot: VirtualFile? = null
 

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoCommandLineTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoCommandLineTest.kt
@@ -51,7 +51,7 @@ class CargoCommandLineTest {
     }
 
     @Test
-    fun `getBuildArguments should return build arguments only preceeding arguments`() {
+    fun `getBuildArguments should return build arguments only preceding arguments`() {
         val cot = CargoCommandLine("run", wd, listOf("--bin", "someproj", "--", "arg1"))
         val actual = cot.subcommandArguments
         val expected = listOf("--bin", "someproj")

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt
@@ -18,7 +18,7 @@ class AddTurbofishFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     )
 
 
-    fun `test should not be applied`() = checkNoIntention("""1 < 5 /*carret*/> 3;""")
+    fun `test should not be applied`() = checkNoIntention("""1 < 5 /*caret*/> 3;""")
 
     fun `test should be available also in right side`() = checkStatement(
             """parse<i32>(/*caret*/"42")""",

--- a/src/test/kotlin/org/rust/ide/hints/parameter/RsParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/parameter/RsParameterInfoHandlerTest.kt
@@ -7,9 +7,6 @@ package org.rust.ide.hints.parameter
 
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.ide.hints.parameter.RsArgumentsDescription
-import org.rust.ide.hints.parameter.RsParameterInfoHandler
-import org.rust.ide.hints.parameter.RsParameterInfoHandlerTestBase
 import org.rust.lang.core.psi.RsValueArgumentList
 
 /**

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -2157,7 +2157,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test import outer item in doctest injection`() = checkAutoImportFixByFileTreeWithouHighlighting("""
+    fun `test import outer item in doctest injection`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /// ```
         /// foo/*caret*/();
@@ -2173,7 +2173,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, Testmarks.doctestInjectionImport)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test import outer item in doctest injection with tildes`() = checkAutoImportFixByFileTreeWithouHighlighting("""
+    fun `test import outer item in doctest injection with tildes`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /// ~~~
         /// foo/*caret*/();
@@ -2189,7 +2189,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, Testmarks.doctestInjectionImport)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test import outer item in doctest injection in star comment`() = checkAutoImportFixByFileTreeWithouHighlighting("""
+    fun `test import outer item in doctest injection in star comment`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /**
          * ```
@@ -2209,7 +2209,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """,  Testmarks.doctestInjectionImport)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test import second outer item in doctest injection`() = checkAutoImportFixByFileTreeWithouHighlighting("""
+    fun `test import second outer item in doctest injection`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /// ```
         /// use test_package::foo;
@@ -2230,7 +2230,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, Testmarks.doctestInjectionImport)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test import second outer item without grouping in doctest injection`() = checkAutoImportFixByFileTreeWithouHighlighting("""
+    fun `test import second outer item without grouping in doctest injection`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /// ```
         /// use test_package::foo;
@@ -2252,7 +2252,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, Testmarks.insertNewLineBeforeUseItem)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test import outer item in doctest injection with inner module`() = checkAutoImportFixByFileTreeWithouHighlighting("""
+    fun `test import outer item in doctest injection with inner module`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /// ```
         /// mod bar {

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
@@ -31,7 +31,7 @@ abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferen
         testmark: Testmark? = null
     ) = doTest { checkFixByFileTree(AutoImportFix.NAME, before, after, testmark = testmark) }
 
-    protected fun checkAutoImportFixByFileTreeWithouHighlighting(
+    protected fun checkAutoImportFixByFileTreeWithoutHighlighting(
         @Language("Rust") before: String,
         @Language("Rust") after: String,
         testmark: Testmark? = null

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -312,7 +312,7 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
         }
     """)
 
-    fun `test no type mismatch E0308 on reference coecrion of partially unknown type`() = checkByText("""
+    fun `test no type mismatch E0308 on reference coercion of partially unknown type`() = checkByText("""
         struct Bar;
         fn foo(a: &Bar) {}
 

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt
@@ -45,7 +45,7 @@ class RsGotoTypeDeclarationTest : RsTestBase() {
 
     fun `test argument declaration`() = doTest("""
         struct /*caret_after*/Foo;
-        fn foo(foo/*caret_before*/: Foo) { unimplemeneted!() }
+        fn foo(foo/*caret_before*/: Foo) { unimplemented!() }
     """)
 
     fun `test function call`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/structure/RsMacroExpandedFilterTest.kt
+++ b/src/test/kotlin/org/rust/ide/structure/RsMacroExpandedFilterTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.ide.structure
 
-import org.intellij.lang.annotations.Language
-
 class RsMacroExpandedFilterTest : RsStructureViewToggleableActionTest() {
 
     fun `test macro expanded filter`() = doTest("""

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionTest.kt
@@ -7,10 +7,11 @@ package org.rust.lang.core.completion
 
 import com.intellij.openapi.module.Module
 import com.intellij.util.Urls
-import org.rust.*
+import org.rust.ProjectDescriptor
+import org.rust.RustProjectDescriptorBase
+import org.rust.WithRustup
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.workspace.CargoWorkspace
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import java.nio.file.Paths
 

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -58,7 +58,7 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
                 checkMacroExpansion(
                     macroCall,
                     expectedExpansion,
-                    "${i + 1} macro comparision failed",
+                    "${i + 1} macro comparison failed",
                     mark
                 )
             }
@@ -67,13 +67,13 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
     fun checkSingleMacro(@Language("Rust") code: String, @Language("Rust") expectedExpansion: String) {
         InlineFile(code)
         val call = findElementInEditor<RsMacroCall>("^")
-        checkMacroExpansion(call, expectedExpansion, "Macro comparision failed")
+        checkMacroExpansion(call, expectedExpansion, "Macro comparison failed")
     }
 
     fun checkSingleMacroByTree(@Language("Rust") code: String, @Language("Rust") expectedExpansion: String) {
         fileTreeFromText(code).createAndOpenFileWithCaretMarker()
         val call = findElementInEditor<RsMacroCall>("^")
-        checkMacroExpansion(call, expectedExpansion, "Macro comparision failed")
+        checkMacroExpansion(call, expectedExpansion, "Macro comparison failed")
     }
 
     fun doErrorTest(@Language("Rust") code: String, mark: Testmark) {

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
@@ -9,8 +9,8 @@ import com.intellij.psi.tree.TokenSet
 import com.intellij.util.text.SemVer
 import org.rust.*
 import org.rust.cargo.project.model.cargoProjects
-import org.rust.cargo.project.workspace.CargoWorkspace
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition.*
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2018
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2021
 import org.rust.lang.core.macros.RsMacroExpansionTestBase
 import org.rust.lang.core.psi.RS_KEYWORDS
 import org.rust.lang.core.psi.RsElementTypes.CRATE

--- a/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
@@ -73,7 +73,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
         }
     """)
 
-    fun `test highlights from other files do not interfer`() {
+    fun `test highlights from other files do not interfere`() {
         fileTree {
             toml("Cargo.toml", """
                 [package]


### PR DESCRIPTION
* Removed unused imports.
* Removed redundant semicolon.
* Changed `if (v.isNotEmpty()) v else { f}` into more idiomatic `v.ifEmpty { f }`.
* Fixed typos in test names, variable names, function names and strings.
* In AddTurbofishFixTest.kt, `test should not be applied`, the test that an intention doesn't fire includes a typo ("carret" instead of "caret") which makes the test always pass. Fixed the typo.