### PR TITLE
INSP: Insert import at correct location during auto-import

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
@@ -7,14 +7,15 @@ package org.rust.ide.refactoring
 
 import com.intellij.lang.ImportOptimizer
 import com.intellij.psi.PsiDocumentManager
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
-import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.inspections.lints.RsUnusedImportInspection
 import org.rust.ide.inspections.lints.isUsed
+import org.rust.ide.utils.import.COMPARATOR_FOR_SPECKS_IN_USE_GROUP
+import org.rust.ide.utils.import.UseItemWrapper
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.stdext.withNext
 
 class RsImportOptimizer : ImportOptimizer {
     override fun supports(file: PsiFile): Boolean = file is RsFile
@@ -79,13 +80,16 @@ class RsImportOptimizer : ImportOptimizer {
                 useGroup.useSpeckList.forEach { optimizeUseSpeck(psiFactory, it, checkUnusedImports) }
                 if (removeUseSpeckIfEmpty(useSpeck)) return false
                 if (removeCurlyBracesIfPossible(psiFactory, useSpeck)) return true
-
-                val sortedList = useGroup.useSpeckList
-                    .sortedWith(compareBy<RsUseSpeck> { it.path?.self == null }.thenBy { it.pathText })
-                    .map { it.copy() }
-                useGroup.useSpeckList.zip(sortedList).forEach { it.first.replace(it.second) }
+                useGroup.sortUseSpecks()
                 return true
             }
+        }
+
+        fun RsUseGroup.sortUseSpecks() {
+            val sortedList = useSpeckList
+                .sortedWith(COMPARATOR_FOR_SPECKS_IN_USE_GROUP)
+                .map { it.copy() }
+            useSpeckList.zip(sortedList).forEach { it.first.replace(it.second) }
         }
 
         /** Returns true if successfully removed, e.g. `use aaa::{bbb};` -> `use aaa::bbb;` */
@@ -118,62 +122,26 @@ class RsImportOptimizer : ImportOptimizer {
             val first = mod.childrenOfType<RsElement>()
                 .firstOrNull { it.textOffset >= offset && it !is RsExternCrateItem && it !is RsAttr } ?: return
             val psiFactory = RsPsiFactory(mod.project)
-            val sortedUsesGroups = uses
+            val sortedUses = uses
                 .asSequence()
                 .map { UseItemWrapper(it) }
                 .filter {
                     val useSpeck = it.useItem.useSpeck ?: return@filter false
                     optimizeUseSpeck(psiFactory, useSpeck)
                 }
-                .groupBy({ it.packageGroupLevel }, { it })
-                .map { (groupLevel, useItemWrapper) ->
-                    val useItems = useItemWrapper
-                        .sortedBy { it.useSpeckText }
-                        .mapNotNull { it.useItem.copy() as? RsUseItem }
-                    groupLevel to useItems
-                }
-                .sortedBy { it.first }
+                .sorted()
 
-            for ((_, sortedUses) in sortedUsesGroups) {
-                var lastAddedUseItem: PsiElement? = null
-                for (importPath in sortedUses) {
-                    lastAddedUseItem = mod.addBefore(importPath, first)
-                    mod.addAfter(psiFactory.createNewline(), lastAddedUseItem)
+            for ((useWrapper, nextUseWrapper) in sortedUses.withNext()) {
+                val addedUseItem = mod.addBefore(useWrapper.useItem, first)
+                mod.addAfter(psiFactory.createNewline(), addedUseItem)
+                if (useWrapper.packageGroupLevel != nextUseWrapper?.packageGroupLevel) {
+                    mod.addAfter(psiFactory.createNewline(), addedUseItem)
                 }
-                mod.addAfter(psiFactory.createNewline(), lastAddedUseItem)
             }
             uses.forEach {
                 (it.nextSibling as? PsiWhiteSpace)?.delete()
                 it.delete()
             }
-        }
-    }
-}
-
-private val RsUseSpeck.pathText get() = path?.text?.toLowerCase()
-
-private class UseItemWrapper(val useItem: RsUseItem) {
-    private val basePath: RsPath? = useItem.useSpeck?.path?.basePath()
-
-    val useSpeckText: String? = useItem.useSpeck?.pathText
-
-    // `use` order:
-    // 1. Standard library (stdlib)
-    // 2. Related third party (extern crate)
-    // 3. Local
-    //    - otherwise
-    //    - crate::
-    //    - super::
-    //    - self::
-    val packageGroupLevel: Int = when {
-        basePath?.self != null -> 6
-        basePath?.`super` != null -> 5
-        basePath?.crate != null -> 4
-        else -> when (basePath?.reference?.resolve()?.containingCrate?.origin) {
-            PackageOrigin.WORKSPACE -> 3
-            PackageOrigin.DEPENDENCY -> 2
-            PackageOrigin.STDLIB, PackageOrigin.STDLIB_DEPENDENCY -> 1
-            null -> 3
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/utils/import/UseItemWrapper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/UseItemWrapper.kt
@@ -1,0 +1,47 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.utils.import
+
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsUseItem
+import org.rust.lang.core.psi.RsUseSpeck
+import org.rust.lang.core.psi.ext.basePath
+import org.rust.lang.core.psi.ext.containingCrate
+
+class UseItemWrapper(val useItem: RsUseItem) : Comparable<UseItemWrapper> {
+    private val basePath: RsPath? = useItem.useSpeck?.path?.basePath()
+
+    private val useSpeckText: String? = useItem.useSpeck?.pathTextLower
+
+    // `use` order:
+    // 1. Standard library (stdlib)
+    // 2. Related third party (extern crate)
+    // 3. Local
+    //    - otherwise
+    //    - crate::
+    //    - super::
+    //    - self::
+    val packageGroupLevel: Int = when {
+        basePath?.self != null -> 6
+        basePath?.`super` != null -> 5
+        basePath?.crate != null -> 4
+        else -> when (basePath?.reference?.resolve()?.containingCrate?.origin) {
+            PackageOrigin.WORKSPACE -> 3
+            PackageOrigin.DEPENDENCY -> 2
+            PackageOrigin.STDLIB, PackageOrigin.STDLIB_DEPENDENCY -> 1
+            null -> 3
+        }
+    }
+
+    override fun compareTo(other: UseItemWrapper): Int =
+        compareValuesBy(this, other, { it.packageGroupLevel }, { it.useSpeckText })
+}
+
+private val RsUseSpeck.pathTextLower: String? get() = path?.text?.toLowerCase()
+
+val COMPARATOR_FOR_SPECKS_IN_USE_GROUP: Comparator<RsUseSpeck> =
+    compareBy<RsUseSpeck> { it.path?.self == null }.thenBy { it.pathTextLower }

--- a/src/main/kotlin/org/rust/stdext/Collections.kt
+++ b/src/main/kotlin/org/rust/stdext/Collections.kt
@@ -163,6 +163,9 @@ fun <T> dequeOf(vararg elements: T): Deque<T> =
 
 inline fun <reified T : Enum<T>> enumSetOf(): EnumSet<T> = EnumSet.noneOf(T::class.java)
 
+fun <T> List<T>.isSortedWith(comparator: Comparator<T>): Boolean =
+    asSequence().zipWithNext { a, b -> comparator.compare(a, b) <= 0 }.all { it }
+
 typealias LookbackValue<T> = Pair<T, T?>
 
 fun <T> Sequence<T>.withPrevious(): Sequence<LookbackValue<T>> = LookbackSequence(this)

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -72,7 +72,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         use dep_lib_target::foo::Bar;
 
         fn foo(t: Bar/*caret*/) {}
-    """)
+    """, checkOptimizeImports = false)
 
     fun `test insert extern crate item after inner attributes`() = checkAutoImportFixByFileTree("""
         //- main.rs

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -269,6 +269,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test insert use item after existing use items`() = checkAutoImportFixByText("""
+        use foo::Bar;
+
         mod foo {
             pub struct Bar;
         }
@@ -276,13 +278,14 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         mod bar {
             pub struct Foo;
         }
-
-        use foo::Bar;
 
         fn main() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
     """, """
+        use bar::Foo;
+        use foo::Bar;
+
         mod foo {
             pub struct Bar;
         }
@@ -290,9 +293,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         mod bar {
             pub struct Foo;
         }
-
-        use foo::Bar;
-        use bar::Foo;
 
         fn main() {
             let f = Foo/*caret*/;
@@ -665,11 +665,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import reexported item`() = checkAutoImportFixByText("""
         mod foo {
+            pub use self::bar::Bar;
+
             mod bar {
                 pub struct Bar;
             }
-
-            pub use self::bar::Bar;
         }
 
         fn main() {
@@ -679,11 +679,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use foo::Bar;
 
         mod foo {
+            pub use self::bar::Bar;
+
             mod bar {
                 pub struct Bar;
             }
-
-            pub use self::bar::Bar;
         }
 
         fn main() {
@@ -693,11 +693,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import reexported item with alias`() = checkAutoImportFixByText("""
         mod foo {
+            pub use self::bar::Bar as Foo;
+
             mod bar {
                 pub struct Bar;
             }
-
-            pub use self::bar::Bar as Foo;
         }
 
         fn main() {
@@ -707,11 +707,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use foo::Foo;
 
         mod foo {
+            pub use self::bar::Bar as Foo;
+
             mod bar {
                 pub struct Bar;
             }
-
-            pub use self::bar::Bar as Foo;
         }
 
         fn main() {
@@ -721,12 +721,12 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import reexported item via use group`() = checkAutoImportFixByText("""
         mod foo {
+            pub use self::bar::{Baz, Qwe};
+
             mod bar {
                 pub struct Baz;
                 pub struct Qwe;
             }
-
-            pub use self::bar::{Baz, Qwe};
         }
 
         fn main() {
@@ -736,12 +736,12 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use foo::Baz;
 
         mod foo {
+            pub use self::bar::{Baz, Qwe};
+
             mod bar {
                 pub struct Baz;
                 pub struct Qwe;
             }
-
-            pub use self::bar::{Baz, Qwe};
         }
 
         fn main() {
@@ -751,11 +751,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import reexported item via 'self'`() = checkAutoImportFixByText("""
         mod foo {
+            pub use self::bar::Baz::{self};
+
             mod bar {
                 pub struct Baz;
             }
-
-            pub use self::bar::Baz::{self};
         }
 
         fn main() {
@@ -765,11 +765,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use foo::Baz;
 
         mod foo {
+            pub use self::bar::Baz::{self};
+
             mod bar {
                 pub struct Baz;
             }
-
-            pub use self::bar::Baz::{self};
         }
 
         fn main() {
@@ -779,12 +779,12 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import reexported item with complex reexport`() = checkAutoImportFixByText("""
         mod foo {
+            pub use self::bar::{Baz as Foo, Qwe};
+
             mod bar {
                 pub struct Baz;
                 pub struct Qwe;
             }
-
-            pub use self::bar::{Baz as Foo, Qwe};
         }
 
         fn main() {
@@ -794,12 +794,12 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use foo::Foo;
 
         mod foo {
+            pub use self::bar::{Baz as Foo, Qwe};
+
             mod bar {
                 pub struct Baz;
                 pub struct Qwe;
             }
-
-            pub use self::bar::{Baz as Foo, Qwe};
         }
 
         fn main() {
@@ -809,13 +809,13 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test module reexport`() = checkAutoImportFixByText("""
         mod foo {
+            pub use self::bar::baz;
+
             mod bar {
                 pub mod baz {
                     pub struct FooBar;
                 }
             }
-
-            pub use self::bar::baz;
         }
 
         fn main() {
@@ -825,13 +825,13 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use foo::baz::FooBar;
 
         mod foo {
+            pub use self::bar::baz;
+
             mod bar {
                 pub mod baz {
                     pub struct FooBar;
                 }
             }
-
-            pub use self::bar::baz;
         }
 
         fn main() {
@@ -893,19 +893,19 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         mod bar {
+            pub use self::baz::Foo;
+
             mod baz {
                 pub struct Foo;
             }
-
-            pub use self::baz::Foo;
         }
 
         mod qwe {
+            pub use self::xyz::Bar as Foo;
+
             mod xyz {
                 pub struct Bar;
             }
-
-            pub use self::xyz::Bar as Foo;
         }
 
         fn main() {
@@ -919,19 +919,19 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         mod bar {
+            pub use self::baz::Foo;
+
             mod baz {
                 pub struct Foo;
             }
-
-            pub use self::baz::Foo;
         }
 
         mod qwe {
+            pub use self::xyz::Bar as Foo;
+
             mod xyz {
                 pub struct Bar;
             }
-
-            pub use self::xyz::Bar as Foo;
         }
 
         fn main() {
@@ -985,8 +985,9 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test cyclic module reexports`() = checkAutoImportFixByTextWithMultipleChoice("""
         pub mod x {
-            pub struct Z;
             pub use y;
+
+            pub struct Z;
         }
 
         pub mod y {
@@ -1000,8 +1001,9 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use x::Z;
 
         pub mod x {
-            pub struct Z;
             pub use y;
+
+            pub struct Z;
         }
 
         pub mod y {
@@ -1016,14 +1018,17 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     fun `test crazy cyclic module reexports`() = checkAutoImportFixByTextWithMultipleChoice("""
         pub mod x {
             pub use u;
+
             pub mod y {
                 pub use u::v;
+
                 pub struct Z;
             }
         }
 
         pub mod u {
             pub use x::y;
+
             pub mod v {
                 pub use x;
             }
@@ -1044,14 +1049,17 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         pub mod x {
             pub use u;
+
             pub mod y {
                 pub use u::v;
+
                 pub struct Z;
             }
         }
 
         pub mod u {
             pub use x::y;
+
             pub mod v {
                 pub use x;
             }
@@ -1064,11 +1072,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test filter imports`() = checkAutoImportFixByTextWithMultipleChoice("""
         mod foo {
+            pub use self::bar::FooBar;
+
             pub mod bar {
                 pub struct FooBar;
             }
-
-            pub use self::bar::FooBar;
         }
 
         mod baz {
@@ -1086,11 +1094,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use baz::FooBar;
 
         mod foo {
+            pub use self::bar::FooBar;
+
             pub mod bar {
                 pub struct FooBar;
             }
-
-            pub use self::bar::FooBar;
         }
 
         mod baz {
@@ -1541,6 +1549,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import reexported trait method`() = checkAutoImportFixByText("""
         mod foo {
+            pub use self::bar::baz;
+
             mod bar {
                 pub mod baz {
                     pub trait FooBar {
@@ -1552,8 +1562,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
                     }
                 }
             }
-
-            pub use self::bar::baz;
         }
 
         fn main() {
@@ -1563,6 +1571,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use foo::baz::FooBar;
 
         mod foo {
+            pub use self::bar::baz;
+
             mod bar {
                 pub mod baz {
                     pub trait FooBar {
@@ -1574,8 +1584,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
                     }
                 }
             }
-
-            pub use self::bar::baz;
         }
 
         fn main() {
@@ -1897,10 +1905,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import with wildcard reexport 1`() = checkAutoImportFixByText("""
         mod c {
+            pub use self::a::*;
+
             mod a {
                 pub struct A;
             }
-            pub use self::a::*;
         }
 
         fn main() {
@@ -1910,10 +1919,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use c::A;
 
         mod c {
+            pub use self::a::*;
+
             mod a {
                 pub struct A;
             }
-            pub use self::a::*;
         }
 
         fn main() {
@@ -1923,10 +1933,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import with wildcard reexport 2`() = checkAutoImportFixByText("""
         mod c {
+            pub use self::a::{{*}};
+
             mod a {
                 pub struct A;
             }
-            pub use self::a::{{*}};
         }
 
         fn main() {
@@ -1936,10 +1947,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         use c::A;
 
         mod c {
+            pub use self::a::{{*}};
+
             mod a {
                 pub struct A;
             }
-            pub use self::a::{{*}};
         }
 
         fn main() {
@@ -1961,7 +1973,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """, """
         // comment
-        use foo::{Foo, Bar};
+        use foo::{Bar, Foo};
 
         mod foo {
             pub struct Foo;
@@ -1975,7 +1987,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test add import to existing group`() = checkAutoImportFixByText("""
         // comment
-        use foo::{Foo, Bar};
+        use foo::{Bar, Foo};
 
         mod foo {
             pub struct Foo;
@@ -1988,7 +2000,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """, """
         // comment
-        use foo::{Foo, Bar, Baz};
+        use foo::{Bar, Baz, Foo};
 
         mod foo {
             pub struct Foo;
@@ -2015,8 +2027,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        use foo::Foo;
         use foo::bar::Bar;
+        use foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -2042,8 +2054,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        pub use foo::Foo;
         use foo::Bar;
+        pub use foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -2068,9 +2080,9 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
+        use foo::Bar;
         #[attribute = "value"]
         use foo::Foo;
-        use foo::Bar;
 
         mod foo {
             pub struct Foo;
@@ -2094,7 +2106,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        use foo::{Foo as F, Bar};
+        use foo::{Bar, Foo as F};
 
         mod foo {
             pub struct Foo;
@@ -2107,7 +2119,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test group imports with aliases 2`() = checkAutoImportFixByText("""
-        use foo::{Foo as F, Bar as B};
+        use foo::{Bar as B, Foo as F};
 
         mod foo {
             pub struct Foo;
@@ -2118,7 +2130,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        use foo::{Foo as F, Bar as B, Bar};
+        use foo::{Bar as B, Bar, Foo as F};
 
         mod foo {
             pub struct Foo;
@@ -2131,7 +2143,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test group imports with nested groups`() = checkAutoImportFixByText("""
-        use foo::{{Foo, Bar}};
+        use foo::{{Bar, Foo}};
 
         mod foo {
             pub struct Foo;
@@ -2143,7 +2155,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Baz`">Baz/*caret*/</error>;
         }
     """, """
-        use foo::{{Foo, Bar}, Baz};
+        use foo::{{Bar, Foo}, Baz};
 
         mod foo {
             pub struct Foo;
@@ -2155,6 +2167,66 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = Baz/*caret*/;
         }
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test insert import at correct location`() = checkAutoImportFixByText("""
+        use crate::aaa::A;
+        use crate::bbb::B;
+        use crate::ddd::D;
+
+        pub mod aaa { pub struct A; }
+        pub mod bbb { pub struct B; }
+        pub mod ccc { pub struct C; }
+        pub mod ddd { pub struct D; }
+
+        fn main() {
+            let _ = <error descr="Unresolved reference: `C`">C/*caret*/</error>;
+        }
+    """, """
+        use crate::aaa::A;
+        use crate::bbb::B;
+        use crate::ccc::C;
+        use crate::ddd::D;
+
+        pub mod aaa { pub struct A; }
+        pub mod bbb { pub struct B; }
+        pub mod ccc { pub struct C; }
+        pub mod ddd { pub struct D; }
+
+        fn main() {
+            let _ = C/*caret*/;
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test insert import at correct location (unsorted imports)`() = checkAutoImportFixByText("""
+        use crate::aaa::A;
+        use crate::ddd::D;
+        use crate::bbb::B;
+
+        pub mod aaa { pub struct A; }
+        pub mod bbb { pub struct B; }
+        pub mod ccc { pub struct C; }
+        pub mod ddd { pub struct D; }
+
+        fn main() {
+            let _ = <error descr="Unresolved reference: `C`">C/*caret*/</error>;
+        }
+    """, """
+        use crate::aaa::A;
+        use crate::ddd::D;
+        use crate::bbb::B;
+        use crate::ccc::C;
+
+        pub mod aaa { pub struct A; }
+        pub mod bbb { pub struct B; }
+        pub mod ccc { pub struct C; }
+        pub mod ddd { pub struct D; }
+
+        fn main() {
+            let _ = C/*caret*/;
+        }
+    """, checkOptimizeImports = false)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test import outer item in doctest injection`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
@@ -2221,7 +2293,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, """
     //- lib.rs
         /// ```
-        /// use test_package::{foo, bar};
+        /// use test_package::{bar, foo};
         /// foo();
         /// bar();
         /// ```
@@ -2242,14 +2314,14 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, """
     //- lib.rs
         /// ```
-        /// use test_package::foo;
         /// use test_package::bar::baz;
+        /// use test_package::foo;
         /// foo();
         /// baz();
         /// ```
         pub fn foo() {}
         pub mod bar { pub fn baz() {} }
-    """, Testmarks.insertNewLineBeforeUseItem)
+    """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test import outer item in doctest injection with inner module`() = checkAutoImportFixByFileTreeWithoutHighlighting("""

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
@@ -6,30 +6,34 @@
 package org.rust.ide.inspections.import
 
 import org.intellij.lang.annotations.Language
+import org.rust.ide.injected.isDoctestInjection
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsUnresolvedReferenceInspection
 import org.rust.ide.utils.import.ImportCandidate
 import org.rust.openapiext.Testmark
+import org.rust.lang.core.psi.RsFile
 
 abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
 
     protected fun checkAutoImportFixIsUnavailable(@Language("Rust") text: String, testmark: Testmark? = null) =
-        doTest { checkFixIsUnavailable(AutoImportFix.NAME, text, testmark = testmark) }
+        doTest(checkOptimizeImports = false) { checkFixIsUnavailable(AutoImportFix.NAME, text, testmark = testmark) }
 
     protected fun checkAutoImportFixIsUnavailableByFileTree(@Language("Rust") text: String, testmark: Testmark? = null) =
-        doTest { checkFixIsUnavailableByFileTree(AutoImportFix.NAME, text, testmark = testmark) }
+        doTest(checkOptimizeImports = false) { checkFixIsUnavailableByFileTree(AutoImportFix.NAME, text, testmark = testmark) }
 
     protected fun checkAutoImportFixByText(
         @Language("Rust") before: String,
         @Language("Rust") after: String,
-        testmark: Testmark? = null
-    ) = doTest { checkFixByText(AutoImportFix.NAME, before, after, testmark = testmark) }
+        testmark: Testmark? = null,
+        checkOptimizeImports: Boolean = true,
+    ) = doTest(checkOptimizeImports) { checkFixByText(AutoImportFix.NAME, before, after, testmark = testmark) }
 
     protected fun checkAutoImportFixByFileTree(
         @Language("Rust") before: String,
         @Language("Rust") after: String,
-        testmark: Testmark? = null
-    ) = doTest { checkFixByFileTree(AutoImportFix.NAME, before, after, testmark = testmark) }
+        testmark: Testmark? = null,
+        checkOptimizeImports: Boolean = true,
+    ) = doTest(checkOptimizeImports) { checkFixByFileTree(AutoImportFix.NAME, before, after, testmark = testmark) }
 
     protected fun checkAutoImportFixByFileTreeWithoutHighlighting(
         @Language("Rust") before: String,
@@ -81,14 +85,24 @@ abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferen
         check(chooseItemWasCalled) { "`chooseItem` was not called" }
     }
 
-    private inline fun doTest(action: () -> Unit) {
+    private inline fun doTest(checkOptimizeImports: Boolean = true, action: () -> Unit) {
         val inspection = inspection as RsUnresolvedReferenceInspection
         val defaultValue = inspection.ignoreWithoutQuickFix
         try {
             inspection.ignoreWithoutQuickFix = false
             action()
+            if (checkOptimizeImports) {
+                checkNoChangeAfterOptimizeImports()
+            }
         } finally {
             inspection.ignoreWithoutQuickFix = defaultValue
         }
+    }
+
+    private fun checkNoChangeAfterOptimizeImports() {
+        if ((myFixture.file as? RsFile)?.isDoctestInjection == true) return
+        val text = myFixture.file.text
+        myFixture.performEditorAction("OptimizeImports")
+        myFixture.checkResult(text)
     }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
@@ -443,8 +443,8 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
     """)
 
     fun `test import unresolved type`() = checkFixByText("Add remaining patterns", """
-        use a::foo;
         use a::E::A;
+        use a::foo;
 
         mod a {
             pub enum E { A, B }
@@ -457,8 +457,8 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
             };
         }
     """, """
-        use a::{foo, E};
         use a::E::A;
+        use a::{E, foo};
 
         mod a {
             pub enum E { A, B }

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
@@ -140,7 +140,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
             <error>bar()<caret></error>
         }
     """, """
-        use a::{bar, A, S};
+        use a::{A, bar, S};
 
         mod a {
             pub struct S;
@@ -166,7 +166,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
             <error>bar()<caret></error>
         }
     """, """
-        use a::{bar, A, S};
+        use a::{A, bar, S};
 
         mod a {
             pub struct S;

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1303,7 +1303,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>s;</selection>
         }
     """, """
-        use a::{foo, A};
+        use a::{A, foo};
 
         mod a {
             pub struct A;
@@ -1332,7 +1332,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>foo()</selection>;
         }
     """, """
-        use a::{foo, A};
+        use a::{A, foo};
 
         mod a {
             pub struct A;
@@ -1361,7 +1361,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>foo()</selection>;
         }
     """, """
-        use a::{foo, A};
+        use a::{A, foo};
 
         mod a {
             pub struct S;
@@ -1392,7 +1392,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>foo()</selection>;
         }
     """, """
-        use a::{foo, A, S2};
+        use a::{A, foo, S2};
 
         mod a {
             pub struct S1;

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -103,7 +103,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (R, R)", byDefault = true, isSelected = true)
     ), """
-        use a::{T, R};
+        use a::{R, T};
         mod a {
             pub struct R;
             pub trait T {
@@ -172,7 +172,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f(a: <R as WithAssoc>::Item)", byDefault = true, isSelected = true)
     ), """
-        use a::{T, R, WithAssoc};
+        use a::{R, T, WithAssoc};
         mod a {
             pub struct R;
             pub trait WithAssoc { type Item; }
@@ -206,7 +206,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (R, U, V)", byDefault = true, isSelected = true)
     ), """
-        use a::{T, R, U, V};
+        use a::{R, T, U, V};
         mod a {
             pub struct R;
             pub type U = R;
@@ -301,7 +301,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f<A: Bound1>() where A: Bound2", byDefault = true, isSelected = true)
     ), """
-        use a::{T, Bound1, Bound2};
+        use a::{Bound1, Bound2, T};
         mod a {
             pub trait Bound1 {}
             pub trait Bound2 {}
@@ -330,7 +330,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> [u8; C]", byDefault = true, isSelected = true)
     ), """
-        use a::{T, C};
+        use a::{C, T};
         mod a {
             pub const C: usize = 1;
             pub trait T {

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -389,8 +389,8 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
     """, """
     //- lib.rs
         mod mod1 {
-            use crate::mod2::{foo1, Foo3, Foo4, Foo5, Foo6, Foo7};
             use crate::mod2;
+            use crate::mod2::{foo1, Foo3, Foo4, Foo5, Foo6, Foo7};
 
             fn bar() {
                 foo1::foo1_func();


### PR DESCRIPTION
Previously import was added after all existing imports. Now import will be added at correct location (according to order used by "Optimize imports" action). This is also needed for #7660

changelog: Insert import at correct location during auto-import
