### PR TITLE
PRJ: Use intellij-rust fork for wasm-pack template

### DIFF
--- a/src/main/kotlin/org/rust/ide/newProject/RsProjectTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsProjectTemplate.kt
@@ -21,7 +21,7 @@ open class RsCustomTemplate(
     name: String, val url: String
 ) : RsProjectTemplate(name, false, RsIcons.CARGO_GENERATE) {
     object ProcMacroTemplate : RsCustomTemplate("Procedural Macro", "https://github.com/intellij-rust/rust-procmacro-quickstart-template")
-    object WasmPackTemplate : RsCustomTemplate("WebAssembly Lib", "https://github.com/rustwasm/wasm-pack-template")
+    object WasmPackTemplate : RsCustomTemplate("WebAssembly Lib", "https://github.com/intellij-rust/wasm-pack-template")
 
     val shortLink: String
         get() = url.substringAfter("//")


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/7262

Changes the wasm-pack template to our fork [intellij-rust/wasm-pack-template](https://github.com/intellij-rust/wasm-pack-template) where the `wasm32-unknown-unknown` target is specified inside `.cargo/config.toml`

changelog: Specify `wasm32-unknown-unknown` target when creating new `WebAssembly Lib` project
