### PR TITLE
REF: fix alias test in GenerateGetterActionTest

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -410,6 +410,7 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test type alias 2`() = doTest("""
         type Alias = (u32, u32);
         struct S {
@@ -424,8 +425,8 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
 
         impl S {
-            pub fn a(&self) -> &Alias {
-                &self.a
+            pub fn a(&self) -> Alias {
+                self.a
             }
         }
     """)


### PR DESCRIPTION
Fixes test which didn't handle `Copy` correctly, as noted by @lancelote [here](https://github.com/intellij-rust/intellij-rust/pull/7412#issuecomment-907643898).