### PR TITLE
ANN: Show error when defaults for const parameters are used in `fn`s or `impl`s

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1378,6 +1378,14 @@ private fun checkConstGenerics(holder: RsAnnotationHolder, constParameter: RsCon
 private fun checkConstGenericsDefaults(holder: RsAnnotationHolder, default: RsExpr?) {
     if (default == null) return
     CONST_GENERICS_DEFAULTS.check(holder, default, "const generics defaults")
+    when (default.ancestorStrict<RsGenericDeclaration>()) {
+        is RsStructItem,
+        is RsEnumItem,
+        is RsTypeAlias,
+        is RsTraitItem,
+        null -> {}
+        else -> RsDiagnostic.DefaultsConstGenericNotAllowed(default).addToHolder(holder)
+    }
 }
 
 private fun checkConstArguments(holder: RsAnnotationHolder, args: List<RsExpr>) {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1361,6 +1361,14 @@ sealed class RsDiagnostic(
         )
     }
 
+    class DefaultsConstGenericNotAllowed(expr: RsExpr) : RsDiagnostic(expr) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            null,
+            "Defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions",
+        )
+    }
+
     class InherentImplDifferentCrateError(element: PsiElement) : RsDiagnostic(element) {
         override fun prepare() = PreparedAnnotation(
             ERROR,

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -2915,19 +2915,23 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
     @MockRustcVersion("1.51.0")
     fun `test const generics defaults E0658 1`() = checkErrors("""
-        fn f<const C: i32 = <error descr="const generics defaults is experimental [E0658]">0</error>>() {}
+        fn f<const C: i32 = <error descr="Defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions"><error descr="const generics defaults is experimental [E0658]">0</error></error>>() {}
         struct S<const C: i32 = <error descr="const generics defaults is experimental [E0658]">0</error>>(A);
         trait T<const C: i32 = <error descr="const generics defaults is experimental [E0658]">0</error>> {}
+        impl <const C: i32 = <error descr="Defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions"><error descr="const generics defaults is experimental [E0658]">0</error></error>> T<C> for S<C> {}
         enum E<const C: i32 = <error descr="const generics defaults is experimental [E0658]">0</error>> {}
+        type A<const C: i32 = <error descr="const generics defaults is experimental [E0658]">0</error>> = S<C>;
     """)
 
     @MockRustcVersion("1.51.0-nightly")
     fun `test const generics defaults E0658 2`() = checkErrors("""
         #![feature(const_generics_defaults)]
-        fn f<const C: i32 = 0>() {}
+        fn f<const C: i32 = <error descr="Defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions">0</error>>() {}
         struct S<const C: i32 = 0>(A);
         trait T<const C: i32 = 0> {}
+        impl <const C: i32 = <error descr="Defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions">0</error>> T<C> for S<C> {}
         enum E<const C: i32 = 0> {}
+        type A<const C: i32 = 0> = S<C>;
     """)
 
     @MockRustcVersion("1.47.0")


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/7866.

changelog: Show error when defaults for const parameters are used in `fn`s or `impl`s
