### PR TITLE
Render negative `impl`s properly

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/Utils.kt
@@ -74,6 +74,9 @@ private fun presentableName(psi: RsElement): String? {
             val trait = psi.traitRef?.text
             buildString {
                 if (trait != null) {
+                    if (psi.isNegativeImpl) {
+                        append("!")
+                    }
                     append("$trait for ")
                 }
                 append(type)

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
@@ -50,14 +50,23 @@ class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         impl Foo for Bar {}
     """)
 
+    fun `test negative impls`() = doPopupTest("""
+        trait Foo {}
+        struct Bar/*caret*/;
+        impl !Foo for Bar {}
+    """, "!Foo for Bar")
+
     fun `test impls sorting`() = doPopupTest("""
         trait Bar {}
         trait Foo {}
+        trait Baz {}
         struct FooBar/*caret*/;
 
         impl Foo for FooBar {}
         impl Bar for FooBar {}
+        impl !Baz for FooBar {}
     """,
+        "!Baz for FooBar",
         "Bar for FooBar",
         "Foo for FooBar"
     )


### PR DESCRIPTION
Fixes #7749

changelog: Properly render negative `impl` items in `Go to implementation` popup
