### PR TITLE
CARGO: don't fetch stdlib metadata for rustc project

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -119,7 +119,7 @@ class CargoSyncTask(
                                 .withWorkspace(fetchCargoWorkspace(context, rustcInfo))
                             CargoProjectWithStdlib(
                                 cargoProjectWithRustcInfoAndWorkspace,
-                                fetchStdlib(context, rustcInfo)
+                                fetchStdlib(context, cargoProjectWithRustcInfoAndWorkspace, rustcInfo)
                             )
                         }
                     }
@@ -351,11 +351,11 @@ private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext, rustcInfo: R
     }
 }
 
-private fun fetchStdlib(context: CargoSyncTask.SyncContext, rustcInfo: RustcInfo?): TaskResult<StandardLibrary> {
+private fun fetchStdlib(context: CargoSyncTask.SyncContext, cargoProject: CargoProjectImpl, rustcInfo: RustcInfo?): TaskResult<StandardLibrary> {
     return context.runWithChildProgress("Getting Rust stdlib") { childContext ->
 
-        val workingDirectory = childContext.oldCargoProject.workingDirectory
-        if (childContext.oldCargoProject.doesProjectLooksLikeRustc()) {
+        val workingDirectory = cargoProject.workingDirectory
+        if (cargoProject.doesProjectLooksLikeRustc()) {
             // rust-lang/rust contains stdlib inside the project
             val std = StandardLibrary.fromPath(
                 childContext.project,


### PR DESCRIPTION
In [rustc](https://github.com/rust-lang/rust) project, we use project crates as stdlib so we don't need to do anything special to get proper metadata for them. Otherwise, it may break our analysis

Note, we still have a lot of false-positive errors in rustc project but it looks like they are not related to stdlib metadata machinery and they should be fixed separately

Related to #6104

changelog: Don't fetch stdlib metadata for `rustc` project since it's already fetched during project structure setup