### PR TITLE
TY: introduce `Ty.isEquivalentTo` that should replace `==` for `Ty`s

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1070,10 +1070,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
                     RsDiagnostic.InvalidStartAttrError.InvalidParam(params[0].typeReference ?: params[0], 0)
                         .addToHolder(holder)
                 }
-                if (params[1].typeReference?.type != TyPointer(
+                if (params[1].typeReference?.type?.isEquivalentTo(TyPointer(
                         TyPointer(TyInteger.U8.INSTANCE, Mutability.IMMUTABLE),
                         Mutability.IMMUTABLE
-                    )
+                    )) == false
                 ) {
                     RsDiagnostic.InvalidStartAttrError.InvalidParam(params[1].typeReference ?: params[1], 1)
                         .addToHolder(holder)

--- a/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
@@ -86,7 +86,7 @@ class RsChainMethodTypeHintsProvider : InlayHintsProvider<RsChainMethodTypeHints
                 for (call in chain.dropLast(1)) {
                     val type = normalizeType(call.type, lookup, iterator)
                     if (type != TyUnknown && call.isLastOnLine) {
-                        if (settings.showSameConsecutiveTypes || type != lastType) {
+                        if (settings.showSameConsecutiveTypes || !type.isEquivalentTo(lastType)) {
                             presentTypeForMethodCall(call, type)
                         }
                         lastType = type

--- a/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
@@ -291,10 +291,10 @@ class RsTypeHintsPresentationFactory(
         level + elementsCount > FOLDING_THRESHOLD
 
     private fun isDefaultTypeParameter(argument: Ty, parameter: RsTypeParameter): Boolean =
-        argument == parameter.typeReference?.type
+        argument.isEquivalentTo(parameter.typeReference?.type)
 
     private fun isDefaultTypeAlias(argument: Ty, alias: RsTypeAlias): Boolean =
-        argument == alias.typeReference?.type
+        argument.isEquivalentTo(alias.typeReference?.type)
 
     private fun List<InlayPresentation>.join(separator: String = ""): InlayPresentation {
         if (separator.isEmpty()) {

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -275,7 +275,7 @@ private data class TypeRenderer(
             if (skipUnchangedDefaultTypeArguments && !nonDefaultParamFound) {
                 if (parameter is RsTypeParameter &&
                     parameter.typeReference != null &&
-                    parameter.typeReference?.type == subst[parameter]) {
+                    parameter.typeReference?.type?.isEquivalentTo(subst[parameter]) == true) {
                     continue
                 } else {
                     nonDefaultParamFound = true

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -7,7 +7,10 @@ package org.rust.ide.utils.import
 
 import org.rust.ide.settings.RsCodeInsightSettings
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.RsQualifiedNamedElement
+import org.rust.lang.core.psi.ext.typeParameters
 import org.rust.lang.core.resolve.TYPES
 import org.rust.lang.core.resolve.createProcessor
 import org.rust.lang.core.resolve.processNestedScopesUpwards
@@ -162,7 +165,7 @@ object RsImportHelper {
                         if (skipUnchangedDefaultTypeArguments) {
                             val filteredTypeArguments = ty.typeArguments
                                 .zip(ty.item.typeParameters)
-                                .dropLastWhile { (argumentTy, param) -> argumentTy == param.typeReference?.type }
+                                .dropLastWhile { (argumentTy, param) -> argumentTy.isEquivalentTo(param.typeReference?.type) }
                                 .map { (argumentTy, _) -> argumentTy }
                             return ty.copy(typeArguments = filteredTypeArguments).superVisitWith(this)
                         }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
@@ -161,7 +161,7 @@ class RsDefaultValueBuilder(
         val binding = bindings[name] ?: return null
         val escapedName = fieldDecl.escapedName ?: return null
         return when {
-            type == binding.type -> {
+            type.isEquivalentTo(binding.type) -> {
                 val field = psiFactory.createStructLiteralField(escapedName, psiFactory.createExpression(escapedName))
                 RsFieldInitShorthandInspection.applyShorthandInit(field)
                 field

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -201,7 +201,7 @@ sealed class TraitImplSource {
  */
 data class ParamEnv(val callerBounds: List<TraitRef>) {
     fun boundsFor(ty: Ty): Sequence<BoundElement<RsTraitItem>> =
-        callerBounds.asSequence().filter { it.selfTy == ty }.map { it.trait }
+        callerBounds.asSequence().filter { it.selfTy.isEquivalentTo(ty) }.map { it.trait }
 
     fun isEmpty(): Boolean = callerBounds.isEmpty()
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -49,6 +49,20 @@ abstract class Ty(override val flags: TypeFlags = 0) : Kind, TypeFoldable<Ty> {
      * User visible string representation of a type
      */
     final override fun toString(): String = render(useAliasNames = false, skipUnchangedDefaultTypeArguments = false)
+
+    /**
+     * Use it instead of [equals] if you want to check that the types are the same from the Rust perspective.
+     *
+     * ```rust
+     * type A = i32;
+     * fn foo(a: A, b: i32) {
+     *     // Types `A` and `B` are *equivalent*, but not equal
+     * }
+     * ```
+     */
+    fun isEquivalentTo(other: Ty?): Boolean = other != null && isEquivalentToInner(other)
+
+    protected open fun isEquivalentToInner(other: Ty): Boolean = equals(other)
 }
 
 enum class Mutability {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt
@@ -69,6 +69,20 @@ data class TyAdt private constructor(
     override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): TyAdt =
         copy(aliasedBy = aliasedBy)
 
+    override fun isEquivalentToInner(other: Ty): Boolean {
+        if (this === other) return true
+        if (other !is TyAdt) return false
+
+        if (item != other.item) return false
+        if (constArguments != other.constArguments) return false
+        if (typeArguments.size != other.typeArguments.size) return false
+        for (i in typeArguments.indices) {
+            if (!typeArguments[i].isEquivalentTo(other.typeArguments[i])) return false
+        }
+
+        return true
+    }
+
     companion object {
         fun valueOf(struct: RsStructOrEnumItemElement): TyAdt =
             TyAdt(

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
@@ -26,4 +26,14 @@ data class TyArray(
         base.visitWith(visitor) || const.visitWith(visitor)
 
     override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = copy(aliasedBy = aliasedBy)
+
+    override fun isEquivalentToInner(other: Ty): Boolean {
+        if (this === other) return true
+        if (other !is TyArray) return false
+
+        if (!base.isEquivalentTo(other.base)) return false
+        if (const != other.const) return false
+
+        return true
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
@@ -24,4 +24,17 @@ data class TyFunction(
         paramTypes.any { it.visitWith(visitor) } || retType.visitWith(visitor)
 
     override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = copy(aliasedBy = aliasedBy)
+
+    override fun isEquivalentToInner(other: Ty): Boolean {
+        if (this === other) return true
+        if (other !is TyFunction) return false
+
+        if (paramTypes.size != other.paramTypes.size) return false
+        for (i in paramTypes.indices) {
+            if (!paramTypes[i].isEquivalentTo(other.paramTypes[i])) return false
+        }
+        if (!retType.isEquivalentTo(other.retType)) return false
+
+        return true
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
@@ -23,4 +23,14 @@ data class TyPointer(
         referenced.visitWith(visitor)
 
     override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = copy(aliasedBy = aliasedBy)
+
+    override fun isEquivalentToInner(other: Ty): Boolean {
+        if (this === other) return true
+        if (other !is TyPointer) return false
+
+        if (!referenced.isEquivalentTo(other.referenced)) return false
+        if (mutability != other.mutability) return false
+
+        return true
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -29,6 +29,10 @@ sealed class TyPrimitive : Ty() {
         }
     }
 
+    override fun isEquivalentToInner(other: Ty): Boolean {
+        return javaClass == other.javaClass
+    }
+
     companion object {
         fun fromPath(path: RsPath): TyPrimitive? {
             if (path.hasColonColon) return null

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
@@ -36,6 +36,7 @@ data class TyReference(
         other !is TyReference -> false
         referenced != other.referenced -> false
         mutability != other.mutability -> false
+        aliasedBy != other.aliasedBy -> false
         else -> true
     }
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
@@ -41,4 +41,14 @@ data class TyReference(
     }
 
     override fun hashCode(): Int = 31 * referenced.hashCode() + mutability.hashCode()
+
+    override fun isEquivalentToInner(other: Ty): Boolean {
+        if (this === other) return true
+        if (other !is TyReference) return false
+
+        if (!referenced.isEquivalentTo(other.referenced)) return false
+        if (mutability != other.mutability) return false
+
+        return true
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
@@ -22,4 +22,13 @@ data class TySlice(
         elementType.visitWith(visitor)
 
     override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = copy(aliasedBy = aliasedBy)
+
+    override fun isEquivalentToInner(other: Ty): Boolean {
+        if (this === other) return true
+        if (other !is TySlice) return false
+
+        if (!elementType.isEquivalentTo(other.elementType)) return false
+
+        return true
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
@@ -19,6 +19,7 @@ import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.mergeElementFlags
 import org.rust.lang.core.types.regions.ReUnknown
 import org.rust.lang.core.types.regions.Region
+import org.rust.stdext.zipValues
 
 /**
  * A "trait object" type should not be confused with a trait.
@@ -64,6 +65,24 @@ class TyTraitObject(
     }
 
     override fun hashCode(): Int = traits.hashCode()
+
+    override fun isEquivalentToInner(other: Ty): Boolean {
+        if (this === other) return true
+        if (other !is TyTraitObject) return false
+
+        if (traits.size != other.traits.size) return false
+        for (i in traits.indices) {
+            val be1 = traits[i]
+            val be2 = other.traits[i]
+            if (be1.element != be2.element) return false
+
+            if (!be1.subst.zipTypeValues(be2.subst).all { it.first.isEquivalentTo(it.second) }) return false
+            if (be1.subst.constSubst != be2.subst.constSubst) return false
+            if (!zipValues(be1.assoc, be2.assoc).all { it.first.isEquivalentTo(it.second) }) return false
+        }
+
+        return true
+    }
 
     companion object {
         fun valueOf(trait: RsTraitItem): TyTraitObject {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
@@ -59,6 +59,7 @@ class TyTraitObject(
         javaClass != other?.javaClass -> false
         other !is TyTraitObject -> false
         traits != other.traits -> false
+        aliasedBy != other.aliasedBy -> false
         else -> true
     }
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
@@ -23,4 +23,16 @@ data class TyTuple(
         types.any { it.visitWith(visitor) }
 
     override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): TyTuple = copy(aliasedBy = aliasedBy)
+
+    override fun isEquivalentToInner(other: Ty): Boolean {
+        if (this === other) return true
+        if (other !is TyTuple) return false
+
+        if (types.size != other.types.size) return false
+        for (i in types.indices) {
+            if (!types[i].isEquivalentTo(other.types[i])) return false
+        }
+
+        return true
+    }
 }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -130,7 +130,7 @@ sealed class RsDiagnostic(
                         add(ConvertToOwnedTyFix(element, expectedTy))
                     }
                     val stringTy = items.String.asTy()
-                    if (expectedTy == stringTy
+                    if (expectedTy.isEquivalentTo(stringTy)
                         && (isToStringImplForActual(items, lookup) || isActualTyNumeric())) {
                         add(ConvertToStringFix(element))
                     } else if (expectedTy is TyReference) {
@@ -157,17 +157,17 @@ sealed class RsDiagnostic(
                         }
                     } else if (expectedTy is TyAdt && expectedTy.item == items.Result) {
                         val (expOkTy, expErrTy) = expectedTy.typeArguments
-                        if (expErrTy == errTyOfTryFromActualImplForTy(expOkTy, items, lookup)) {
+                        if (expErrTy.isEquivalentTo(errTyOfTryFromActualImplForTy(expOkTy, items, lookup))) {
                             add(ConvertToTyUsingTryFromTraitFix(element, expOkTy))
                         }
-                        if (expErrTy == ifActualIsStrGetErrTyOfFromStrImplForTy(expOkTy, items, lookup)) {
+                        if (expErrTy.isEquivalentTo(ifActualIsStrGetErrTyOfFromStrImplForTy(expOkTy, items, lookup))) {
                             add(ConvertToTyUsingFromStrFix(element, expOkTy))
                         }
                     }
-                    if (actualTy == stringTy) {
-                        if (expectedTy == REF_STR_TY) {
+                    if (actualTy.isEquivalentTo(stringTy)) {
+                        if (expectedTy.isEquivalentTo(REF_STR_TY)) {
                             add(ConvertToImmutableStrFix(element))
-                        } else if (expectedTy == MUT_REF_STR_TY) {
+                        } else if (expectedTy.isEquivalentTo(MUT_REF_STR_TY)) {
                             add(ConvertToMutStrFix(element))
                         }
                     }
@@ -206,7 +206,7 @@ sealed class RsDiagnostic(
             val toOwnedTrait = items.ToOwned ?: return false
             val result = lookup.selectProjectionStrictWithDeref(TraitRef(actualTy, BoundElement(toOwnedTrait)),
                 toOwnedTrait.findAssociatedType("Owned") ?: return false)
-            return expectedTy == result.ok()?.value
+            return expectedTy.isEquivalentTo(result.ok()?.value)
         }
 
         private fun isToStringImplForActual(items: KnownItems, lookup: ImplLookup): Boolean {

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprBuilder.kt
@@ -63,6 +63,7 @@ private abstract class ConstExprBuilder<T : Ty, V> {
                 }
 
                 val typeElementPath = (typeReference?.skipParens() as? RsBaseType)?.path ?: return null
+                // TODO take into account type aliases
                 if (TyPrimitive.fromPath(typeElementPath) != expectedTy) return null
 
                 when (element) {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
@@ -389,6 +389,7 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test local variable`() = checkBothQuickFix("""
+        type AliasedString = String;
         struct A {
             x: u64
         }
@@ -399,6 +400,7 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
             d: u32,
             e: u64,
             f: String,
+            g: AliasedString,
             obj: A
         }
 
@@ -410,11 +412,13 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
                 let e: u64 = 5;
             }
             let f = "".to_string();
+            let g = "".to_string();
             let obj = A { x: 5 };
 
             <error>S</error>{/*caret*/};
         }
     """, """
+        type AliasedString = String;
         struct A {
             x: u64
         }
@@ -425,6 +429,7 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
             d: u32,
             e: u64,
             f: String,
+            g: AliasedString,
             obj: A
         }
 
@@ -436,6 +441,7 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
                 let e: u64 = 5;
             }
             let f = "".to_string();
+            let g = "".to_string();
             let obj = A { x: 5 };
 
             S{
@@ -445,6 +451,7 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
                 d: 0,
                 e: 0,
                 f,
+                g,
                 obj
             };
         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1371,6 +1371,17 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ u8
     """)
 
+    fun `test inherited generic type parameter method with bound for reference type 2`() = testExpr("""
+        type Alias<'a, T> = &'a T;
+
+        trait Tr1<A> { fn foo(&self) -> A { unimplemented!() } }
+        trait Tr2<B>: Tr1<B> {}
+        fn bar<'a, T>(t: Alias<'a, T>) where &'a T: Tr2<u8> {
+            let a = t.foo();
+            a;
+        } //^ u8
+    """)
+
     fun `test inherited generic type parameter bound`() = testExpr("""
         trait Tr1<A> {}
         trait Tr2<D>: Tr1<D> {}


### PR DESCRIPTION
Advanced type alias support in the type system (#4243, #7521) introduced a challenge: `==` can't be used for type comparison (because it takes into account type aliases) and there's no handy way to check that types are equivalent from the Rust perspective (a non-handy and slow way is `ImplLookup.relativeTo(psi).ctx.canCombineTypes(ty1, ty2)`).

In this PR I introduce `Ty.isEquivalentTo(Ty)` that does the thing. I've used it wherever I can find incorrect `==` for `Ty`s. It looks like I fixed several bugs.

changelog: Introduce `Ty.isEquivalentTo(Ty)` for `Ty`s comparison. Unlike `== `, it ignores `aliasedBy`
 field.