### PR TITLE
TY: ignore associated type aliases

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -61,7 +61,8 @@ fun inferTypeReferenceType(type: RsTypeReference, defaultTraitObjectRegion: Regi
                     target is RsTypeDeclarationElement -> {
                         val ty = target.declaredType
                             .substituteWithTraitObjectRegion(subst, defaultTraitObjectRegion ?: ReStatic)
-                        if (target is RsTypeAlias) {
+                        // Ignore associated type aliases, as these are usually not very useful
+                        if (target is RsTypeAlias && !target.owner.isImplOrTrait) {
                             ty.withAlias(boundElement.downcast()!!)
                         } else {
                             ty

--- a/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
@@ -6,10 +6,12 @@
 package org.rust.ide.hints.type
 
 import com.intellij.openapi.vfs.VirtualFileFilter
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.fileTreeFromText
 import org.rust.ide.hints.parameter.RsInlayParameterHintsProvider
+import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsMethodCall
 
 class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsProvider::class) {
@@ -481,6 +483,28 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
             let a/*hint text="[:  [( [i32 ,] )]]"*/ = (1,);
             let b/*hint text="[:  [( [i32 ,  i32] )]]"*/ = (1, 2);
             let c/*hint text="[:  [( … )]]"*/ = (1, 2, 3);
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    fun `test iterator into_iter`() = checkByText("""
+        fn main() {
+            let xs<hint text="[:  i32]"/> = vec![1, 2, 3]
+                .into_iter()
+                .find(|x<hint text="[:  [& i32]]"/>| *x == 1)
+                .unwrap();
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    fun `test iterator iter`() = checkByText("""
+        fn main() {
+            let xs<hint text="[:  [& i32]]"/> = vec![1, 2, 3]
+                .iter()
+                .find(|x<hint text="[:  [& [& i32]]]"/>| **x == 1)
+                .unwrap();
         }
     """)
 }


### PR DESCRIPTION
https://github.com/intellij-rust/intellij-rust/pull/7521 somehow regressed inlay type hints, as described in https://github.com/intellij-rust/intellij-rust/issues/7689. I suppose that associated type aliases should be unwrapped to provide more meaningful information for the user. In this PR I did it in a quite heavy way, by outright not setting `aliasedBy` for associated type aliases. We can also just ignore it in selected places (e.g. for inlay type hints [here](https://github.com/intellij-rust/intellij-rust/blob/master/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt#L35)).

I have some issues with tests though. Namely, the added `test iterator iter` succeeds even without the change from this PR, even though in the IDE it shows the associated type alias without this PR. It seems that in the test the plugin is not able to infer the type of `&u32` (with `aliasedBy`) correctly, as `inferTypeReferenceType` does not correctly set `aliasedBy` for the reference and that's why the test succeeds even without the change from this PR.

I also don't know why the alias was not applied for `into_iter`, but was applied for `iter`.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7689

changelog: TODO