### PR TITLE
RUN: Allow to configure addition arguments and other options for Rustfmt

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -178,7 +178,7 @@ jobs:
               with:
                   profile: minimal
                   toolchain: nightly
-                  components: rust-src
+                  components: rust-src, rustfmt
                   default: false
 
             - name: Cache cargo binaries

--- a/src/main/kotlin/org/rust/cargo/RustfmtWatcher.kt
+++ b/src/main/kotlin/org/rust/cargo/RustfmtWatcher.kt
@@ -17,7 +17,7 @@ import com.intellij.util.DocumentUtil
 import com.intellij.util.containers.ContainerUtil
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
-import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.settings.rustfmtSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.tools.Rustfmt
@@ -46,7 +46,7 @@ class RustfmtWatcher {
         val file = document.virtualFile ?: return false
         if (file.isNotRustFile) return false
         val project = guessProjectForFile(file) ?: return false
-        if (!project.rustSettings.runRustfmtOnSave) return false
+        if (!project.rustfmtSettings.state.runRustfmtOnSave) return false
         return documentsToReformatLater.add(document)
     }
 
@@ -100,7 +100,7 @@ class RustfmtWatcher {
 
         private fun reformatDocuments(cargoProject: CargoProject, documents: List<Document>) {
             val project = cargoProject.project
-            if (!project.rustSettings.runRustfmtOnSave) return
+            if (!project.rustfmtSettings.state.runRustfmtOnSave) return
             val rustfmt = project.toolchain?.rustfmt() ?: return
             if (checkNeedInstallRustfmt(cargoProject.project, cargoProject.workingDirectory)) return
             documents.forEach { rustfmt.reformatDocument(cargoProject, it) }

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
@@ -5,14 +5,64 @@
 
 package org.rust.cargo.project.configurable
 
+import com.intellij.execution.configuration.EnvironmentVariablesComponent
+import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.RawCommandLineEditor
+import com.intellij.ui.components.Label
 import com.intellij.ui.layout.panel
+import com.intellij.ui.layout.toBinding
 import org.rust.RsBundle
+import org.rust.cargo.project.settings.rustfmtSettings
+import org.rust.cargo.toolchain.RustChannel
 
-class RustfmtConfigurable(project: Project) : RsConfigurableBase(project, RsBundle.message("settings.rust.rustfmt.name")) {
+class RustfmtConfigurable(project: Project) : BoundConfigurable(RsBundle.message("settings.rust.rustfmt.name")) {
+    private val settings = project.rustfmtSettings
+
+    private val additionalArguments = RawCommandLineEditor()
+
+    private val channelLabel = Label(RsBundle.message("settings.rust.rustfmt.channel.label"))
+    private val channel = ComboBox<RustChannel>().apply {
+        RustChannel.values()
+            .sortedBy { it.index }
+            .forEach { addItem(it) }
+    }
+
+    private val environmentVariables = EnvironmentVariablesComponent()
+
     override fun createPanel(): DialogPanel = panel {
-        row { checkBox(RsBundle.message("settings.rust.rustfmt.builtin.formatter.label"), state::useRustfmt) }
-        row { checkBox(RsBundle.message("settings.rust.rustfmt.run.on.save.label"), state::runRustfmtOnSave) }
+        blockRow {
+            row(RsBundle.message("settings.rust.rustfmt.additional.arguments.label")) {
+                additionalArguments(pushX, growX)
+                    .comment(RsBundle.message("settings.rust.rustfmt.additional.arguments.comment"))
+                    .withBinding(
+                        componentGet = { it.text },
+                        componentSet = { component, value -> component.text = value },
+                        modelBinding = settings.state::additionalArguments.toBinding()
+                    )
+
+                channelLabel.labelFor = channel
+                channelLabel()
+                channel().withBinding(
+                    componentGet = { it.item },
+                    componentSet = { component, value -> component.item = value },
+                    modelBinding = settings.state::channel.toBinding()
+                )
+            }
+
+            row(environmentVariables.label) {
+                environmentVariables(growX)
+                    .withBinding(
+                        componentGet = { it.envs },
+                        componentSet = { component, value -> component.envs = value },
+                        modelBinding = settings.state::envs.toBinding()
+                    )
+            }
+        }
+
+        row { checkBox(RsBundle.message("settings.rust.rustfmt.builtin.formatter.label"), settings.state::useRustfmt) }
+        row { checkBox(RsBundle.message("settings.rust.rustfmt.run.on.save.label"), settings.state::runRustfmtOnSave) }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -49,7 +49,9 @@ interface RustProjectSettingsService {
         var macroExpansionEngine: MacroExpansionEngine = defaultMacroExpansionEngine,
         @AffectsHighlighting
         var doctestInjectionEnabled: Boolean = true,
+        // BACKCOMPAT: 2022.1
         var useRustfmt: Boolean = false,
+        // BACKCOMPAT: 2022.1
         var runRustfmtOnSave: Boolean = false,
     ) {
         @get:Transient
@@ -106,8 +108,6 @@ interface RustProjectSettingsService {
     val useOffline: Boolean
     val macroExpansionEngine: MacroExpansionEngine
     val doctestInjectionEnabled: Boolean
-    val useRustfmt: Boolean
-    val runRustfmtOnSave: Boolean
 
     @Suppress("DEPRECATION")
     @Deprecated("Use toolchain property")

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustfmtProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustfmtProjectSettingsService.kt
@@ -1,0 +1,57 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.settings
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.*
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import org.jetbrains.annotations.TestOnly
+import org.rust.cargo.project.settings.RustfmtProjectSettingsService.RustfmtState
+import org.rust.cargo.toolchain.RustChannel
+
+val Project.rustfmtSettings: RustfmtProjectSettingsService get() = service()
+
+private const val serviceName: String = "RustfmtProjectSettings"
+
+@State(name = serviceName, storages = [Storage(StoragePathMacros.WORKSPACE_FILE)])
+class RustfmtProjectSettingsService(
+    private val project: Project
+) : SimplePersistentStateComponent<RustfmtState>(RustfmtState()) {
+
+    override fun noStateLoaded() {
+        project.rustSettings.modify {
+            state.useRustfmt = it.useRustfmt
+            it.useRustfmt = false
+            state.runRustfmtOnSave = it.runRustfmtOnSave
+            it.runRustfmtOnSave = false
+        }
+    }
+
+    @TestOnly
+    fun modifyTemporary(parentDisposable: Disposable, action: (RustfmtState) -> Unit) {
+        val oldState = state
+        loadState(oldState.copy().also(action))
+        Disposer.register(parentDisposable) {
+            loadState(oldState)
+        }
+    }
+
+    class RustfmtState : BaseState() {
+        var version by property(0)
+        var additionalArguments by property("") { it.isEmpty() }
+        var channel by enum(RustChannel.DEFAULT)
+        var envs by map<String, String>()
+        var useRustfmt by property(false)
+        var runRustfmtOnSave by property(false)
+
+        fun copy(): RustfmtState {
+            val state = RustfmtState()
+            state.copyFrom(this)
+            return state
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -61,8 +61,6 @@ class RustProjectSettingsServiceImpl(
     override val useOffline: Boolean get() = _state.useOffline
     override val macroExpansionEngine: MacroExpansionEngine get() = _state.macroExpansionEngine
     override val doctestInjectionEnabled: Boolean get() = _state.doctestInjectionEnabled
-    override val useRustfmt: Boolean get() = _state.useRustfmt
-    override val runRustfmtOnSave: Boolean get() = _state.runRustfmtOnSave
 
     @Suppress("OverridingDeprecatedMember", "DEPRECATION")
     override fun getToolchain(): RsToolchain? = _state.toolchain?.let(RsToolchain::from)
@@ -86,7 +84,7 @@ class RustProjectSettingsServiceImpl(
     @TestOnly
     override fun modifyTemporary(parentDisposable: Disposable, action: (State) -> Unit) {
         val oldState = settingsState
-        settingsState = oldState.also(action)
+        settingsState = oldState.copy().also(action)
         Disposer.register(parentDisposable) {
             _state = oldState
         }

--- a/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
@@ -138,12 +138,16 @@ data class CargoCommandLine(
             cargoProject: CargoProject,
             command: String,
             additionalArguments: List<String> = emptyList(),
-            channel: RustChannel = RustChannel.DEFAULT
+            toolchain: String? = null,
+            channel: RustChannel = RustChannel.DEFAULT,
+            environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
         ): CargoCommandLine = CargoCommandLine(
             command,
             workingDirectory = cargoProject.workingDirectory,
             additionalArguments = additionalArguments,
-            channel = channel
+            toolchain = toolchain,
+            channel = channel,
+            environmentVariables = environmentVariables
         )
 
         fun forPackage(

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -388,10 +388,9 @@ class Cargo(
     private fun toGeneralCommandLine(project: Project, commandLine: CargoCommandLine, colors: Boolean): GeneralCommandLine =
         with(commandLine.patchArgs(project, colors)) {
             val parameters = buildList<String> {
-                if (channel != RustChannel.DEFAULT) {
-                    add("+$channel")
-                } else if (toolchain != null) {
-                    add("+$toolchain")
+                when {
+                    channel != RustChannel.DEFAULT -> add("+$channel")
+                    toolchain != null -> add("+$toolchain")
                 }
                 if (project.rustSettings.useOffline) {
                     val cargoProject = findCargoProject(project, additionalArguments, workingDirectory)

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
@@ -5,22 +5,29 @@
 
 package org.rust.cargo.toolchain.tools
 
+import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.execution.ParametersListUtil
 import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.settings.rustfmtSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.RsToolchainBase
+import org.rust.cargo.toolchain.RustChannel
+import org.rust.ide.actions.RustfmtEditSettingsAction
+import org.rust.ide.notifications.showBalloon
 import org.rust.lang.core.psi.ext.edition
 import org.rust.lang.core.psi.isNotRustFile
 import org.rust.openapiext.*
 import org.rust.stdext.RsResult.Ok
-import org.rust.stdext.buildList
 import org.rust.stdext.unwrapOrElse
 import java.nio.file.Path
 
@@ -29,36 +36,59 @@ fun RsToolchainBase.rustfmt(): Rustfmt = Rustfmt(this)
 class Rustfmt(toolchain: RsToolchainBase) : RustupComponent(NAME, toolchain) {
 
     fun reformatDocumentTextOrNull(cargoProject: CargoProject, document: Document): String? {
+        val project = cargoProject.project
         return createCommandLine(cargoProject, document)
-            ?.execute(cargoProject.project, stdIn = document.text.toByteArray())
-            ?.unwrapOrElse { if (isUnitTestMode) throw it else return null }
-            ?.stdout
+            ?.execute(project, stdIn = document.text.toByteArray())
+            ?.unwrapOrElse { e ->
+                e.showRustfmtError(project)
+                if (isUnitTestMode) throw e else return null
+            }?.stdout
     }
 
     fun createCommandLine(cargoProject: CargoProject, document: Document): GeneralCommandLine? {
         val file = document.virtualFile ?: return null
         if (file.isNotRustFile || !file.isValid) return null
 
-        val arguments = buildList<String> {
-            add("--emit=stdout")
+        val project = cargoProject.project
+        val settingsState = project.rustfmtSettings.state
 
-            val configPath = findConfigPathRecursively(file.parent, stopAt = cargoProject.workingDirectory)
-            if (configPath != null) {
-                add("--config-path")
-                add(configPath.toString())
-            }
+        val arguments = ParametersListUtil.parse(settingsState.additionalArguments)
+        val cleanArguments = mutableListOf<String>()
 
-            val currentRustcVersion = cargoProject.rustcInfo?.version?.semver
-            if (currentRustcVersion != null) {
-                val edition = runReadAction {
-                    val psiFile = file.toPsiFile(cargoProject.project)
-                    psiFile?.edition ?: Edition.DEFAULT
-                }
-                add("--edition=${edition.presentation}")
-            }
+        val toolchain = arguments.firstOrNull()?.takeIf { it.startsWith("+") }
+        when {
+            settingsState.channel != RustChannel.DEFAULT -> cleanArguments += "+${settingsState.channel}"
+            toolchain != null -> cleanArguments += toolchain
         }
 
-        return createBaseCommandLine(arguments, cargoProject.workingDirectory)
+        var idx = if (toolchain == null) 0 else 1
+        while (idx < arguments.size) {
+            val arg = arguments[idx]
+            when {
+                arg == "--emit" -> idx += 2
+                arg.startsWith("--emit") -> idx += 1
+                else -> {
+                    cleanArguments += arg
+                    idx += 1
+                }
+            }
+        }
+        cleanArguments.add("--emit=stdout")
+
+        cleanArguments.addArgument("config-path") {
+            findConfigPathRecursively(file.parent, stopAt = cargoProject.workingDirectory)?.toString()
+        }
+
+        cleanArguments.addArgument("edition") {
+            if (cargoProject.rustcInfo?.version == null) return@addArgument null
+            val edition = runReadAction {
+                val psiFile = file.toPsiFile(project)
+                psiFile?.edition ?: Edition.DEFAULT
+            }
+            edition.presentation
+        }
+
+        return createBaseCommandLine(cleanArguments, cargoProject.workingDirectory, settingsState.envs)
     }
 
     fun reformatCargoProject(
@@ -66,12 +96,32 @@ class Rustfmt(toolchain: RsToolchainBase) : RustupComponent(NAME, toolchain) {
         owner: Disposable = cargoProject.project
     ): RsProcessResult<Unit> {
         val project = cargoProject.project
+        val settingsState = project.rustfmtSettings.state
+        val arguments = ParametersListUtil.parse(settingsState.additionalArguments).toMutableList()
+        val toolchain = if (arguments.firstOrNull()?.startsWith("+") == true) {
+            arguments.removeFirst()
+        } else {
+            null
+        }
+        val commandLine = CargoCommandLine.forProject(
+            cargoProject,
+            "fmt",
+            listOf("--all", "--") + arguments,
+            toolchain,
+            settingsState.channel,
+            EnvironmentVariablesData.create(settingsState.envs, true)
+        )
+
         return project.computeWithCancelableProgress("Reformatting Cargo Project with Rustfmt...") {
             project.toolchain
                 ?.cargoOrWrapper(cargoProject.workingDirectory)
-                ?.toGeneralCommandLine(project, CargoCommandLine.forProject(cargoProject, "fmt", listOf("--all")))
+                ?.toGeneralCommandLine(project, commandLine)
                 ?.execute(owner)
                 ?.map { }
+                ?.mapErr { e ->
+                    e.showRustfmtError(project)
+                    e
+                }
                 ?: Ok(Unit)
         }
     }
@@ -81,11 +131,24 @@ class Rustfmt(toolchain: RsToolchainBase) : RustupComponent(NAME, toolchain) {
 
         private val CONFIG_FILES: List<String> = listOf("rustfmt.toml", ".rustfmt.toml")
 
+        private fun MutableList<String>.addArgument(flagName: String, value: () -> String?) {
+            if (any { it.startsWith("--$flagName") }) return
+            val flagValue = value() ?: return
+            add("--$flagName=$flagValue")
+        }
+
         private fun findConfigPathRecursively(directory: VirtualFile, stopAt: Path): Path? {
             val path = directory.pathAsPath
             if (!path.startsWith(stopAt) || path == stopAt) return null
             if (directory.children.any { it.name in CONFIG_FILES }) return path
             return findConfigPathRecursively(directory.parent, stopAt)
+        }
+
+        private fun RsProcessExecutionException.showRustfmtError(project: Project) {
+            val message = message.orEmpty().trimEnd('\n')
+            if (message.isNotEmpty()) {
+                project.showBalloon("Rustfmt", message, NotificationType.ERROR, RustfmtEditSettingsAction("Show settings..."))
+            }
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/actions/RustfmtEditSettingsAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RustfmtEditSettingsAction.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.DumbAware
+import org.rust.cargo.project.configurable.RustfmtConfigurable
+
+class RustfmtEditSettingsAction(text: String) : AnAction(text), DumbAware {
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        e.presentation.isEnabledAndVisible = e.project != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        ShowSettingsUtil.getInstance().showSettingsDialog(e.project, RustfmtConfigurable::class.java)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/formatter/RustfmtFormattingService.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/RustfmtFormattingService.kt
@@ -16,7 +16,7 @@ import com.intellij.openapi.progress.util.ProgressIndicatorBase
 import com.intellij.psi.PsiFile
 import com.intellij.psi.formatter.FormatterUtil
 import org.rust.cargo.project.model.cargoProjects
-import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.settings.rustfmtSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.tools.Rustup.Companion.checkNeedInstallRustfmt
@@ -35,7 +35,7 @@ class RustfmtFormattingService : AsyncDocumentFormattingService() {
     override fun getFeatures(): Set<FormattingService.Feature> = FEATURES
 
     override fun canFormat(file: PsiFile): Boolean =
-        file is RsFile && file.project.rustSettings.useRustfmt && getFormattingReason() == FormattingReason.ReformatCode
+        file is RsFile && file.project.rustfmtSettings.state.useRustfmt && getFormattingReason() == FormattingReason.ReformatCode
 
     override fun createFormattingTask(request: AsyncFormattingRequest): FormattingTask? {
         val context = request.context

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1016,6 +1016,9 @@
 
         <projectService serviceInterface="org.rust.cargo.project.settings.RustProjectSettingsService"
                         serviceImplementation="org.rust.cargo.project.settings.impl.RustProjectSettingsServiceImpl"/>
+
+        <projectService serviceImplementation="org.rust.cargo.project.settings.RustfmtProjectSettingsService"/>
+
         <projectService serviceInterface="org.rust.cargo.project.model.CargoProjectsService"
                         serviceImplementation="org.rust.cargo.project.model.impl.CargoProjectsServiceImpl"
                         testServiceImplementation="org.rust.cargo.project.model.impl.TestCargoProjectsServiceImpl"/>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -190,7 +190,10 @@ settings.rust.inlay.hints.title.method.chains=Method chains
 settings.rust.inlay.hints.title.types=Types
 settings.rust.inlay.parameter.hints.only.smart=Only smart hints
 
+settings.rust.rustfmt.additional.arguments.comment=Additional arguments to pass to <b>rustfmt</b> or <b>cargo fmt</b> command
+settings.rust.rustfmt.additional.arguments.label=Additional arguments:
 settings.rust.rustfmt.builtin.formatter.label=Use rustfmt instead of the built-in formatter
+settings.rust.rustfmt.channel.label=Channel
 settings.rust.rustfmt.name=Rustfmt
 settings.rust.rustfmt.run.on.save.label=Run rustfmt on Save
 

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -58,8 +58,6 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         assertEquals(true, service.useOffline)
         assertEquals(MacroExpansionEngine.DISABLED, service.macroExpansionEngine)
         assertEquals(false, service.doctestInjectionEnabled)
-        assertEquals(true, service.useRustfmt)
-        assertEquals(true, service.runRustfmtOnSave)
     }
 
     fun `test update from version 1`() {

--- a/src/test/kotlin/org/rust/cargo/project/RustfmtProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustfmtProjectSettingsServiceTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project
+
+import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.util.xmlb.XmlSerializer
+import org.intellij.lang.annotations.Language
+import org.junit.internal.runners.JUnit38ClassRunner
+import org.junit.runner.RunWith
+import org.rust.cargo.project.settings.RustfmtProjectSettingsService
+import org.rust.cargo.toolchain.RustChannel
+import org.rust.openapiext.elementFromXmlString
+import org.rust.openapiext.toXmlString
+
+@RunWith(JUnit38ClassRunner::class) // TODO: drop the annotation when issue with Gradle test scanning go away
+class RustfmtProjectSettingsServiceTest : LightPlatformTestCase() {
+    fun `test serialization`() {
+        val service = RustfmtProjectSettingsService(project)
+
+        @Language("XML")
+        val text = """
+            <RustfmtState>
+              <option name="additionalArguments" value="--unstable-features" />
+              <option name="channel" value="nightly" />
+              <option name="envs">
+                <map>
+                  <entry key="ABC" value="123" />
+                </map>
+              </option>
+              <option name="runRustfmtOnSave" value="true" />
+              <option name="useRustfmt" value="true" />
+            </RustfmtState>
+        """.trimIndent()
+        service.loadState(stateFromXmlString(text))
+
+        val actual = service.state
+        assertEquals(text, XmlSerializer.serialize(actual).toXmlString())
+
+        assertEquals("--unstable-features", actual.additionalArguments)
+        assertEquals(RustChannel.NIGHTLY, actual.channel)
+        assertEquals(mapOf("ABC" to "123"), actual.envs)
+        assertEquals(true, actual.useRustfmt)
+        assertEquals(true, actual.runRustfmtOnSave)
+    }
+
+    companion object {
+        private fun stateFromXmlString(xml: String): RustfmtProjectSettingsService.RustfmtState {
+            val element = elementFromXmlString(xml)
+            return XmlSerializer.deserialize(element, RustfmtProjectSettingsService.RustfmtState::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt
@@ -6,7 +6,7 @@
 package org.rust.ide.formatter
 
 import org.intellij.lang.annotations.Language
-import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.settings.rustfmtSettings
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.ext.descendantOfTypeStrict
@@ -164,7 +164,7 @@ class RsTrailingCommaFormatProcessorTest : RsFormatterTestBase() {
         """.trimIndent()
 
         // This enables usage of `RustfmtExternalFormatProcessor`, but not `Rustfmt` itself
-        project.rustSettings.modifyTemporary(testRootDisposable) { it.useRustfmt = true }
+        project.rustfmtSettings.modifyTemporary(testRootDisposable) { it.useRustfmt = true }
         // `Rustfmt` will not be used because of range restriction
         myTextRange = RsPsiFactory(project).createFile(before).descendantOfTypeStrict<RsStructItem>()!!.textRange
 


### PR DESCRIPTION
Also, shows rustfmt errors in a ballon.

Closes https://github.com/intellij-rust/intellij-rust/issues/4024.
Closes https://github.com/intellij-rust/intellij-rust/issues/6061.
Closes https://github.com/intellij-rust/intellij-rust/issues/7422.

<img width="1094" alt="Screen Shot 2022-03-27 at 23 11 22" src="https://user-images.githubusercontent.com/6079006/160298993-f0dd1170-b1dc-4c95-b6b2-ad65703a90f3.png">

changelog: Allow to configure addition arguments and other options for Rustfmt
