### PR TITLE
"Add remaining patterns" quickfix: add patterns even if no `match` body

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
@@ -913,6 +913,44 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
         }
     """)
 
+    fun `test no match body with enum expr`() = checkFixByText("Add remaining patterns", """
+        enum E { A, B, C }
+
+        fn test(e: E) {
+            <error descr="Match must be exhaustive [E0004]">match/*caret*/</error> e<EOLError descr="'!', '(', '::', <operator>, '[' or '{' expected, got '}'"></EOLError>
+        }
+    """, """
+        enum E { A, B, C }
+
+        fn test(e: E) {
+            match/*caret*/ e {
+                E::A => {}
+                E::B => {}
+                E::C => {}
+            }
+        }
+    """)
+
+    fun `test no match body with i32 expr`() = checkFixByText("Add remaining patterns", """
+        fn test(i: i32) {
+            <error descr="Match must be exhaustive [E0004]">match/*caret*/</error> i<EOLError descr="'!', '(', '::', <operator>, '[' or '{' expected, got '}'"></EOLError>
+        }
+    """, """
+        fn test(i: i32) {
+            match/*caret*/ i { _ => {} }
+        }
+    """)
+
+    fun `test no match body with {} expr`() = checkFixByText("Add remaining patterns", """
+        fn test() {
+            <error descr="Match must be exhaustive [E0004]">match/*caret*/</error> {}<EOLError descr="'(', <operator>, '[' or '{' expected, got '}'"></EOLError>
+        }
+    """, """
+        fn test() {
+            match/*caret*/ {} { _ => {} }
+        }
+    """)
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test pair of Options`() = checkByText("""
         fn foo(a: Option<bool>, b: Option<bool>) {


### PR DESCRIPTION
Fixes #7759

```kotlin
enum E { A, B, C }

fn test(e: E, i: i32) {
    match e

    match i

    match {}
}
```

<img width="332" alt="スクリーンショット 2021-09-01 18 59 40" src="https://user-images.githubusercontent.com/1121855/131653263-f8601fb2-5db2-41ea-b876-6ed749d58eb1.png">

↓

<img width="342" alt="スクリーンショット 2021-09-01 19 00 00" src="https://user-images.githubusercontent.com/1121855/131653280-9bfc2eab-6638-46e5-87a6-b865025c47ce.png">
