### PR TITLE
Show completion autopopup when typing let mut with existing ident

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
@@ -128,6 +128,18 @@ class RsCompletionAutoPopupTest : RsCompletionTestBase() {
         }
     """, "u")
 
+    fun `test popup is shown when typing let mut 3`() = checkPopupIsShownAfterTyping("""
+        fn main() {
+            let /*caret*/foo
+        }
+    """, "m")
+
+    fun `test popup is shown when typing let mut 4`() = checkPopupIsShownAfterTyping("""
+        fn main() {
+            let m/*caret*/foo
+        }
+    """, "u")
+
     fun `test popup is not shown when typing lowercase let mut binding`() = checkPopupIsNotShownAfterTyping("""
         struct a1 { f: i32 }
         const a2: i32 = 1;


### PR DESCRIPTION
Fixes #7789
The bug was introduced in #7582

```
let /*typing mut here*/foo = 1;
```

changelog: Fix showing completion autopopup when typing `let mut` with existing ident (`let /*typing mut here*/foo = 1;`)