### PR TITLE
CI: drop temporary 211 builds from release workflow

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -172,7 +172,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                platform-version: [ 211, 212 ]
+                platform-version: [ 212 ]
         env:
             ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}


### PR DESCRIPTION
bors r+