### PR TITLE
CARGO: enable fetching actual stdlib metadata

### DIFF
--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -9,7 +9,7 @@
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.cargo.fetch.actual.stdlib.metadata" percentOfUsers="0">
+        <experimentalFeature id="org.rust.cargo.fetch.actual.stdlib.metadata" percentOfUsers="100">
             <description>Fetch metadata of actual stdlib crates instead of using hardcoded data</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.macros.new.engine" percentOfUsers="100">


### PR DESCRIPTION
Fixes #3957
Fixes #4960
Fixes #5881
Fixes #6081

Part of #6104

changelog: Enable fetching actual info about stdlib packages like dependencies, [edition](https://doc.rust-lang.org/edition-guide/editions/index.html), Cargo [features](https://doc.rust-lang.org/cargo/reference/features.html) by default. It should help the plugin better understand stdlib structure, for example, provide proper completion and navigation for items defined in `std::os` module. In case of any issue, you can turn this feature off via `org.rust.cargo.fetch.actual.stdlib.metadata` [experimental feature](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features)