### PR TITLE
Enable by default ML code completion ranking for Rust

### DIFF
--- a/ml-completion/src/main/kotlin/org/rust/ml/RsMLRankingProvider.kt
+++ b/ml-completion/src/main/kotlin/org/rust/ml/RsMLRankingProvider.kt
@@ -17,4 +17,6 @@ class RsMLRankingProvider : CatBoostJarCompletionModelProvider("Rust", "rust_fea
         DecoratingItemsPolicy.ByAbsoluteThreshold(3.0),
         DecoratingItemsPolicy.ByRelativeThreshold(2.5)
     )
+
+    override fun isEnabledByDefault(): Boolean = true
 }


### PR DESCRIPTION
This PR enables the new ML-based code completion ranking by default. See https://github.com/intellij-rust/intellij-rust/pull/6419 for more information on this feature.

In case of any issues, the new ranking model can be disabled in `Editor | General | Code Completion | Machine Learning-Assisted Completion` settings. 

Part of #6411

changelog: Enable by default code completion ranking for Rust based on machine learning. Now the completion suggestions are sorted by their relevance based on the rules learned from data we have gathered anonymously during our EAPs. Note that we have not collected any source code, only information about your interactions with the code completion UI. In case of any issues, you can disable the new ranking model via `Editor | General | Code Completion | Machine Learning-Assisted Completion` settings.


