### PR TITLE
TYPE: complete crate names for toplevel item macro calls

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsMacroCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsMacroCompletionProvider.kt
@@ -22,10 +22,7 @@ import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.unescapedText
 import org.rust.lang.core.psiElement
-import org.rust.lang.core.resolve.collectCompletionVariants
-import org.rust.lang.core.resolve.createProcessor
-import org.rust.lang.core.resolve.processMacroCallVariantsInScope
-import org.rust.lang.core.resolve.processMacrosExportedByCrateName
+import org.rust.lang.core.resolve.*
 import org.rust.lang.core.withPrevSiblingSkipping
 
 /**
@@ -67,6 +64,7 @@ object RsMacroCompletionProvider : RsCompletionProvider() {
                 processMacrosExportedByCrateName(rsElement, firstSegmentText, processor)
             } else {
                 processMacroCallVariantsInScope(position, isAttrOrDerive = false, processor)
+                processExternCrateResolveVariants(rsElement, isCompletion = true, withSelf = true, processor = originalProcessor)
             }
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -613,6 +613,19 @@ class RsCompletionTest : RsCompletionTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test complete extern crate for macro`() = doSingleCompletionByFileTree("""
+    //- lib.rs
+        dep_lib_/*caret*/
+        fn foo(){}
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo_bar { () => () }
+    """, """
+        dep_lib_target/*caret*/
+        fn foo(){}
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test complete outer macro with qualified path 1`() = doSingleCompletionByFileTree("""
     //- lib.rs
         dep_lib_target::fo/*caret*/


### PR DESCRIPTION
This example now works:
```rust
stat/*caret*/
// choose completion
static_assertions/*caret*/
// type
static_assertions::impl/*caret*/
// choose completion
static_assertions::assert_not_impl_all!(/*caret*/);
```

changelog: added completion for crate names in top level qualified macro calls.
