### PR TITLE
CARGO: show warning/error during stdlib metadata fetching in Sync View

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/ProcessProgressListener.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/ProcessProgressListener.kt
@@ -1,0 +1,13 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model
+
+import com.intellij.execution.process.ProcessListener
+
+interface ProcessProgressListener : ProcessListener {
+    fun error(title: String, message: String)
+    fun warning(title: String, message: String)
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -164,10 +164,11 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
     fun vendorDependencies(
         owner: Project,
         projectDirectory: Path,
-        dstPath: Path
+        dstPath: Path,
+        listener: ProcessListener? = null
     ) {
         val commandLine = CargoCommandLine("vendor", projectDirectory, listOf(dstPath.toString()))
-        commandLine.execute(owner)
+        commandLine.execute(owner, listener = listener)
     }
 
     /**


### PR DESCRIPTION
<img width="1007" alt="Screen Shot 2021-09-01 at 16 33 17" src="https://user-images.githubusercontent.com/2539310/131680669-25be2afc-d5fd-48fb-87b8-9b7e74c55f19.png">

The main goal is to show the user what went wrong during project structure setup (if it happened). Also, it may help to catch some tricky cases that we haven't caught yet, since now warnings/errors are visible for users

Note, currently there is no way to show an error in `Sync View` and not to add an error icon for parent nodes

changelog: Show warning/errors during fetching info about stdlib in [Sync View](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-cargo-tool-window.html)
