### PR TITLE
INT: use template to fill unknown field types in Create(Tuple)StructIntention

### DIFF
--- a/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
@@ -71,17 +71,18 @@ class CreateStructIntentionTest : RsIntentionTestBase(CreateStructIntention::cla
         }
     """)
 
-    fun `test unknown type`() = doAvailableTest("""
+    fun `test unknown types`() = doAvailableTestWithLiveTemplate("""
         fn main() {
-            Foo/*caret*/ { a: Bar };
+            Foo/*caret*/ { x1: Bar, x2: (Unknown1, Unknown2) };
         }
-    """, """
+    """, "x1\tType1\tx2\tType2\tType3\t", """
         struct Foo {
-            a: _
+            x1: Type1,
+            x2: (Type2, Type3)
         }
 
         fn main() {
-            Foo { a: Bar };
+            Foo { x1: Bar, x2: (Unknown1, Unknown2) };
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
@@ -62,15 +62,15 @@ class CreateTupleStructIntentionTest : RsIntentionTestBase(CreateTupleStructInte
         }
     """)
 
-    fun `test unknown type`() = doAvailableTest("""
+    fun `test unknown types`() = doAvailableTestWithLiveTemplate("""
         fn main() {
-            Foo/*caret*/(Bar);
+            Foo/*caret*/(1, Bar, 2, Baz, (Unknown1, Unknown2));
         }
-    """, """
-        struct Foo(_);
+    """, "Type1\tType2\tType3\tType4\t", """
+        struct Foo(i32, Type1, i32, Type2, (Type3, Type4));
 
         fn main() {
-            Foo(Bar);
+            Foo(1, Bar, 2, Baz, (Unknown1, Unknown2));
         }
     """)
 


### PR DESCRIPTION
This PR adds a template builder to fill in unknown types in `CreateStructIntention` and `CreateTupleStructIntention`.

Structs:
![struct](https://user-images.githubusercontent.com/4539057/129354823-d4d9f190-6178-48c5-b52e-4f5fafa28fe4.gif)

Tuple structs:
![tuple-struct](https://user-images.githubusercontent.com/4539057/129354828-5ed20098-d5d1-4fa2-aec9-77d6cb09c61f.gif)

It seems that the hacky `RsMultipleVariableRenamer` is no longer needed with the new template API, I'll try to remove it in another PR.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7672

changelog: Intentions to create structs and tuple structs will now let the user fill in unknown field types.