### PR TITLE
RES: Fix visibility of reexported item with restricted visibility

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -511,7 +511,7 @@ data class VisItem(
 
     fun adjust(visibilityNew: Visibility, isFromNamedImport: Boolean): VisItem =
         copy(
-            visibility = if (visibility.isInvisible) visibility else visibilityNew,
+            visibility = visibilityNew.intersect(visibility),
             isFromNamedImport = isFromNamedImport
         )
 
@@ -570,6 +570,8 @@ sealed class Visibility {
             }
         }
     }
+
+    fun intersect(other: Visibility): Visibility = if (isStrictlyMorePermissive(other)) other else this
 
     val type: VisibilityType
         get() = when (this) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -5,7 +5,9 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.MockEdition
 import org.rust.UseNewResolve
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ignoreInNewResolve
 
 class RsStubOnlyResolveTest : RsResolveTestBase() {
@@ -775,5 +777,26 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         impl <const N: usize> T for S<{ N }> {
             fn foo(&self) {}
         }
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test item reexported from 'pub(crate)' mod in dependency crate`() = stubOnlyResolve("""
+    //- main.rs
+        use test_package::*;
+        use foo::*;
+
+        fn main() {
+            func();
+        } //^ main.rs
+
+        mod foo {
+            pub fn func() {}
+        }        //X
+    //- lib.rs
+        mod foo {
+            pub(crate) fn func() {}
+        }
+        pub use foo::*;
     """)
 }


### PR DESCRIPTION
Consider import adds item to scope of module. Previously in new resolve visibility of added scope entry will be same as visibility of import. Actually its visibility should be intersection of import visibility and item visibility

changelog: Fix visibility of publicly reexported item with restricted visibility
