### PR TITLE
Fix RsMacroType stub

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -67,7 +67,7 @@ class RsFileStub(
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 217
+        private const val STUB_VERSION = 218
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
@@ -254,7 +254,7 @@ fun factory(name: String): RsStubElementType<*, *> = when (name) {
     "BASE_TYPE" -> RsBaseTypeStub.Type
     "FOR_IN_TYPE" -> RsPlaceholderStub.Type("FOR_IN_TYPE", ::RsForInTypeImpl)
     "TRAIT_TYPE" -> RsTraitTypeStub.Type
-    "MACRO_TYPE" -> RsPlaceholderStub.Type("MACRO_TYPE", ::RsForInTypeImpl)
+    "MACRO_TYPE" -> RsPlaceholderStub.Type("MACRO_TYPE", ::RsMacroTypeImpl)
 
     "VALUE_PARAMETER_LIST" -> RsPlaceholderStub.Type("VALUE_PARAMETER_LIST", ::RsValueParameterListImpl)
     "VALUE_PARAMETER" -> RsValueParameterStub.Type
@@ -1602,7 +1602,7 @@ class RsMacroCallStub(
         override fun shouldCreateStub(node: ASTNode): Boolean {
             val parent = node.treeParent.elementType
             return parent in RS_MOD_OR_FILE || parent == MEMBERS ||
-                (parent == MACRO_EXPR || parent == BLOCK) && createStubIfParentIsStub(node)
+                (parent == MACRO_EXPR || parent == MACRO_TYPE || parent == BLOCK) && createStubIfParentIsStub(node)
         }
 
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.macros
 
 import org.rust.ExpandMacros
-import org.rust.UseOldResolve
 import org.rust.lang.core.resolve.RsResolveTestBase
 import org.rust.lang.core.resolve.ref.RsMacroBodyReferenceDelegateImpl.Testmarks
 
@@ -41,7 +40,6 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
         }              //^
     """, Testmarks.touched)
 
-    @UseOldResolve
     fun `test type context`() = checkByCode("""
         struct X;
              //X


### PR DESCRIPTION
Fixes a typo from #2719 which may lead to incorrect PSI creation when macro is in type context, e.g. `type X = foo!();`
