### PR TITLE
INT: generalize UnwrapSingleExprIntention to support single statement expressions

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntention.kt
@@ -8,38 +8,48 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.RsBlockExpr
-import org.rust.lang.core.psi.RsExpr
-import org.rust.lang.core.psi.RsMatchArm
-import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.TyUnit
+import org.rust.lang.core.types.type
 import kotlin.math.max
 import kotlin.math.min
 
-class UnwrapSingleExprIntention : RsElementBaseIntentionAction<RsBlockExpr>() {
-    override fun getText() = "Remove braces from single expression"
-    override fun getFamilyName() = text
+class UnwrapSingleExprIntention : RsElementBaseIntentionAction<UnwrapSingleExprIntention.Context>() {
+    override fun getFamilyName() = "Remove braces from single expression"
 
-    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsBlockExpr? {
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val blockExpr = element.ancestorStrict<RsBlockExpr>() ?: return null
         if (blockExpr.isUnsafe || blockExpr.isAsync || blockExpr.isTry) return null
         val block = blockExpr.block
 
-        return if (block.expr != null && block.lbrace.getNextNonCommentSibling() == block.expr)
-            blockExpr
-        else
-            null
+        val singleStatement = block.expandedStmtsAndTailExpr.first.singleOrNull()
+        val expr = block.expr
+        return when {
+            expr != null && block.lbrace.getNextNonCommentSibling() == expr -> {
+                text = "Remove braces from single expression"
+                Context(blockExpr, expr)
+            }
+            expr == null && singleStatement is RsExprStmt && singleStatement.expr.type is TyUnit -> {
+                text = "Remove braces from single expression statement"
+                Context(blockExpr, singleStatement.expr)
+            }
+            else -> null
+        }
     }
 
-    override fun invoke(project: Project, editor: Editor, ctx: RsBlockExpr) {
-        val blockBody = ctx.block.expr ?: return
-        val parent = ctx.parent
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val parent = ctx.blockExpr.parent
         if (parent is RsMatchArm && parent.comma == null) {
             parent.add(RsPsiFactory(project).createComma())
         }
-        val relativeCaretPosition = min(max(editor.caretModel.offset - blockBody.textOffset, 0), blockBody.textLength)
 
-        val offset = (ctx.replace(blockBody) as RsExpr).textOffset
+        val element = ctx.expr
+        val relativeCaretPosition = min(max(editor.caretModel.offset - element.textOffset, 0), element.textLength)
+
+        val offset = (ctx.blockExpr.replace(element) as RsExpr).textOffset
         editor.caretModel.moveToOffset(offset + relativeCaretPosition)
     }
+
+    data class Context(val blockExpr: RsBlockExpr, val expr: RsExpr)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntentionTest.kt
@@ -48,11 +48,43 @@ class UnwrapSingleExprIntentionTest : RsIntentionTestBase(UnwrapSingleExprIntent
         }
     """)
 
-    fun `test available lambda unwrap braces single statement`() = doUnavailableTest("""
+    fun `test unavailable lambda unwrap braces single statement`() = doUnavailableTest("""
         fn main() {
             {
                 /*caret*/42;
             }
+        }
+    """)
+
+    fun `test unwrap braces single unit statement caret before`() = doAvailableTest("""
+        fn foo() {}
+
+        fn main() {
+            {
+                /*caret*/foo();
+            }
+        }
+    """, """
+        fn foo() {}
+
+        fn main() {
+            /*caret*/foo()
+        }
+    """)
+
+    fun `test unwrap braces single unit statement caret after`() = doAvailableTest("""
+        fn foo() {}
+
+        fn main() {
+            {
+                foo();/*caret*/
+            }
+        }
+    """, """
+        fn foo() {}
+
+        fn main() {
+            foo()/*caret*/
         }
     """)
 
@@ -149,6 +181,28 @@ class UnwrapSingleExprIntentionTest : RsIntentionTestBase(UnwrapSingleExprIntent
         fn main() {
             match x {
                 0 => /*caret*/println!("x = 0"),
+                _ => println!("x != 0")
+            }
+        }
+    """)
+
+    fun `test available unwrap brace expression statement match`() = doAvailableTest("""
+        fn foo() {}
+
+        fn main() {
+            match x {
+                0 => /*caret*/{
+                    foo();
+                }
+                _ => println!("x != 0")
+            }
+        }
+    """, """
+        fn foo() {}
+
+        fn main() {
+            match x {
+                0 => /*caret*/foo(),
                 _ => println!("x != 0")
             }
         }


### PR DESCRIPTION
I noticed that `UnwrapSingleExprIntention` does not work for blocks with a single statement. I suppose that if a block contains exactly a single statement, no tail expressions, and that statement is a `RsExprStmt` statement with type `()`, then the intention should be available for it.

For example:
```rust
match foo {
    // here the intention should be able to turn this into `V1 => println!("foo")`
    V1 => { println!("foo");/*caret*/ }
}
```

I'm not sure if `expandedStmtsAndTailExpr` is necessary or if it's fine to just use `stmtList`.

changelog: The intention for removing braces from a single expression now also works for blocks that contain a single statement.