### PR TITLE
QDOC: improve macro 2.0 documentation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -245,10 +245,14 @@ data class RsQualifiedName private constructor(
                 element.containingCrate?.normName ?: return null
             }
 
-            val modSegments = if (parentType == PRIMITIVE || parentType == KEYWORD || parentType == MACRO) {
+            val parentElement = parentItem.element
+            val withoutModSegments = parentType == PRIMITIVE ||
+                parentType == KEYWORD ||
+                parentType == MACRO && parentElement is RsMacro
+            val modSegments = if (withoutModSegments) {
                 emptyList()
             } else {
-                val parentElement = parentItem.element ?: return null
+                if (parentElement == null) return null
                 val mod = parentElement as? RsMod ?: parentElement.containingMod
                 mod.superMods
                     .asReversed()
@@ -265,7 +269,7 @@ data class RsQualifiedName private constructor(
             val modSegments = mutableListOf<String>()
 
             val (parentItem, childItem) = qualifiedNamedItem.item.toItems() ?: return null
-            if (parentItem.type != MACRO) {
+            if (parentItem.type != MACRO || parentItem.element is RsMacro2) {
                 qualifiedNamedItem.superMods
                     ?.asReversed()
                     ?.drop(1)

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
@@ -114,6 +114,17 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
         }
     """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/macro.foo.html")
 
+    fun `test macro in module`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        pub mod bar {
+            #[macro_export]
+            macro_rules! foo {
+                        //^
+                () => { unimplemented!() };
+            }
+        }
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/macro.foo.html")
+
     fun `test not exported macro`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
         macro_rules! foo {
@@ -124,9 +135,17 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
 
     fun `test macro 2`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
-        pub macro Bar() {}
+        pub macro bar() {}
                  //^
-    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/macro.Bar.html")
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/macro.bar.html")
+
+    fun `test macro 2 in module`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        pub mod foo {
+            pub macro bar() {}
+        }            //^
+
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/foo/macro.bar.html")
 
     fun `test not external url for workspace package`() = doUrlTestByFileTree("""
         //- lib.rs

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -732,8 +732,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         Module level docs</p></div>
     """)
 
-    //
-    fun `test macro outer docstring`() = doTest("""
+    fun `test macro outer docstring 1`() = doTest("""
         /// Outer documentation
         macro_rules! makro {
                    //^
@@ -748,16 +747,48 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='content'><p>Outer documentation</p></div>
     """)
 
-    fun `test macro 2 outer docs`() = doTest("""
+    fun `test macro outer docstring 2`() = doTest("""
+        pub mod foo {
+            /// Outer documentation
+            macro_rules! makro {
+                       //^
+                () => { };
+            }
+        }
+
+        fn main() {
+        }
+    """, """
+        <div class='definition'><pre>test_package
+        macro <b>makro</b></pre></div>
+        <div class='content'><p>Outer documentation</p></div>
+    """)
+
+    fun `test macro 2 outer docs 1`() = doTest("""
         pub struct Foo;
 
         /// Outer doc
         /// [link](Foo)
-        pub macro Bar() {}
+        pub macro bar() {}
                  //^
     """, """
-        <div class='definition'><pre>test_package::Bar
-        </pre></div>
+        <div class='definition'><pre>test_package
+        pub macro <b>bar</b></pre></div>
+        <div class='content'><p>Outer doc
+        <a href="psi_element://Foo">link</a></p></div>
+    """)
+
+    fun `test macro 2 outer docs 2`() = doTest("""
+        pub mod foo_bar {
+            pub struct Foo;
+
+            /// Outer doc
+            /// [link](Foo)
+            pub macro bar() {}
+        }           //^
+    """, """
+        <div class='definition'><pre>test_package::foo_bar
+        pub macro <b>bar</b></pre></div>
         <div class='content'><p>Outer doc
         <a href="psi_element://Foo">link</a></p></div>
     """)

--- a/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
@@ -157,6 +157,22 @@ class RsResolveLinkTest : RsTestBase() {
              //^
     """, "test_package/macro.bar.html")
 
+    fun `test macro 2 fqn link 1`() = doTest("""
+        pub macro foo() {}
+                 //X
+        struct Bar;
+              //^
+    """, "test_package/macro.foo.html")
+
+    fun `test macro 2 fqn link 2`() = doTest("""
+        pub mod foo {
+            pub macro bar() {}
+                     //X
+        }
+        struct Foo;
+             //^
+    """, "test_package/foo/macro.bar.html")
+
     fun `test method fqn link`() = doTest("""
         struct Foo;
         impl Foo {


### PR DESCRIPTION
* Improve rendering of macro 2.0 header

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2539310/132830513-373d1273-b83b-4248-bc0c-ed0686787714.png) | ![image](https://user-images.githubusercontent.com/2539310/132830488-cb36e934-719d-4870-81be-f5ee231e5b73.png) |

* Properly generate external links if a macro has parent modules, for example, `std::prt::addr_of`
* Improve documentation link resolution if a macro has parent modules. Note, these changes do nothing with [intra-doc links](https://doc.rust-lang.org/rustdoc/linking-to-items-by-name.html)

Also, I've added some missing tests for macro 1.0

changelog: Improve documentation rendering for [macro 2.0](https://rust-lang.github.io/rfcs/1584-macros.html) as well as external link generation and resolution
