### PR TITLE
PERF: Expand macros in parallel during CrateDefMap building

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -63,10 +63,7 @@ import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.concurrent.Executors
-import java.util.concurrent.ForkJoinPool
-import java.util.concurrent.ForkJoinTask
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.*
 import kotlin.system.measureTimeMillis
 
 typealias MacroExpansionCachedResult = CachedValueProvider.Result<RsResult<MacroExpansion, GetMacroExpansionError>>
@@ -448,7 +445,7 @@ private class MacroExpansionServiceImplInner(
      * In short, use of [ForkJoinPool.commonPool] in this place leads to crashes.
      * See [issue](https://github.com/intellij-rust/intellij-rust/issues/3966)
      */
-    private val pool = Executors.newWorkStealingPool()
+    private val pool: ExecutorService = Executors.newWorkStealingPool()
 
     private val stepModificationTracker: SimpleModificationTracker = SimpleModificationTracker()
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -49,7 +49,7 @@ import kotlin.system.measureNanoTime
 abstract class MacroExpansionTaskBase(
     project: Project,
     private val storage: ExpandedMacroStorage,
-    private val pool: Executor,
+    private val pool: ExecutorService,
     private val vfsBatchFactory: () -> MacroExpansionVfsBatch,
     private val createExpandedSearchScope: (Int) -> GlobalSearchScope,
     private val stepModificationTracker: SimpleModificationTracker

--- a/src/main/kotlin/org/rust/stdext/CompletableFuture.kt
+++ b/src/main/kotlin/org/rust/stdext/CompletableFuture.kt
@@ -8,11 +8,12 @@ package org.rust.stdext
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executor
+import java.util.concurrent.Future
 
 fun <T> supplyAsync(executor: Executor, supplier: () -> T): CompletableFuture<T> =
     CompletableFuture.supplyAsync({ supplier() }, executor)
 
-fun <T> CompletableFuture<T>.getWithRethrow(): T =
+fun <T> Future<T>.getWithRethrow(): T =
     try {
         get()
     } catch (e: ExecutionException) {


### PR DESCRIPTION
Now we expand macros in new resolve using following pipeline:
* Resolve all macros (single thread)
* Expand macros in batches (multithread). Usually [macro cache](https://github.com/intellij-rust/intellij-rust/pull/6212) is used here
* Add expanded elements from all macros to DefMap (single thread)

Most performance impact will be on crates with lots of procedural macros (such as [`web-sys`](https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys)) or when we expand macros first time (without cache).

Here is performance comparison on my 8-core machine with code from #7194 (note that currently we use at most 4 processes to expand procedural macros):

project | macro cache? | single-thread | multi-thread | difference
------- | ------------ | ------------- | ------------ | ----------
web-sys |           no |          ~35s |         ~14s |      ~2.5x
web-sys |          yes |        2920ms |       2620ms |       ~10%
cargo   |           no |        3750ms |       3090ms |       ~17%
cargo   |          yes |        1540ms |       1500ms |        ~0%

changelog: Optimize macro expansion — now they are expanded in parallel