### PR TITLE
Fix `RsTomlElementBaseIntentionAction` for compatibility with non-latest Toml plugin

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/intentions/RsTomlElementBaseIntentionAction.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/RsTomlElementBaseIntentionAction.kt
@@ -8,10 +8,10 @@ package org.rust.toml.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.toml.tomlPluginIsAbiCompatible
-import org.toml.ide.intentions.TomlElementBaseIntentionAction
 
-abstract class RsTomlElementBaseIntentionAction<Ctx> : TomlElementBaseIntentionAction<Ctx>() {
+abstract class RsTomlElementBaseIntentionAction<Ctx> : RsElementBaseIntentionAction<Ctx>() {
     final override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Ctx? {
         if (!tomlPluginIsAbiCompatible()) return null
         return findApplicableContextInternal(project, editor, element)


### PR DESCRIPTION
Fixes Rust plugin incompatibility with Toml `0.2.153.4056-212` introduced in https://github.com/intellij-rust/intellij-rust/pull/7646.

Fixes https://github.com/intellij-rust/intellij-rust/issues/7684
