### PR TITLE
RUN: Correctly handle `+toolchain` in Cargo command configuration

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskProvider.kt
@@ -9,6 +9,7 @@ import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.util.Key
+import com.intellij.util.execution.ParametersListUtil
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.tools.Rustup
@@ -30,7 +31,7 @@ class CargoBuildTaskProvider : RsBuildTaskProvider<CargoBuildTaskProvider.BuildT
 
         val projectDirectory = configuration.workingDirectory ?: return false
 
-        val configArgs = configuration.command.split(' ')
+        val configArgs = ParametersListUtil.parse(configuration.command)
         val targetFlagIdx = configArgs.indexOf("--target")
         val targetTriple = if (targetFlagIdx != -1) configArgs.getOrNull(targetFlagIdx + 1).orEmpty() else ""
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
@@ -52,6 +52,7 @@ data class CargoCommandLine(
     override val additionalArguments: List<String> = emptyList(),
     override val redirectInputFrom: File? = null,
     val backtraceMode: BacktraceMode = BacktraceMode.DEFAULT,
+    val toolchain: String? = null,
     val channel: RustChannel = RustChannel.DEFAULT,
     val environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT,
     val requiredFeatures: Boolean = true,

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -382,6 +382,8 @@ class Cargo(
             val parameters = buildList<String> {
                 if (channel != RustChannel.DEFAULT) {
                     add("+$channel")
+                } else if (toolchain != null) {
+                    add(toolchain)
                 }
                 if (project.rustSettings.useOffline) {
                     val cargoProject = findCargoProject(project, additionalArguments, workingDirectory)
@@ -393,8 +395,8 @@ class Cargo(
                 add(command)
                 addAll(additionalArguments)
             }
-            val rustcExecutable = toolchain.rustc().executable.toString()
-            toolchain.createGeneralCommandLine(
+            val rustcExecutable = this@Cargo.toolchain.rustc().executable.toString()
+            this@Cargo.toolchain.createGeneralCommandLine(
                 executable,
                 workingDirectory,
                 redirectInputFrom,

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
@@ -81,6 +81,24 @@ class CargoTest : RsTestBase() {
         env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=short, TERM=ansi
     """)
 
+    fun `test use +nightly explicitly`() = checkCommandLine(
+        cargo.toColoredCommandLine(project, CargoCommandLine("run", wd, toolchain = "+nightly")), """
+        cmd: /usr/bin/cargo +nightly run --color=always
+        env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=short, TERM=ansi
+        """, """
+        cmd: C:/usr/bin/cargo.exe +nightly run --color=always
+        env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=short, TERM=ansi
+    """)
+
+    fun `test override explicitly used +toolchain flag if channel is set`() = checkCommandLine(
+        cargo.toColoredCommandLine(project, CargoCommandLine("run", wd, toolchain = "+nightly", channel = RustChannel.BETA)), """
+        cmd: /usr/bin/cargo +beta run --color=always
+        env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=short, TERM=ansi
+        """, """
+        cmd: C:/usr/bin/cargo.exe +beta run --color=always
+        env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=short, TERM=ansi
+    """)
+
     @MockRustcVersion("1.36.0")
     fun `test adds --offline option`() = withOfflineMode {
         checkCommandLine(cargo.toColoredCommandLine(project, CargoCommandLine("run", wd, listOf("--release", "--", "foo"))), """

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RunConfigurationTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RunConfigurationTest.kt
@@ -214,4 +214,29 @@ class RunConfigurationTest : RunConfigurationTestBase() {
         check("2. bbb" in stdout)
         check("3. ccc" !in stdout)
     }
+
+    fun `test toolchain override`() {
+        fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    #![feature(if_let)]
+
+                    fn main() {
+                        println!("Hello, world!");
+                    }
+                """)
+            }
+        }.create()
+        val configuration = createConfiguration("+nightly run")
+        val result = executeAndGetOutput(configuration)
+
+        check("Hello, world!" in result.stdout)
+    }
 }


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/issues/2165#issuecomment-922349293.

changelog: Correctly handle `+toolchain` at the beginning of Cargo command line
