### PR TITLE
IDE: convert JSON object to Rust struct after paste

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/paste/JsonStructParser.kt
+++ b/src/main/kotlin/org/rust/ide/typing/paste/JsonStructParser.kt
@@ -1,0 +1,168 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.typing.paste
+
+import com.fasterxml.jackson.core.JsonFactoryBuilder
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.core.json.JsonReadFeature
+import java.io.IOException
+
+sealed class DataType {
+    object Integer : DataType()
+    object Float : DataType()
+    object Boolean : DataType()
+    object String : DataType()
+    object Unknown : DataType()
+    data class StructRef(val struct: Struct) : DataType()
+    data class Array(val type: DataType) : DataType()
+    data class Nullable(val type: DataType) : DataType()
+}
+
+// Structs with the same field names and types are considered the same, regardless of field order.
+// LinkedHashMap::equals ignores key (field) order.
+data class Struct(val fields: LinkedHashMap<String, DataType>)
+
+/**
+ * Try to parse the input text as a JSON object.
+ *
+ * Extract a list of (unique) structs that were encountered in the JSON object.
+ */
+fun extractStructsFromJson(text: String): List<Struct>? {
+    // Fast path to avoid creating a parser if the input does not look like a JSON object
+    val input = text.trim()
+    if (input.isEmpty() || input.first() != '{' || input.last() != '}') return null
+
+    return try {
+        val factory = JsonFactoryBuilder()
+            .enable(JsonReadFeature.ALLOW_TRAILING_COMMA)
+            .build()
+        val parser = factory.createParser(input)
+
+        val structParser = StructParser()
+        val rootStruct = parser.use {
+            // There must be an object at the root
+            val token = parser.nextToken()
+            if (token != JsonToken.START_OBJECT) return null
+
+            structParser.parseStruct(parser)
+        } ?: return null
+
+        // Return structs in reversed order to generate the inner structs first
+        gatherEncounteredStructs(rootStruct).toList().reversed()
+    } catch (e: IOException) {
+        null
+    }
+}
+
+data class Field(val name: String, val type: DataType)
+
+/**
+ * Finds all unique structs contained in the root struct.
+ */
+fun gatherEncounteredStructs(root: Struct): Set<Struct> {
+    val structs = linkedSetOf<Struct>()
+    gatherStructs(DataType.StructRef(root), structs)
+    return structs
+}
+
+private fun gatherStructs(type: DataType, structs: MutableSet<Struct>) {
+    when (type) {
+        is DataType.Array -> gatherStructs(type.type, structs)
+        is DataType.Nullable -> gatherStructs(type.type, structs)
+        is DataType.StructRef -> {
+            structs.add(type.struct)
+            for (fieldType in type.struct.fields.values) {
+                gatherStructs(fieldType, structs)
+            }
+        }
+        DataType.Boolean, DataType.Float, DataType.Integer,
+        DataType.String, DataType.Unknown -> {}
+    }
+}
+
+private class StructParser {
+    private val structMap = linkedSetOf<Struct>()
+
+    fun parseStruct(parser: JsonParser): Struct? {
+        if (parser.currentToken != JsonToken.START_OBJECT) return null
+
+        val fields = linkedMapOf<String, DataType>()
+        while (true) {
+            val field = parseField(parser) ?: break
+
+            // Ignore duplicate fields
+            if (field.name in fields) continue
+            fields[field.name] = field.type
+        }
+
+        if (parser.currentToken != JsonToken.END_OBJECT) return null
+
+        val struct = Struct(fields)
+        if (struct !in structMap) {
+            structMap.add(struct)
+        }
+        return struct
+    }
+
+    private fun parseField(parser: JsonParser): Field? {
+        if (parser.nextToken() != JsonToken.FIELD_NAME) return null
+
+        val name = parser.currentName
+        val type = parseDataType(parser)
+        return Field(name, type)
+    }
+
+    private fun parseArray(parser: JsonParser): DataType? {
+        if (parser.currentToken != JsonToken.START_ARRAY) return null
+
+        val foundDataTypes = linkedSetOf<DataType>()
+        val firstType = parseDataType(parser)
+
+        // Empty array
+        if (firstType == DataType.Unknown) {
+            return DataType.Array(DataType.Unknown)
+        }
+
+        foundDataTypes.add(firstType)
+        while (parser.currentToken != null) {
+            val dataType = parseDataType(parser)
+            if (dataType == DataType.Unknown && parser.currentToken == JsonToken.END_ARRAY) {
+                break
+            }
+            foundDataTypes.add(dataType)
+        }
+
+        val containsNull = foundDataTypes.any { it is DataType.Nullable }
+        val innerType = when {
+            foundDataTypes.size == 1 -> foundDataTypes.first()
+            foundDataTypes.size == 2 && containsNull -> DataType.Nullable(foundDataTypes.first())
+            else -> DataType.Unknown
+        }
+
+        return DataType.Array(innerType)
+    }
+
+    private fun parseDataType(parser: JsonParser): DataType {
+        return when (parser.nextToken()) {
+            JsonToken.START_OBJECT -> {
+                val struct = parseStruct(parser)
+                if (struct == null) {
+                    DataType.Unknown
+                } else {
+                    DataType.StructRef(struct)
+                }
+            }
+            JsonToken.START_ARRAY -> parseArray(parser) ?: DataType.Unknown
+            JsonToken.VALUE_NULL -> DataType.Nullable(DataType.Unknown)
+            JsonToken.VALUE_FALSE, JsonToken.VALUE_TRUE -> DataType.Boolean
+            JsonToken.VALUE_NUMBER_INT -> DataType.Integer
+            JsonToken.VALUE_NUMBER_FLOAT -> DataType.Float
+            JsonToken.VALUE_STRING -> DataType.String
+            else -> DataType.Unknown
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteProcessor.kt
@@ -1,0 +1,283 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.typing.paste
+
+import com.intellij.codeInsight.editorActions.CopyPastePostProcessor
+import com.intellij.codeInsight.editorActions.TextBlockTransferableData
+import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.ui.showYesNoDialog
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPsiElementPointer
+import org.rust.RsBundle
+import org.rust.ide.inspections.lints.toSnakeCase
+import org.rust.ide.utils.template.newTemplateBuilder
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.openapiext.createSmartPointer
+import org.rust.openapiext.isUnitTestMode
+import org.rust.openapiext.runWriteCommandAction
+import org.rust.openapiext.toPsiFile
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+
+class RsConvertJsonToStructCopyPasteProcessor : CopyPastePostProcessor<TextBlockTransferableData>() {
+    override fun collectTransferableData(
+        file: PsiFile?,
+        editor: Editor?,
+        startOffsets: IntArray?,
+        endOffsets: IntArray?
+    ): List<TextBlockTransferableData> = emptyList()
+
+    override fun extractTransferableData(content: Transferable): List<TextBlockTransferableData> {
+        try {
+            if (content.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+                val text = content.getTransferData(DataFlavor.stringFlavor) as String
+                return listOf(PotentialJsonTransferableData(text))
+            }
+            return emptyList()
+        } catch (e: Throwable) {
+            return emptyList()
+        }
+    }
+
+    override fun processTransferableData(
+        project: Project,
+        editor: Editor,
+        bounds: RangeMarker,
+        caretOffset: Int,
+        indented: Ref<in Boolean>,
+        values: List<TextBlockTransferableData>
+    ) {
+        val file = editor.document.toPsiFile(project) as? RsFile ?: return
+
+        val data = values.getOrNull(0) as? PotentialJsonTransferableData ?: return
+        val text = data.text
+
+        val elementAtCaret = file.findElementAt(caretOffset)
+        if (elementAtCaret != null && elementAtCaret.parent !is RsMod) return
+
+        val structs = extractStructsFromJson(text) ?: return
+        if (!shouldConvertJson(project)) return
+
+        val factory = RsPsiFactory(project)
+        val nameMap = generateStructNames(structs)
+
+        val psiDocumentManager = PsiDocumentManager.getInstance(project)
+        val insertedItems: MutableList<SmartPsiElementPointer<RsStructItem>> = mutableListOf()
+
+        runWriteAction {
+            // Delete original text
+            editor.document.deleteString(bounds.startOffset, bounds.endOffset)
+            psiDocumentManager.commitDocument(editor.document)
+
+            val element = file.findElementAt(caretOffset)
+
+            val parent = element?.parent ?: file
+            var anchor = element
+
+            for (struct in structs) {
+                val inserted = createAndInsertStruct(factory, anchor, parent, struct, nameMap) ?: continue
+                anchor = inserted
+                insertedItems.add(inserted.createSmartPointer())
+            }
+        }
+
+        if (insertedItems.isNotEmpty()) {
+            replacePlaceholders(editor, insertedItems, nameMap, file)
+        }
+    }
+}
+
+private fun shouldConvertJson(project: Project): Boolean {
+    return if (isUnitTestMode) {
+        true
+    } else {
+        showYesNoDialog(
+            RsBundle.message("copy.paste.convert.json.to.struct.dialog.title"),
+            RsBundle.message("copy.paste.convert.json.to.struct.dialog.text"),
+            project,
+            icon = Messages.getQuestionIcon()
+        )
+    }
+}
+
+private fun generateStructNames(structs: List<Struct>): Map<Struct, String> {
+    return if (structs.size == 1) {
+        mapOf(structs[0] to "Struct")
+    } else {
+        structs.mapIndexed { index, struct -> struct to "Struct${index + 1}" }.toMap()
+    }
+}
+
+/**
+ * Creates a PSI struct from the given Struct datatype description and inserts it after the given anchor.
+ */
+private fun createAndInsertStruct(
+    factory: RsPsiFactory,
+    anchor: PsiElement?,
+    parent: PsiElement,
+    struct: Struct,
+    nameMap: Map<Struct, String>
+): RsStructItem? {
+    val structPsi = generateStruct(factory, struct, nameMap) ?: return null
+
+    val inserted = if (anchor == null) {
+        parent.add(structPsi)
+    } else {
+        parent.addAfter(structPsi, anchor)
+    } as RsStructItem
+
+    return inserted
+}
+
+fun generateStruct(factory: RsPsiFactory, struct: Struct, nameMap: Map<Struct, String>): RsStructItem? {
+    val structString = buildString {
+        append("struct ${nameMap[struct]} {\n")
+
+        for ((field, type) in struct.fields) {
+            val name = normalizeFieldName(field)
+            val serdeType = getSerdeType(type, nameMap)
+            append("pub $name: ${serdeType},\n")
+        }
+
+        append("}")
+    }
+    return factory.tryCreateStruct(structString)
+}
+
+private val NON_IDENTIFIER_REGEX: Regex = Regex("[^a-zA-Z_0-9]")
+
+fun normalizeFieldName(field: String): String {
+    var name = field.replace(NON_IDENTIFIER_REGEX, "_")
+    if (name.getOrNull(0)?.isDigit() == true) {
+        name = "_$name"
+    }
+
+    return name.toSnakeCase(false).escapeIdentifierIfNeeded()
+}
+
+private fun getSerdeType(type: DataType, nameMap: Map<Struct, String>): String {
+    return when (type) {
+        DataType.Boolean -> "bool"
+        DataType.String -> "String"
+        DataType.Integer -> "i64"
+        DataType.Float -> "f64"
+        is DataType.Nullable -> "Option<${getSerdeType(type.type, nameMap)}>"
+        is DataType.StructRef -> nameMap[type.struct] ?: "_"
+        is DataType.Array -> "Vec<${getSerdeType(type.type, nameMap)}>"
+        DataType.Unknown -> "_"
+    }
+}
+
+/**
+ * Replace generated struct names and _ types in the inserted structs.
+ */
+private fun replacePlaceholders(
+    editor: Editor,
+    insertedItems: List<SmartPsiElementPointer<RsStructItem>>,
+    nameMap: Map<Struct, String>,
+    file: RsFile
+) {
+    invokeLater {
+        if (editor.isDisposed) return@invokeLater
+
+        editor.project?.runWriteCommandAction {
+            if (!file.isValid) return@runWriteCommandAction
+            val template = editor.newTemplateBuilder(file) ?: return@runWriteCommandAction
+
+
+            // Gather usages of structs in fields
+            val structNames = nameMap.values.toSet()
+            val visitor = StructFieldVisitor(structNames)
+
+            val items = insertedItems.mapNotNull { it.element }
+            items.forEach { it.accept(visitor) }
+            val nameUsages = visitor.usages
+
+            // Gather struct names, references to struct names and _ placeholders
+            for (item in items) {
+                val identifier = item.identifier
+                if (identifier != null) {
+                    val variable = template.introduceVariable(identifier)
+                    for (usage in nameUsages[identifier.text].orEmpty()) {
+                        variable.replaceElementWithVariable(usage)
+                    }
+                }
+
+                val underscoreVisitor = UnderscorePathVisitor()
+                item.accept(underscoreVisitor)
+
+                for (wildcard in underscoreVisitor.paths) {
+                    template.replaceElement(wildcard)
+                }
+            }
+
+            template.runInline()
+        }
+    }
+}
+
+/**
+ * Looks for underscore (`_`) paths.
+ */
+private class UnderscorePathVisitor : RsRecursiveVisitor() {
+    private val _paths: MutableSet<RsBaseType> = linkedSetOf()
+
+    val paths: Set<RsBaseType> get() = _paths
+
+    override fun visitBaseType(o: RsBaseType) {
+        if (o.text == "_") {
+            _paths.add(o)
+        }
+        super.visitBaseType(o)
+    }
+}
+
+/**
+ * Looks for base paths that are contained in `nameMap`.
+ * Returns a mapping from name to a list of usages of that name.
+ */
+private class StructFieldVisitor(private val structNames: Set<String>) : RsRecursiveVisitor() {
+    private val _usages = linkedMapOf<String, MutableList<PsiElement>>()
+
+    val usages: Map<String, List<PsiElement>> get() = _usages
+
+    override fun visitBaseType(o: RsBaseType) {
+        val path = o.text
+        if (o.ancestorStrict<RsNamedFieldDecl>() != null && path in structNames) {
+            _usages.getOrPut(path) { mutableListOf() }.add(o)
+        }
+        super.visitBaseType(o)
+    }
+}
+
+private class PotentialJsonTransferableData(val text: String) : TextBlockTransferableData {
+    override fun getFlavor(): DataFlavor = DATA_FLAVOR
+    override fun getOffsetCount(): Int = 0
+
+    override fun getOffsets(offsets: IntArray, index: Int): Int = index
+    override fun setOffsets(offsets: IntArray, index: Int): Int = index
+
+    companion object {
+        val DATA_FLAVOR: DataFlavor = DataFlavor(
+            RsConvertJsonToStructCopyPasteProcessor::class.java,
+            "class: RsConvertJsonToStructCopyPasteProcessor"
+        )
+    }
+}
+
+// TODO: add serde to dependencies
+// TODO: derive and import Serialize/Deserialize
+// TODO: settings GUI + do not ask checkbox

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -136,6 +136,9 @@
         <lang.smartEnterProcessor language="Rust"
                                   implementationClass="org.rust.ide.typing.assist.RsSmartEnterProcessor"/>
 
+        <!-- Copy paste processors -->
+        <copyPastePostProcessor implementation="org.rust.ide.typing.paste.RsConvertJsonToStructCopyPasteProcessor"/>
+
         <!-- Imports -->
 
         <lang.importOptimizer language="Rust" implementationClass="org.rust.ide.refactoring.RsImportOptimizer"/>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -220,3 +220,6 @@ intention.Rust.ToggleFeatureIntention.family.name=Toggle feature state
 
 # copy of `untrusted.project.notification.execution.error` from `ExternalSystemBundle.properties`
 untrusted.project.notification.execution.error=Cargo project is untrusted, so its task cannot be executed.
+
+copy.paste.convert.json.to.struct.dialog.title=Generate Rust Struct from JSON
+copy.paste.convert.json.to.struct.dialog.text=The inserted text seems to be a JSON object. Do you want to generate a Rust struct from it?

--- a/src/test/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteTest.kt
@@ -1,0 +1,438 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.typing.paste
+
+import com.intellij.codeInsight.template.impl.TemplateManagerImpl
+import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.testFramework.PlatformTestUtil
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.fileTreeFromText
+import java.awt.datatransfer.StringSelection
+
+class RsConvertJsonToStructCopyPasteTest : RsTestBase() {
+    fun `test paste into string literal`() = doCopyPasteTest("""
+        //- lib.rs
+        fn foo() {
+            let a = "/*caret*/";
+        }
+    """, """
+        //- lib.rs
+        fn foo() {
+            let a = "{"a": null, "b": []}";
+        }
+    """, """{"a": null, "b": []}""")
+
+    fun `test paste into function`() = doCopyPasteTest("""
+        //- lib.rs
+        fn foo() {
+            /*caret*/
+        }
+    """, """
+        //- lib.rs
+        fn foo() {
+            {"a": null, "b": []}
+        }
+    """, """{"a": null, "b": []}""")
+
+    fun `test paste into empty document`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: i64,
+        }
+    """, """{"a":  5}""")
+
+    fun `test paste into module`() = doCopyPasteTest("""
+        //- lib.rs
+        mod foo {
+            /*caret*/
+
+            struct S;
+        }
+    """, """
+        //- lib.rs
+        mod foo {
+            struct Struct {
+                pub a: i64,
+            }
+
+            struct S;
+        }
+    """, """{"a":  5}""")
+
+    fun `test paste reserved identifier`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub r#type: i64,
+        }
+    """, """{"type":  5}""")
+
+    fun `test paste invalid identifier`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub _oi_d: i64,
+        }
+    """, """{"${'$'}oi/d":  5}""")
+
+    fun `test paste numeric identifier`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub _1: i64,
+        }
+    """, """{"1":  5}""")
+
+    fun `test paste array`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        [1]
+    """, "[1]")
+
+    fun `test paste number`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        1
+    """, "1")
+
+    fun `test invalid json`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        {a:
+    """, """{a:""")
+
+    fun `test empty struct`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {}
+    """, "{}")
+
+    fun `test duplicated struct keys`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: bool,
+        }
+    """, """{"a": true, "a": 0}""")
+
+    fun `test bool true field`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: bool,
+        }
+    """, """{"a": true}""")
+
+    fun `test bool false field`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: bool,
+        }
+    """, """{"a": false}""")
+
+    fun `test integer field`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: i64,
+        }
+    """, """{"a": 0}""")
+
+    fun `test float field`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: f64,
+        }
+    """, """{"a": 0.1}""")
+
+    fun `test string field`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: String,
+        }
+    """, """{"a": "foo"}""")
+
+    fun `test null field`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: Option<_>,
+        }
+    """, """{"a": null}""")
+
+    fun `test empty array`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: Vec<_>,
+        }
+    """, """{"a": []}""")
+
+    fun `test integer array`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: Vec<i64>,
+        }
+    """, """{"a": [1, 2, 3]}""")
+
+    fun `test null array`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: Vec<Option<_>>,
+        }
+    """, """{"a": [null]}""")
+
+    fun `test nullable type array`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: Vec<Option<i64>>,
+        }
+    """, """{"a": [1, null]}""")
+
+    fun `test nested array in array`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: Vec<Vec<i64>>,
+        }
+    """, """{"a": [[1], [2]]}""")
+
+    fun `test nested struct in array`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct1 {
+            pub b: i64,
+        }
+
+        struct Struct2 {
+            pub a: Vec<Struct1>,
+        }
+    """, """{"a": [{"b": 5}, {"b": 4}]}""")
+
+    fun `test mixed array`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: Vec<_>,
+        }
+    """, """{"a": [1, true]}""")
+
+    fun `test mixed array ignore encountered struct`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: Vec<_>,
+        }
+    """, """{"a": [1, true, {"c":  5}]}""")
+
+    fun `test multiple fields`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: String,
+            pub b: i64,
+            pub bar: bool,
+        }
+    """, """{"a": "foo", "b": 1, "bar": true}""")
+
+    fun `test object field`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct1 {
+            pub foo: i64,
+        }
+
+        struct Struct2 {
+            pub a: Struct1,
+        }
+    """, """{"a": {"foo": 5}}""")
+
+    fun `test same object appears multiple times`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct1 {
+            pub foo: i64,
+        }
+
+        struct Struct2 {
+            pub a: Struct1,
+            pub b: Struct1,
+        }
+    """, """{"a": {"foo": 5}, "b":  {"foo": 3}}""")
+
+    fun `test same object appears multiple times with different field order`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct1 {
+            pub bar: bool,
+            pub foo: i64,
+        }
+
+        struct Struct2 {
+            pub a: Struct1,
+            pub b: Struct1,
+        }
+    """, """{"a": {"bar": false, "foo": 5}, "b":  {"foo": 3, "bar": true}}""")
+
+    fun `test fill struct name`() = doCopyPasteTestWithLiveTemplate("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Foo {
+            pub a: i64,
+        }
+    """, """{"a": 0}""", "Foo\t")
+
+    fun `test rename struct references`() = doCopyPasteTestWithLiveTemplate("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Foo {
+            pub b: i64,
+        }
+
+        struct Bar {
+            pub a: Foo,
+            pub b: Foo,
+        }
+    """, """{"a": {"b": 5}, "b": {"b": 5}}""", "Foo\tBar\t")
+
+    fun `test struct field to snake case`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub my_long_field: i64,
+        }
+    """, """{"MyLongField": 1}""")
+
+    fun `test fill underscore types`() = doCopyPasteTestWithLiveTemplate("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Foo {
+            pub a: Option<u32>,
+            pub b: Vec<bool>,
+        }
+    """, """{"a": null, "b": []}""", "Foo\tu32\tbool\t")
+
+    fun `test allow trailing commas`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct Struct {
+            pub a: Vec<i64>,
+        }
+    """, """{"a": [1, 2, 3,],}""")
+
+    private fun doCopyPasteTest(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        @Language("JSON") toPaste: String
+    ) = doTest(before, after, toPaste)
+
+    private fun doCopyPasteTestWithLiveTemplate(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        @Language("JSON") toPaste: String,
+        toType: String
+    ) {
+        TemplateManagerImpl.setTemplateTesting(testRootDisposable)
+
+        doTest(before, after, toPaste) {
+            PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
+
+            assertNotNull(TemplateManagerImpl.getTemplateState(myFixture.editor))
+            myFixture.type(toType)
+            assertNull(TemplateManagerImpl.getTemplateState(myFixture.editor))
+        }
+    }
+
+    private fun doTest(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        @Language("JSON") toPaste: String,
+        action: () -> Unit = {}
+    ) {
+        val testProject = fileTreeFromText(before).create()
+        CopyPasteManager.getInstance().setContents(StringSelection(toPaste))
+
+        myFixture.configureFromTempProjectFile(testProject.fileWithCaret)
+        myFixture.performEditorAction(IdeActions.ACTION_PASTE)
+
+        action()
+
+        fileTreeFromText(after).assertEquals(myFixture.findFileInTempDir("."))
+    }
+}


### PR DESCRIPTION
This PR adds a copy paste processor that tries to convert pasted JSON-like text to a Rust struct (according to the `serde` data model). Currently it does not actually implement any `serde` things on the struct to keep this PR simpler (but it's easy to add `Serialize/Deserialize` derive to the struct using existing intentions and completion).

It currently works like this:
![json](https://user-images.githubusercontent.com/4539057/136369971-6dd99a4d-372d-4ebc-ba78-aed3bbb17850.gif)

Improvements (possibly for follow-up PRs):
- [ ] Add `#[derive(Serialize, Deserialize)]`, possibly with auto import of these traits.
- [ ] Add `serde` with `derive` feature (or `serde_derive` in edition 2015) to `Cargo.toml` if it's not already included (https://github.com/intellij-rust/intellij-rust/pull/7405)
- [ ] Parametrize the behaviour in settings (allow to turn it off). Not sure if this is needed @Undin?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7783

changelog: You can now paste JSON objects into Rust files and convert them to a Rust struct.