### PR TITLE
TYPE: removed most restrictions on follow-up tokens for brace matching

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt
@@ -132,7 +132,7 @@ private class RsBaseBraceMatcher : PairedBraceMatcher {
     override fun getPairs() = PAIRS
 
     override fun isPairedBracesAllowedBeforeType(lbraceType: IElementType, next: IElementType?): Boolean =
-        next in InsertPairBraceBefore
+        next != IDENTIFIER
 
     override fun getCodeConstructStart(file: PsiFile?, openingBraceOffset: Int): Int = openingBraceOffset
 
@@ -142,18 +142,6 @@ private class RsBaseBraceMatcher : PairedBraceMatcher {
             BracePair(LPAREN, RPAREN, false),
             BracePair(LBRACK, RBRACK, false),
             BracePair(LT, GT, false)
-        )
-
-        private val InsertPairBraceBefore = TokenSet.orSet(
-            RS_COMMENTS,
-            TokenSet.create(
-                WHITE_SPACE,
-                SEMICOLON,
-                COMMA,
-                RPAREN,
-                RBRACK,
-                RBRACE, LBRACE
-            )
         )
     }
 }

--- a/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt
@@ -48,6 +48,109 @@ class RsBraceMatcherTest : RsTestBase() {
         "fn main() { let _ = &[foo(<caret>)]; }"
     )
 
+    fun `test parenthesis in impl generic parameters`() = doTest(
+        "impl Foo<<caret>>",
+        '(',
+        "impl Foo<(<caret>)>",
+    )
+
+    fun `test brackets in impl generic parameters`() = doTest(
+        "impl Foo<<caret>>",
+        '[',
+        "impl Foo<[<caret>]>",
+    )
+
+    fun `test braces in impl generic parameters`() = doTest(
+        "impl Foo<<caret>>",
+        '{',
+        "impl Foo<{<caret>}>",
+    )
+
+    fun `test parenthesis in function generic parameters`() = doTest(
+        "fn f() { foo::<<caret>> }",
+        '(',
+        "fn f() { foo::<(<caret>)> }",
+    )
+
+    fun `test brackets in function generic parameters`() = doTest(
+        "fn f() { foo::<<caret>> }",
+        '[',
+        "fn f() { foo::<[<caret>]> }",
+    )
+
+    fun `test braces in function generic parameters`() = doTest(
+        "fn f() { foo::<<caret>> }",
+        '{',
+        "fn f() { foo::<{<caret>}> }",
+    )
+
+    fun `test parentheses in method calls`() = doTest(
+        "fn f() { foo<caret>.bar }",
+        '(',
+        "fn f() { foo(<caret>).bar }",
+    )
+
+    fun `test brackets in method calls`() = doTest(
+        "fn f() { foo<caret>.bar }",
+        '[',
+        "fn f() { foo[<caret>].bar }",
+    )
+
+    fun `test parentheses in closure arguments`() = doTest(
+        "fn f() { let f = |<caret>| true; }",
+        '(',
+        "fn f() { let f = |(<caret>)| true; }",
+    )
+
+    fun `test brackets in closure arguments`() = doTest(
+        "fn f() { let f = |<caret>| true; }",
+        '[',
+        "fn f() { let f = |[<caret>]| true; }",
+    )
+
+    fun `test parentheses in let bindings`() = doTest(
+        "fn f() { let <caret>= (true, 0u8); }",
+        '(',
+        "fn f() { let (<caret>)= (true, 0u8); }",
+    )
+
+    fun `test brackets in let bindings`() = doTest(
+        "fn f() { let <caret>= [true, true]; }",
+        '[',
+        "fn f() { let [<caret>]= [true, true]; }",
+    )
+
+    fun `test parentheses in let bindings with type`() = doTest(
+        "fn f() { let <caret>: T = ; }",
+        '(',
+        "fn f() { let (<caret>): T = ; }",
+    )
+
+    fun `test brackets in let bindings with type`() = doTest(
+        "fn f() { let <caret>: T = ; }",
+        '[',
+        "fn f() { let [<caret>]: T = ; }",
+    )
+
+    fun `test parentheses in match pattern`() = doTest(
+        "fn f(x: Foo) { match x { <caret>=> {} } }",
+        '(',
+        "fn f(x: Foo) { match x { (<caret>)=> {} } }",
+    )
+
+    fun `test brackets in match pattern`() = doTest(
+        "fn f(x: Foo) { match x { <caret>=> {} } }",
+        '[',
+        "fn f(x: Foo) { match x { [<caret>]=> {} } }",
+    )
+
+    fun `test braces in match pattern`() = doTest(
+        "fn f(x: Foo) { match x { Foo<caret>=> {} } }",
+        '{',
+        "fn f(x: Foo) { match x { Foo{<caret>}=> {} } }",
+    )
+
+
     fun `test match parenthesis`() = doMatch("fn foo<caret>(x: (i32, ()) ) {}", ")")
 
     fun `test match square brackets`() = doMatch("fn foo(x: <caret>[i32; 192]) {}", "]")


### PR DESCRIPTION
Closes #7528

Currently the plugin very aggressively filters tokens which are allowed to follow the caret during brace completion. The follow-ups can be, basically, whitespace, comma, semicolon, or other braces, brackets and parentheses. Notably, it doesn't include the angle brackets. This means that brace matching isn't performed within generic parameters, which is quite annoying. For example, `Box<caret>` after typing `[` will become `Box<[caret>`, while I would want to eventually get `Box<[u8]>`. Similarly, typing `Vec<(A, B)>` cannot use parentheses matching.

The reason that angle brackets aren't allowed are simple: we don't have access to the parse tree during brace matching, and angle brackets can be LT/GT operators. However, this doesn't look like a valid reason to forbid brace matching. Firstly, binary operators are usually formatted surrounded by whitespace. Secondly, it is unclear why would anyone want `foo/*caret*/>bar` to complete to `foo(/*caret*/>bar` instead of  `foo(/*caret*/)>bar`. The latter is a function call inside a relational operator, while the former is syntactically invalid, and fixing it requires at the very least an extra identifier and a matching parenthesis somewhere after `bar`.

For the same reason I don't see a reason to exclude other binary operators: either they will already be correctly treated due to formatting, or the resulting unmatched braces cannot be easily completed to a valid expression anyway.

More generally, it is very hard to find a valid case where one really wouldn't want to match braces before some token type, but there are many cases where one would want to do it, but can't under the current strict rules. Examples include generic parameters, patterns in let binding, function arguments and closure arguments, nested match patterns, chained method calls and many others.

Additionally, brace matching behaviour, intuitively, shouldn't depend on the formatting. One would expect that they can just bang out code with help from the IDE and reformat it later, but disabling brace matching without following whitespace completely invalidates this workflow. While there may be some cases where adding a following whitespace can change IDE behaviour, they are confusing, and should be in just a handful of well-motivated cases.

The current status quo has barely any tests, except for a few checks that stuff like `foo<caret>bar` doesn't receive brace matching. I leave the current tests intact, but treat everything else as undefined behaviour, redefining it to have brace matching.

There are barely any discussions which motivate the current status quo of brace matching. It is entirely unclear why someone thought that only the simplest cases should receive it. Most likely it was just a very conservative choice in the face of high uncertainty. I propose a reverse approach: allow everything unless someone proposes a compelling use case where brace matching is unreasonable.

Currently the only excluded case is when a caret is directly followed by an identifier.


changelog: paired braces are now correctly inserted inside of generic parameter lists and in patterns.
