### PR TITLE
Don't highlight string literals in macros as exit points

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
@@ -341,7 +341,7 @@ private class ExitPointVisitor(
             for (ancestor in ancestors) {
                 when (ancestor) {
                     is RsFunction, is RsLambdaExpr -> return true
-                    is RsStmt, is RsCondition, is RsMatchArmGuard, is RsPat -> return false
+                    is RsStmt, is RsCondition, is RsMatchArmGuard, is RsPat, is RsMacroArgument -> return false
                     else -> {
                         val parent = ancestor.parent
                         if ((ancestor is RsExpr && parent is RsMatchExpr) || parent is RsLoopExpr)

--- a/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
+++ b/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
@@ -399,6 +399,14 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """)
 
+    // Issue https://github.com/intellij-rust/intellij-rust/issues/7833
+    fun `test string literals in macros are not highlighted`() = doTest("""
+        fn foo() -> i32 {
+            foo!("foobar");
+            /*caret*/return 1;
+        }
+    """, "return 1")
+
     private fun doTest(@Language("Rust") check: String, vararg usages: String) {
         InlineFile(check)
         HighlightUsagesHandler.invoke(myFixture.project, myFixture.editor, myFixture.file)


### PR DESCRIPTION
Fixes #7833

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/3221931/133041657-913a9793-3e46-4082-a043-41234607ea32.png) | ![image](https://user-images.githubusercontent.com/3221931/133063298-58917a18-6015-459a-8e3f-3a709d3c6733.png) |

changelog: Don't highlight string literals in macros as exit points
