### PR TITLE
T&PERF: speed up toolchain tests by caching some values from rustc

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -46,6 +46,7 @@ import org.rust.cargo.toolchain.RsToolchainBase
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.cargo.toolchain.tools.*
 import org.rust.cargo.util.DownloadResult
+import org.rust.cargo.util.UnitTestRustcCacheService
 import org.rust.openapiext.TaskResult
 import org.rust.stdext.mapNotNullToSet
 import java.nio.file.Path
@@ -298,11 +299,11 @@ private fun fetchRustcInfo(context: CargoSyncTask.SyncContext): TaskResult<Rustc
         }
 
         val workingDirectory = childContext.oldCargoProject.workingDirectory
-        val sysroot = childContext.toolchain.rustc().getSysroot(workingDirectory)
-            ?: return@runWithChildProgress TaskResult.Err("failed to get project sysroot")
 
         val rustcVersion = childContext.toolchain.rustc().queryVersion(workingDirectory)
-        val rustcTargets = childContext.toolchain.rustc().getTargets(workingDirectory)
+        val sysroot = UnitTestRustcCacheService.cached(rustcVersion) { childContext.toolchain.rustc().getSysroot(workingDirectory) }
+            ?: return@runWithChildProgress TaskResult.Err("failed to get project sysroot")
+        val rustcTargets = UnitTestRustcCacheService.cached(rustcVersion) { childContext.toolchain.rustc().getTargets(workingDirectory) }
 
         TaskResult.Ok(RustcInfo(sysroot, rustcVersion, rustcTargets))
     }
@@ -348,7 +349,9 @@ private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext, rustcInfo: R
             val manifestPath = projectDirectory.resolve("Cargo.toml")
 
             val cfgOptions = try {
-                cargo.getCfgOption(childContext.project, projectDirectory)
+                 UnitTestRustcCacheService.cached(rustcInfo?.version, cacheIf = { !projectDirectory.resolve(".cargo").exists() }) {
+                     cargo.getCfgOption(childContext.project, projectDirectory)
+                 }
             } catch (e: ExecutionException) {
                 val rustcVersion = rustcInfo?.version?.semver
                 if (rustcVersion == null || rustcVersion > RUST_1_51) {
@@ -401,7 +404,7 @@ private fun fetchStdlib(context: CargoSyncTask.SyncContext, cargoProject: CargoP
 
 
 private fun Rustup.fetchStdlib(context: CargoSyncTask.SyncContext, rustcInfo: RustcInfo?): TaskResult<StandardLibrary> {
-    return when (val download = downloadStdlib()) {
+    return when (val download = UnitTestRustcCacheService.cached(rustcInfo?.version) { downloadStdlib() }) {
         is DownloadResult.Ok -> {
             val lib = StandardLibrary.fromFile(context.project, download.value, rustcInfo, listener = SyncProcessAdapter(context))
             if (lib == null) {

--- a/src/main/kotlin/org/rust/cargo/util/TestUnitTestRustcCacheService.kt
+++ b/src/main/kotlin/org/rust/cargo/util/TestUnitTestRustcCacheService.kt
@@ -6,10 +6,12 @@
 package org.rust.cargo.util
 
 import com.intellij.util.containers.orNull
+import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.toolchain.impl.RustcVersion
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
+@TestOnly
 class TestUnitTestRustcCacheService : UnitTestRustcCacheService {
     private val cache: ConcurrentHashMap<Pair<RustcVersion, Class<*>>, Optional<Any>> = ConcurrentHashMap()
 

--- a/src/main/kotlin/org/rust/cargo/util/UnitTestRustcCacheService.kt
+++ b/src/main/kotlin/org/rust/cargo/util/UnitTestRustcCacheService.kt
@@ -1,0 +1,47 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.util
+
+import com.intellij.openapi.components.service
+import org.rust.cargo.toolchain.impl.RustcVersion
+
+/**
+ * This cache is used *only* in unit tests.
+ *
+ * We assume that `sysroot`, a `list of targets`, `--print cfg` and `stdlib` are not changed
+ * (in unit tests) until the version of rustc is changed, so we can cache these values for all tests.
+ * The cache significantly speeds up heavy tests with a full toolchain (`RsWithToolchainTestBase`)
+ */
+interface UnitTestRustcCacheService {
+    fun <T> cachedInner(
+        rustcVersion: RustcVersion?,
+        cls: Class<T>,
+        cacheIf: () -> Boolean,
+        computation: () -> T
+    ): T
+
+    companion object {
+        inline fun <reified T> cached(
+            rustcVersion: RustcVersion?,
+            noinline cacheIf: () -> Boolean = { true },
+            noinline computation: () -> T
+        ): T {
+            return service<UnitTestRustcCacheService>().cachedInner(rustcVersion, T::class.java, cacheIf, computation)
+        }
+    }
+}
+
+class UnitTestRustcCacheServiceImpl : UnitTestRustcCacheService {
+    override fun <T> cachedInner(
+        rustcVersion: RustcVersion?,
+        cls: Class<T>,
+        cacheIf: () -> Boolean,
+        computation: () -> T
+    ): T {
+        return computation()
+    }
+
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -997,6 +997,10 @@
         <additionalLibraryRootsProvider
                 implementation="org.rust.cargo.project.workspace.RsAdditionalLibraryRootsProvider"/>
 
+        <applicationService serviceInterface="org.rust.cargo.util.UnitTestRustcCacheService"
+                            serviceImplementation="org.rust.cargo.util.UnitTestRustcCacheServiceImpl"
+                            testServiceImplementation="org.rust.cargo.util.TestUnitTestRustcCacheService"/>
+
         <!-- Icon Provider -->
 
         <fileIconProvider implementation="org.rust.cargo.icons.CargoIconProvider"/>

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -96,7 +96,9 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
                 )
             )
         }
-        // RsExperiments.FETCH_ACTUAL_STDLIB_METADATA significantly slows down tests
+        // RsExperiments.FETCH_ACTUAL_STDLIB_METADATA significantly slows down tests.
+        // It's possible to make it cheap, we just need to wrap `Rustup.fetchStdlib()` call into
+        // `UnitTestRustcCache.cached()`
         setExperimentalFeatureEnabled(RsExperiments.FETCH_ACTUAL_STDLIB_METADATA, fetchActualStdlibMetadata, testRootDisposable)
     }
 

--- a/src/test/kotlin/org/rust/cargo/util/TestUnitTestRustcCacheService.kt
+++ b/src/test/kotlin/org/rust/cargo/util/TestUnitTestRustcCacheService.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.util
+
+import com.intellij.util.containers.orNull
+import org.rust.cargo.toolchain.impl.RustcVersion
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+class TestUnitTestRustcCacheService : UnitTestRustcCacheService {
+    private val cache: ConcurrentHashMap<Pair<RustcVersion, Class<*>>, Optional<Any>> = ConcurrentHashMap()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> cachedInner(
+        rustcVersion: RustcVersion?,
+        cls: Class<T>,
+        cacheIf: () -> Boolean,
+        computation: () -> T
+    ): T {
+        if (rustcVersion == null) return computation()
+        return cache.getOrPut(rustcVersion to cls) { Optional.ofNullable(computation()) }.orNull() as T
+    }
+}


### PR DESCRIPTION
I suppose that `sysroot`, a `list of targets`, `--print cfg` and `stdlib` are not changed until the version of rustc is changed, so we can cache these values for all tests. The cache significantly speeds up heavy tests with a full toolchain (`RsWithToolchainTestBase`), in my case it is 30% speedup for `rustSlowTests`.
