### PR TITLE
QDOC: print actual visibility for items with restricted visibility

### DIFF
--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -349,9 +349,7 @@ private val RsTraitItem.declarationText: List<String>
 private val RsItemElement.declarationModifiers: List<String>
     get() {
         val modifiers = mutableListOf<String>()
-        if (isPublic) {
-            modifiers += "pub"
-        }
+        vis?.text?.let { modifiers += it }
         when (this) {
             is RsFunction -> {
                 if (isAsync) {

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -46,6 +46,52 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         pub fn <b>foo</b>()</pre></div>
     """)
 
+    fun `test pub(crate) fn`() = doTest("""
+        pub(crate) fn foo() {}
+                     //^
+    """, """
+        <div class='definition'><pre>test_package
+        pub(crate) fn <b>foo</b>()</pre></div>
+    """)
+
+    fun `test pub(self) fn`() = doTest("""
+        pub(self) fn foo() {}
+                     //^
+    """, """
+        <div class='definition'><pre>test_package
+        pub(self) fn <b>foo</b>()</pre></div>
+    """)
+
+    fun `test pub(super) fn`() = doTest("""
+        mod bar {
+            pub(super) fn foo() {}
+                         //^
+        }
+    """, """
+        <div class='definition'><pre>test_package::bar
+        pub(super) fn <b>foo</b>()</pre></div>
+    """)
+
+    fun `test crate fn`() = doTest("""
+        mod bar {
+            crate fn foo() {}
+                    //^
+        }
+    """, """
+        <div class='definition'><pre>test_package::bar
+        crate fn <b>foo</b>()</pre></div>
+    """)
+
+    fun `test pub(in crate-bar) fn`() = doTest("""
+        mod bar {
+            pub(in crate::bar) fn foo() {}
+                                //^
+        }
+    """, """
+        <div class='definition'><pre>test_package::bar
+        pub(in crate::bar) fn <b>foo</b>()</pre></div>
+    """)
+
     fun `test const fn`() = doTest("""
         const fn foo() {}
                  //^
@@ -56,7 +102,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
 
     fun `test unsafe fn`() = doTest("""
         unsafe fn foo() {}
-                  //^
+                 //^
     """, """
         <div class='definition'><pre>test_package
         unsafe fn <b>foo</b>()</pre></div>


### PR DESCRIPTION
Closes #7722 

Previously the plugin either printed no visibility qualifiers in the quick documentation (for private items with no visibility specified), or always printed "pub", even for items with restricted visibility. That's confusing: you invoke completion and pick a function from the list looking at the documentation, but the function turns out private to some module, even though it was listed as public. It's also confusing to get a "cannot use private item" error from the compiler while the item is "pub" in the docs.

I have changed it to print the actual qualifiers specified in the source code. Benefits:
* It doesn't provide false information (e.g. `pub(crate)` items printed as if they are public);
* It faithfully represents the visibility specified in the code, which may be relevant to the user;
* It is simple in implementation;
* It automatically supports any other possible future visibility qualifiers (e.g. when the `crate` visibility is used, the items are automatically printed as `crate fn foo`, which will be relevant if the feature becomes stable and idiomatic in a future edition).

A possible downside is that the visibility may be hard to interpret. E.g. a `pub(super) fn foo` can be defined in `crate_foo::mod_foo`, but used in `crate_bar::mod_bar`. Does the `super` refer to `crate_foo` or `crate_bar`? It may be a good idea to provide an explicit answer in the quick documentation, resolving `super` visibility path to specifically `crate_foo`. However, the implementation of that feature would be more complicated, and it also raises new questions, e.g. should it take the visibility of containing modules into account?

Perhaps the item is reexported from `crate_zux` which has `crate_foo` as private dependency. E.g. we have `pub fn bar()` in `crate_foo`, but `crate_zux` reexports it as `pub(crate) use crate_foo::bar;`. It may be confusing for the user if the documentation stated `pub fn foo` instead of `pub(in crate_zux) fn bar();`. But what if `crate_foo::bar` is visible from several locations? What if the user is interested in the original definition, rather than reexported paths? Calculating effective visibility would mean that the quick documentation would change depending on the location of the referencing element. Would it be confusing, and would it even be feasible to implement given a multitude of various PSI references?

Given that those questions don't have any obvious answer and that the current behaviour is very predictable and easily understandable, I postpone any further improvements.


changelog: correctly print restricted visibility of items in quick documentation instead of always printing "pub".
