### PR TITLE
Optimize Rust completion contributors order to collect keywords first

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -242,9 +242,13 @@
         <codeCompletionConfigurable instance="org.rust.ide.settings.RsCodeCompletionConfigurable"/>
 
         <completion.contributor language="Rust"
-                                implementationClass="org.rust.lang.core.completion.RsCompletionContributor"/>
+                                implementationClass="org.rust.lang.core.completion.RsKeywordCompletionContributor"
+                                id="RsKeywordCompletionContributor"
+                                order="first"/>
         <completion.contributor language="Rust"
-                                implementationClass="org.rust.lang.core.completion.RsKeywordCompletionContributor"/>
+                                implementationClass="org.rust.lang.core.completion.RsCompletionContributor"
+                                id="RsCompletionContributor"
+                                order="after RsKeywordCompletionContributor"/>
 
         <!-- Description Provider -->
 


### PR DESCRIPTION
Fixes #7701
Also fixes #7325

| Keyword | Before | After |
|---|---|---|
| `let` | ![before](https://user-images.githubusercontent.com/4854600/129868692-e3d36981-999e-44d1-ab0c-7b838911463b.gif) | ![after](https://user-images.githubusercontent.com/4854600/129868683-d717fb72-c0d0-4a22-81ab-ca853999b851.gif) |
| `else` | ![before2](https://user-images.githubusercontent.com/4854600/129868704-33111ee5-c3db-4de9-a160-ee0216892ca6.gif) | ![after2](https://user-images.githubusercontent.com/4854600/129868701-e4bfb659-a886-40ea-95a3-c385787d12d9.gif) |


#### Important note
This PR also affects the completion variants order. For example, now keywords might be prior to local variables in some cases when they were behind before. However, this particular PR does not change completion variants priority: the order is regulated by `org.rust.lang.core.completion.LookupElementsKt#KEYWORD_PRIORITY` and it was actually different only because keywords were collected at the very end of the completion session.

The order of the completion variants will be eventually improved with the [new ML completion ranking](https://github.com/intellij-rust/intellij-rust/issues/6411) (which is currently disabled by default).

| Before | After |
|---|---|
| <img width="527" alt="Screenshot 2021-08-18 at 11 19 02" src="https://user-images.githubusercontent.com/4854600/129872706-8b0dcd19-45e0-41d1-b322-830b42f5f08b.png"> | <img width="543" alt="Screenshot 2021-08-18 at 11 05 22" src="https://user-images.githubusercontent.com/4854600/129870741-897d3be3-24eb-4b21-8619-26537ffd19b3.png"> |


changelog: Collect keywords first during Rust code completion. Now keywords are suggested much more quickly.