### PR TITLE
INSP: do not show E0046 for negative trait impls

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
@@ -8,10 +8,7 @@ package org.rust.ide.inspections
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsVisitor
-import org.rust.lang.core.psi.ext.TraitImplementationInfo
-import org.rust.lang.core.psi.ext.resolveToTrait
-import org.rust.lang.core.psi.ext.selfParameter
-import org.rust.lang.core.psi.ext.valueParameters
+import org.rust.lang.core.psi.ext.*
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
 
@@ -25,7 +22,7 @@ class RsTraitImplementationInspection : RsLocalInspectionTool() {
 
             val implInfo = TraitImplementationInfo.create(trait, impl) ?: return
 
-            if (implInfo.missingImplementations.isNotEmpty()) {
+            if (!impl.isNegativeImpl && implInfo.missingImplementations.isNotEmpty()) {
                 val missing = implInfo.missingImplementations
                     .mapNotNull { missing -> missing.name?.let { "`$it`" } }
                     .joinToString(", ")

--- a/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
@@ -105,6 +105,15 @@ class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImpleme
         }
     """)
 
+    fun `test absent method in negative trait impl`() = checkErrors("""
+        trait TError {
+            fn bar();
+            fn baz();
+            fn boo();
+        }
+        impl !TError for (){}
+    """)
+
     fun `test unknown method in trait impl E0407`() = checkErrors("""
         trait T {
             fn foo();


### PR DESCRIPTION
While checking `rustc` sources, I noticed that the plugin wrongly shows E0046 (methods missing in trait impl) for negative impls. This PR fixes that. 

changelog: Do not show the E0046 error for negative trait impls.