### PR TITLE
ANN: disable Make Public fix for trait impl methods

### DIFF
--- a/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
@@ -399,6 +399,23 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         fn quux<T: foo::Bar/*caret*/>() {}
     """)
 
+    fun `test unavailable on trait method`() = checkFixIsUnavailable("Make `foo` public", """
+        mod foo {
+            trait Bar {
+                fn foo(&self);
+            }
+
+            impl Bar for super::S {
+                fn foo(&self) {}
+            }
+        }
+        struct S;
+
+        fn bar(s: S) {
+            s.<error>foo/*caret*/</error>();
+        }
+    """)
+
     fun `test make unsafe auto trait public`() = checkFixByText("Make `Bar` public", """
         mod foo {
             // Some unsafe auto trait


### PR DESCRIPTION
I noticed that the `Make public fix` has incorrect behaviour when applied to trait impl methods:
![vis](https://user-images.githubusercontent.com/4539057/129223304-edfb6521-9612-41bb-bc36-4144a62e316d.gif)

The fix could in theory make the whole trait public, but that would be inconsistent with its normal behaviour and it might be weird if the user was calling a method and the fix was offering to make a trait public. So as a first attempt I just disabled the fix in this case.

Btw, when the fix was performed and the method got a `pub(crate)` modifier, the error disappeared from its usage, which is wrong (the visibility should probably be ignored on impl trait methods).

changelog: Do not offer the Make public quick fix on method calls from trait impls.