### PR TITLE
Fix `Generate Parser` run configuration

### DIFF
--- a/.idea/runConfigurations/Generate_Parser.xml
+++ b/.idea/runConfigurations/Generate_Parser.xml
@@ -4,19 +4,14 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="" />
+      <option name="scriptParameters" value=":generateRustLexer :generateRustParser" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
-        <list>
-          <option value=":generateRustLexer" />
-          <option value=":generateRustParser" />
-          <option value="intellij-toml:core:generateTomlLexer" />
-          <option value="intellij-toml:core:generateTomlParser" />
-        </list>
+        <list />
       </option>
-      <option name="vmOptions" value="" />
+      <option name="vmOptions" />
     </ExternalSystemSettings>
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>


### PR DESCRIPTION
The configuration was broken in #7828 because of TOML plugin source removal