### PR TITLE
RES: Fix injecting prelude in 2021 edition

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -39,18 +39,17 @@ class CrateDefMap(
     /** Used only by `extern crate crate_name;` declarations */
     val directDependenciesDefMaps: Map<String, CrateDefMap>,
     private val allDependenciesDefMaps: Map<CratePersistentId, CrateDefMap>,
-    /**
-     * The prelude module for this crate. This either comes from an import
-     * marked with the `prelude_import` attribute, or (in the normal case) from
-     * a dependency (`std` or `core`).
-     */
-    var prelude: ModData?,
     val metaData: CrateMetaData,
     /** Equal to `root.macroIndex.single()` */
     val rootModMacroIndex: Int,
+    /** Attributes of root module */
+    val stdlibAttributes: RsFile.Attributes,
     /** Only for debug */
     val crateDescription: String,
 ) {
+    /** The prelude module for this crate. See [injectPrelude] */
+    var prelude: ModData? = null
+
     /** It is needed at least to handle `extern crate name as alias;` */
     val externPrelude: MutableMap<String, CrateDefMap> = directDependenciesDefMaps.toMap(hashMapOf())
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
@@ -6,7 +6,8 @@
 package org.rust.lang.core.resolve2
 
 import com.intellij.openapi.project.Project
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2015
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2018
 import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
@@ -16,7 +17,6 @@ import org.rust.lang.core.psi.shouldIndexFile
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.fileId
 import org.rust.openapiext.testAssert
-import org.rust.stdext.mapToSet
 
 /**
  * Returns `null` if [crate] has null `id` or `rootMod`,
@@ -83,13 +83,14 @@ private fun buildDefMapContainingExplicitItems(
         root = crateRootData,
         directDependenciesDefMaps = directDependenciesDefMaps,
         allDependenciesDefMaps = allDependenciesDefMapsById,
-        prelude = findPrelude(crate, allDependenciesDefMaps),
         metaData = CrateMetaData(crate),
         rootModMacroIndex = rootModMacroIndex,
+        stdlibAttributes = crateRoot.getStdlibAttributes(crate),
         crateDescription = crateDescription
     )
 
-    createExternCrateStdImport(crate, crateRoot, crateRootData)?.let {
+    injectPrelude(defMap)
+    createExternCrateStdImport(defMap)?.let {
         context.imports += it
         defMap.importExternCrateMacros(it.usePath.single())
     }
@@ -123,41 +124,47 @@ private fun getDirectAndAllDependencies(
 }
 
 /**
- * Look for the prelude.
- * If the dependency defines a prelude, we overwrite an already defined prelude.
- * This is necessary to import the "std" prelude if a crate depends on both "core" and "std".
+ * Finds prelude based on edition and root module attributes such as ```#[no_std]```.
+ * Prelude for current crate can be overwritten by ```#[prelude_import]```.
+ * See also:
+ * - https://github.com/rust-lang/rust/blob/master/compiler/rustc_builtin_macros/src/standard_library_imports.rs
+ * - https://github.com/rust-lang/rust/pull/82217
  */
-private fun findPrelude(crate: Crate, allDependenciesDefMaps: Map<Crate, CrateDefMap>): ModData? {
-    /**
-     * Correct prelude is always selected (core vs std), because [Crate.flatDependencies] is top sorted.
-     * And we peek prelude from latest dependency.
-     */
-    val dependencies = crate.dependencies.mapToSet { it.crate }
-    val dependenciesTopSorted = crate.flatDependencies.filter { it in dependencies }
-    return dependenciesTopSorted
-        .asReversed()
-        .asSequence()
-        .mapNotNull { allDependenciesDefMaps[it]?.prelude }
-        .firstOrNull()
+private fun injectPrelude(defMap: CrateDefMap) {
+    val preludeCrate = when (defMap.stdlibAttributes) {
+        RsFile.Attributes.NONE -> AutoInjectedCrates.STD
+        RsFile.Attributes.NO_STD -> AutoInjectedCrates.CORE
+        RsFile.Attributes.NO_CORE -> return
+    }
+    val preludeName = when (val edition = defMap.metaData.edition) {
+        // BACKCOMPAT: Rust 1.55.0. Always use "rust_$edition"
+        // We don't use "rust_2015" and "rust_2018" in order to be compatible with old rustc
+        EDITION_2015, EDITION_2018 -> "v1"
+        else -> "rust_${edition.presentation}"
+    }
+    val path = arrayOf("" /* absolute path */, preludeCrate, "prelude", preludeName)
+    val result = defMap.resolvePathFp(defMap.root, path, ResolveMode.IMPORT, withInvisibleItems = false)
+    val resultItem = result.resolvedDef.types.singleOrNull() ?: return
+    defMap.prelude = defMap.tryCastToModData(resultItem)
 }
 
-private fun createExternCrateStdImport(crate: Crate, crateRoot: RsFile, crateRootData: ModData): Import? {
+private fun createExternCrateStdImport(defMap: CrateDefMap): Import? {
     // Rust injects implicit `extern crate std` in every crate root module unless it is
     // a `#![no_std]` crate, in which case `extern crate core` is injected. However, if
     // there is a (unstable?) `#![no_core]` attribute, nothing is injected.
     //
     // https://doc.rust-lang.org/book/using-rust-without-the-standard-library.html
     // The stdlib lib itself is `#![no_std]`, and the core is `#![no_core]`
-    val name = when (crateRoot.getStdlibAttributes(crate)) {
+    val name = when (defMap.stdlibAttributes) {
         RsFile.Attributes.NONE -> AutoInjectedCrates.STD
         RsFile.Attributes.NO_STD -> AutoInjectedCrates.CORE
         RsFile.Attributes.NO_CORE -> return null
     }
     return Import(
-        crateRootData,
+        defMap.root,
         arrayOf(name),
-        nameInScope = if (crate.edition == CargoWorkspace.Edition.EDITION_2015) name else "_",
-        visibility = crateRootData.visibilityInSelf,
+        nameInScope = if (defMap.metaData.edition == EDITION_2015) name else "_",
+        visibility = defMap.root.visibilityInSelf,
         isExternCrate = true
     )
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -6,9 +6,8 @@
 package org.rust.ide.inspections
 
 import org.intellij.lang.annotations.Language
-import org.rust.MockAdditionalCfgOptions
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+import org.rust.*
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.inspections.import.AutoImportFix
 
 class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
@@ -211,6 +210,15 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         #[cfg(not(intellij_rust))]
         extern crate unknown_crate2;
     """)
+
+    @MinRustcVersion("1.56.0-nightly")
+    @MockEdition(Edition.EDITION_2021)
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test 2021 edition prelude`() = checkByText("""
+        fn main() {
+            char::try_from(0u32);
+        }
+    """, false)
 
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val inspection = inspection as RsUnresolvedReferenceInspection

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2021.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2021.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import org.rust.MinRustcVersion
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
+
+@MinRustcVersion("1.56.0-nightly")
+@MockEdition(CargoWorkspace.Edition.EDITION_2021)
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+class RsStdlibResolveTestEdition2021 : RsResolveTestBase() {
+    fun `test 2021 edition prelude`() = stubOnlyResolve("""
+    //- main.rs
+        fn main() {
+            char::try_from(0u32);
+        }       //^ .../convert.rs
+    """)
+}


### PR DESCRIPTION
Fixes #7796

Related: https://github.com/rust-analyzer/rust-analyzer/pull/9097

changelog: Use correct prelude for 2021 edition
