### PR TITLE
MACRO&RES: support arbitrary items expanded from custom derive

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsProcMacroPsiUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsProcMacroPsiUtil.kt
@@ -12,6 +12,7 @@ import org.rust.lang.core.macros.proc.ProcMacroApplicationService
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.KNOWN_DERIVABLE_TRAITS
 import org.rust.lang.core.stubs.*
+import org.rust.lang.core.stubs.common.RsAttrProcMacroOwnerPsiOrStub
 import org.rust.lang.core.stubs.common.RsMetaItemPsiOrStub
 
 object RsProcMacroPsiUtil {
@@ -41,8 +42,11 @@ object RsProcMacroPsiUtil {
      */
     fun canBeCustomDerive(metaItem: RsMetaItem): Boolean {
         val isDerive = RsPsiPattern.derivedTraitMetaItem.accepts(metaItem)
-        return isDerive && KNOWN_DERIVABLE_TRAITS[metaItem.name]?.isStd != true
+        return isDerive && canBeCustomDeriveWithoutContextCheck(metaItem)
     }
+
+    fun canBeCustomDeriveWithoutContextCheck(metaItem: RsMetaItemPsiOrStub) =
+        KNOWN_DERIVABLE_TRAITS[metaItem.name]?.isStd != true
 
     private fun canBeProcMacroAttributeCall(
         metaItem: RsMetaItem,
@@ -108,4 +112,7 @@ object RsProcMacroPsiUtil {
                 && item !is RsModItem
                 && item !is RsMacroDefinitionBase
             )
+
+    fun canOwnDeriveAttrs(item: RsAttrProcMacroOwnerPsiOrStub<*>): Boolean =
+        item is RsStructOrEnumItemElement || item is RsStructItemStub || item is RsEnumItemStub
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAttrProcMacroOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAttrProcMacroOwner.kt
@@ -19,4 +19,9 @@ interface RsAttrProcMacroOwner : RsOuterAttributeOwner, RsAttrProcMacroOwnerPsiO
     @JvmDefault
     val procMacroAttribute: ProcMacroAttribute<RsMetaItem>
         get() = ProcMacroAttribute.getProcMacroAttribute(this)
+
+    /** @see ProcMacroAttribute */
+    @JvmDefault
+    val procMacroAttributeWithDerives: ProcMacroAttribute<RsMetaItem>
+        get() = ProcMacroAttribute.getProcMacroAttribute(this, withDerives = true)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
@@ -77,7 +77,7 @@ val RsPossibleMacroCall.isMacroCall: Boolean
                 val owner = kind.meta.owner as? RsAttrProcMacroOwner ?: return false
                 when (val attr = ProcMacroAttribute.getProcMacroAttributeWithoutResolve(owner, ignoreProcMacrosDisabled = true)) {
                     is ProcMacroAttribute.Attr -> attr.attr == this
-                    ProcMacroAttribute.Derive -> RsProcMacroPsiUtil.canBeCustomDerive(kind.meta)
+                    is ProcMacroAttribute.Derive -> RsProcMacroPsiUtil.canBeCustomDerive(kind.meta)
                     ProcMacroAttribute.None -> false
                 }
             }
@@ -148,7 +148,7 @@ private fun doPrepareProcMacroCallBody(
                 ?: return null
             PreparedProcMacroCallBody.Attribute(body, attr)
         }
-        ProcMacroAttribute.Derive -> {
+        is ProcMacroAttribute.Derive -> {
             val crate = explicitCrate ?: owner.containingCrate ?: return null
             val body = doPrepareCustomDeriveMacroCallBody(project, text, endOfAttrsOffset, crate) ?: return null
             PreparedProcMacroCallBody.Derive(body)
@@ -172,7 +172,7 @@ private sealed class PreparedProcMacroCallBody {
  * Does things that Rustc does before passing a body to a **custom derive** proc macro:
  * removes `cfg` and `derive` attributes, unwraps `cfg_attr` attributes, moves docs before other attributes.
  */
-private fun doPrepareCustomDeriveMacroCallBody(
+fun doPrepareCustomDeriveMacroCallBody(
     project: Project,
     text: String,
     endOfAttrsOffset: Int,

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructOrEnumItemElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructOrEnumItemElement.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Query
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.stubs.common.RsMetaItemPsiOrStub
 import org.rust.openapiext.filterIsInstanceQuery
 import org.rust.openapiext.mapQuery
 
@@ -33,9 +34,13 @@ val RsStructOrEnumItemElement.derivedTraitsToMetaItems: Map<RsTraitItem, RsMetaI
 val RsStructOrEnumItemElement.deriveMetaItems: Sequence<RsMetaItem>
     get() = queryAttributes.deriveMetaItems
 
-val QueryAttributes<RsMetaItem>.deriveMetaItems: Sequence<RsMetaItem>
+@Suppress("UNCHECKED_CAST")
+val <T : RsMetaItemPsiOrStub> QueryAttributes<T>.deriveMetaItems: Sequence<T>
     get() = deriveAttributes
-        .flatMap { it.metaItemArgs?.metaItemList?.asSequence() ?: emptySequence() }
+        .flatMap { it.metaItemArgs?.metaItemList?.asSequence() as? Sequence<T> ?: emptySequence() }
+
+val <T : RsMetaItemPsiOrStub> QueryAttributes<T>.customDeriveMetaItems: Sequence<T>
+    get() = deriveMetaItems.filter { RsProcMacroPsiUtil.canBeCustomDeriveWithoutContextCheck(it) }
 
 val RsStructOrEnumItemElement.firstKeyword: PsiElement?
     get() = when (this) {

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -31,6 +31,9 @@ import org.rust.lang.core.resolve2.util.SmartListMap
 import org.rust.openapiext.fileId
 import org.rust.openapiext.testAssert
 import org.rust.stdext.HashCode
+import org.rust.stdext.writeVarInt
+import java.io.DataOutput
+import java.io.IOException
 import java.nio.file.Path
 import java.util.*
 
@@ -217,8 +220,17 @@ class FileInfo(
 @Suppress("EXPERIMENTAL_FEATURE_WARNING")
 inline class MacroIndex(private val indices: IntArray) : Comparable<MacroIndex> {
     fun append(index: Int): MacroIndex = MacroIndex(indices + index)
+    fun append(index: MacroIndex): MacroIndex = MacroIndex(indices + index.indices)
 
     override fun compareTo(other: MacroIndex): Int = Arrays.compare(indices, other.indices)
+
+    @Throws(IOException::class)
+    fun writeTo(data: DataOutput) {
+        data.writeVarInt(indices.size)
+        for (index in indices) {
+            data.writeVarInt(index)
+        }
+    }
 
     companion object {
         /** Equivalent to `call < mod && !isPrefix(call, mod)` */

--- a/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
@@ -417,7 +417,7 @@ class ProcMacroAttributeTest : RsTestBase() {
     private fun ProcMacroAttribute<RsMetaItem>.toTestValue() =
         when (this) {
             is ProcMacroAttribute.Attr -> Attr(attr.path!!.text, index)
-            ProcMacroAttribute.Derive -> Derive
+            is ProcMacroAttribute.Derive -> Derive
             ProcMacroAttribute.None -> None
         }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -117,6 +117,158 @@ class RsProcMacroExpansionResolveTest : RsResolveTestBase() {
         }           //^ unresolved
     """)
 
+    fun `test custom derive expands to a struct`() = checkByCode("""
+        use test_proc_macros::DeriveStructFooDeclaration;
+
+        #[derive(DeriveStructFooDeclaration)] // struct Foo;
+        struct Bar;
+
+        impl Foo {
+            fn bar(&self) {}
+        }     //X
+
+        fn main() {
+            Foo.bar()
+        }     //^
+    """)
+
+    fun `test custom derive expands to macro declaration`() = checkByCode("""
+        use test_proc_macros::DeriveMacroFooThatExpandsToStructFoo;
+
+        #[derive(DeriveMacroFooThatExpandsToStructFoo)] // macro_rules! foo { () => { struct Foo; } }
+        struct Bar;
+        foo!();
+
+        impl Foo {
+            fn bar(&self) {}
+        }     //X
+
+        fn main() {
+            Foo.bar()
+        }     //^
+    """)
+
+    fun `test custom derive expands to a macro declaration, the macro is unresolved inside the struct`() = checkByCode("""
+        use test_proc_macros::DeriveMacroFooThatExpandsToStructFoo;
+
+        #[derive(DeriveMacroFooThatExpandsToStructFoo)] // macro_rules! foo { () => { struct Foo; } }
+        struct Bar {
+            f: foo!()
+        }    //^ unresolved
+    """)
+
+    fun `test custom derive expands to a macro call`() = checkByCode("""
+        use test_proc_macros::DeriveMacroFooInvocation;
+
+        macro_rules! foo { () => { struct Foo; } }
+        #[derive(DeriveMacroFooInvocation)] // foo!()
+        struct Bar;
+
+        impl Foo {
+            fn bar(&self) {}
+        }     //X
+
+        fn main() {
+            Foo.bar()
+        }     //^
+    """)
+
+    fun `test 2 custom derive expands to a macro declaration and a macro call`() = checkByCode("""
+        use test_proc_macros::*;
+
+        #[derive(DeriveMacroFooThatExpandsToStructFoo)] // macro_rules! foo { () => { struct Foo; } }
+        #[derive(DeriveMacroFooInvocation)] // foo!()
+        struct Bar;
+
+        impl Foo {
+            fn bar(&self) {}
+        }     //X
+
+        fn main() {
+            Foo.bar()
+        }     //^
+    """)
+
+    fun `test 2 custom derive expands to a macro declaration and a macro call 1`() = checkByCode("""
+        use test_proc_macros::*;
+
+        macro_rules! bar {
+            () => {
+                #[derive(DeriveMacroFooThatExpandsToStructFoo)] // macro_rules! foo { () => { struct Foo; } }
+                #[derive(DeriveMacroFooInvocation)] // foo!()
+                struct Bar;
+            };
+        }
+        bar!();
+
+        impl Foo {
+            fn bar(&self) {}
+        }     //X
+
+        fn main() {
+            Foo.bar()
+        }     //^
+    """)
+
+    fun `test 2 custom derive expands to a macro declaration and a macro call 2`() = checkByCode("""
+        use test_proc_macros::*;
+
+        #[derive(DeriveMacroFooThatExpandsToStructFoo, DeriveMacroFooInvocation)]
+        // macro_rules! foo { () => { struct Foo; } }
+        // foo!()
+        struct Bar;
+
+        impl Foo {
+            fn bar(&self) {}
+        }     //X
+
+        fn main() {
+            Foo.bar()
+        }     //^
+    """)
+
+    fun `test 2 custom derive expands to a macro declaration and a macro call 3`() = checkByCode("""
+        use test_proc_macros::*;
+
+        macro_rules! foo { () => { struct Bar; } }
+
+        #[derive(DeriveMacroFooInvocation)] // foo!()
+        #[derive(DeriveMacroFooThatExpandsToStructFoo)] // macro_rules! foo { () => { struct Foo; } }
+        struct Baz;
+
+        impl Bar {
+            fn bar(&self) {}
+        }     //X
+
+        fn main() {
+            Bar.bar()
+        }     //^
+    """)
+
+    fun `test 2 custom derive expands to a macro declaration and a macro call 4`() = checkByCode("""
+        use test_proc_macros::*;
+
+        macro_rules! bar { () => { struct Bar; } }
+
+        #[derive(DeriveMacroBarInvocation)] // bar!()
+        #[derive(DeriveMacroFooThatExpandsToStructFoo)] // macro_rules! foo { () => { struct Foo; } }
+        struct Baz;
+
+        foo!(); // struct Foo;
+
+        impl Foo {
+            fn bar(&self) -> Bar { Bar }
+        }
+
+        impl Bar {
+            fn baz(&self) {}
+        }     //X
+
+        fn main() {
+            Foo.bar().baz()
+        }           //^
+    """)
+
     fun `test attr legacy macro`() = checkByCode("""
         use test_proc_macros::attr_as_is;
 

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapMacroIndexConsistencyTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapMacroIndexConsistencyTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import org.intellij.lang.annotations.Language
+import org.rust.*
+import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
+import org.rust.ide.experiments.RsExperiments.PROC_MACROS
+import org.rust.lang.core.macros.MacroExpansionScope
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.toPsiFile
+import org.rust.stdext.withPrevious
+
+@UseNewResolve
+@MinRustcVersion("1.46.0")
+@WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
+class RsDefMapMacroIndexConsistencyTest : RsTestBase() {
+    fun `test simple`() = doTest("""
+        use test_proc_macros::*;
+
+        macro_rules! macro0 { () => {} }
+        macro0!();
+        macro_rules! macro1 { () => {} }
+        mod mod1 {}
+        macro_rules! macro2 { () => {} }
+        mod mod2;
+        macro_rules! macro3 { () => {} }
+    """, """
+        [0, 0] macro macro0
+        [0, 1] macro0!()
+        [0, 2] macro macro1
+        [0, 3] mod mod1
+        [0, 4] macro macro2
+        [0, 5] mod mod2
+        [0, 6] macro macro3
+    """)
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test proc macros`() = doTest("""
+        use test_proc_macros::*;
+
+        macro_rules! macro0 { () => {} }
+        #[attr_as_is]
+        fn func() {}
+        macro_rules! macro1 { () => {} }
+        #[derive(DeriveMacroFooThatExpandsToStructFoo, DeriveMacroFooInvocation)]
+        // macro_rules! foo { () => { struct Foo; } }
+        // foo!()
+        struct Struct;
+        macro_rules! macro2 { () => {} }
+    """, """
+        [1, 0] macro macro0
+        [1, 1] #[attr_as_is]
+        [1, 1, 0] fn func
+        [1, 2] macro macro1
+        [1, 3] struct Struct
+        [1, 3, 0] #[derive(DeriveMacroFooThatExpandsToStructFoo)]
+        [1, 3, 0, 0] macro foo
+        [1, 3, 1] #[derive(DeriveMacroFooInvocation)]
+        [1, 3, 1, 0] foo!()
+        [1, 3, 1, 0, 0] struct Foo
+        [1, 4] macro macro2
+    """)
+
+    fun doTest(@Language("Rust") code: String, itemIndices: String) {
+        InlineFile(code)
+        val crateRoot = myFixture.findFileInTempDir("main.rs").toPsiFile(myFixture.project) as RsFile
+        val crate = crateRoot.crate!!
+        val defMap = project.defMapService.getOrUpdateIfNeeded(crate.id!!)!!
+
+        val expandedItems = mutableListOf<RsElement>()
+        crateRoot.processExpandedItemsInternal(withMacroCalls = true) { item, _ ->
+            expandedItems += item
+            false
+        }
+
+        val macroIndicesDuringResolve = expandedItems
+            .asSequence()
+            .filter {
+                it is RsNamedElement && it is RsItemElement || it is RsMacro || it is RsMacroCall || it is RsMetaItem
+            }
+            .map {
+                val name = when (it) {
+                    is RsItemElement -> "${it.itemDefKeyword.text} ${it.name!!}"
+                    is RsMacro -> "macro ${it.name!!}"
+                    is RsMacroCall -> "${it.path.text}!()"
+                    is RsMetaItem -> if (RsProcMacroPsiUtil.canBeCustomDerive(it)) {
+                        "#[derive(${it.path!!.text})]"
+                    } else {
+                        "#[${it.path!!.text}]"
+                    }
+                    else -> error("impossible")
+                }
+                val index = getMacroIndex(it, defMap, crate)!!
+                index to name
+            }
+            .withPrevious()
+            .filter { (i, prev) -> prev == null || !MacroIndex.equals(i.first, prev.first) }
+            .map { it.first }
+            .toList()
+        val macroIndicesDuringBuild = defMap.root.legacyMacros.values
+            .map { it.single() }
+            .filterIsInstance<DeclMacroDefInfo>()
+            .sortedBy { it.macroIndex }
+            .map { it.macroIndex to "macro ${it.path.name}" }
+
+        fun List<Pair<MacroIndex, String>>.indicesToString(): String =
+            joinToString("\n") { (index, name) -> "$index $name" }
+
+        val expectedItemIndices = itemIndices.trimIndent()
+        val expectedLegacyMacrosIndices = expectedItemIndices
+            .lineSequence()
+            .filter {
+                it.contains("] macro ")
+            }
+            .joinToString(separator = "\n")
+
+        assertEquals(expectedItemIndices, macroIndicesDuringResolve.indicesToString())
+        assertEquals(expectedLegacyMacrosIndices, macroIndicesDuringBuild.indicesToString())
+    }
+}

--- a/testData/test-proc-macros/src/lib.rs
+++ b/testData/test-proc-macros/src/lib.rs
@@ -61,6 +61,26 @@ pub fn derive_impl_for_foo(_item: TokenStream) -> TokenStream {
    "impl Foo { fn foo(&self) -> Bar {} }".parse().unwrap()
 }
 
+#[proc_macro_derive(DeriveStructFooDeclaration)]
+pub fn derive_struct_foo_declaration(_item: TokenStream) -> TokenStream {
+   "struct Foo;".parse().unwrap()
+}
+
+#[proc_macro_derive(DeriveMacroFooThatExpandsToStructFoo)]
+pub fn derive_macro_foo_that_expands_to_struct_foo(_item: TokenStream) -> TokenStream {
+   "macro_rules! foo { () => { struct Foo; } }".parse().unwrap()
+}
+
+#[proc_macro_derive(DeriveMacroFooInvocation)]
+pub fn derive_macro_foo_invocation(_item: TokenStream) -> TokenStream {
+   "foo!{}".parse().unwrap()
+}
+
+#[proc_macro_derive(DeriveMacroBarInvocation)]
+pub fn derive_macro_bar_invocation(_item: TokenStream) -> TokenStream {
+   "bar!{}".parse().unwrap()
+}
+
 #[proc_macro]
 pub fn function_like_generates_impl_for_foo(_input: TokenStream) -> TokenStream {
    "impl Foo { fn foo(&self) -> Bar {} }".parse().unwrap()


### PR DESCRIPTION
Depends on #7194

changelog: Take into account all kinds of items generated by custom derive procedural macros. Previously only `impl` blocks were accounted. Please, note that procedural macro expansion is experimental. If you want to try it, enable `org.rust.cargo.evaluate.build.scripts` and `org.rust.macros.proc` experimental features
