### PR TITLE
ANN: generate const generics by `Implement Members` quick-fix properly

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -177,6 +177,7 @@ open class RsPsiRenderer(
                     sb.append(name ?: "_")
                     val type = typeReference
                     if (type != null) {
+                        sb.append(": ")
                         appendTypeReference(sb, type)
                     }
                 }

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -1752,6 +1752,28 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test const type param`() = doTest("""
+        trait Foo {
+            fn foo<const N: usize>();
+        }
+        struct S;
+        impl Foo for S {
+            /*caret*/
+        }
+    """, listOf(
+        ImplementMemberSelection("foo<const N: usize>()", byDefault = true)
+    ), """
+        trait Foo {
+            fn foo<const N: usize>();
+        }
+        struct S;
+        impl Foo for S {
+            fn foo<const N: usize>() {
+                todo!()
+            }
+        }
+    """)
+
     private data class ImplementMemberSelection(val member: String, val byDefault: Boolean, val isSelected: Boolean = byDefault)
 
     private fun doTest(


### PR DESCRIPTION
Fixes #7788

changelog: Generate [const generics](https://rust-lang.github.io/rfcs/2000-const-generics.html) by `Implement Members` quick-fix properly
