### PR TITLE
ANN: support E0451 for shorthand struct field literals

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -487,7 +487,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         val reference = ref.reference ?: return
         val highlightedElement = ref.referenceNameElement ?: return
         val referenceName = ref.referenceName ?: return
-        val resolvedElement = reference.resolve() as? RsVisible ?: return
+        val resolvedElement = when (ref) {
+            is RsStructLiteralField -> reference.multiResolve().firstOrNull { it is RsVisible }
+            else -> reference.resolve()
+        } as? RsVisible ?: return
         val oMod = o.contextStrict<RsMod>() ?: return
         if (resolvedElement.isVisibleFrom(oMod)) return
         val withinOneCrate = resolvedElement.crateRoot == o.crateRoot

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1203,6 +1203,18 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    fun `test attempted to construct struct which has a private field with field shorthand E0451`() = checkErrors("""
+        mod some_module {
+            pub struct Foo {
+                x: u32,
+            }
+        }
+        fn main() {
+            let x: u32 = 0;
+            let f = some_module::Foo { <error descr="Field `x` of struct `some_module::Foo` is private [E0451]">x</error> };
+        }
+    """)
+
     fun `test construct pub enum (fields in pub enum are public by default)`() = checkErrors("""
         mod some_module {
             pub enum Foo {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
@@ -492,6 +492,24 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    fun `test make struct field public (from shorthand struct literal)`() = checkFixByText("Make `baz` public", """
+        mod foo {
+            pub(crate) struct Bar { baz: i32 }
+        }
+        fn main() {
+            let baz: i32 = 0;
+            let foo = foo::Bar { <error>baz/*caret*/</error> };
+        }
+    """, """
+        mod foo {
+            pub(crate) struct Bar { pub(crate) baz: i32 }
+        }
+        fn main() {
+            let baz: i32 = 0;
+            let foo = foo::Bar { baz };
+        }
+    """)
+
     fun `test make tuple struct field public`() = checkFixByText("Make `0` public", """
         mod foo {
             pub(crate) struct Bar(i32);


### PR DESCRIPTION
I noticed that E0451 (struct field is private) wasn't being applied for shorthand field literals. This PR fixes it.

changelog: Support the E0451 compiler error for struct field literals using shorthand init.