### PR TITLE
RUN: generate proper names for run configurations provided by Cargo tool window

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectsTree.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectsTree.kt
@@ -18,7 +18,7 @@ import javax.swing.SwingUtilities
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.TreeSelectionModel
 
-class CargoProjectsTree : SimpleTree() {
+open class CargoProjectsTree : SimpleTree() {
 
     val selectedProject: CargoProject? get() {
         val path = selectionPath ?: return null
@@ -32,6 +32,7 @@ class CargoProjectsTree : SimpleTree() {
         showsRootHandles = true
         emptyText.text = "There are no Cargo projects to display."
         selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
+        @Suppress("LeakingThis")
         addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
                 if (e.clickCount < 2 || !SwingUtilities.isLeftMouseButton(e)) return
@@ -45,9 +46,16 @@ class CargoProjectsTree : SimpleTree() {
                     return
                 }
                 val cargoProject = selectedProject ?: return
-                CargoCommandLine.forTarget(target, command).run(cargoProject)
+                // Capitalize command name to be consistent with line market providers
+                // TODO: not to use `capitalize` here
+                val configurationName = "${command.capitalize()} ${target.name}"
+                run(CargoCommandLine.forTarget(target, command), cargoProject, configurationName)
             }
         })
+    }
+
+    protected open fun run(commandLine: CargoCommandLine, project: CargoProject, name: String) {
+        commandLine.run(project, name)
     }
 
     companion object {

--- a/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt
@@ -23,9 +23,11 @@ class CargoProjectStructureTest : RsWithToolchainTestBase() {
          Project
           Targets
            Target(bench[bench])
+           Target(build-script-build[custom-build])
            Target(example[example])
            Target(foo[bin])
            Target(foo[lib])
+           Target(lib_example[example])
            Target(test[test])
     """) {
         toml("Cargo.toml", """
@@ -33,6 +35,13 @@ class CargoProjectStructureTest : RsWithToolchainTestBase() {
             name = "foo"
             version = "0.1.0"
             authors = []
+
+            [[example]]
+            name = "example"
+
+            [[example]]
+            name = "lib_example"
+            crate-type = ["lib"]
         """)
 
         dir("src") {
@@ -44,10 +53,12 @@ class CargoProjectStructureTest : RsWithToolchainTestBase() {
         }
         dir("examples") {
             rust("example.rs", "")
+            rust("lib_example.rs", "")
         }
         dir("tests") {
             rust("test.rs", "")
         }
+        rust("build.rs", "")
     }
 
     fun `test workspace members`() = doTest("""

--- a/src/test/kotlin/org/rustSlowTests/CargoProjectsTreeTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/CargoProjectsTreeTest.kt
@@ -16,7 +16,7 @@ import org.rust.cargo.project.toolwindow.CargoProjectTreeStructure.CargoSimpleNo
 import org.rust.cargo.project.toolwindow.CargoProjectsTree
 import org.rust.fileTree
 
-class CargoProjectStructureTest : RsWithToolchainTestBase() {
+class CargoProjectsTreeTest : RsWithToolchainTestBase() {
 
     fun `test targets`() = doTest("""
         Root


### PR DESCRIPTION
New names are the same as line markers provide. Also, it's less likely that they conflict (and replace) existing ones because of more specific names

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2539310/134887330-62bd2ca7-2b80-4ea9-875b-d17ec8630d44.png) | ![image](https://user-images.githubusercontent.com/2539310/134889473-3713cda0-b352-472f-ba3e-77ed8eef038d.png) |


changelog: Generate proper names for run configurations provided by Cargo tool window to be consistent with run configurations created from line markers
