### PR TITLE
CI: speed up check workflow for pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,11 @@ on:
             - staging
             - trying
     pull_request:
+    # Trigger workflow every day to create/update caches for other builds
+    # See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+    # to get more details about cache access
+    schedule:
+        -   cron: '0 3 * * *'
 
 # Allow cancelling all previous runs for the same branch
 # See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
@@ -55,7 +60,10 @@ jobs:
     build-native-code:
         needs: [ calculate-git-info ]
         # `fromJSON` is used here to convert string output to boolean
-        if: ${{ !(fromJSON(needs.calculate-git-info.outputs.is_master_branch) && fromJSON(needs.calculate-git-info.outputs.checked)) }}
+        # We always want to trigger all workflow jobs on `schedule` event because it creates/updates caches for other builds.
+        # See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+        # to get more details about cache access
+        if: ${{ github.event_name == 'schedule' || !fromJSON(needs.calculate-git-info.outputs.is_master_branch) || !fromJSON(needs.calculate-git-info.outputs.checked) }}
         strategy:
             fail-fast: true
             matrix:


### PR DESCRIPTION
Found out that caches created in `branch_A` are available from `branch_B` only of `branch_A` is a base branch for `branch_B`, `branch_A` == `branch_B` or `branch_A` is default branch, i.e. `master` in our case (see https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache for more details). In combination with the fact that we usually don't run `check` workflow for `master` branch (see #7162), it leads to "no caches" situation for the first run of `check` workflow for most pull requests

These changes set up a schedule to run `check` workflow every day to create/update caches from `master` branch and speed up other runs
