### PR TITLE
INSP: simplify lint inspection API

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsUnreachablePatternsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsUnreachablePatternsInspection.kt
@@ -68,7 +68,7 @@ class RsUnreachablePatternsInspection : RsLintInspection() {
                     SubstituteTextFix.delete("Remove unreachable pattern", match.containingFile, range)
                 }
 
-                holder.registerLintProblem(armPat, "Unreachable pattern", fix)
+                holder.registerLintProblem(armPat, "Unreachable pattern", fixes = listOf(fix))
             }
 
             /** If the arm is not guarded, we have "seen" the pattern */

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
@@ -35,18 +35,20 @@ class RsBareTraitObjectsInspection : RsLintInspection() {
                 holder.registerLintProblem(
                     typeReference,
                     "Trait objects without an explicit 'dyn' are deprecated",
-                    object : LocalQuickFix {
-                        override fun getFamilyName(): String = "Add 'dyn' keyword to trait object"
-
-                        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-                            val target = descriptor.psiElement as RsTypeReference
-                            val typeElement = target.skipParens()
-                            val traitText = (typeElement as? RsBaseType)?.path?.text ?: (typeElement as RsTraitType).text
-                            val new = RsPsiFactory(project).createDynTraitType(traitText)
-                            target.replace(new)
-                        }
-                    }
+                    fixes = listOf(AddDynKeywordFix())
                 )
             }
         }
+
+    private class AddDynKeywordFix : LocalQuickFix {
+        override fun getFamilyName(): String = "Add 'dyn' keyword to trait object"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val target = descriptor.psiElement as RsTypeReference
+            val typeElement = target.skipParens()
+            val traitText = (typeElement as? RsBaseType)?.path?.text ?: (typeElement as RsTraitType).text
+            val new = RsPsiFactory(project).createDynTraitType(traitText)
+            target.replace(new)
+        }
+    }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
@@ -5,8 +5,6 @@
 
 package org.rust.ide.inspections.lints
 
-import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ProblemHighlightType.*
 import com.intellij.psi.PsiElement
 import com.vdurmont.semver4j.Semver
 import com.vdurmont.semver4j.SemverException
@@ -48,16 +46,11 @@ class RsDeprecationInspection : RsLintInspection() {
         if (original is RsOuterAttributeOwner) {
             val attr = original.queryAttributes.deprecatedAttribute ?: return
             val (message, highlightType) = attr.extractDeprecatedMessage(identifier.text)
-            holder.registerLintProblem(identifier, message, { level ->
-                when (level) {
-                    RsLint.Deprecated.defaultLevel -> highlightType
-                    else -> null
-                }
-            })
+            holder.registerLintProblem(identifier, message, highlightType)
         }
     }
 
-    private fun RsMetaItem.extractDeprecatedMessage(item: String): Pair<String, ProblemHighlightType> {
+    private fun RsMetaItem.extractDeprecatedMessage(item: String): Pair<String, RsLintHighlightingType> {
         val (note, since) = if (DEPRECATED_ATTR_NAME == name) {
             extract(NOTE_PARAM_NAME, SINCE_PARAM_NAME)
         } else {
@@ -69,12 +62,12 @@ class RsDeprecationInspection : RsLintInspection() {
                 append("`$item` is deprecated")
                 if (since != null) append(" since $since")
                 if (note != null) append(": $note")
-            } to LIKE_DEPRECATED
+            } to RsLintHighlightingType.DEPRECATED
         } else {
             buildString {
                 append("`$item` will be deprecated from $since")
                 if (note != null) append(": $note")
-            } to WEAK_WARNING
+            } to RsLintHighlightingType.WEAK_WARNING
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -18,19 +18,24 @@ enum class RsLint(
     private val groupIds: List<String> = emptyList(),
     private val defaultLevel: RsLintLevel = WARN
 ) {
+    // Rustc lints
+    // warnings
     NonSnakeCase("non_snake_case", listOf("bad_style", "nonstandard_style")),
     NonCamelCaseTypes("non_camel_case_types", listOf("bad_style", "nonstandard_style")),
     NonUpperCaseGlobals("non_upper_case_globals", listOf("bad_style", "nonstandard_style")),
     Deprecated("deprecated"),
     UnusedVariables("unused_variables", listOf("unused")),
     UnusedImports("unused_imports", listOf("unused")),
-    WhileTrue("while_true"),
-    NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy")),
     UnreachablePattern("unreachable_patterns", listOf("unused")),
+    WhileTrue("while_true"),
     UnreachableCode("unreachable_code"),
     BareTraitObjects("bare_trait_objects", listOf("rust_2018_idioms")),
     NonShorthandFieldPatterns("non_shorthand_field_patterns"),
-    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY);
+    // errors
+    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
+
+    // CLippy lints
+    NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy"));
 
     /**
      * Returns the level of the lint for the given PSI element.

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -5,9 +5,9 @@
 
 package org.rust.ide.inspections.lints
 
-import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
-import org.rust.ide.inspections.lints.RsLintLevel.*
+import org.rust.ide.inspections.lints.RsLintLevel.DENY
+import org.rust.ide.inspections.lints.RsLintLevel.WARN
 import org.rust.lang.core.psi.ext.*
 
 /**
@@ -16,81 +16,21 @@ import org.rust.lang.core.psi.ext.*
 enum class RsLint(
     val id: String,
     private val groupIds: List<String> = emptyList(),
-    val defaultLevel: RsLintLevel = WARN
+    private val defaultLevel: RsLintLevel = WARN
 ) {
     NonSnakeCase("non_snake_case", listOf("bad_style", "nonstandard_style")),
     NonCamelCaseTypes("non_camel_case_types", listOf("bad_style", "nonstandard_style")),
     NonUpperCaseGlobals("non_upper_case_globals", listOf("bad_style", "nonstandard_style")),
-    Deprecated("deprecated") {
-        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
-            when (level) {
-                WARN -> ProblemHighlightType.LIKE_DEPRECATED
-                else -> super.toHighlightingType(level)
-            }
-    },
-
-    UnusedVariables("unused_variables", listOf("unused")) {
-        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
-            when (level) {
-                WARN -> ProblemHighlightType.LIKE_UNUSED_SYMBOL
-                else -> super.toHighlightingType(level)
-            }
-    },
-
-    UnusedImports("unused_imports", listOf("unused")) {
-        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
-            when (level) {
-                WARN -> ProblemHighlightType.LIKE_UNUSED_SYMBOL
-                else -> super.toHighlightingType(level)
-            }
-    },
-
-    WhileTrue("while_true") {
-        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
-            when (level) {
-                WARN -> ProblemHighlightType.WEAK_WARNING
-                else -> super.toHighlightingType(level)
-            }
-    },
-
-    NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy")) {
-        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
-            when (level) {
-                WARN -> ProblemHighlightType.WEAK_WARNING
-                else -> super.toHighlightingType(level)
-            }
-    },
-
+    Deprecated("deprecated"),
+    UnusedVariables("unused_variables", listOf("unused")),
+    UnusedImports("unused_imports", listOf("unused")),
+    WhileTrue("while_true"),
+    NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy")),
     UnreachablePattern("unreachable_patterns", listOf("unused")),
-
-    UnreachableCode("unreachable_code") {
-        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
-            when (level) {
-                WARN -> ProblemHighlightType.LIKE_UNUSED_SYMBOL
-                else -> super.toHighlightingType(level)
-            }
-    },
-
+    UnreachableCode("unreachable_code"),
     BareTraitObjects("bare_trait_objects", listOf("rust_2018_idioms")),
-
-    NonShorthandFieldPatterns("non_shorthand_field_patterns") {
-        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
-            when (level) {
-                WARN -> ProblemHighlightType.WEAK_WARNING
-                else -> super.toHighlightingType(level)
-            }
-    },
-
+    NonShorthandFieldPatterns("non_shorthand_field_patterns"),
     UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY);
-
-    protected open fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
-        when (level) {
-            ALLOW -> ProblemHighlightType.INFORMATION
-            WARN -> ProblemHighlightType.WARNING
-            DENY, FORBID -> ProblemHighlightType.GENERIC_ERROR
-        }
-
-    fun getProblemHighlightType(element: PsiElement): ProblemHighlightType = toHighlightingType(levelFor(element))
 
     /**
      * Returns the level of the lint for the given PSI element.

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLintHighlightingType.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLintHighlightingType.kt
@@ -1,0 +1,22 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.codeInspection.ProblemHighlightType
+
+class RsLintHighlightingType private constructor(
+    val allow: ProblemHighlightType = ProblemHighlightType.INFORMATION,
+    val warn: ProblemHighlightType = ProblemHighlightType.WARNING,
+    val deny: ProblemHighlightType = ProblemHighlightType.GENERIC_ERROR,
+    val forbid: ProblemHighlightType = deny
+) {
+    companion object {
+        val DEFAULT = RsLintHighlightingType()
+        val WEAK_WARNING = RsLintHighlightingType(warn = ProblemHighlightType.WEAK_WARNING)
+        val UNUSED_SYMBOL = RsLintHighlightingType(warn = ProblemHighlightType.LIKE_UNUSED_SYMBOL)
+        val DEPRECATED = RsLintHighlightingType(warn = ProblemHighlightType.LIKE_DEPRECATED)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
@@ -14,11 +14,9 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNamedElement
 import org.rust.ide.inspections.RsLocalInspectionTool
 import org.rust.ide.inspections.RsProblemsHolder
-import org.rust.ide.inspections.lints.RsLintLevel.ALLOW
+import org.rust.ide.inspections.lints.RsLintLevel.*
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-
-typealias ProblemHighlightSelector = (level: RsLintLevel) -> ProblemHighlightType?
 
 abstract class RsLintInspection : RsLocalInspectionTool() {
 
@@ -29,35 +27,34 @@ abstract class RsLintInspection : RsLocalInspectionTool() {
     protected fun RsProblemsHolder.registerLintProblem(
         element: PsiElement,
         descriptionTemplate: String,
-        vararg fixes: LocalQuickFix
+        lintHighlightingType: RsLintHighlightingType = RsLintHighlightingType.DEFAULT,
+        fixes: List<LocalQuickFix> = emptyList()
     ) {
-        registerProblem(element, descriptionTemplate, getProblemHighlightType(element), *fixes)
-    }
-
-    protected fun RsProblemsHolder.registerLintProblem(
-        element: PsiElement,
-        descriptionTemplate: String,
-        problemHighlightSelector: ProblemHighlightSelector? = null,
-        vararg fixes: LocalQuickFix
-    ) {
-        registerProblem(element, descriptionTemplate, getProblemHighlightType(element, problemHighlightSelector), *fixes)
+        registerProblem(element, descriptionTemplate, getProblemHighlightType(element, lintHighlightingType), *fixes.toTypedArray())
     }
 
     protected fun RsProblemsHolder.registerLintProblem(
         element: PsiElement,
         descriptionTemplate: String,
         rangeInElement: TextRange,
-        vararg fixes: LocalQuickFix
+        lintHighlightingType: RsLintHighlightingType = RsLintHighlightingType.DEFAULT,
+        fixes: List<LocalQuickFix> = emptyList()
     ) {
-        registerProblem(element, descriptionTemplate, getProblemHighlightType(element), rangeInElement, *fixes)
+        val highlightType = getProblemHighlightType(element, lintHighlightingType)
+        registerProblem(element, descriptionTemplate, highlightType, rangeInElement, *fixes.toTypedArray())
     }
 
     private fun getProblemHighlightType(
         element: PsiElement,
-        problemHighlightSelector: ProblemHighlightSelector? = null
+        lintHighlightingType: RsLintHighlightingType
     ): ProblemHighlightType {
         val lint = getLint(element) ?: return ProblemHighlightType.WARNING
-        return problemHighlightSelector?.invoke(lint.levelFor(element)) ?: lint.getProblemHighlightType(element)
+        return when (lint.levelFor(element)) {
+            ALLOW -> lintHighlightingType.allow
+            WARN -> lintHighlightingType.warn
+            DENY -> lintHighlightingType.deny
+            FORBID -> lintHighlightingType.forbid
+        }
     }
 
     override fun isSuppressedFor(element: PsiElement): Boolean {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
@@ -85,6 +85,6 @@ class RsLivenessInspection : RsLintInspection() {
             }
         }
 
-        holder.registerLintProblem(binding, message, *fixes.toTypedArray())
+        holder.registerLintProblem(binding, message, RsLintHighlightingType.UNUSED_SYMBOL, fixes)
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
@@ -33,12 +33,12 @@ abstract class RsNamingInspection(
         val suggestedName = checkName(name) ?: return
 
         val fixEl = id.parent
-        val fixes = if (fix && fixEl is PsiNamedElement) arrayOf(RenameFix(fixEl, suggestedName)) else emptyArray()
+        val fixes = if (fix && fixEl is PsiNamedElement) listOf(RenameFix(fixEl, suggestedName)) else emptyList()
 
         holder.registerLintProblem(
             id,
             "$elementType `$name` should have $styleName case name such as `$suggestedName`",
-            *fixes
+            fixes = fixes
         )
     }
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -43,7 +43,8 @@ class RsNeedlessLifetimesInspection : RsLintInspection() {
                 fn.fn.startOffsetInParent,
                 fn.block?.getPrevNonCommentSibling()?.endOffsetInParent ?: fn.identifier.endOffsetInParent
             ),
-            ElideLifetimesFix()
+            RsLintHighlightingType.WEAK_WARNING,
+            listOf(ElideLifetimesFix())
         )
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspection.kt
@@ -26,18 +26,20 @@ class RsNonShorthandFieldPatternsInspection : RsLintInspection() {
             holder.registerLintProblem(
                 o,
                 "The `$identifier:` in this pattern is redundant",
-                object : LocalQuickFix {
-                    override fun getFamilyName(): String = "Use shorthand field pattern: `$identifier`"
-
-                    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-                        val field = descriptor.psiElement as RsPatFieldFull
-                        val patBinding = RsPsiFactory(field.project).createPatBinding(field.pat.text)
-                        field.parent.addBefore(patBinding, field)
-                        field.delete()
-                    }
-                }
+                RsLintHighlightingType.WEAK_WARNING,
+                listOf(UseShorthandFieldPatternFix(identifier))
             )
         }
     }
 
+    private class UseShorthandFieldPatternFix(private val identifier: String) : LocalQuickFix {
+        override fun getFamilyName(): String = "Use shorthand field pattern: `$identifier`"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val field = descriptor.psiElement as RsPatFieldFull
+            val patBinding = RsPsiFactory(field.project).createPatBinding(field.pat.text)
+            field.parent.addBefore(patBinding, field)
+            field.delete()
+        }
+    }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
@@ -26,9 +26,9 @@ class RsUnknownCrateTypesInspection : RsLintInspection() {
                 if (elementValue !in KNOWN_CRATE_TYPES) {
                     val fixes = NameSuggestionFix.createApplicable(
                         element, elementValue, KNOWN_CRATE_TYPES, 1
-                    ) { RsPsiFactory(element.project).createExpression("\"$it\"") }.toTypedArray()
+                    ) { RsPsiFactory(element.project).createExpression("\"$it\"") }
 
-                    holder.registerLintProblem(element, "Invalid `crate_type` value", *fixes)
+                    holder.registerLintProblem(element, "Invalid `crate_type` value", fixes = fixes)
                 }
             }
         }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspection.kt
@@ -76,7 +76,8 @@ class RsUnreachableCodeInspection : RsLintInspection() {
             func,
             "Unreachable code",
             strippedRangeInFunction,
-            SubstituteTextFix.delete("Remove unreachable code", func.containingFile, range)
+            RsLintHighlightingType.UNUSED_SYMBOL,
+            listOf(SubstituteTextFix.delete("Remove unreachable code", func.containingFile, range))
         )
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -89,11 +89,12 @@ class RsUnusedImportInspection : RsLintInspection() {
     private fun markAsUnused(useSpeck: RsUseSpeck, holder: RsProblemsHolder) {
         val element = getHighlightElement(useSpeck)
         // https://github.com/intellij-rust/intellij-rust/issues/7565
-        val fixes = if (useSpeck.isDoctestInjection) emptyArray() else arrayOf(RemoveImportFix(element))
+        val fixes = if (useSpeck.isDoctestInjection) emptyList() else listOf((RemoveImportFix(element)))
         holder.registerLintProblem(
             element,
             "Unused import: `${useSpeck.text}`",
-            *fixes
+            RsLintHighlightingType.UNUSED_SYMBOL,
+            fixes
         )
     }
 


### PR DESCRIPTION
Decouple `RsLint` enum and highlighting type, and introduce `RsLintHighlightingType`.
It allows customizing highlighting for any lint even if you need different highlighting in different situations (see #3790 as an example) for the same lint in the same way in a single line. Previously, you had to override `RsLint#toHighlightingType` method and/or pass anonymous function