### PR TITLE
REF: support qualified paths in Generate Constructor refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/generate/StructMember.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/StructMember.kt
@@ -5,14 +5,14 @@
 
 package org.rust.ide.refactoring.generate
 
-import org.rust.lang.core.psi.RsNamedFieldDecl
-import org.rust.lang.core.psi.RsStructItem
-import org.rust.lang.core.psi.RsTupleFieldDecl
+import org.rust.ide.presentation.PsiRenderingOptions
+import org.rust.ide.presentation.TypeSubstitutingPsiRenderer
+import org.rust.ide.presentation.renderTypeReference
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsFieldDecl
 import org.rust.lang.core.psi.ext.isTupleStruct
 import org.rust.lang.core.psi.ext.namedFields
 import org.rust.lang.core.psi.ext.positionalFields
-import org.rust.lang.core.psi.substAndGetText
 import org.rust.lang.core.types.Substitution
 
 data class StructMember(
@@ -32,22 +32,31 @@ data class StructMember(
             }
         }
 
-        private fun fromTupleList(tupleFieldList: List<RsTupleFieldDecl>, substitution: Substitution): List<StructMember> {
+        private fun fromTupleList(
+            tupleFieldList: List<RsTupleFieldDecl>,
+            substitution: Substitution
+        ): List<StructMember> {
             return tupleFieldList.mapIndexed { index, tupleField ->
-                val typeName = tupleField.typeReference.substAndGetText(substitution)
+                val typeName = tupleField.typeReference.render(substitution)
                 StructMember("field$index", "()", typeName, tupleField)
             }
         }
 
-        private fun fromFieldList(fieldDeclList: List<RsNamedFieldDecl>, substitution: Substitution): List<StructMember> {
+        private fun fromFieldList(
+            fieldDeclList: List<RsNamedFieldDecl>,
+            substitution: Substitution
+        ): List<StructMember> {
             return fieldDeclList.map {
                 StructMember(
                     it.identifier.text ?: "()",
                     it.identifier.text + ":()",
-                    it.typeReference?.substAndGetText(substitution) ?: "()",
+                    it.typeReference?.render(substitution) ?: "()",
                     it
                 )
             }
         }
     }
 }
+
+private fun RsTypeReference.render(substitution: Substitution): String =
+    TypeSubstitutingPsiRenderer(PsiRenderingOptions(shortPaths = false), substitution).renderTypeReference(this)

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateConstructorActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateConstructorActionTest.kt
@@ -242,4 +242,48 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
             }
         }
     """)
+
+    fun `test qualified path named struct`() = doTest("""
+        mod foo {
+            pub struct S;
+        }
+
+        struct System/*caret*/ {
+            s: foo::S
+        }
+    """, listOf(MemberSelection("s: foo::S", true)), """
+        mod foo {
+            pub struct S;
+        }
+
+        struct System {
+            s: foo::S
+        }
+
+        impl System {
+            pub fn new(s: foo::S) -> Self {
+                System { s }
+            }
+        }
+    """)
+
+    fun `test qualified path tuple struct`() = doTest("""
+        mod foo {
+            pub struct S;
+        }
+
+        struct System/*caret*/(foo::S);
+    """, listOf(MemberSelection("field0: foo::S", true)), """
+        mod foo {
+            pub struct S;
+        }
+
+        struct System(foo::S);
+
+        impl System {
+            pub fn new(field0: foo::S) -> Self {
+                System(field0)
+            }
+        }
+    """)
 }


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7739

See https://github.com/intellij-rust/intellij-rust/issues/7739#issuecomment-915375161.

changelog: Handle qualified field paths correctly in `Generate constructor` refactoring.