### PR TITLE
RES: add reference to Index trait for bracket indexing expressions

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1311,7 +1311,9 @@ OpenRangeExpr ::= ('..' | '...' | '..=') <<setStmtMode 'StmtMode.OFF'>> (<<check
     { elementType = RangeExpr }
 
 IndexExpr ::= Expr <<isIncompleteBlockExpr>> IndexArg {
- elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+  implements = [ "org.rust.lang.core.psi.ext.RsReferenceElement" ]
+  mixin = "org.rust.lang.core.psi.ext.RsIndexExprImplMixin"
 }
 // Do not inline this rule, it breaks expression parsing
 private IndexArg ::= '[' Expr ']'

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsIndexExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsIndexExpr.kt
@@ -5,11 +5,27 @@
 
 package org.rust.lang.core.psi.ext
 
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsIndexExpr
+import org.rust.lang.core.resolve.ref.RsIndexExprReferenceImpl
+import org.rust.lang.core.resolve.ref.RsReference
+import org.rust.lang.core.stubs.RsPlaceholderStub
 
 val RsIndexExpr.containerExpr: RsExpr?
     get() = exprList.getOrNull(0)
 
 val RsIndexExpr.indexExpr: RsExpr?
     get() = exprList.getOrNull(1)
+
+abstract class RsIndexExprImplMixin : RsStubbedElementImpl<RsPlaceholderStub>, RsIndexExpr {
+    constructor(node: ASTNode) : super(node)
+
+    constructor(stub: RsPlaceholderStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
+
+    override val referenceNameElement: PsiElement? = null
+
+    override fun getReference(): RsReference = RsIndexExprReferenceImpl(this)
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -118,6 +118,7 @@ class KnownItems(
     val FnMut: RsTraitItem? get() = findLangItem("fn_mut")
     val FnOnce: RsTraitItem? get() = findLangItem("fn_once")
     val Index: RsTraitItem? get() = findLangItem("index")
+    val IndexMut: RsTraitItem? get() = findLangItem("index_mut")
     val Clone: RsTraitItem? get() = findLangItem("clone")
     val Copy: RsTraitItem? get() = findLangItem("copy")
     val PartialEq: RsTraitItem? get() = findLangItem("eq")

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsIndexExprReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsIndexExprReferenceImpl.kt
@@ -1,0 +1,67 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.ref
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.MultiRangeReference
+import org.rust.lang.core.psi.RsBinaryExpr
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsIndexExpr
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.invoke
+import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.implLookupAndKnownItems
+import org.rust.lang.core.types.type
+
+class RsIndexExprReferenceImpl(element: RsIndexExpr) : RsReferenceCached<RsIndexExpr>(element), MultiRangeReference {
+    override val cacheDependency: ResolveCacheDependency get() = ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
+
+    override fun resolveInner(): List<RsElement> {
+        val parent = element.parent
+
+        // Assume that IndexMut will be used if the indexed expression is on the left side of some assignment
+        val isMaybeMutableContext = parent is RsBinaryExpr &&
+            parent.operatorType is AssignmentOp &&
+            parent.left == element
+
+        val indexFn = findIndexFunction(element, isMaybeMutableContext)
+            ?.takeIf { it.existsAfterExpansion }
+        return listOfNotNull(indexFn)
+    }
+
+    override fun getRanges(): List<TextRange> = listOf(
+        element.lbrack.textRangeInParent,
+        element.rbrack.textRangeInParent
+    )
+}
+
+/**
+ * Tries to resolve a function that implements either `Index` or `IndexMut` for the given index expression.
+ * If `preferMutable` is true, `IndexMut` will be attempted for resolution first.
+ */
+fun findIndexFunction(element: RsIndexExpr, preferMutable: Boolean): RsFunction? {
+    val container = element.containerExpr ?: return null
+    val index = element.indexExpr ?: return null
+
+    val (lookup, items) = element.implLookupAndKnownItems
+
+    val candidates = mutableListOf(
+        items.Index to "index",
+        items.IndexMut to "index_mut"
+    )
+    if (preferMutable) {
+        candidates.reverse()
+    }
+
+    return candidates.map { (trait, functionName) ->
+        if (trait == null) return@map null
+        val impl = lookup.select(TraitRef(container.type, trait.withSubst(index.type))).ok()?.impl ?: return@map null
+        impl.expandedMembers
+            .functions
+            .find { it.name == functionName }
+    }.firstOrNull()
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsIndexExprResolve.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsIndexExprResolve.kt
@@ -1,0 +1,100 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+class RsIndexExprResolve : RsResolveTestBase() {
+    private val langItems: String = """
+        #[lang = "index"]
+        pub trait Index<Idx: ?Sized> {
+            type Output: ?Sized;
+
+            fn index(&self, index: Idx) -> &Self::Output;
+        }
+
+        #[lang = "index_mut"]
+        pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
+            fn index_mut(&mut self, index: Idx) -> &mut Self::Output;
+        }
+    """.trimIndent()
+
+    fun `test left bracket`() = checkByCode("""
+        $langItems
+
+        struct Foo(u32);
+
+        impl Index<i32> for Foo {
+            type Output = u32;
+
+            fn index(&self, index: i32) -> &Self::Output { &self.0 }
+             //X
+        }
+
+        fn foo(a: Foo) {
+            let index: i32 = 0;
+            let x: u32 = a[index];
+                        //^
+        }
+    """)
+
+    fun `test right bracket`() = checkByCode("""
+        $langItems
+
+        struct Foo(u32);
+
+        impl Index<i32> for Foo {
+            type Output = u32;
+
+            fn index(&self, index: i32) -> &Self::Output { &self.0 }
+             //X
+        }
+
+        fn foo(a: Foo) {
+            let index: i32 = 0;
+            let x: u32 = a[index];
+                              //^
+        }
+    """)
+
+    fun `test prefer IndexMut in assignment lhs`() = checkByCode("""
+        $langItems
+
+        struct Foo(u32);
+
+        impl Index<i32> for Foo {
+            type Output = u32;
+            fn index(&self, index: i32) -> &Self::Output { &self.0 }
+        }
+        impl IndexMut<i32> for Foo {
+            fn index_mut(&mut self, index: i32) -> &mut Self::Output { &mut self.0 }
+             //X
+        }
+
+        fn foo(mut a: Foo) {
+            a[0] = 0;
+           //^
+        }
+    """)
+
+    fun `test prefer Index in assignment rhs`() = checkByCode("""
+        $langItems
+
+        struct Foo(u32);
+
+        impl Index<i32> for Foo {
+            type Output = u32;
+            fn index(&self, index: i32) -> &Self::Output { &self.0 }
+             //X
+        }
+        impl IndexMut<i32> for Foo {
+            fn index_mut(&mut self, index: i32) -> &mut Self::Output { &mut self.0 }
+        }
+
+        fn foo(a: Foo) {
+            let b = a[0];
+                   //^
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds reference to `Index` trait implementation from the left bracket of indexing expressions. I'm not sure how to also add support for the right bracket though. The `referenceNameElement` property allows returning only a single element and I cannot set `rangeInElement`, because the bracket ranges are disjoint.

The only thing that comes to mind is to implement something like `RsIndexExprImplMixin1` and `RsIndexExprImplMixin2`, where each will provide a reference for one of the brackets. But it seems like there should be an easier way.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7895

changelog: Resolve references to `Index` trait implementations for brackets (`[`, `]`) inside indexing expressions.