### PR TITLE
RES: Fix resolving macros 2 from prelude

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionProvider.kt
@@ -48,7 +48,7 @@ object RsPartialMacroArgumentCompletionProvider : RsCompletionProvider() {
 
         val bodyTextRange = macroCall.bodyTextRange ?: return
         val macroCallBody = macroCall.macroBody ?: return
-        val macro = macroCall.resolveToMacro() ?: return
+        val macro = macroCall.resolveToMacro() as? RsMacro ?: return  // TODO macro 2
         val graph = macro.graph ?: return
         val offsetInArgument = parameters.offset - bodyTextRange.startOffset
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -14,7 +14,6 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
-import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.RsToolchainBase
 import org.rust.lang.core.crate.Crate
@@ -156,8 +155,8 @@ val RsMacroCall.bodyHash: HashCode?
         }
     }
 
-fun RsMacroCall.resolveToMacro(): RsMacro? =
-    path.reference?.resolve() as? RsMacro
+fun RsMacroCall.resolveToMacro(): RsMacroDefinitionBase? =
+    path.reference?.resolve() as? RsMacroDefinitionBase
 
 val RsMacroCall.expansionFlatten: List<RsExpandedElement>
     get() {

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -865,7 +865,7 @@ fun processMacroCallPathResolveVariants(path: RsPath, isCompletion: Boolean, pro
                     ?.resolveToMacroAndProcessLocalInnerMacros(processor) {
                         /* this code will be executed if new resolve can't be used */
                         val def = expandedFrom.resolveToMacro() ?: return@resolveToMacroAndProcessLocalInnerMacros null
-                        if (!def.hasMacroExportLocalInnerMacros) return@resolveToMacroAndProcessLocalInnerMacros null
+                        if (def !is RsMacro || !def.hasMacroExportLocalInnerMacros) return@resolveToMacroAndProcessLocalInnerMacros null
                         val crateRoot = def.crateRoot as? RsFile ?: return@resolveToMacroAndProcessLocalInnerMacros false
                         processAll(exportedMacros(crateRoot), processor)
                     }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -379,7 +379,8 @@ private val RsPath.pathSegmentsAdjusted: List<String>?
                 is CantUseNewResolve -> {
                     val expandedFrom = callExpandedFrom.resolveToMacro() ?: return segments
                     val crateId = expandedFrom.containingCrate?.id ?: return segments
-                    expandedFrom.hasMacroExportLocalInnerMacros to crateId
+                    val hasMacroExportLocalInnerMacros = expandedFrom is RsMacro && expandedFrom.hasMacroExportLocalInnerMacros
+                    hasMacroExportLocalInnerMacros to crateId
                 }
                 InfoNotFound -> return segments
                 is RsModInfo -> {

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -136,23 +136,17 @@ private fun ModData.processMacros(
 ): Boolean {
     val isQualified = macroPath == null || macroPath is RsPath && macroPath.qualifier != null
 
-    for ((name, perNs) in visibleItems.entriesWithName(processor.name)) {
-        for (visItem in perNs.macros) {
-            val isLegacyMacroDeclaredInSameMod = !isQualified && legacyMacros[name].orEmpty().any {
-                (!isAttrOrDerive || it is ProcMacroDefInfo) && it.path.parent == path
-            }
-            if (isLegacyMacroDeclaredInSameMod) {
-                // Resolve order for unqualified macros:
-                // - textual macros in same mod
-                // - scoped macros (imported by `use`)
-                // - textual macros
-                continue
-            }
-            val macro = visItem.scopedMacroToPsi(defMap, project) ?: continue
-            val visibilityFilter = visItem.visibility.createFilter(project)
-            if (processor(name, macro, visibilityFilter)) return true
+    val stop = processScopedMacros(processor, defMap, project) { name ->
+        val isLegacyMacroDeclaredInSameMod = !isQualified && legacyMacros[name].orEmpty().any {
+            (!isAttrOrDerive || it is ProcMacroDefInfo) && it.path.parent == path
         }
+        // Resolve order for unqualified macros:
+        // - textual macros in same mod
+        // - scoped macros (imported by `use`)
+        // - textual macros
+        !isLegacyMacroDeclaredInSameMod
     }
+    if (stop) return true
 
     if (!isQualified) {
         check(macroPath != null)
@@ -169,8 +163,29 @@ private fun ModData.processMacros(
             val macro = macroInfo.legacyMacroToPsi(macroContainingMod, macroDefMap) ?: continue
             if (processor(name, macro)) return true
         }
+
+        defMap.prelude?.let { prelude ->
+            if (prelude.processScopedMacros(processor, defMap, project)) return true
+        }
     }
 
+    return false
+}
+
+private fun ModData.processScopedMacros(
+    processor: RsResolveProcessor,
+    defMap: CrateDefMap,
+    project: Project,
+    filter: (name: String) -> Boolean = { true },
+): Boolean {
+    for ((name, perNs) in visibleItems.entriesWithName(processor.name)) {
+        for (visItem in perNs.macros) {
+            if (!filter(name)) continue
+            val macro = visItem.scopedMacroToPsi(defMap, project) ?: continue
+            val visibilityFilter = visItem.visibility.createFilter(project)
+            if (processor(name, macro, visibilityFilter)) return true
+        }
+    }
     return false
 }
 

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphWalkerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphWalkerTest.kt
@@ -9,6 +9,7 @@ import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.*
 
@@ -16,7 +17,7 @@ class RsMacroGraphWalkerTest : RsTestBase() {
     private fun check(@Language("Rust") code: String, expected: HashSet<FragmentKind>) {
         InlineFile(code)
         val macroCall = myFixture.file.descendantsOfType<RsMacroCall>().single()
-        val macro = macroCall.resolveToMacro()!!
+        val macro = macroCall.resolveToMacro() as RsMacro
         val graph = macro.graph!!
 
         val position = myFixture.file.findElementAt(myFixture.caretOffset - 1)!!

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -276,6 +276,15 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }   //^ ...libcore/macros/mod.rs|...core/src/macros/mod.rs
     """)
 
+    // macro 2.0 since rust 1.55
+    fun `test asm macro`() = stubOnlyResolve("""
+    //- main.rs
+        #![feature(asm)]
+        fn main() {
+            asm!("nop");
+        } //^ ...core/src/lib.rs|...libcore/macros/mod.rs|...core/src/macros/mod.rs
+    """)
+
     fun `test iterating a vec`() = stubOnlyResolve("""
     //- main.rs
         struct FooBar;


### PR DESCRIPTION
Fixes #7785

changelog: Fix resolving [`asm!`](https://doc.rust-lang.org/beta/unstable-book/library-features/asm.html) macro on nightly rust
