### PR TITLE
INT: import types in create function/struct/tuple struct intentions

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
@@ -13,6 +13,7 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.utils.GenericConstraints
+import org.rust.ide.utils.import.RsImportHelper
 import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -127,6 +128,9 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
     override fun invoke(project: Project, editor: Editor, ctx: Context) {
         val function = buildCallable(project, ctx) ?: return
         val inserted = insertCallable(ctx, function) ?: return
+
+        val types = ctx.arguments.exprList.map { it.type } + ctx.returnType.type
+        RsImportHelper.importTypeReferencesFromTys(inserted, types)
 
         if (inserted.containingFile == ctx.callElement.containingFile) {
             val toBeReplaced = inserted.rawValueParameters

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.util.parentOfType
 import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.refactoring.RsMultipleVariableRenamer
+import org.rust.ide.utils.import.RsImportHelper
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyUnknown
@@ -45,6 +46,9 @@ class CreateStructIntention : RsElementBaseIntentionAction<CreateStructIntention
         val struct = buildStruct(project, ctx) ?: return
         val function = ctx.literalElement.parentOfType<RsFunction>() ?: return
         val inserted = insertStruct(ctx.target, struct, function)
+
+        val types = ctx.literalElement.structLiteralBody.structLiteralFieldList.mapNotNull { it.expr?.type }
+        RsImportHelper.importTypeReferencesFromTys(inserted, types)
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
 

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateTupleStructIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateTupleStructIntention.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.util.parentOfType
 import org.rust.ide.inspections.lints.isCamelCase
 import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.utils.import.RsImportHelper
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.PathResolveStatus
 import org.rust.lang.core.psi.ext.RsMod
@@ -54,6 +55,9 @@ class CreateTupleStructIntention : RsElementBaseIntentionAction<CreateTupleStruc
         val struct = buildStruct(project, ctx) ?: return
         val containingFunction = ctx.call.parentOfType<RsFunction>() ?: return
         val inserted = insertStruct(ctx.target, struct, containingFunction)
+
+        val types = ctx.call.valueArgumentList.exprList.map { it.type }
+        RsImportHelper.importTypeReferencesFromTys(inserted, types)
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
 

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -829,8 +829,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-
-
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test method call type to create async function`() = doAvailableTest("""
         struct S;
@@ -993,6 +991,34 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn bar(p0: Alias) {
+            todo!()
+        }
+    """)
+
+    fun `test import argument and return types`() = doAvailableTest("""
+        mod bar {
+            pub struct S;
+            pub struct T;
+            pub fn get_s() -> S { S }
+        }
+
+        fn foo() -> bar::T {
+            baz/*caret*/(bar::get_s())
+        }
+    """, """
+        use bar::{S, T};
+
+        mod bar {
+            pub struct S;
+            pub struct T;
+            pub fn get_s() -> S { S }
+        }
+
+        fn foo() -> bar::T {
+            baz(bar::get_s())
+        }
+
+        fn baz(p0: S) -> T {
             todo!()
         }
     """)

--- a/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
@@ -164,4 +164,28 @@ class CreateStructIntentionTest : RsIntentionTestBase(CreateStructIntention::cla
             Foo { a: bar };
         }
     """)
+
+    fun `test import type`() = doAvailableTest("""
+        mod bar {
+            pub struct S;
+        }
+
+        fn foo() {
+            Foo/*caret*/ { a: bar::S };
+        }
+    """, """
+        use bar::S;
+
+        mod bar {
+            pub struct S;
+        }
+
+        struct Foo {
+            a: S
+        }
+
+        fn foo() {
+            Foo { a: bar::S };
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
@@ -143,4 +143,26 @@ class CreateTupleStructIntentionTest : RsIntentionTestBase(CreateTupleStructInte
             Foo(bar);
         }
     """)
+
+    fun `test import`() = doAvailableTest("""
+        mod bar {
+            pub struct S;
+        }
+
+        fn foo() {
+            Foo/*caret*/(bar::S);
+        }
+    """, """
+        use bar::S;
+
+        mod bar {
+            pub struct S;
+        }
+
+        struct Foo(S);
+
+        fn foo() {
+            Foo(bar::S);
+        }
+    """)
 }


### PR DESCRIPTION
This PR adds import of unresolved types after using `CreateFunction/Struct/Tuple struct` intentions.

changelog: Import types after invoking create function/struct/tuple struct intentions.