### PR TITLE
RES: Fix inserting import to different crate at correct location

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -92,6 +92,7 @@ private fun RsMod.insertExternCrateItem(psiFactory: RsPsiFactory, crateName: Str
 
 fun RsItemsOwner.insertUseItem(psiFactory: RsPsiFactory, usePath: String) {
     val useItem = psiFactory.createUseItem(usePath)
+    useItem.setContext(containingMod)  // needed for correct sorting of added import
     insertUseItem(psiFactory, useItem)
 }
 

--- a/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
@@ -198,8 +198,8 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
             }
             fn main() { let var/*caret*/ = foo(); }
     """, """
-            use a::foo;
             use std::collections::HashMap;
+            use a::foo;
 
             mod a {
                 use std::collections::HashMap;


### PR DESCRIPTION
changelog: Fix inserting import at the correct location when importing an item from the different crate
