### PR TITLE
DOC: update GH issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,4 +20,6 @@ Feel free to remove all the irrelevant text to request a new feature.
 <!--
 Please include as much of your codebase as needed to reproduce the error.
 If the relevant files are large, please provide a link to a public repository or a [Gist](https://gist.github.com/).
+
+If you provide a screenshot of some code, please also copy-paste the corresponding code snippet here.
 -->


### PR DESCRIPTION
When issues contain only screenshots of code, it's tedious to write the code into the editor by hand, so I thought that we could add this little nudge to the issue template.