### PR TITLE
RES: Fix that cfg-disabled mod can affect cfg-enabled mod with same name

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -151,6 +151,8 @@ class CrateDefMap(
         val fileId = file.virtualFile.fileId
         // TODO: File included in module tree multiple times ?
         // testAssert { fileId !in fileInfos }
+        val existing = fileInfos[fileId]
+        if (existing != null && !modData.isDeeplyEnabledByCfg && existing.modData.isDeeplyEnabledByCfg) return
         fileInfos[fileId] = FileInfo(file.modificationStampForResolve, modData, fileHash)
     }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -987,4 +987,23 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     //- foo.rs
         pub fn func() {}
     """)
+
+    @ExpandMacros
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test cfg-disabled mod does not affect cfg-enabled mod`() = stubOnlyResolve("""
+    //- main.rs
+        #[cfg(intellij_rust)]
+        mod foo;
+        #[cfg(not(intellij_rust))]
+        mod foo;
+        fn main() {
+            foo::func();
+        }      //^ foo.rs
+    //- foo.rs
+        macro_rules! as_is { ($($ t:tt)*) => { $($ t)* } }
+        as_is! {
+            pub fn func() {}
+        }
+    """)
 }


### PR DESCRIPTION
Strictly speaking, this fixes the case when several mod declarations point to the same file:
```rust
#[cfg(foo)]
mod foo; // foo.rs

#[cfg(not(foo))]
mod foo; // foo.rs, as well
```

changelog: Fix incorrect resolve in some cases when there is both cfg-disabled and cfg-enabled mod with the same name
