### PR TITLE
Simplify `contextualFileAndIsEnabledByCfgOnThisWay`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
@@ -30,7 +30,7 @@ val PsiElement.existsAfterExpansion: Boolean get() = isEnabledByCfg
 fun PsiElement.isEnabledByCfg(crate: Crate): Boolean = isEnabledByCfgInner(crate)
 
 private fun PsiElement.isEnabledByCfgInner(crate: Crate?): Boolean =
-    ancestors.all {
+    stubAncestors.all {
         when (it) {
             is RsDocAndAttributeOwner -> it.isEnabledByCfgSelfInner(crate)
             is RsMetaItem -> !it.isRootMetaItem()


### PR DESCRIPTION
Since we now don't expand cfg-disabled macros, this complex function can be simplified