### PR TITLE
ANN: Check builtin attributes even when there is proc macro in scope

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1216,7 +1216,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
     // E0132: Invalid `start` attribute
     private fun checkStartAttribute(holder: RsAnnotationHolder, attr: RsAttr) {
-        if (!attr.isBuiltinWithName("start")) return
+        if (attr.metaItem.name != "start") return
 
         START.check(holder, attr.metaItem, "#[start] function")
 
@@ -1256,7 +1256,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkReprAttribute(holder: RsAnnotationHolder, attr: RsAttr) {
-        if (!attr.isBuiltinWithName("repr")) return
+        if (attr.metaItem.name != "repr") return
 
         val owner = attr.owner ?: return
 
@@ -1300,7 +1300,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
     // E0518: Inline attribute is allowed only on functions
     private fun checkInlineAttr(holder: RsAnnotationHolder, attr: RsAttr) {
-        if (!attr.isBuiltinWithName("inline")) return
+        if (attr.metaItem.name != "inline") return
 
         val owner = attr.owner
         if (owner !is RsFunction && owner !is RsLambdaExpr) {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -4094,7 +4094,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         use dep_proc_macro::repr;
 
-        #[repr/*caret*/(C)]
+        #[repr/*caret*/(<error descr="C attribute should be applied to struct, enum, or union [E0517]">C</error>)]
         type Foo = i32;
     """)
 
@@ -4112,7 +4112,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         use dep_proc_macro::start;
 
-        #[start/*caret*/]
+        #[<error descr="Start attribute can be placed only on functions [E0132]">start/*caret*/</error>]
         type Foo = i32;
     """)
 
@@ -4130,7 +4130,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         use dep_proc_macro::inline;
 
-        #[inline/*caret*/]
+        #[<error descr="Attribute should be applied to function or closure [E0518]">inline/*caret*/</error>]
         type Foo = i32;
     """)
 
@@ -4152,10 +4152,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         type Foo = i32;
     """)
 
-    // TODO the test has been regressed after switching to Name Resolution 2.0
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test custom inline proc macro attr and disable cfg`() = expect<org.junit.ComparisonFailure> {
-    checkByFileTree("""
+    fun `test custom inline proc macro attr and disable cfg`() = checkByFileTree("""
     //- dep-proc-macro/lib.rs
         use proc_macro::TokenStream;
 
@@ -4172,7 +4170,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         #[<error descr="Attribute should be applied to function or closure [E0518]">inline/*caret*/</error>]
         type Foo = i32;
     """)
-    }
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test custom inline proc macro attr but ref invalid`() = checkByFileTree("""
@@ -4210,7 +4207,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         fn foo() {
             use dep_proc_macro::inline;
 
-            #[inline/*caret*/]
+            #[<error descr="Attribute should be applied to function or closure [E0518]">inline/*caret*/</error>]
             struct Test(i32);
         }
     """)


### PR DESCRIPTION
This PR is about four builtin macros: `inline`, `repr`, `start` and `derive`. 
* `inline`, `repr` and `start` can't be overwritten by user macro (there will be ambigiuos error E0659). So I think we can still annotate them even if there is user attr proc macro in scope
* `derive` can be user attr proc macro. Note that there is `derive` macro 2.0 in stdlib, that's why `DeriveAttrUnsupportedItem` currently doesn't work. This should be fixed in separate PR like #5911

changelog: Fixes [`E0518`](https://doc.rust-lang.org/error-index.html#E0518) error detection when there is cfg-disabled import of `inline` proc macro
