### PR TITLE
DOC: Drop CLA requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,12 +5,6 @@ We don't have any strict rules about pull requests, but you might check
 https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
 for some hints!
 
-Note that we need an electronic CLA for contributions:
-https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla
-
-After you sign the CLA, please add your name to
-https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt
-
 Also, please write a short description explaining your change in the following format: `changelog: %description%`
 This description will help a lot to create release changelog. 
 Drop these lines for internal only changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,13 +114,6 @@ And also a tutorial series "Contributing to Intellij-Rust" by [@Kobzol](https://
   - [\#5: Lint attribute completion](https://kobzol.github.io/rust/intellij/2020/10/26/contributing-5-lint-attribute-completion.html).
 
 
-## CLA
-
-We require a contributor license agreement for all contributions. You can sign it 
-electronically at https://www.jetbrains.com/agreements/cla/ via DocuSign. The procedure
-consists of a couple of emails and clicks: no need to scan or print or snail-mail anything :)
-`CONTRIBUTORS.txt` file stores GitHub usernames of people who already signed a CLA.
-  
 ## Code style
 
 Please use **reformat code** action to maintain consistent style. Pay attention

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -2,11 +2,6 @@
 
 ## Accepting pull requests
 
-We require a CLA from all contributors. See [CONTRIBUTING.md](CONTRIBUTING.md) 
-for the details. The most important one is that signing is fully electronic 
-and can be done in seconds. The list of GitHub users who have already signed 
-the CLA is at [CONTRIBUTORS.txt](CONTRIBUTORS.txt).
-
 We use [bors](https://bors.tech/) to make sure master is always green. Common commands are
 
 * `bors r+` to merge a PR,
@@ -33,6 +28,14 @@ if the corresponding change should be mentioned in documentation or affects exis
 Each non-stalled pull-request should be assigned to a reviewer, who should make
 sure that PR moves forward. However, anybody with r+ can accept any PR, if
 they are confident that the PR is in a good state.
+
+## Accepting contributions outside of GitHub
+
+In case you receive a contribution (a patch) outside of GitHub (e.g. by email),
+we require a CLA from that contributor. The CLA can be signed at 
+https://www.jetbrains.com/agreements/cla/ via DocuSign. The most important one 
+is that signing is fully electronic and can be done in seconds
+
 
 ## Upgrades
 


### PR DESCRIPTION
Signing CLA is not needed because of GitHub Terms of Service:

> 6. Contributions Under Repository License
> Whenever you add Content to a repository containing notice of
> a license, you license that Content under the same terms, and
> you agree that you have the right to license that Content
> under those terms. If you have a separate agreement to license
> that Content under different terms, such as a contributor
> license agreement, that agreement will supersede.
>
> Isn't this just how it works already? Yep.
> This is widely accepted as the norm in the open-source
> community; it's commonly referred to by the shorthand
> "inbound=outbound". We're just making it explicit.

https://docs.github.com/en/github/site-policy/github-terms-of-service#6-contributions-under-repository-license
