### PR TITLE
RES: Fix that `alloc` crate can be resolved without `extern crate`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -25,6 +25,8 @@ import com.intellij.psi.util.CachedValuesManager
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.util.AutoInjectedCrates.CORE
+import org.rust.cargo.util.AutoInjectedCrates.STD
 import org.rust.ide.injected.isDoctestInjection
 import org.rust.lang.RsConstants
 import org.rust.lang.RsFileType
@@ -253,7 +255,21 @@ class RsFile(
         }
 
     enum class Attributes {
-        NO_CORE, NO_STD, NONE
+        NO_CORE, NO_STD, NONE;
+
+        fun getAutoInjectedCrate(): String? =
+            when (this) {
+                NONE -> STD
+                NO_STD -> CORE
+                NO_CORE -> null
+            }
+
+        fun canUseStdlibCrate(crateName: String): Boolean =
+            when (this) {
+                NONE -> true
+                NO_STD -> crateName != STD
+                NO_CORE -> crateName != STD && crateName != CORE
+            }
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -40,6 +40,7 @@ class CrateDefMap(
     /** Used only by `extern crate crate_name;` declarations */
     val directDependenciesDefMaps: Map<String, CrateDefMap>,
     private val allDependenciesDefMaps: Map<CratePersistentId, CrateDefMap>,
+    initialExternPrelude: Map<String, CrateDefMap>,
     val metaData: CrateMetaData,
     /** Equal to `root.macroIndex.single()` */
     val rootModMacroIndex: Int,
@@ -52,7 +53,7 @@ class CrateDefMap(
     var prelude: ModData? = null
 
     /** It is needed at least to handle `extern crate name as alias;` */
-    val externPrelude: MutableMap<String, CrateDefMap> = directDependenciesDefMaps.toMap(hashMapOf())
+    val externPrelude: MutableMap<String, CrateDefMap> = initialExternPrelude.toMap(hashMapOf())
 
     /**
      * File included via `include!` macro has same [FileInfo.modData] as main file,

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
@@ -5,11 +5,8 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.MockEdition
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
-import org.rust.ignoreInNewResolve
 
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
@@ -29,4 +26,17 @@ class RsStdlibResolveTestEdition2018 : RsResolveTestBase() {
             let a = Vec::<i32>::new();
         }         //^ .../vec.rs|...vec/mod.rs
     """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve(project))
+
+    fun `test resolve core crate without extern crate`() = stubOnlyResolve("""
+    //- main.rs
+        use core::cell::Cell;
+          //^ ...core/src/lib.rs|...core/lib.rs
+    """)
+
+    @UseNewResolve
+    fun `test alloc crate unresolved without extern crate`() = stubOnlyResolve("""
+    //- main.rs
+        use alloc::rc::Rc;
+          //^ unresolved
+    """)
 }


### PR DESCRIPTION
changelog: Fixes that some stdlib crates (e.g. `alloc`) can be resolved without corresponding `extern crate` declaration
