### PR TITLE
CARGO: handle stdlib crates without Cargo.toml

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
@@ -274,6 +274,13 @@ class StdlibDataFetcher private constructor(
     }
 
     private fun VirtualFile.collectPackageMetadata() {
+        val manifest = findChild(CargoConstants.MANIFEST_FILE)
+        // Don't try to get metadata without Cargo.toml, it will fail anyway
+        if (manifest == null) {
+            LOG.warn("There isn't `${CargoConstants.MANIFEST_FILE}` in `$path` directory")
+            return
+        }
+
         val metadataProject = try {
             cargo.fetchMetadata(project, pathAsPath)
         } catch (e: ExecutionException) {


### PR DESCRIPTION
Should help to avoid unnecessary error logs during fetching stdlib metadata (enabled by `org.rust.cargo.fetch.actual.stdlib.metadata` [experimental feature](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features))