### PR TITLE
ANN: fix infinite loop when invoking a quick fix on an element with a syntax error

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -179,13 +179,31 @@ fun RsElement.deleteWithSurroundingComma() {
  * See [deleteWithSurroundingComma].
  */
 fun RsElement.deleteWithSurroundingCommaAndWhitespace() {
-    while (nextSibling?.isWhitespaceOrComment == true) {
-        nextSibling?.delete()
+    guardedLoop(5) {
+        if (nextSibling?.isWhitespaceOrComment == true) {
+            nextSibling?.delete()
+            return@guardedLoop false
+        }
+        true
     }
-    while (prevSibling?.isWhitespaceOrComment == true) {
-        prevSibling?.delete()
+    guardedLoop(5) {
+        if (prevSibling?.isWhitespaceOrComment == true) {
+            prevSibling?.delete()
+            return@guardedLoop false
+        }
+        true
     }
     deleteWithSurroundingComma()
+}
+
+/**
+ * Run the given `action` up to `count` times.
+ * If the action returns true, the loop immediately ends.
+ */
+private fun guardedLoop(count: Int, action: () -> Boolean) {
+    for (i in 0 until count) {
+        if (action()) return
+    }
 }
 
 private val PsiElement.isWhitespaceOrComment

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
@@ -96,4 +96,21 @@ class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnot
             foo(0);
         }
     """)
+
+    // https://github.com/intellij-rust/intellij-rust/issues/7830
+    fun `test avoid infinite loop with syntax error`() = checkFixByText("Remove redundant arguments", """
+        fn foo(a: &u32) {}
+
+        fn main() {
+            let a = 1;
+            foo<error>(&<error>'/*caret*/</error>static<error> </error><error>a</error>)</error>;
+        }
+    """, """
+        fn foo(a: &u32) {}
+
+        fn main() {
+            let a = 1;
+            foo(&'static);
+        }
+    """)
 }


### PR DESCRIPTION
This [issue](https://github.com/intellij-rust/intellij-rust/issues/7830) produced an interesting situation. In the following code (which has a syntax error in the reference lifetime):
```rust
fn foo(a: &u32) {}

fn main() {
    let a = 1;
    foo(&'static a);
}
```
the `foo` call is parsed as having two arguments. Therefore the `RemoveRedundantFunctionArgumentsFix` shows up, which tries to remove the argument `a`, along with its surrounding whitespace and comments. The code that handles this is `RsElement.deleteWithSurroundingCommaAndWhitespace` in `RsElement.kt`:
```kotlin
fun RsElement.deleteWithSurroundingCommaAndWhitespace() {
    while (nextSibling?.isWhitespaceOrComment == true) {
        nextSibling?.delete()
    }
    while (prevSibling?.isWhitespaceOrComment == true) {
        prevSibling?.delete()
    }
    deleteWithSurroundingComma()
}
```
The problem is that when the whitespace before `a` in `&'static a` gets removed, the plugin somehow automatically adds it back again (maybe because it's preceded by an error element?). This caused the above function to end in an infinite loop. To resolve this pathetic case, I introduced a simple infinite loop guard, which will run the removal at most five times (this should be enough to remove successive whitespace/comments in most situations).

The bug was pretty nasty, as it immediately deadlocked the whole IDE.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7830

changelog: Avoid IDE freeze in certain situations when invoking quick fixes or intentions on elements with syntax errors.