### PR TITLE
RUN: show build error balloon over proper tool window

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -27,12 +27,10 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageType
 import com.intellij.openapi.util.text.StringUtil
-import com.intellij.openapi.wm.ToolWindowId
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapiext.isHeadlessEnvironment
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.ui.SystemNotifications
-import com.intellij.ui.content.MessageView
 import com.intellij.util.concurrency.FutureResult
 import com.intellij.util.execution.ParametersListUtil
 import com.intellij.util.text.SemVer
@@ -94,7 +92,8 @@ object CargoBuildManager {
         val cargoProject = state.cargoProject ?: return CANCELED_BUILD_RESULT
 
         // Make sure build tool window is initialized:
-        ServiceManager.getService(project, BuildContentManager::class.java)
+        @Suppress("UsePropertyAccessSyntax")
+        BuildContentManager.getInstance(project).getOrCreateToolWindow()
 
         if (isUnitTestMode) {
             lastBuildCommandLine = state.prepareCommandLine()
@@ -194,7 +193,6 @@ object CargoBuildManager {
                         return@Runnable
                     }
 
-                    MessageView.SERVICE.getInstance(context.project) // register ToolWindowId.MESSAGES_WINDOW
                     saveAllDocuments()
                     context.doExecute()
                 }
@@ -270,10 +268,9 @@ object CargoBuildManager {
         notification.notify(project)
 
         if (messageType === MessageType.ERROR) {
-            MessageView.SERVICE.getInstance(project) // register ToolWindowId.MESSAGES_WINDOW
             val manager = ToolWindowManager.getInstance(project)
             invokeLater {
-                manager.notifyByBalloon(ToolWindowId.MESSAGES_WINDOW, messageType, notificationContent)
+                manager.notifyByBalloon(BuildContentManager.TOOL_WINDOW_ID, messageType, notificationContent)
             }
         }
 


### PR DESCRIPTION
Previously, build manager showed build error balloon over `Messages` tool window tab for some reason.
But the plugin doesn't interact with this tool window at all and prints all build output to `Build` tool window.
Moreover, in most cases `Messages` tool window doesn't have any active tab and a user can't even open it. It's rather confusing

After these changes, the plugin will show build error balloon over `Build` tool window tab to be consistent with build output and not confuse users

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2539310/132104584-2b8087cc-e33f-4bb6-9063-4434bcce06f5.png) | ![image](https://user-images.githubusercontent.com/2539310/132104582-5140ac9a-a38d-46e4-a594-a59daa453dfe.png) |


changelog: Show build error balloon over `Build` tool window instead of `Messages` one
