### PR TITLE
RES: Move option to disable new resolve from settings to registry

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -39,9 +39,6 @@ class RsProjectConfigurable(
             )
         }
         row {
-            checkBox("Use new name resolution engine", state::newResolveEnabled)
-        }
-        row {
             checkBox("Inject Rust language into documentation comments", state::doctestInjectionEnabled)
         }
     }

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -49,9 +49,6 @@ interface RustProjectSettingsService {
         var useOffline: Boolean = false,
         var macroExpansionEngine: MacroExpansionEngine = defaultMacroExpansionEngine,
         @AffectsHighlighting
-        var newResolveEnabled: Boolean = isFeatureEnabled(RsExperiments.RESOLVE_NEW_ENGINE)
-            && System.getenv("INTELLIJ_RUST_FORCE_USE_OLD_RESOLVE") == null,
-        @AffectsHighlighting
         var doctestInjectionEnabled: Boolean = true,
         var useRustfmt: Boolean = false,
         var runRustfmtOnSave: Boolean = false,
@@ -109,7 +106,6 @@ interface RustProjectSettingsService {
     val compileAllTargets: Boolean
     val useOffline: Boolean
     val macroExpansionEngine: MacroExpansionEngine
-    val newResolveEnabled: Boolean
     val doctestInjectionEnabled: Boolean
     val useRustfmt: Boolean
     val runRustfmtOnSave: Boolean

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -26,7 +26,6 @@ import org.rust.cargo.project.settings.RustProjectSettingsService.Companion.RUST
 import org.rust.cargo.toolchain.ExternalLinter
 import org.rust.cargo.toolchain.RsToolchain
 import org.rust.cargo.toolchain.RsToolchainBase
-import org.rust.lang.core.resolve2.defMapService
 
 private const val serviceName: String = "RustProjectSettings"
 
@@ -61,7 +60,6 @@ class RustProjectSettingsServiceImpl(
     override val compileAllTargets: Boolean get() = _state.compileAllTargets
     override val useOffline: Boolean get() = _state.useOffline
     override val macroExpansionEngine: MacroExpansionEngine get() = _state.macroExpansionEngine
-    override val newResolveEnabled: Boolean get() = _state.newResolveEnabled
     override val doctestInjectionEnabled: Boolean get() = _state.doctestInjectionEnabled
     override val useRustfmt: Boolean get() = _state.useRustfmt
     override val runRustfmtOnSave: Boolean get() = _state.runRustfmtOnSave
@@ -105,9 +103,6 @@ class RustProjectSettingsServiceImpl(
         if (event.isChanged(State::doctestInjectionEnabled)) {
             // flush injection cache
             PsiManager.getInstance(project).dropPsiCaches()
-        }
-        if (event.isChanged(State::newResolveEnabled)) {
-            project.defMapService.onNewResolveEnabledChanged(newState.newResolveEnabled)
         }
         if (event.affectsHighlighting) {
             DaemonCodeAnalyzer.getInstance(project).restart()

--- a/src/main/kotlin/org/rust/ide/actions/diagnostic/CreateNewGithubIssue.kt
+++ b/src/main/kotlin/org/rust/ide/actions/diagnostic/CreateNewGithubIssue.kt
@@ -19,6 +19,7 @@ import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.runconfig.hasCargoProject
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.lang.core.psi.isRustFile
+import org.rust.lang.core.resolve2.isNewResolveEnabled
 import org.rust.openapiext.plugin
 import org.rust.openapiext.virtualFile
 
@@ -41,7 +42,7 @@ class CreateNewGithubIssue : DumbAwareAction() {
         val os = SystemInfo.getOsNameAndVersion()
         val codeSnippet = e.getData(PlatformDataKeys.EDITOR)?.codeExample ?: ""
         val macroEngine = project.rustSettings.macroExpansionEngine.name.toLowerCase()
-        val resolveEngine = if (project.rustSettings.newResolveEnabled) "new" else "old"
+        val resolveEngine = if (project.isNewResolveEnabled) "new" else "old"
 
         val body = ISSUE_TEMPLATE.format(pluginVersion, toolchainVersion, ideNameAndVersion, os, macroEngine, resolveEngine, codeSnippet)
         val link = "https://github.com/intellij-rust/intellij-rust/issues/new?body=${URLUtil.encodeURIComponent(body)}"

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -12,7 +12,6 @@ object RsExperiments {
     const val CARGO_FEATURES_SETTINGS_GUTTER = "org.rust.cargo.features.settings.gutter"
     const val MACROS_NEW_ENGINE = "org.rust.macros.new.engine"
     const val PROC_MACROS = "org.rust.macros.proc"
-    const val RESOLVE_NEW_ENGINE = "org.rust.resolve.new.engine"
     const val FETCH_ACTUAL_STDLIB_METADATA = "org.rust.cargo.fetch.actual.stdlib.metadata"
     const val CRATES_LOCAL_INDEX = "org.rust.crates.local.index"
     const val WSL_TOOLCHAIN = "org.rust.wsl"

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -7,12 +7,14 @@ package org.rust.lang.core.resolve2
 
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.registry.RegistryValue
 import com.intellij.openapi.vfs.VirtualFileWithId
 import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
 import com.intellij.psi.PsiElement
 import com.intellij.psi.StubBasedPsiElement
-import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.refactoring.move.common.RsMoveUtil.containingModOrSelf
 import org.rust.lang.core.completion.RsMacroCompletionProvider
 import org.rust.lang.core.crate.Crate
@@ -29,11 +31,13 @@ import org.rust.lang.core.resolve.ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS
 import org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl
 import org.rust.lang.core.resolve.ref.RsResolveCache
 import org.rust.lang.core.resolve2.RsModInfoBase.*
+import org.rust.openapiext.isFeatureEnabled
 import org.rust.openapiext.toPsiFile
 import org.rust.stdext.RsResult
 
+val IS_NEW_RESOLVE_ENABLED_KEY: RegistryValue = Registry.get("org.rust.resolve.new.engine")
 val Project.isNewResolveEnabled: Boolean
-    get() = rustSettings.newResolveEnabled
+    get() = IS_NEW_RESOLVE_ENABLED_KEY.asBoolean()
 
 /** null return value means that new resolve can't be used */
 fun processItemDeclarations2(

--- a/src/main/kotlin/org/rust/lang/core/resolve2/actions/RsToggleNewResolveAction.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/actions/RsToggleNewResolveAction.kt
@@ -7,16 +7,14 @@ package org.rust.lang.core.resolve2.actions
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
-import org.rust.cargo.project.settings.rustSettings
 import org.rust.ide.notifications.setStatusBarText
+import org.rust.lang.core.resolve2.IS_NEW_RESOLVE_ENABLED_KEY
 
 class RsToggleNewResolveAction : DumbAwareAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        project.rustSettings.modify {
-            val value = !it.newResolveEnabled
-            it.newResolveEnabled = value
-            project.setStatusBarText("New resolve is ${if (value) "enabled" else "disabled"}")
-        }
+        val value = !IS_NEW_RESOLVE_ENABLED_KEY.asBoolean()
+        IS_NEW_RESOLVE_ENABLED_KEY.setValue(value)
+        project.setStatusBarText("New resolve is ${if (value) "enabled" else "disabled"}")
     }
 }

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -18,9 +18,6 @@
         <experimentalFeature id="org.rust.macros.proc" percentOfUsers="0">
             <description>Enables procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="100">
-            <description>Enables experimental resolve engine</description>
-        </experimentalFeature>
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="100">
             <description>Enables crates local index</description>
         </experimentalFeature>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -18,9 +18,6 @@
         <experimentalFeature id="org.rust.macros.proc" percentOfUsers="0">
             <description>Enables procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="100">
-            <description>Enables experimental resolve engine</description>
-        </experimentalFeature>
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="0">
             <description>Enables crates local index</description>
         </experimentalFeature>

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1119,6 +1119,8 @@
                      Run Tool Window instead of raw console"/>
         <registryKey key="org.rust.macros.proc.timeout" defaultValue="5000" restartRequired="false"
                      description="The maximum time (in milliseconds) allotted to one procedural macro expansion"/>
+        <registryKey key="org.rust.resolve.new.engine" defaultValue="true" restartRequired="true"
+                     description="Enables new name resolution engine"/>
 
         <!-- Move refactoring -->
 

--- a/src/test/kotlin/org/rust/NewResolve.kt
+++ b/src/test/kotlin/org/rust/NewResolve.kt
@@ -9,7 +9,7 @@ import com.intellij.findAnnotationInstance
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import junit.framework.TestCase
-import org.rust.lang.core.resolve2.DefMapService
+import org.rust.lang.core.resolve2.defMapService
 import org.rust.lang.core.resolve2.isNewResolveEnabled
 import org.rust.openapiext.TestmarkPred
 
@@ -31,10 +31,11 @@ fun TestmarkPred.ignoreInNewResolve(project: Project): TestmarkPred {
 }
 
 fun TestCase.setupResolveEngine(project: Project, testRootDisposable: Disposable) {
+    val defMap = project.defMapService
     findAnnotationInstance<UseNewResolve>()?.let {
-        DefMapService.setNewResolveEnabled(project, testRootDisposable, true)
+        defMap.setNewResolveEnabled(testRootDisposable, true)
     }
     findAnnotationInstance<UseOldResolve>()?.let {
-        DefMapService.setNewResolveEnabled(project, testRootDisposable, false)
+        defMap.setNewResolveEnabled(testRootDisposable, false)
     }
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
@@ -10,6 +10,7 @@ import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.lints.RsUnusedImportInspection
 
+@UseNewResolve  // because of RsUnusedImportInspection
 @WithEnabledInspections(RsUnusedImportInspection::class)
 class RsImportOptimizerTest: RsTestBase() {
 

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -9,6 +9,7 @@ import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.lints.RsUnusedImportInspection
 
+@UseNewResolve  // because of RsUnusedImportInspection
 @WithEnabledInspections(RsUnusedImportInspection::class)
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -410,6 +410,7 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
     """)
 
     // TODO fix name resolution order
+    @UseNewResolve
     fun `test resolve bang proc macro through macro_use to the last extern crate 4`() = expect<IllegalStateException> {
     stubOnlyResolve("""
         //- dep-proc-macro/lib.rs


### PR DESCRIPTION
We plan to gradually remove ability to use old resolve. As a first step option from settings is removed. Users can still disable new resolve using `org.rust.resolve.new.engine` registry option.

changelog: We gradually deprecate old name resolution engine. As a first step we remove option "Use new name resolution engine" from settings. Please fill an issue if you encounter any problems with new resolve engine.
