### PR TITLE
CARGO: show build script errors in Sync View

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildAdapterBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildAdapterBase.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.buildtool
+
+import com.intellij.build.BuildProgressListener
+import com.intellij.build.output.BuildOutputInstantReaderImpl
+import com.intellij.execution.process.ProcessAdapter
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.text.StringUtil.convertLineSeparators
+
+@Suppress("UnstableApiUsage")
+abstract class CargoBuildAdapterBase(
+    private val context: CargoBuildContextBase,
+    protected val buildProgressListener: BuildProgressListener
+) : ProcessAdapter() {
+    private val instantReader = BuildOutputInstantReaderImpl(
+        context.buildId,
+        context.parentId,
+        buildProgressListener,
+        listOf(RsBuildEventsConverter(context))
+    )
+
+    override fun processTerminated(event: ProcessEvent) {
+        instantReader.closeAndGetFuture().whenComplete { _, error ->
+            val isSuccess = event.exitCode == 0 && context.errors.get() == 0
+            val isCanceled = context.indicator?.isCanceled ?: false
+            onBuildOutputReaderFinish(event, isSuccess = isSuccess, isCanceled = isCanceled, error)
+        }
+    }
+
+    open fun onBuildOutputReaderFinish(event: ProcessEvent, isSuccess: Boolean, isCanceled: Boolean, error: Throwable?) {}
+
+    override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+        // Progress messages end with '\r' instead of '\n'. We want to replace '\r' with '\n'
+        // so that `instantReader` sends progress messages to parsers separately from other messages.
+        val text = convertLineSeparators(event.text)
+        instantReader.append(text)
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -100,15 +100,16 @@ object CargoBuildManager {
             lastBuildCommandLine = state.prepareCommandLine()
         }
 
-        return execute(
-            CargoBuildContext(
-                cargoProject = cargoProject,
-                environment = environment,
-                taskName = "Build",
-                progressTitle = "Building...",
-                isTestBuild = state.commandLine.command == "test"
-            )
-        ) {
+        val buildId = Any()
+        return execute(CargoBuildContext(
+            cargoProject = cargoProject,
+            environment = environment,
+            taskName = "Build",
+            progressTitle = "Building...",
+            isTestBuild = state.commandLine.command == "test",
+            buildId = buildId,
+            parentId = buildId
+        )) {
             val buildProgressListener = ServiceManager.getService(project, BuildViewManager::class.java)
             if (!isHeadlessEnvironment) {
                 @Suppress("UsePropertyAccessSyntax")

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -242,7 +242,7 @@ open class WithProcMacros(
             setExperimentalFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS, true, disposable)
             val testProcMacroProjectPath = Path.of("testData/$TEST_PROC_MACROS")
             fullyRefreshDirectoryInUnitTests(LocalFileSystem.getInstance().findFileByNioFile(testProcMacroProjectPath)!!)
-            val testProcMacroProject = toolchain!!.cargo().fullProjectDescription(project, testProcMacroProjectPath)
+            val (testProcMacroProject, _) = toolchain!!.cargo().fullProjectDescription(project, testProcMacroProjectPath)
             procMacroPackage = testProcMacroProject.packages.find { it.name == TEST_PROC_MACROS }!!
                 .copy(origin = PackageOrigin.DEPENDENCY)
             procMacroPackage

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -5,6 +5,7 @@
 
 package org.rust.cargo
 
+import com.intellij.findAnnotationInstance
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.RecursionManager
@@ -81,6 +82,7 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
         if (disableMissedCacheAssertions) {
             RecursionManager.disableMissedCacheAssertions(testRootDisposable)
         }
+        setupExperimentalFeatures()
         setupResolveEngine(project, testRootDisposable)
         findAnnotationInstance<ExpandMacros>()?.let { ann ->
             Disposer.register(
@@ -93,6 +95,12 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
         }
         // RsExperiments.FETCH_ACTUAL_STDLIB_METADATA significantly slows down tests
         setExperimentalFeatureEnabled(RsExperiments.FETCH_ACTUAL_STDLIB_METADATA, fetchActualStdlibMetadata, testRootDisposable)
+    }
+
+    private fun setupExperimentalFeatures() {
+        for (feature in findAnnotationInstance<WithExperimentalFeatures>()?.features.orEmpty()) {
+            setExperimentalFeatureEnabled(feature, true, testRootDisposable)
+        }
     }
 
     override fun tearDown() {
@@ -110,10 +118,6 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
 
     protected fun buildProject(builder: FileTreeBuilder.() -> Unit): TestProject =
         fileTree { builder() }.create()
-
-    /** Tries to find the specified annotation on the current test method and then on the current class */
-    private inline fun <reified T : Annotation> findAnnotationInstance(): T? =
-        javaClass.getMethod(name).getAnnotation(T::class.java) ?: javaClass.getAnnotation(T::class.java)
 
     /**
      * Tries to launches [action]. If it returns `false`, invokes [UIUtil.dispatchAllInvocationEvents] and tries again

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
@@ -6,13 +6,16 @@
 package org.rust.cargo.project.model.impl
 
 import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.BuildViewTestFixture
+import org.rust.WithExperimentalFeatures
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.toolwindow.CargoToolWindow
 import org.rust.fileTree
+import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.launchAction
 
 class SyncToolWindowTest : RsWithToolchainTestBase() {
@@ -209,6 +212,110 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
                Getting Rust stdlib
         """)
     }
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
+    fun `test with build script evaluation`() {
+        val project = buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    fn main() {}
+                """)
+            }
+            rust("build.rs", """
+                fn main() {}
+            """)
+        }
+        checkSyncViewTree("""
+            -
+             -finished
+              -Sync ${project.root.name} project
+               Getting toolchain version
+               -Updating workspace info
+                -Build scripts evaluation
+                 Compiling hello v0.1.0
+               Getting Rust stdlib
+        """)
+    }
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
+    fun `test with compile error in build script`() {
+        val project = buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    fn main() {}
+                """)
+            }
+            rust("build.rs", """
+                fn main() {
+                    let a: i32 = "";
+                }
+            """)
+        }
+        checkSyncViewTree("""
+            -
+             -finished
+              -Sync ${project.root.name} project
+               Getting toolchain version
+               -Updating workspace info
+                -Build scripts evaluation
+                 -Compiling hello v0.1.0
+                  -build.rs
+                   Mismatched types
+                Build scripts evaluation failed
+               Getting Rust stdlib
+        """)
+    }
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
+    fun `test with panic in build script`() {
+        val project = buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    fn main() {}
+                """)
+            }
+            rust("build.rs", """
+                fn main() {
+                    panic!("I'm panic!");
+                }
+            """)
+        }
+        checkSyncViewTree(        """
+            -
+             -finished
+              -Sync ${project.root.name} project
+               Getting toolchain version
+               -Updating workspace info
+                -Build scripts evaluation
+                 Compiling hello v0.1.0
+                 -${project.root.name}
+                  Failed to run custom build command for `hello v0.1.0 (${FileUtil.toSystemDependentName(project.root.path)})`
+                Build scripts evaluation failed
+               Getting Rust stdlib
+        """)
+    }
+
 
     private fun attachCargoProject(cargoProjectRoot: VirtualFile) {
         myFixture.launchAction("Cargo.AttachCargoProject", PlatformDataKeys.VIRTUAL_FILE to cargoProjectRoot)


### PR DESCRIPTION
These changes use code to parse Cargo build messages and show them in Build View to show compilation errors in build scripts during project loading.

For example, compilation error in build script code
![image](https://user-images.githubusercontent.com/2539310/134939870-934a5471-ae4d-4439-9a3f-9fb67fbcb5e0.png)
or even compilation-time panics from build script launches
![image](https://user-images.githubusercontent.com/2539310/134945333-daaaacd3-beca-44b8-a44d-d7de2c0a95b8.png)

Fixes #4699

changelog: Show build script evaluation errors in Sync View when `org.rust.cargo.evaluate.build.scripts` [experimental feature](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features) is enabled. It should simplify diagnostics why features based on compile-time information don't work as expected
