### PR TITLE
REF: Add trait imports for UFCS in move refactoring if necessary

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -159,8 +159,8 @@ class RsMoveCommonProcessor(
                     // TODO: two threads
                     outsideReferences = collectOutsideReferences()
                     val insideReferences = preprocessInsideReferences(usages)
-                    traitMethodsProcessor.preprocessOutsideReferencesToTraitMethods(conflicts, elementsToMove)
-                    traitMethodsProcessor.preprocessInsideReferencesToTraitMethods(conflicts, elementsToMove)
+                    traitMethodsProcessor.preprocessOutsideReferences(conflicts, elementsToMove)
+                    traitMethodsProcessor.preprocessInsideReferences(conflicts, elementsToMove)
 
                     if (!isUnitTestMode) {
                         @Suppress("DialogTitleCapitalization")

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
@@ -230,16 +230,21 @@ object RsMoveUtil {
     val LOG: Logger = logger<RsMoveUtil>()
 }
 
-inline fun <reified T : RsElement> movedElementsShallowDescendantsOfType(elementsToMove: List<ElementToMove>): List<T> =
-    movedElementsShallowDescendantsOfType(elementsToMove, T::class.java)
+inline fun <reified T : RsElement> movedElementsShallowDescendantsOfType(
+    elementsToMove: List<ElementToMove>,
+    processInlineModules: Boolean = true
+): List<T> = movedElementsShallowDescendantsOfType(elementsToMove, T::class.java, processInlineModules)
 
 fun <T : RsElement> movedElementsShallowDescendantsOfType(
     elementsToMove: List<ElementToMove>,
-    aClass: Class<T>
+    aClass: Class<T>,
+    processInlineModules: Boolean = true,
 ): List<T> {
     return elementsToMove.flatMap {
         val element = it.element
-        if (element is RsFile) return@flatMap emptyList<T>()
+        if (element is RsFile || !processInlineModules && element is RsMod) {
+            return@flatMap emptyList<T>()
+        }
         PsiTreeUtil.findChildrenOfAnyType(element, false, aClass)
     }
 }


### PR DESCRIPTION
Fixes #7781

Related: #6301

E.g. when moving
```rust
use std::str::FromStr;
fn func() {
    Foo::from_str("");
}
```
when `Foo` implements `FromStr`, then import for `FromStr` will be added to target mod.

changelog: Add trait imports for UFCS trait method calls in move refactoring if necessary
