### PR TITLE
COMP: improve macro 2.0 completion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -217,7 +217,7 @@ private fun RsElement.getLookupElementBuilder(scopeName: String, subst: Substitu
 
         is RsMacroBinding -> base.withTypeText(fragmentSpecifier)
 
-        is RsMacro -> base.withTailText("!")
+        is RsMacroDefinitionBase -> base.withTailText("!")
 
         else -> base
     }
@@ -310,7 +310,7 @@ open class RsDefaultInsertHandler : InsertHandler<LookupElement> {
                 }
             }
 
-            is RsMacro -> {
+            is RsMacroDefinitionBase -> {
                 if (curUseItem == null) {
                     var caretShift = 2
                     if (!context.nextCharIs('!')) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -19,7 +19,6 @@ import org.rust.lang.core.macros.decl.MacroGraph
 import org.rust.lang.core.macros.decl.MacroGraphBuilder
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsMacroStub
-import org.rust.lang.doc.documentation
 import org.rust.stdext.HashCode
 import java.util.*
 import javax.swing.Icon
@@ -74,6 +73,9 @@ abstract class RsMacroImplMixin : RsStubbedNamedElementImpl<RsMacroStub>,
 
     override val hasRustcBuiltinMacro: Boolean
         get() = HAS_RUSTC_BUILTIN_MACRO_PROP.getByPsi(this)
+
+    override val preferredBraces: MacroBraces
+        get() = stub?.preferredBraces ?: guessPreferredBraces()
 }
 
 /** "macro_rules" identifier of `macro_rules! foo {}`; guaranteed to be non-null by the grammar */
@@ -111,29 +113,6 @@ val RsMacro.isRustcDocOnlyMacro: Boolean
 
 val QueryAttributes<*>.isRustcDocOnlyMacro: Boolean
     get() = hasAttribute("rustc_doc_only_macro")
-
-val RsMacro.preferredBraces: MacroBraces
-    get() = stub?.preferredBraces ?: guessPreferredBraces()
-
-
-private val MACRO_CALL_PATTERN: Regex = """(^|[^\p{Alnum}_])(r#)?(?<name>\w+)\s*!\s*(?<brace>[({\[])""".toRegex()
-
-/**
- * Analyses documentation of macro definition to determine what kind of brackets usually used
- */
-private fun RsMacro.guessPreferredBraces(): MacroBraces {
-    val documentation = documentation()
-    if (documentation.isEmpty()) return MacroBraces.PARENS
-
-    val map: MutableMap<MacroBraces, Int> = EnumMap(MacroBraces::class.java)
-    for (result in MACRO_CALL_PATTERN.findAll(documentation)) {
-        if (result.groups["name"]?.value != name) continue
-        val braces = MacroBraces.values().find { it.openText == result.groups["brace"]?.value } ?: continue
-        map.merge(braces, 1, Int::plus)
-    }
-
-    return map.maxByOrNull { it.value }?.key ?: MacroBraces.PARENS
-}
 
 private val MACRO_BODY_HASH_KEY: Key<CachedValue<HashCode>> = Key.create("MACRO_BODY_HASH_KEY")
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro2.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro2.kt
@@ -63,6 +63,9 @@ abstract class RsMacro2ImplMixin : RsStubbedNamedElementImpl<RsMacro2Stub>,
 
     override val hasRustcBuiltinMacro: Boolean
         get() = MACRO2_HAS_RUSTC_BUILTIN_MACRO_PROP.getByPsi(this)
+
+    override val preferredBraces: MacroBraces
+        get() = stub?.preferredBraces ?: guessPreferredBraces()
 }
 
 val MACRO2_HAS_RUSTC_BUILTIN_MACRO_PROP: StubbedAttributeProperty<RsMacro2, RsMacro2Stub> =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinitionBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinitionBase.kt
@@ -6,17 +6,42 @@
 package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.macros.RsExpandedElement
+import org.rust.lang.core.psi.MacroBraces
 import org.rust.lang.core.psi.RsMacroBody
+import org.rust.lang.doc.documentation
 import org.rust.stdext.HashCode
+import java.util.*
 
 /**
  * [org.rust.lang.core.psi.RsMacro] or [org.rust.lang.core.psi.RsMacro2]
  */
 interface RsMacroDefinitionBase : RsNameIdentifierOwner,
                                   RsQualifiedNamedElement,
+                                  RsOuterAttributeOwner,
                                   RsExpandedElement,
                                   RsModificationTrackerOwner {
     val macroBodyStubbed: RsMacroBody?
     val bodyHash: HashCode?
     val hasRustcBuiltinMacro: Boolean
+
+    val preferredBraces: MacroBraces
 }
+
+/**
+ * Analyses documentation of macro definition to determine what kind of brackets usually used
+ */
+fun RsMacroDefinitionBase.guessPreferredBraces(): MacroBraces {
+    val documentation = documentation()
+    if (documentation.isEmpty()) return MacroBraces.PARENS
+
+    val map: MutableMap<MacroBraces, Int> = EnumMap(MacroBraces::class.java)
+    for (result in MACRO_CALL_PATTERN.findAll(documentation)) {
+        if (result.groups["name"]?.value != name) continue
+        val braces = MacroBraces.values().find { it.openText == result.groups["brace"]?.value } ?: continue
+        map.merge(braces, 1, Int::plus)
+    }
+
+    return map.maxByOrNull { it.value }?.key ?: MacroBraces.PARENS
+}
+
+private val MACRO_CALL_PATTERN: Regex = """(^|[^\p{Alnum}_])(r#)?(?<name>\w+)\s*!\s*(?<brace>[({\[])""".toRegex()

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -67,7 +67,7 @@ class RsFileStub(
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 216
+        private const val STUB_VERSION = 217
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
@@ -1538,6 +1538,7 @@ class RsMacro2Stub(
     override val name: String?,
     val macroBody: String,
     val bodyHash: HashCode,
+    val preferredBraces: MacroBraces,
     override val flags: Int
 ) : RsAttributeOwnerStubBase<RsMacro2>(parent, elementType),
     RsNamedStub {
@@ -1553,6 +1554,7 @@ class RsMacro2Stub(
                 dataStream.readNameAsString(),
                 dataStream.readUTFFast(),
                 dataStream.readHashCode(),
+                dataStream.readEnum(),
                 dataStream.readUnsignedByte()
             )
 
@@ -1561,6 +1563,7 @@ class RsMacro2Stub(
                 writeName(stub.name)
                 writeUTFFast(stub.macroBody)
                 writeHashCode(stub.bodyHash)
+                writeEnum(stub.preferredBraces)
                 writeByte(stub.flags)
             }
 
@@ -1572,7 +1575,8 @@ class RsMacro2Stub(
             flags = BitUtil.set(flags, HAS_RUSTC_BUILTIN_MACRO, MACRO2_HAS_RUSTC_BUILTIN_MACRO_PROP.getDuringIndexing(psi))
             val body = psi.prepareMacroBody()
             val bodyHash = HashCode.compute(body)
-            return RsMacro2Stub(parentStub, this, psi.name, body, bodyHash, flags)
+            val preferredBraces = psi.preferredBraces
+            return RsMacro2Stub(parentStub, this, psi.name, body, bodyHash, preferredBraces, flags)
         }
 
         override fun indexStub(stub: RsMacro2Stub, sink: IndexSink) = sink.indexMacroDef(stub)

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -644,6 +644,34 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
+    @UseNewResolve
+    fun `test complete macro2`() = doSingleCompletion("""
+        macro foo() {}
+        fn main() {
+            fo/*caret*/
+        }
+    """, """
+        macro foo() {}
+        fn main() {
+            foo!(/*caret*/)
+        }
+    """)
+
+    @UseNewResolve
+    fun `test complete macro2 in use statement`() = doSingleCompletion("""
+        pub mod bar {
+            pub macro foo() {}
+        }
+
+        use bar::fo/*caret*/
+    """, """
+        pub mod bar {
+            pub macro foo() {}
+        }
+
+        use bar::foo;/*caret*/
+    """)
+
     // https://github.com/intellij-rust/intellij-rust/issues/1598
     fun `test no macro completion in item element definition`() {
         for (itemKeyword in listOf("fn", "struct", "enum", "union", "trait", "type", "impl")) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
@@ -123,6 +123,11 @@ class RsLookupElementTest : RsTestBase() {
                      //^
     """, tailText = "!", typeText = null)
 
+    fun `test macro 2 definition`() = check("""
+        macro test() {}
+              //^
+    """, tailText = "!", typeText = null)
+
     fun `test deprecated fn`() = check("""
         #[deprecated]
         fn foo() {}


### PR DESCRIPTION
Use the same rules that we use for macro 1.0, i.e.:
- add `!` to item in completion list
- insert `;` if complete item in `use` statement and `!` otherwise
- insert proper braces (based on documentation) outside of use items

changelog: Improve completion of [macro 2.0](https://rust-lang.github.io/rfcs/1584-macros.html), i.e. insert `!` and proper braces (based on documentation) if needed
