### PR TITLE
Show unstable macro 2.0 items in structure view

### DIFF
--- a/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt
@@ -105,26 +105,17 @@ class RsStructureViewElement(
         buildList {
             for (item in itemsAndMacros) {
                 when (item) {
-                    is RsMacro,
-                    is RsFunction,
-                    is RsModDeclItem,
-                    is RsModItem,
-                    is RsStructOrEnumItemElement,
-                    is RsTraitOrImpl,
-                    is RsTypeAlias,
-                    is RsConstant -> add(item)
-
                     is RsForeignModItem -> {
-                        for (child in item.children) {
-                            if (child is RsFunction || child is RsConstant) {
-                                add(child as RsElement)
-                            }
-                        }
+                        addAll(extractItems(item.children.asSequence().filterIsInstance<RsElement>()))
                     }
 
                     is RsMacroCall -> {
                         addAll(extractItems(item.expansionFlatten.asSequence()))
                     }
+
+                    is RsUseItem -> Unit
+
+                    is RsMacro, is RsItemElement -> add(item)
                 }
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro2.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro2.kt
@@ -25,7 +25,7 @@ abstract class RsMacro2ImplMixin : RsStubbedNamedElementImpl<RsMacro2Stub>,
 
     constructor(stub: RsMacro2Stub, elementType: IStubElementType<*, *>) : super(stub, elementType)
 
-    override fun getIcon(flags: Int): Icon? = RsIcons.MACRO
+    override fun getIcon(flags: Int): Icon = iconWithVisibility(flags, RsIcons.MACRO)
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 

--- a/src/test/kotlin/org/rust/ide/structure/RsStructureViewModelTest.kt
+++ b/src/test/kotlin/org/rust/ide/structure/RsStructureViewModelTest.kt
@@ -194,6 +194,7 @@ class RsStructureViewModelTest : RsStructureViewTestBase() {
 
     fun `test extern`() = doTest("""
         extern {
+            type T;
             static N: i32;
             static NAME: &'static str;
             pub static mut MUT_N: i64;
@@ -202,6 +203,7 @@ class RsStructureViewModelTest : RsStructureViewTestBase() {
         }
     """, """
         |-main.rs visibility=none
+        | T visibility=private
         | N: i32 visibility=private
         | NAME: &'static str visibility=private
         | MUT_N: i64 visibility=public
@@ -209,13 +211,19 @@ class RsStructureViewModelTest : RsStructureViewTestBase() {
         | something(i32) -> u8 visibility=restricted
     """)
 
-    fun `test macro`() = doTest("""
+    fun `test macros`() = doTest("""
         macro_rules! makro {
             () => { };
         }
+        macro makro2 {}
+        pub macro makro3 {}
+        pub(crate) macro makro3 {}
     """, """
         |-main.rs visibility=none
         | makro visibility=none
+        | makro2 visibility=private
+        | makro3 visibility=public
+        | makro3 visibility=restricted
     """)
 
     fun `test structs`() = doTest("""
@@ -396,6 +404,14 @@ class RsStructureViewModelTest : RsStructureViewTestBase() {
         | -A<T> where T: ?Sized + Clone visibility=none
         |  aaa() visibility=public
         | Bar<F> for A<T> where T: ?Sized, F: ?Sized visibility=none
+    """)
+
+    fun `test use item is not shown`() = doTest("""
+        use foo::bar;
+        fn function() {}
+    """, """
+        |-main.rs visibility=none
+        | function() visibility=private
     """)
 
     fun `test console variables basic`() = doTestForREPL("""


### PR DESCRIPTION
1. Provide visibility icons for macro 2.0 items
2. Show macro 2.0 items in Structure view (`Ctrl` + `F12`)

![Screenshot from 2021-08-11 17-20-50](https://user-images.githubusercontent.com/3221931/129047027-759cd7d7-c3a6-4bce-9c0c-379d47d054c1.png)

Also, make `structure view` forward-compatible for possible new kinds of Rust items

c.c. @afetisov

changelog: Show macro 2.0 items in structure view (`Ctrl` + `F12`)
