### PR TITLE
CI: automatically update nightly rustc version from CI

### DIFF
--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -1,0 +1,35 @@
+name: auto updates
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '0 0 * * 1' # try each Monday
+
+jobs:
+    update-nightly:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
+
+            - name: Set up nightly Rust
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: nightly
+                  components: rust-src, rustfmt, clippy # should be synchronized with `check` workflow
+                  default: true
+
+            - name: Set up Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.9
+
+            - name: Set up git user
+              run: |
+                  git config --local user.email "intellij.rust@gmail.com"
+                  git config --local user.name "intellij-rust-bot"
+
+            - name: Update nightly
+              run: python scripts/update_nightly.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }}

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -42,7 +42,7 @@ def execute_command(*args, print_stdout=True, check=True, cwd: Optional[str] = N
                                 cwd=cwd)
     except subprocess.CalledProcessError as e:
         if print_stdout:
-            print(e.output)
+            print(e.output.decode("utf-8"))
         raise e
 
     stdout_str = result.stdout.decode("utf-8").strip()

--- a/scripts/git.py
+++ b/scripts/git.py
@@ -1,3 +1,4 @@
+from subprocess import CalledProcessError
 from typing import Optional
 
 from common import execute_command
@@ -5,3 +6,12 @@ from common import execute_command
 
 def git_command(*args, print_stdout=True, check=True, cwd: Optional[str] = None) -> str:
     return execute_command("git", *args, print_stdout=print_stdout, check=check, cwd=cwd)
+
+
+def has_git_changes() -> bool:
+    git_command("update-index", "-q", "--refresh")
+    try:
+        git_command("diff-index", "--quiet", "HEAD", "--")
+        return False
+    except CalledProcessError:
+        return True

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -1,6 +1,7 @@
 # TODO: think about using library for GitHub API
 import json
 from typing import Dict, Optional, List
+from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from common import get_patch_version
@@ -75,4 +76,18 @@ def get_all_branches(repo: str, token: str) -> List[Dict]:
                "Accept": "application/vnd.github.v3+json"}
     request = Request(f"https://api.github.com/repos/{repo}/branches", headers=headers)
     response = urlopen(request)
+    return json.load(response)
+
+
+def get_branch(repo: str, token: str, branch_name: str) -> Optional[Dict]:
+    headers = {"Authorization": f"token {token}",
+               "Accept": "application/vnd.github.v3+json"}
+    request = Request(f"https://api.github.com/repos/{repo}/branches/{branch_name}", headers=headers)
+    try:
+        response = urlopen(request)
+    except HTTPError as e:
+        if e.code == 404:
+            return None
+        else:
+            raise e
     return json.load(response)

--- a/scripts/update_nightly.py
+++ b/scripts/update_nightly.py
@@ -1,0 +1,56 @@
+import re
+
+import argparse
+
+from common import execute_command, env
+from git import git_command, has_git_changes
+from github import add_assignee, get_branch, create_pull_request
+
+CHECK_WORKFLOW_PATH = ".github/workflows/check.yml"
+RUSTC_VERSION_RE = re.compile(r".* \(\w*\s*(\d{4}-\d{2}-\d{2})\)")
+WORKFLOW_RUSTC_VERSION_RE = re.compile(r"(rust-version: \[.*nightly-)\d{4}-\d{2}-\d{2}(.*])")
+NIGHTLY_BRANCH = "nightly"
+DEFAULT_ASSIGNEE = "Undin"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--token", type=str, required=True, help="github token")
+
+    args = parser.parse_args()
+
+    repo = env("GITHUB_REPOSITORY")
+
+    nightly_branch = get_branch(repo, args.token, NIGHTLY_BRANCH)
+    if nightly_branch is not None:
+        print("Repo already has nightly branch")
+        return
+
+    git_command("checkout", "-b", NIGHTLY_BRANCH)
+
+    output = execute_command("rustc", "-V")
+    match_result = RUSTC_VERSION_RE.match(output)
+    date = match_result.group(1)
+    with open(CHECK_WORKFLOW_PATH) as f:
+        workflow_text = f.read()
+    new_workflow_text = re.sub(WORKFLOW_RUSTC_VERSION_RE, f"\\g<1>{date}\\g<2>", workflow_text)
+    if new_workflow_text == workflow_text:
+        print("The latest nightly rustc version is already used")
+        return
+
+    with open(CHECK_WORKFLOW_PATH, "w") as f:
+        f.write(new_workflow_text)
+
+    if has_git_changes():
+        git_command("add", CHECK_WORKFLOW_PATH)
+        git_command("commit", "-m", ":arrow_up nightly")
+
+        git_command("push", "origin", NIGHTLY_BRANCH)
+        pull_request = create_pull_request(repo, args.token, NIGHTLY_BRANCH, ":arrow_up nightly")
+        add_assignee(repo, args.token, pull_request["number"], DEFAULT_ASSIGNEE)
+    else:
+        print("Everything is up to date")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/update_nightly.py
+++ b/scripts/update_nightly.py
@@ -33,6 +33,11 @@ def main():
     date = match_result.group(1)
     with open(CHECK_WORKFLOW_PATH) as f:
         workflow_text = f.read()
+
+    result = re.search(WORKFLOW_RUSTC_VERSION_RE, workflow_text)
+    if result is None:
+        raise ValueError("Failed to find the current version of nightly rust")
+
     new_workflow_text = re.sub(WORKFLOW_RUSTC_VERSION_RE, f"\\g<1>{date}\\g<2>", workflow_text)
     if new_workflow_text == workflow_text:
         print("The latest nightly rustc version is already used")


### PR DESCRIPTION
Currently, nightly rustc version is updated manually and not regularly, which leads to an outdated version of nightly compiler.
These changes introduce new GitHub workflow to update this version automatically from CI.
The schedule is set up to invoke this workflow each Monday for now