### PR TITLE
ANN: Annotate non-structural-match types in const generic parameters (E0741)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -971,6 +971,7 @@ class ImplLookup(
     fun isSized(ty: Ty): Boolean = ty.isTraitImplemented(items.Sized)
     fun isDebug(ty: Ty): Boolean = ty.isTraitImplemented(items.Debug)
     fun isDefault(ty: Ty): Boolean = ty.isTraitImplemented(items.Default)
+    fun isEq(ty: Ty, rhsType: Ty = ty): Boolean = ty.isTraitImplemented(items.Eq, rhsType)
     fun isPartialEq(ty: Ty, rhsType: Ty = ty): Boolean = ty.isTraitImplemented(items.PartialEq, rhsType)
     fun isIntoIterator(ty: Ty): Boolean = ty.isTraitImplemented(items.IntoIterator)
     fun isAnyFn(ty: Ty): Boolean = isFn(ty) || isFnOnce(ty) || isFnMut(ty)

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1151,6 +1151,14 @@ sealed class RsDiagnostic(
         )
     }
 
+    class `NonStructuralMatchTypeAsConstGenericParameter`(element: PsiElement, private val typeName: String) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0741,
+            "$typeName doesn't derive both `PartialEq` and `Eq`"
+        )
+    }
+
     class ImplTraitNotAllowedHere(traitType: RsTraitType) : RsDiagnostic(traitType) {
         override fun prepare(): PreparedAnnotation =
             PreparedAnnotation(
@@ -1436,7 +1444,7 @@ enum class RsErrorCode {
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0433, E0435, E0449, E0451, E0463,
     E0517, E0518, E0537, E0552, E0562, E0569, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0688, E0695,
-    E0703, E0704, E0732;
+    E0703, E0704, E0732, E0741;
 
     val code: String
         get() = toString()

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.annotator
 
 import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.experiments.RsExperiments
 
 class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
@@ -3134,6 +3135,32 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
                 b: u16,
             } = 1,
         }
+    """)
+
+    @MockRustcVersion("1.56.0-nightly")
+    @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
+    fun `test non-structural match type as const generic parameter E0741`() = checkErrors("""
+        #![feature(adt_const_params)]
+        struct A;
+        #[derive(PartialEq)]
+        struct B;
+        #[derive(Eq)]
+        struct C;
+        #[derive(PartialEq, Eq)]
+        struct D;
+        struct S<
+            const P1: A,
+            const P2: B,
+            const P3: C,
+            const P4: D
+        >;
+    """)
+
+    @MockRustcVersion("1.56.0-nightly")
+    fun `test non-structural match type as const generic parameter E0741 (proc macros are disabled)`() = checkErrors("""
+        #![feature(adt_const_params)]
+        struct A;
+        struct S<const P: A>;
     """)
 
     @MockRustcVersion("1.37.0-nightly")


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/pull/7839#discussion_r715574954.

changelog: Annotate non-structural-match types in const generic parameters ([E0741](https://doc.rust-lang.org/error-index.html#E0741))
