### PR TITLE
Fix false-positive assert in unit tests

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1048,11 +1048,7 @@ private class MacroResolver private constructor(
     private fun tryProcessAllMacrosUsingNewResolve(element: PsiElement, isAttrOrDerive: Boolean): MacroResolveResult? {
         if (!project.isNewResolveEnabled) return null
         if (element !is RsElement) return null
-        if (element.parent !is RsMod) return null  // we are interested only in top-level elements
-
-        val expandedFrom = (element as? RsExpandedElement)?.expandedFromRecursively
-        val item = expandedFrom ?: element
-        val scope = item.parent as? RsMod ?: return null
+        val scope = element.context as? RsMod ?: return null // we are interested only in top-level elements
         /** [processRemainedExportedMacros] processes local imports */
         return processMacros(scope, processor, macroPath, isAttrOrDerive, ::processRemainedExportedMacros)
             ?.toResult(usedNewResolve = true)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -445,5 +445,22 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test resolve macro from including file included to a function-local mod`() = stubOnlyResolve("""
+    //- main.rs
+        macro_rules! foo {
+                   //X
+            () => {}
+        }
+
+        fn main() {
+            mod bar {
+                include!("baz.rs");
+            }
+        }
+    //- baz.rs
+        foo!();
+        //^ main.rs
+    """)
+
     /** More macro tests in [RsPackageLibraryResolveTest] and [RsStubOnlyResolveTest] */
 }


### PR DESCRIPTION
Fixes this exception in the test I've added

<details>
  <summary>Stacktrace</summary>
  
  ```
  java.lang.AssertionError: todo
	at org.rust.lang.core.resolve2.CrateDefMap.getModData(CrateDefMap.kt:652)
	at org.rust.lang.core.resolve2.FacadeResolveKt.getModInfo(FacadeResolve.kt:451)
	at org.rust.lang.core.resolve2.FacadeResolveKt.processMacros(FacadeResolve.kt:119)
	at org.rust.lang.core.resolve.MacroResolver.tryProcessAllMacrosUsingNewResolve(NameResolution.kt:1057)
	at org.rust.lang.core.resolve.MacroResolver.psiBasedProcessScopesInLexicalOrderUpward(NameResolution.kt:975)
	at org.rust.lang.core.resolve.MacroResolver.processScopesInLexicalOrderUpward(NameResolution.kt:970)
	at org.rust.lang.core.resolve.MacroResolver.processMacrosInLexicalOrderUpward(NameResolution.kt:949)
	at org.rust.lang.core.resolve.MacroResolver.access$processMacrosInLexicalOrderUpward(NameResolution.kt:939)
	at org.rust.lang.core.resolve.MacroResolver$Companion.processMacrosInLexicalOrderUpward(NameResolution.kt:1073)
	at org.rust.lang.core.resolve.NameResolutionKt.processMacroCallVariantsInScope(NameResolution.kt:923)
	at org.rust.lang.core.resolve.NameResolutionKt$processMacroCallPathResolveVariants$resolved$1.invoke(NameResolution.kt:873)
	at org.rust.lang.core.resolve.NameResolutionKt$processMacroCallPathResolveVariants$resolved$1.invoke(NameResolution.kt:872)
	at org.rust.lang.core.resolve.ProcessorsKt.pickFirstResolveEntry(Processors.kt:175)
	at org.rust.lang.core.resolve.NameResolutionKt.processMacroCallPathResolveVariants(NameResolution.kt:872)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl$Resolver$invoke$1.invoke(RsMacroPathReferenceImpl.kt:66)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl$Resolver$invoke$1.invoke(RsMacroPathReferenceImpl.kt:65)
	at org.rust.lang.core.resolve.ProcessorsKt.pickFirstResolveEntry(Processors.kt:175)
	at org.rust.lang.core.resolve.ProcessorsKt.pickFirstResolveVariant(Processors.kt:160)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl$Resolver.invoke(RsMacroPathReferenceImpl.kt:65)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl$Resolver.invoke(RsMacroPathReferenceImpl.kt:63)
	at org.rust.lang.core.resolve.ref.RsResolveCache.resolveWithCaching$lambda-1$lambda-0(RsResolveCache.kt:101)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at org.rust.lang.core.resolve.ref.RsResolveCache.resolveWithCaching(RsResolveCache.kt:101)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl.resolve(RsMacroPathReferenceImpl.kt:55)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl.resolve(RsMacroPathReferenceImpl.kt:38)
	at org.rust.CommonKt.checkedResolve(common.kt:97)
	at org.rust.CommonKt.checkedResolve$default(common.kt:95)
	at org.rust.lang.core.resolve.RsResolveTestBase.resolveByFileTree(RsResolveTestBase.kt:117)
	at org.rust.lang.core.resolve.RsResolveTestBase.access$resolveByFileTree(RsResolveTestBase.kt:20)
	at org.rust.lang.core.resolve.RsResolveTestBase.stubOnlyResolve(RsResolveTestBase.kt:154)
	at org.rust.lang.core.resolve.RsResolveTestBase.stubOnlyResolve$default(RsResolveTestBase.kt:72)
	at org.rust.lang.core.resolve.RsMacroResolveTest.test resolve macro from including file included to a function-local mod(RsMacroResolveTest.kt:448)
  ```
</details>