### PR TITLE
INSP: Add unused_must_use and double_must_use warnings

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspection.kt
@@ -38,7 +38,8 @@ class RsDoubleMustUseInspection : RsLintInspection() {
             val attrType = type?.item?.findFirstMetaItem(mustUseAttrName)
             if (attrFunc != null && attrType != null) {
                 val description = RsBundle.message("inspection.DoubleMustUse.description")
-                holder.registerLintProblem(attrFunc.parent, description, fixes=listOf(FixRemoveMustUseAttr()))
+                val highlighting = RsLintHighlightingType.WEAK_WARNING
+                holder.registerLintProblem(attrFunc.parent, description, highlighting, fixes = listOf(FixRemoveMustUseAttr()))
             }
         }
     }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspection.kt
@@ -1,0 +1,45 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.RsBundle
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.TyAdt
+
+private class FixRemoveMustUseAttr : LocalQuickFix {
+    override fun getFamilyName() = RsBundle.message("inspection.DoubleMustUse.FixRemoveMustUseAttr.name")
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        descriptor.psiElement?.delete()
+    }
+}
+
+/** Analogue of Clippy's double_must_use. */
+class RsDoubleMustUseInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.DoubleMustUse
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+        override fun visitFunction(o: RsFunction) {
+            super.visitFunction(o)
+
+            val mustUseAttrName = "must_use"
+            val attrFunc = o.findFirstMetaItem(mustUseAttrName)
+            val type = o.returnType as? TyAdt
+            val attrType = type?.item?.findFirstMetaItem(mustUseAttrName)
+            if (attrFunc != null && attrType != null) {
+                val description = RsBundle.message("inspection.DoubleMustUse.description")
+                holder.registerLintProblem(attrFunc.parent, description, fixes=listOf(FixRemoveMustUseAttr()))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -32,10 +32,12 @@ enum class RsLint(
     BareTraitObjects("bare_trait_objects", listOf("rust_2018_idioms")),
     NonShorthandFieldPatterns("non_shorthand_field_patterns"),
     UnusedQualifications("unused_qualifications", listOf("unused")),
+    UnusedMustUse("unused_must_use", listOf("unused")),
     // errors
     UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
     // CLippy lints
-    NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy"));
+    NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy")),
+    DoubleMustUse("clippy::double_must_use", listOf("clippy::style", "clippy::all", "clippy"));
 
     /**
      * Returns the level of the lint for the given PSI element.

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
@@ -33,8 +33,8 @@ private class FixAddLetUnderscore : LocalQuickFix {
     override fun getFamilyName() = RsBundle.message("inspection.UnusedMustUse.FixAddLetUnderscore.name")
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val stmt = descriptor.psiElement as RsExprStmt
-        stmt.replace(RsPsiFactory(project).createLetDeclaration("_", stmt.expr))
+        val expr = descriptor.psiElement as RsExpr
+        expr.parent.replace(RsPsiFactory(project).createLetDeclaration("_", expr))
     }
 }
 
@@ -42,8 +42,8 @@ private class FixAddUnwrap : LocalQuickFix {
     override fun getFamilyName() = RsBundle.message("inspection.UnusedMustUse.FixAddUnwrap.name")
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val stmt = descriptor.psiElement as RsExprStmt
-        stmt.expr.replace(RsPsiFactory(project).createExpression("${stmt.expr.text}.unwrap()"))
+        val expr = descriptor.psiElement as RsExpr
+        expr.replace(RsPsiFactory(project).createExpression("${expr.text}.unwrap()"))
     }
 }
 
@@ -97,7 +97,7 @@ class RsUnusedMustUseInspection : RsLintInspection() {
             super.visitExprStmt(o)
             val problem = inspectAndProposeFixes(o.expr)
             if (problem != null) {
-                holder.registerLintProblem(o, problem.description, fixes=problem.fixes)
+                holder.registerLintProblem(o.expr, problem.description, fixes=problem.fixes)
             }
         }
     }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
@@ -104,6 +104,12 @@ class RsUnusedMustUseInspection : RsLintInspection() {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitExprStmt(o: RsExprStmt) {
             super.visitExprStmt(o)
+            val parent = o.parent
+            if (parent is RsBlock) {
+                // Ignore if o is actually a tail expr
+                val (_, tailExpr) = parent.expandedStmtsAndTailExpr
+                if (o.expr == tailExpr) return
+            }
             val problem = inspectAndProposeFixes(o.expr)
             if (problem != null) {
                 holder.registerLintProblem(o.expr, problem.description, RsLintHighlightingType.WEAK_WARNING, problem.fixes)

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
@@ -22,6 +22,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.implLookupAndKnownItems
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.type
+import org.rust.openapiext.createSmartPointer
 
 private fun RsExpr.returnsStdResult(): Boolean {
     val (_, knownItems) = implLookupAndKnownItems
@@ -55,7 +56,8 @@ private class FixAddExpect(anchor: PsiElement) : LocalQuickFixAndIntentionAction
         val dotExpr = RsPsiFactory(project).createExpression("${startElement.text}.expect(\"\")")
         val newDotExpr = startElement.replace(dotExpr) as RsDotExpr
         val expectArgs = newDotExpr.methodCall?.valueArgumentList?.exprList
-        val stringLiteral = expectArgs?.singleOrNull() as RsLitExpr
+        val stringLiteralPointer = (expectArgs?.singleOrNull() as RsLitExpr).createSmartPointer()
+        val stringLiteral = stringLiteralPointer.element ?: return
         val template = editor?.newTemplateBuilder(newDotExpr) ?: return
         val rangeWithoutQuotes = TextRange(1, stringLiteral.textRange.length - 1)
         template.replaceElement(stringLiteral, rangeWithoutQuotes, "TODO: panic message")

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
@@ -1,0 +1,104 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.RsBundle
+import org.rust.ide.annotator.getFunctionCallContext
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.utils.template.newTemplateBuilder
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.implLookupAndKnownItems
+import org.rust.lang.core.types.ty.TyAdt
+import org.rust.lang.core.types.type
+
+private fun RsExpr.returnsStdResult(): Boolean {
+    val (_, knownItems) = implLookupAndKnownItems
+    val type = type as? TyAdt ?: return false
+    return type.item == knownItems.Result
+}
+
+private class FixAddLetUnderscore : LocalQuickFix {
+    override fun getFamilyName() = RsBundle.message("inspection.UnusedMustUse.FixAddLetUnderscore.name")
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val stmt = descriptor.psiElement as RsExprStmt
+        stmt.replace(RsPsiFactory(project).createLetDeclaration("_", stmt.expr))
+    }
+}
+
+private class FixAddUnwrap : LocalQuickFix {
+    override fun getFamilyName() = RsBundle.message("inspection.UnusedMustUse.FixAddUnwrap.name")
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val stmt = descriptor.psiElement as RsExprStmt
+        stmt.expr.replace(RsPsiFactory(project).createExpression("${stmt.expr.text}.unwrap()"))
+    }
+}
+
+private class FixAddExpect(anchor: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(anchor) {
+    override fun getFamilyName() = RsBundle.message("inspection.UnusedMustUse.FixAddExpect.family.name")
+    override fun getText() = familyName
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        val dotExpr = RsPsiFactory(project).createExpression("${startElement.text}.expect(\"\")")
+        val newDotExpr = startElement.replace(dotExpr) as RsDotExpr
+        val expectArgs = newDotExpr.methodCall?.valueArgumentList?.exprList
+        val stringLiteral = expectArgs?.singleOrNull() as RsLitExpr
+        val template = editor?.newTemplateBuilder(newDotExpr) ?: return
+        val rangeWithoutQuotes = TextRange(1, stringLiteral.textRange.length - 1)
+        template.replaceElement(stringLiteral, rangeWithoutQuotes, "TODO: panic message")
+        template.runInline()
+    }
+}
+
+private class InspectionResult(val description: String, val fixes: List<LocalQuickFix>)
+
+private fun inspectAndProposeFixes(expr: RsExpr): InspectionResult? {
+    val mustUseAttrName = "must_use"
+    val type = expr.type as? TyAdt
+    val func = when (expr) {
+        is RsDotExpr -> expr.methodCall?.getFunctionCallContext()?.function
+        is RsCallExpr -> expr.getFunctionCallContext()?.function
+        else -> null
+    }
+    val attrType = type?.item?.findFirstMetaItem(mustUseAttrName)
+    val attrFunc = func?.findFirstMetaItem(mustUseAttrName)
+    val description = when {
+        attrType != null -> RsBundle.message("inspection.UnusedMustUse.description.type.attribute", type)
+        attrFunc != null -> RsBundle.message("inspection.UnusedMustUse.description.function.attribute", func.name.toString())
+        else -> return null
+    }
+    val fixes: MutableList<LocalQuickFix> = mutableListOf(FixAddLetUnderscore())
+    if (expr.returnsStdResult()) {
+        fixes += FixAddExpect(expr)
+        fixes += FixAddUnwrap()
+    }
+    return InspectionResult(description, fixes)
+}
+
+/** Analogue of rustc's unused_must_use. See also [RsDoubleMustUseInspection]. */
+class RsUnusedMustUseInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement) = RsLint.UnusedMustUse
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+        override fun visitExprStmt(o: RsExprStmt) {
+            super.visitExprStmt(o)
+            val problem = inspectAndProposeFixes(o.expr)
+            if (problem != null) {
+                holder.registerLintProblem(o, problem.description, fixes=problem.fixes)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
@@ -39,8 +39,8 @@ private class FixAddLetUnderscore(anchor: PsiElement) : LocalQuickFixAndIntentio
         val letExpr = RsPsiFactory(project).createLetDeclaration("_", originalExpr)
         val newLetExpr = originalExpr.parent.replace(letExpr) as RsLetDecl
         val patPointer = newLetExpr.pat?.createSmartPointer() ?: return
-        val pat = patPointer.element ?: return
         val template = editor?.newTemplateBuilder(newLetExpr) ?: return
+        val pat = patPointer.element ?: return
         template.replaceElement(pat)
         template.runInline()
     }
@@ -63,9 +63,9 @@ private class FixAddExpect(anchor: PsiElement) : LocalQuickFixAndIntentionAction
         val dotExpr = RsPsiFactory(project).createExpression("${startElement.text}.expect(\"\")")
         val newDotExpr = startElement.replace(dotExpr) as RsDotExpr
         val expectArgs = newDotExpr.methodCall?.valueArgumentList?.exprList
+        val template = editor?.newTemplateBuilder(newDotExpr) ?: return
         val stringLiteralPointer = (expectArgs?.singleOrNull() as RsLitExpr).createSmartPointer()
         val stringLiteral = stringLiteralPointer.element ?: return
-        val template = editor?.newTemplateBuilder(newDotExpr) ?: return
         val rangeWithoutQuotes = TextRange(1, stringLiteral.textRange.length - 1)
         template.replaceElement(stringLiteral, rangeWithoutQuotes, "TODO: panic message")
         template.runInline()

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
@@ -99,7 +99,7 @@ class RsUnusedMustUseInspection : RsLintInspection() {
             super.visitExprStmt(o)
             val problem = inspectAndProposeFixes(o.expr)
             if (problem != null) {
-                holder.registerLintProblem(o.expr, problem.description, fixes=problem.fixes)
+                holder.registerLintProblem(o.expr, problem.description, RsLintHighlightingType.WEAK_WARNING, problem.fixes)
             }
         }
     }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
@@ -63,8 +63,8 @@ private class FixAddExpect(anchor: PsiElement) : LocalQuickFixAndIntentionAction
         val dotExpr = RsPsiFactory(project).createExpression("${startElement.text}.expect(\"\")")
         val newDotExpr = startElement.replace(dotExpr) as RsDotExpr
         val expectArgs = newDotExpr.methodCall?.valueArgumentList?.exprList
-        val template = editor?.newTemplateBuilder(newDotExpr) ?: return
         val stringLiteralPointer = (expectArgs?.singleOrNull() as RsLitExpr).createSmartPointer()
+        val template = editor?.newTemplateBuilder(newDotExpr) ?: return
         val stringLiteral = stringLiteralPointer.element ?: return
         val rangeWithoutQuotes = TextRange(1, stringLiteral.textRange.length - 1)
         template.replaceElement(stringLiteral, rangeWithoutQuotes, "TODO: panic message")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -141,6 +141,9 @@ object RsInnerAttributeOwnerRegistry {
     }
 }
 
+fun RsDocAndAttributeOwner.findFirstMetaItem(name: String): RsMetaItem? =
+    rawMetaItems.find { it.name == name }
+
 /**
  * Find the first outer attribute with the given identifier.
  */

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -539,12 +539,12 @@
 
         <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Unused must_use"
-                         enabledByDefault="true" level="WARNING"
+                         enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsUnusedMustUseInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Double must_use"
-                         enabledByDefault="true" level="WARNING"
+                         enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsDoubleMustUseInspection"/>
 
         <localInspection language="Rust" groupName="Rust"

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -537,6 +537,16 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsNonShorthandFieldPatternsInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Unused must_use"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsUnusedMustUseInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Double must_use"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsDoubleMustUseInspection"/>
+
         <localInspection language="Rust" groupName="Rust"
                          displayName="Assert Equal"
                          enabledByDefault="true" level="WEAK WARNING"

--- a/src/main/resources/inspectionDescriptions/RsDoubleMustUse.html
+++ b/src/main/resources/inspectionDescriptions/RsDoubleMustUse.html
@@ -1,0 +1,9 @@
+<html lang="en">
+<body>
+Checks for a <code>#[must_use]</code> attribute without further information on functions and methods
+that return a type already marked as <code>#[must_use]</code>.
+
+Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable#double_must_use">double_must_use</a>
+lint from Rust Clippy.
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/RsUnusedMustUse.html
+++ b/src/main/resources/inspectionDescriptions/RsUnusedMustUse.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Detects unused result of a type flagged as <code>#[must_use]</code>.
+</body>
+</html>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -237,3 +237,12 @@ copy.paste.convert.json.to.struct.dialog.title=Generate Rust Struct from JSON
 copy.paste.convert.json.to.struct.dialog.text=The inserted text seems to be a JSON object. Do you want to generate a Rust struct from it?
 advanced.setting.rust.group=Rust
 advanced.setting.org.rust.convert.json.to.struct=Enable JSON to Rust conversion on paste
+
+inspection.UnusedMustUse.description.type.attribute=Unused {0} that must be used
+inspection.UnusedMustUse.description.function.attribute=Unused return value of {0} that must be used
+inspection.UnusedMustUse.FixAddLetUnderscore.name=Add `let _ =`
+inspection.UnusedMustUse.FixAddUnwrap.name=Add `.unwrap()`
+inspection.UnusedMustUse.FixAddExpect.family.name=Add `.expect("")`
+
+inspection.DoubleMustUse.description=This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`
+inspection.DoubleMustUse.FixRemoveMustUseAttr.name=Remove `#[must_use]` from the function

--- a/src/test/kotlin/org/rust/ide/annotator/AnnotationTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/AnnotationTestFixtureBase.kt
@@ -111,6 +111,17 @@ abstract class AnnotationTestFixtureBase(
         checkAfter = this::checkByText,
     )
 
+    fun checkFixPartial(
+        fixName: String,
+        before: String,
+        checkWarn: Boolean = true,
+        checkInfo: Boolean = false,
+        checkWeakWarn: Boolean = false
+    ) = checkFix(fixName, before, before,
+        configure = this::configureByText,
+        checkBefore = { codeInsightFixture.checkHighlighting(checkWarn, checkInfo, checkWeakWarn) },
+        checkAfter = { })
+
     fun checkFixIsUnavailable(
         fixName: String,
         text: String,

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
@@ -87,6 +87,21 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         stubOnly: Boolean = true,
     ) = annotationFixture.checkFixByFileTreeWithoutHighlighting(fixName, before, after, stubOnly)
 
+    protected fun checkFixByTextWithLiveTemplate(
+        fixName: String,
+        @Language("Rust") before: String,
+        toType: String,
+        @Language("Rust") after: String,
+        fileName: String = "main.rs",
+        checkWarn: Boolean = true,
+        checkInfo: Boolean = false,
+        checkWeakWarn: Boolean = false
+    ) {
+        checkByTextWithLiveTemplate(before, after.trimIndent(), toType, fileName) {
+            annotationFixture.checkFixPartial(fixName, before, checkWarn, checkInfo, checkWeakWarn)
+        }
+    }
+
     protected fun checkFixIsUnavailable(
         fixName: String,
         @Language("Rust") text: String,

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspectionTest.kt
@@ -12,7 +12,7 @@ class RsDoubleMustUseInspectionTest : RsInspectionsTestBase(RsDoubleMustUseInspe
         #[must_use]
         struct S;
 
-        <warning descr="This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`">/*caret*/#[must_use]</warning>
+        <weak_warning descr="This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`">/*caret*/#[must_use]</weak_warning>
         fn foo() -> S { S }
 
         fn main() {}
@@ -30,7 +30,7 @@ class RsDoubleMustUseInspectionTest : RsInspectionsTestBase(RsDoubleMustUseInspe
         struct S;
 
         fn foo() -> S {
-            <warning descr="This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`">/*caret*/#![must_use]</warning>
+            <weak_warning descr="This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`">/*caret*/#![must_use]</weak_warning>
             S
         }
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspectionTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsDoubleMustUseInspectionTest : RsInspectionsTestBase(RsDoubleMustUseInspection::class) {
+    fun `test double must_use with outer attr`() = checkFixByText("Remove `#[must_use]` from the function", """
+        #[must_use]
+        struct S;
+
+        <warning descr="This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`">/*caret*/#[must_use]</warning>
+        fn foo() -> S { S }
+
+        fn main() {}
+    """, """
+        #[must_use]
+        struct S;
+
+        fn foo() -> S { S }
+
+        fn main() {}
+    """)
+
+    fun `test double must_use with inner attr`() = checkFixByText("Remove `#[must_use]` from the function", """
+        #[must_use]
+        struct S;
+
+        fn foo() -> S {
+            <warning descr="This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`">/*caret*/#![must_use]</warning>
+            S
+        }
+
+        fn main() {}
+    """, """
+        #[must_use]
+        struct S;
+
+        fn foo() -> S {
+            S
+        }
+
+        fn main() {}
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
@@ -15,7 +15,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> bool { false }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">foo();</warning>
+            <warning descr="Unused return value of foo that must be used">foo()</warning>;
         }
     """)
 
@@ -26,7 +26,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">foo();</warning>
+            <warning descr="Unused return value of foo that must be used">foo()</warning>;
         }
     """)
 
@@ -35,7 +35,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         struct S;
 
         fn main() {
-            <warning descr="Unused S that must be used">S;</warning>
+            <warning descr="Unused S that must be used">S</warning>;
         }
     """)
 
@@ -48,7 +48,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">S.foo();</warning>
+            <warning descr="Unused return value of foo that must be used">S.foo()</warning>;
         }
     """)
 
@@ -59,7 +59,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> S { S }
 
         fn main() {
-            <warning descr="Unused S that must be used">foo();</warning>
+            <warning descr="Unused S that must be used">foo()</warning>;
         }
     """)
 
@@ -74,7 +74,22 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         struct S2 { s: S }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">S2 { s: S }.s.foo();</warning>
+            <warning descr="Unused return value of foo that must be used">S2 { s: S }.s.foo()</warning>;
+        }
+    """)
+
+    fun `test unused must_use block disabled by cfg`() = checkByText("""
+        #[must_use]
+        struct S;
+
+        fn xyz() -> S {
+            #[cfg(undeclared_feature)]
+            { S }
+
+            <warning descr="Unused S that must be used">#[cfg(not(undeclared_feature))]
+            { S }</warning>
+
+            { S }
         }
     """)
 
@@ -83,7 +98,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> bool { false }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">/*caret*/foo();</warning>
+            <warning descr="Unused return value of foo that must be used">/*caret*/foo()</warning>;
         }
     """, """
         #[must_use]
@@ -99,7 +114,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> Result<bool, ()> { false }
 
         fn main() {
-            <warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo();</warning>
+            <warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo()</warning>;
         }
     """, """
         fn foo() -> Result<bool, ()> { false }
@@ -114,7 +129,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> Result<bool, ()> { false }
 
         fn main() {
-            <warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo();</warning>
+            <warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo()</warning>;
         }
     """, """
         fn foo() -> Result<bool, ()> { false }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspection::class) {
+    fun `test unused must_use with simple function call`() = checkByText("""
+        #[must_use]
+        fn foo() -> bool { false }
+
+        fn main() {
+            <warning descr="Unused return value of foo that must be used">foo();</warning>
+        }
+    """)
+
+    fun `test unused must_use with simple function call and inner attribute`() = checkByText("""
+        fn foo() -> bool {
+            #![must_use]
+            false
+        }
+
+        fn main() {
+            <warning descr="Unused return value of foo that must be used">foo();</warning>
+        }
+    """)
+
+    fun `test unused must_use with custom struct`() = checkByText("""
+        #[must_use]
+        struct S;
+
+        fn main() {
+            <warning descr="Unused S that must be used">S;</warning>
+        }
+    """)
+
+    fun `test unused must_use with method call though nested struct literal`() = checkByText("""
+        struct S;
+
+        impl S {
+            #[must_use]
+            fn foo(&self) -> S { S }
+        }
+
+        fn main() {
+            <warning descr="Unused return value of foo that must be used">S.foo();</warning>
+        }
+    """)
+
+    fun `test unused must_use with marked struct returned from function`() = checkByText("""
+        #[must_use]
+        struct S;
+
+        fn foo() -> S { S }
+
+        fn main() {
+            <warning descr="Unused S that must be used">foo();</warning>
+        }
+    """)
+
+    fun `test unused must_use with method call`() = checkByText("""
+        struct S;
+
+        impl S {
+            #[must_use]
+            fn foo(&self) -> S { S }
+        }
+
+        struct S2 { s: S }
+
+        fn main() {
+            <warning descr="Unused return value of foo that must be used">S2 { s: S }.s.foo();</warning>
+        }
+    """)
+
+    fun `test fixing by adding assigning to _`() = checkFixByText("Add `let _ =`","""
+        #[must_use]
+        fn foo() -> bool { false }
+
+        fn main() {
+            <warning descr="Unused return value of foo that must be used">/*caret*/foo();</warning>
+        }
+    """, """
+        #[must_use]
+        fn foo() -> bool { false }
+
+        fn main() {
+            let _ = foo();
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test fixing unused result by adding unwrap`() = checkFixByText("Add `.unwrap()`","""
+        fn foo() -> Result<bool, ()> { false }
+
+        fn main() {
+            <warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo();</warning>
+        }
+    """, """
+        fn foo() -> Result<bool, ()> { false }
+
+        fn main() {
+            foo().unwrap();
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test fixing unused result by adding expect`() = checkFixByText("Add `.expect(\"\")`","""
+        fn foo() -> Result<bool, ()> { false }
+
+        fn main() {
+            <warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo();</warning>
+        }
+    """, """
+        fn foo() -> Result<bool, ()> { false }
+
+        fn main() {
+            foo().expect("TODO: panic message");
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
@@ -15,7 +15,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> bool { false }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">foo()</warning>;
+            <weak_warning descr="Unused return value of foo that must be used">foo()</weak_warning>;
         }
     """)
 
@@ -26,7 +26,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">foo()</warning>;
+            <weak_warning descr="Unused return value of foo that must be used">foo()</weak_warning>;
         }
     """)
 
@@ -35,7 +35,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         struct S;
 
         fn main() {
-            <warning descr="Unused S that must be used">S</warning>;
+            <weak_warning descr="Unused S that must be used">S</weak_warning>;
         }
     """)
 
@@ -48,7 +48,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">S.foo()</warning>;
+            <weak_warning descr="Unused return value of foo that must be used">S.foo()</weak_warning>;
         }
     """)
 
@@ -59,7 +59,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> S { S }
 
         fn main() {
-            <warning descr="Unused S that must be used">foo()</warning>;
+            <weak_warning descr="Unused S that must be used">foo()</weak_warning>;
         }
     """)
 
@@ -74,7 +74,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         struct S2 { s: S }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">S2 { s: S }.s.foo()</warning>;
+            <weak_warning descr="Unused return value of foo that must be used">S2 { s: S }.s.foo()</weak_warning>;
         }
     """)
 
@@ -86,9 +86,22 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
             #[cfg(undeclared_feature)]
             { S }
 
-            <warning descr="Unused S that must be used">#[cfg(not(undeclared_feature))]
-            { S }</warning>
+            <weak_warning descr="Unused S that must be used">#[cfg(not(undeclared_feature))]
+            { S }</weak_warning>
 
+            { S }
+        }
+    """)
+
+    fun `test no warning on reverse cfg disabled blocks`() = checkByText("""
+        #[must_use]
+        struct S;
+
+        fn xyz() -> S {
+            #[cfg(not(undeclared_feature))]
+            { S }
+
+            #[cfg(undeclared_feature)]
             { S }
         }
     """)
@@ -98,7 +111,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> bool { false }
 
         fn main() {
-            <warning descr="Unused return value of foo that must be used">/*caret*/foo()</warning>;
+            <weak_warning descr="Unused return value of foo that must be used">/*caret*/foo()</weak_warning>;
         }
     """, """
         #[must_use]
@@ -114,7 +127,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> Result<bool, ()> { false }
 
         fn main() {
-            <warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo()</warning>;
+            <weak_warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo()</weak_warning>;
         }
     """, """
         fn foo() -> Result<bool, ()> { false }
@@ -129,7 +142,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         fn foo() -> Result<bool, ()> { false }
 
         fn main() {
-            <warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo()</warning>;
+            <weak_warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo()</weak_warning>;
         }
     """, """
         fn foo() -> Result<bool, ()> { false }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
@@ -122,6 +122,22 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         }
     """)
 
+    fun `test fixing by adding assigning to _ with template`() = checkFixByTextWithLiveTemplate("Add `let _ =`","""
+        #[must_use]
+        fn foo() -> bool { false }
+
+        fn main() {
+            <weak_warning descr="Unused return value of foo that must be used">/*caret*/foo()</weak_warning>;
+        }
+    """, "a\t", """
+        #[must_use]
+        fn foo() -> bool { false }
+
+        fn main() {
+            let a = foo();
+        }
+    """)
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test fixing unused result by adding unwrap`() = checkFixByText("Add `.unwrap()`","""
         fn foo() -> Result<bool, ()> { false }
@@ -149,6 +165,21 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
 
         fn main() {
             foo().expect("TODO: panic message");
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test fixing unused result by adding expect with template`() = checkFixByTextWithLiveTemplate("Add `.expect(\"\")`","""
+        fn foo() -> Result<bool, ()> { false }
+
+        fn main() {
+            <weak_warning descr="Unused Result<bool, ()> that must be used">/*caret*/foo()</weak_warning>;
+        }
+    """, "abc\t", """
+        fn foo() -> Result<bool, ()> { false }
+
+        fn main() {
+            foo().expect("abc");
         }
     """)
 }


### PR DESCRIPTION
This PR introduces `unused_must_use` and `clippy::double_must_use` lints and quickfixes for them.

![image](https://user-images.githubusercontent.com/662976/133413166-e093a97d-52e4-4317-9fdc-986d672d8bcd.png)

Closes #7549 ("_Implement unused-must-use lint"_)

changelog: Add unused_must_use and clippy::double_must_use inspections and quick-fixes