### PR TITLE
add `rust-version` to package manifest example

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/completion/RsTomlKeysCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/RsTomlKeysCompletionProvider.kt
@@ -79,6 +79,7 @@ include = ["src/**/*", "Cargo.toml"]
 publish = false
 workspace = "path/to/workspace/root"
 edition = "2018"
+rust-version = "1.56"  # supported in the coming 1.56 release
 
 description = "..."
 homepage = "..."


### PR DESCRIPTION
This commit adds the `rust-version` field to the package manifest example with the addition of the field in the upcoming version of `1.56.0`, which is deemed to be released on 21 October.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

changelog:
- addition of the `rust-version` field to the `[package]` table of the Cargo manifest
