### PR TITLE
RES: Temporary disable parallel macro expansion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -9,6 +9,8 @@ import com.intellij.concurrency.SensitiveProgressWrapper
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.registry.RegistryValue
 import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.lang.core.crate.CratePersistentId
@@ -33,6 +35,7 @@ import java.util.concurrent.ExecutorService
 import kotlin.math.ceil
 
 private const val CONSIDER_INDETERMINATE_IMPORTS_AS_RESOLVED: Boolean = false
+private val EXPAND_MACROS_IN_PARALLEL: RegistryValue = Registry.get("org.rust.resolve.new.engine.macros.parallel")
 
 /** Resolves all imports and expands macros (new items are added to [defMap]) using fixed point iteration algorithm */
 class DefCollector(
@@ -310,7 +313,7 @@ class DefCollector(
         if (macros.isEmpty()) return
         val batches = macros.splitInBatches(100)
 
-        val result = if (pool != null) {
+        val result = if (pool != null && EXPAND_MACROS_IN_PARALLEL.asBoolean()) {
             val indicator = indicator.toThreadSafeProgressIndicator()
             // Don't use `.parallelStream()` - for typical count of batches (10-20) it will run all tasks on current thread
             val tasks = batches.map { batch ->

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1121,6 +1121,8 @@
                      description="The maximum time (in milliseconds) allotted to one procedural macro expansion"/>
         <registryKey key="org.rust.resolve.new.engine" defaultValue="true" restartRequired="true"
                      description="Enables new name resolution engine"/>
+        <registryKey key="org.rust.resolve.new.engine.macros.parallel" defaultValue="false" restartRequired="false"
+                     description="Expand macros in parallel"/>
 
         <!-- Move refactoring -->
 


### PR DESCRIPTION
Reverts #7915 and temporary disables parallel macro expansion in new resolve because of potential exception:

See #7937

<details>

```
java.lang.IllegalStateException: Can not run nested type inference
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn(TypeInference.kt:35)
	at org.rust.lang.core.types.ExtensionsKt._get_inference_$lambda-0(Extensions.kt:75)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:230)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:74)
	at org.rust.ide.inspections.RsDiagnosticBasedInspection.collectDiagnostics(RsDiagnosticBasedInspection.kt:25)
	at org.rust.ide.inspections.RsDiagnosticBasedInspection.access$collectDiagnostics(RsDiagnosticBasedInspection.kt:13)
	at org.rust.ide.inspections.RsDiagnosticBasedInspection$buildVisitor$1.visitFunction(RsDiagnosticBasedInspection.kt:15)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:27)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:32)
	at com.intellij.codeInspection.InspectionEngine.acceptElements(InspectionEngine.java:64)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$7(LocalInspectionsPass.java:353)
	at com.intellij.util.AstLoadingFilter.lambda$toComputable$2(AstLoadingFilter.java:172)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:125)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:119)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:109)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$10(LocalInspectionsPass.java:353)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:136)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:149)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:149)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1078)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapInReadActionAndIndicator$1(ApplierCompleter.java:92)
	at com.intellij.concurrency.ApplierCompleter.wrapInReadActionAndIndicator(ApplierCompleter.java:101)
	at com.intellij.concurrency.ApplierCompleter.lambda$compute$0(ApplierCompleter.java:83)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:174)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:183)
	at com.intellij.concurrency.ApplierCompleter.compute(ApplierCompleter.java:83)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool.awaitJoin(ForkJoinPool.java:1708)
	at java.base/java.util.concurrent.ForkJoinTask.doJoin(ForkJoinTask.java:397)
	at java.base/java.util.concurrent.ForkJoinTask.get(ForkJoinTask.java:1004)
	at org.rust.stdext.CompletableFutureKt.getWithRethrow(CompletableFuture.kt:18)
	at org.rust.lang.core.resolve2.DefMapsBuilderKt.invokeOnPoolThread(DefMapsBuilder.kt:169)
	at org.rust.lang.core.resolve2.DefMapsBuilderKt.access$invokeOnPoolThread(DefMapsBuilder.kt:1)
	at org.rust.lang.core.resolve2.DefMapsBuilder.build(DefMapsBuilder.kt:55)
	at org.rust.lang.core.resolve2.DefMapUpdater.doRun(FacadeUpdateDefMap.kt:186)
	at org.rust.lang.core.resolve2.DefMapUpdater.runWithStrongReferencesToDefMapHolders(FacadeUpdateDefMap.kt:164)
	at org.rust.lang.core.resolve2.DefMapUpdater.access$runWithStrongReferencesToDefMapHolders(FacadeUpdateDefMap.kt:122)
	at org.rust.lang.core.resolve2.DefMapUpdater$run$time$1$1.invoke(FacadeUpdateDefMap.kt:149)
	at org.rust.lang.core.resolve2.DefMapUpdater$run$time$1$1.invoke(FacadeUpdateDefMap.kt:148)
	at org.rust.openapiext.UtilsKt.executeUnderProgress$lambda-13(utils.kt:316)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:654)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
	at org.rust.openapiext.UtilsKt.executeUnderProgress(utils.kt:316)
	at org.rust.lang.core.resolve2.DefMapUpdater.run(FacadeUpdateDefMap.kt:148)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt:52)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt:44)
	at org.rust.stdext.ConcurrencyKt.withLockAndCheckingCancelled$lambda-0(Concurrency.kt:114)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.computeWithLockAndCheckingCanceled(ProgressIndicatorUtils.java:339)
	at org.rust.stdext.ConcurrencyKt.withLockAndCheckingCancelled(Concurrency.kt:114)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.getOrUpdateIfNeeded(FacadeUpdateDefMap.kt:44)
	at org.rust.lang.core.resolve2.FacadeResolveKt.findModDataFor(FacadeResolve.kt:663)
	at org.rust.lang.core.psi.RsFile.doGetCachedData(RsFile.kt:103)
	at org.rust.lang.core.psi.RsFile._get_cachedData_$lambda-1$lambda-0(RsFile.kt:93)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:74)
	at org.rust.openapiext.UtilsKt.recursionGuard$default(utils.kt:73)
	at org.rust.lang.core.psi.RsFile._get_cachedData_$lambda-1(RsFile.kt:93)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at org.rust.lang.core.psi.RsFile.getCachedData(RsFile.kt:92)
	at org.rust.lang.core.psi.RsFile.isDeeplyEnabledByCfg(RsFile.kt:78)
	at org.rust.lang.core.psi.RsFileKt.isValidProjectMember(RsFile.kt:311)
	at org.rust.lang.core.resolve.RsCachedImplItem.<init>(RsCachedImplItem.kt:29)
	at org.rust.lang.core.psi.ext.RsImplItemImplMixin.cachedImplItem$lambda-3(RsImplItem.kt:82)
	at com.intellij.util.CachedValueImpl.doCompute(CachedValueImpl.java:22)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.util.CachedValueImpl.getValue(CachedValueImpl.java:33)
	at org.rust.lang.core.resolve.RsCachedImplItem$Companion.forImpl(RsCachedImplItem.kt:57)
	at org.rust.lang.core.resolve.indexes.RsImplIndex$Companion.findPotentialImpls(RsImplIndex.kt:50)
	at org.rust.lang.core.resolve.ImplLookup.findExplicitImplsWithoutAliases(ImplLookup.kt:492)
	at org.rust.lang.core.resolve.ImplLookup.access$findExplicitImplsWithoutAliases(ImplLookup.kt:247)
	at org.rust.lang.core.resolve.ImplLookup$findExplicitImpls$1.invoke(ImplLookup.kt:487)
	at org.rust.lang.core.resolve.ImplLookup$findExplicitImpls$1.invoke(ImplLookup.kt:486)
	at org.rust.lang.core.resolve.ImplLookup.processTyFingerprintsWithAliases(ImplLookup.kt:521)
	at org.rust.lang.core.resolve.ImplLookup.findExplicitImpls(ImplLookup.kt:486)
	at org.rust.lang.core.resolve.ImplLookup.rawFindImplsAndTraits(ImplLookup.kt:343)
	at org.rust.lang.core.resolve.ImplLookup.access$rawFindImplsAndTraits(ImplLookup.kt:247)
	at org.rust.lang.core.resolve.ImplLookup$findImplsAndTraits$cached$1.invoke(ImplLookup.kt:308)
	at org.rust.lang.core.resolve.ImplLookup$findImplsAndTraits$cached$1.invoke(ImplLookup.kt:308)
	at org.rust.stdext.Cache$Companion$fromConcurrentMap$1.getOrPut(Cache.kt:37)
	at org.rust.lang.core.resolve.ImplLookup.findImplsAndTraits(ImplLookup.kt:308)
	at org.rust.lang.core.resolve.NameResolutionKt.processAssociatedItems(NameResolution.kt:1376)
	at org.rust.lang.core.resolve.NameResolutionKt.processAssociatedItemsWithSelfSubst(NameResolution.kt:1423)
	at org.rust.lang.core.resolve.NameResolutionKt.processTypeQualifiedPathResolveVariants(NameResolution.kt:630)
	at org.rust.lang.core.resolve.NameResolutionKt.processQualifiedPathResolveVariants(NameResolution.kt:488)
	at org.rust.lang.core.resolve.NameResolutionKt.processPathResolveVariants(NameResolution.kt:348)
	at org.rust.lang.core.resolve.ref.RsPathReferenceImplKt$resolvePathRaw$1.invoke(RsPathReferenceImpl.kt:158)
	at org.rust.lang.core.resolve.ref.RsPathReferenceImplKt$resolvePathRaw$1.invoke(RsPathReferenceImpl.kt:157)
	at org.rust.lang.core.resolve.ProcessorsKt.collectResolveVariantsAsScopeEntries(Processors.kt:155)
	at org.rust.lang.core.resolve.ref.RsPathReferenceImplKt.resolvePathRaw(RsPathReferenceImpl.kt:157)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferPathExprType(TypeInferenceWalker.kt:331)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:165)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType$default(TypeInferenceWalker.kt:154)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferCallExprType(TypeInferenceWalker.kt:598)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:171)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.processStatement(TypeInferenceWalker.kt:137)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:108)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:101)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferFnBody(TypeInferenceWalker.kt:96)
	at org.rust.lang.core.types.infer.RsInferenceContext.infer(TypeInference.kt:175)
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn$lambda-0(TypeInference.kt:34)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:74)
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn(TypeInference.kt:34)
	at org.rust.lang.core.types.ExtensionsKt._get_inference_$lambda-0(Extensions.kt:75)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:74)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:81)
	at org.rust.lang.core.types.ExtensionsKt.getType(Extensions.kt:93)
	at org.rust.lang.core.dfa.ControlFlowGraphKt.markNeverTypeAsExit(ControlFlowGraph.kt:357)
	at org.rust.lang.core.dfa.ControlFlowGraphKt.access$markNeverTypeAsExit(ControlFlowGraph.kt:1)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitCallExpr(ControlFlowGraph.kt:282)
	at org.rust.lang.core.psi.impl.RsCallExprImpl.accept(RsCallExprImpl.java:27)
	at org.rust.lang.core.psi.impl.RsCallExprImpl.accept(RsCallExprImpl.java:32)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitElement(ControlFlowGraph.kt:247)
	at org.rust.lang.core.psi.RsVisitor.visitValueArgumentList(RsVisitor.java:780)
	at org.rust.lang.core.psi.impl.RsValueArgumentListImpl.accept(RsValueArgumentListImpl.java:21)
	at org.rust.lang.core.psi.impl.RsValueArgumentListImpl.accept(RsValueArgumentListImpl.java:26)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitExpr(ControlFlowGraph.kt:319)
	at org.rust.lang.core.psi.RsVisitor.visitCallExpr(RsVisitor.java:145)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitCallExpr(ControlFlowGraph.kt:281)
	at org.rust.lang.core.psi.impl.RsCallExprImpl.accept(RsCallExprImpl.java:27)
	at org.rust.lang.core.psi.impl.RsCallExprImpl.accept(RsCallExprImpl.java:32)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitElement(ControlFlowGraph.kt:247)
	at org.rust.lang.core.psi.RsVisitor.visitExpandedElement(RsVisitor.java:836)
	at org.rust.lang.core.psi.RsVisitor.visitStmt(RsVisitor.java:635)
	at org.rust.lang.core.psi.RsVisitor.visitLetDecl(RsVisitor.java:330)
	at org.rust.lang.core.psi.impl.RsLetDeclImpl.accept(RsLetDeclImpl.java:21)
	at org.rust.lang.core.psi.impl.RsLetDeclImpl.accept(RsLetDeclImpl.java:26)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitElement(ControlFlowGraph.kt:247)
	at org.rust.lang.core.psi.RsVisitor.visitItemsOwner(RsVisitor.java:864)
	at org.rust.lang.core.psi.RsVisitor.visitBlock(RsVisitor.java:121)
	at org.rust.lang.core.psi.impl.RsBlockImpl.accept(RsBlockImpl.java:27)
	at org.rust.lang.core.psi.impl.RsBlockImpl.accept(RsBlockImpl.java:32)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPoint$Companion.process(ControlFlowGraph.kt:235)
	at org.rust.ide.inspections.RsExtraSemicolonInspectionKt.inspect(RsExtraSemicolonInspection.kt:38)
	at org.rust.ide.inspections.RsExtraSemicolonInspectionKt.access$inspect(RsExtraSemicolonInspection.kt:1)
	at org.rust.ide.inspections.RsExtraSemicolonInspection$buildVisitor$1.visitFunction(RsExtraSemicolonInspection.kt:30)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:27)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:32)
	at com.intellij.codeInspection.InspectionEngine.acceptElements(InspectionEngine.java:64)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$7(LocalInspectionsPass.java:353)
	at com.intellij.util.AstLoadingFilter.lambda$toComputable$2(AstLoadingFilter.java:172)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:130)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:119)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:109)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$10(LocalInspectionsPass.java:353)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:136)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:149)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:149)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1078)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapInReadActionAndIndicator$1(ApplierCompleter.java:92)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:705)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:647)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
	at com.intellij.concurrency.ApplierCompleter.wrapInReadActionAndIndicator(ApplierCompleter.java:104)
	at com.intellij.concurrency.ApplierCompleter.lambda$compute$0(ApplierCompleter.java:83)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:174)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:183)
	at com.intellij.concurrency.ApplierCompleter.compute(ApplierCompleter.java:83)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
ERROR: com.intellij.testFramework.TestLogger$TestLoggerAssertionError: Can not run nested type inference
java.lang.RuntimeException: com.intellij.testFramework.TestLogger$TestLoggerAssertionError: Can not run nested type inference
	at com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl.lambda$waitInOtherThread$5(DaemonCodeAnalyzerImpl.java:434)
	at com.intellij.openapi.application.impl.ApplicationImpl$2.call(ApplicationImpl.java:296)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.intellij.testFramework.TestLogger$TestLoggerAssertionError: Can not run nested type inference
	at com.intellij.testFramework.TestLogger.error(TestLogger.java:45)
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:208)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:426)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1078)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:407)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:705)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:647)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:406)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:382)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:174)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:183)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:380)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:188)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.lang.IllegalStateException: Can not run nested type inference
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn(TypeInference.kt:35)
	at org.rust.lang.core.types.ExtensionsKt._get_inference_$lambda-0(Extensions.kt:75)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:230)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:74)
	at org.rust.ide.inspections.RsDiagnosticBasedInspection.collectDiagnostics(RsDiagnosticBasedInspection.kt:25)
	at org.rust.ide.inspections.RsDiagnosticBasedInspection.access$collectDiagnostics(RsDiagnosticBasedInspection.kt:13)
	at org.rust.ide.inspections.RsDiagnosticBasedInspection$buildVisitor$1.visitFunction(RsDiagnosticBasedInspection.kt:15)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:27)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:32)
	at com.intellij.codeInspection.InspectionEngine.acceptElements(InspectionEngine.java:64)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$7(LocalInspectionsPass.java:353)
	at com.intellij.util.AstLoadingFilter.lambda$toComputable$2(AstLoadingFilter.java:172)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:125)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:119)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:109)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$10(LocalInspectionsPass.java:353)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:136)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:149)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:149)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1078)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapInReadActionAndIndicator$1(ApplierCompleter.java:92)
	at com.intellij.concurrency.ApplierCompleter.wrapInReadActionAndIndicator(ApplierCompleter.java:101)
	at com.intellij.concurrency.ApplierCompleter.lambda$compute$0(ApplierCompleter.java:83)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:174)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:183)
	at com.intellij.concurrency.ApplierCompleter.compute(ApplierCompleter.java:83)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool.awaitJoin(ForkJoinPool.java:1708)
	at java.base/java.util.concurrent.ForkJoinTask.doJoin(ForkJoinTask.java:397)
	at java.base/java.util.concurrent.ForkJoinTask.get(ForkJoinTask.java:1004)
	at org.rust.stdext.CompletableFutureKt.getWithRethrow(CompletableFuture.kt:18)
	at org.rust.lang.core.resolve2.DefMapsBuilderKt.invokeOnPoolThread(DefMapsBuilder.kt:169)
	at org.rust.lang.core.resolve2.DefMapsBuilderKt.access$invokeOnPoolThread(DefMapsBuilder.kt:1)
	at org.rust.lang.core.resolve2.DefMapsBuilder.build(DefMapsBuilder.kt:55)
	at org.rust.lang.core.resolve2.DefMapUpdater.doRun(FacadeUpdateDefMap.kt:186)
	at org.rust.lang.core.resolve2.DefMapUpdater.runWithStrongReferencesToDefMapHolders(FacadeUpdateDefMap.kt:164)
	at org.rust.lang.core.resolve2.DefMapUpdater.access$runWithStrongReferencesToDefMapHolders(FacadeUpdateDefMap.kt:122)
	at org.rust.lang.core.resolve2.DefMapUpdater$run$time$1$1.invoke(FacadeUpdateDefMap.kt:149)
	at org.rust.lang.core.resolve2.DefMapUpdater$run$time$1$1.invoke(FacadeUpdateDefMap.kt:148)
	at org.rust.openapiext.UtilsKt.executeUnderProgress$lambda-13(utils.kt:316)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:654)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
	at org.rust.openapiext.UtilsKt.executeUnderProgress(utils.kt:316)
	at org.rust.lang.core.resolve2.DefMapUpdater.run(FacadeUpdateDefMap.kt:148)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt:52)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt:44)
	at org.rust.stdext.ConcurrencyKt.withLockAndCheckingCancelled$lambda-0(Concurrency.kt:114)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.computeWithLockAndCheckingCanceled(ProgressIndicatorUtils.java:339)
	at org.rust.stdext.ConcurrencyKt.withLockAndCheckingCancelled(Concurrency.kt:114)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.getOrUpdateIfNeeded(FacadeUpdateDefMap.kt:44)
	at org.rust.lang.core.resolve2.FacadeResolveKt.findModDataFor(FacadeResolve.kt:663)
	at org.rust.lang.core.psi.RsFile.doGetCachedData(RsFile.kt:103)
	at org.rust.lang.core.psi.RsFile._get_cachedData_$lambda-1$lambda-0(RsFile.kt:93)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:74)
	at org.rust.openapiext.UtilsKt.recursionGuard$default(utils.kt:73)
	at org.rust.lang.core.psi.RsFile._get_cachedData_$lambda-1(RsFile.kt:93)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at org.rust.lang.core.psi.RsFile.getCachedData(RsFile.kt:92)
	at org.rust.lang.core.psi.RsFile.isDeeplyEnabledByCfg(RsFile.kt:78)
	at org.rust.lang.core.psi.RsFileKt.isValidProjectMember(RsFile.kt:311)
	at org.rust.lang.core.resolve.RsCachedImplItem.<init>(RsCachedImplItem.kt:29)
	at org.rust.lang.core.psi.ext.RsImplItemImplMixin.cachedImplItem$lambda-3(RsImplItem.kt:82)
	at com.intellij.util.CachedValueImpl.doCompute(CachedValueImpl.java:22)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.util.CachedValueImpl.getValue(CachedValueImpl.java:33)
	at org.rust.lang.core.resolve.RsCachedImplItem$Companion.forImpl(RsCachedImplItem.kt:57)
	at org.rust.lang.core.resolve.indexes.RsImplIndex$Companion.findPotentialImpls(RsImplIndex.kt:50)
	at org.rust.lang.core.resolve.ImplLookup.findExplicitImplsWithoutAliases(ImplLookup.kt:492)
	at org.rust.lang.core.resolve.ImplLookup.access$findExplicitImplsWithoutAliases(ImplLookup.kt:247)
	at org.rust.lang.core.resolve.ImplLookup$findExplicitImpls$1.invoke(ImplLookup.kt:487)
	at org.rust.lang.core.resolve.ImplLookup$findExplicitImpls$1.invoke(ImplLookup.kt:486)
	at org.rust.lang.core.resolve.ImplLookup.processTyFingerprintsWithAliases(ImplLookup.kt:521)
	at org.rust.lang.core.resolve.ImplLookup.findExplicitImpls(ImplLookup.kt:486)
	at org.rust.lang.core.resolve.ImplLookup.rawFindImplsAndTraits(ImplLookup.kt:343)
	at org.rust.lang.core.resolve.ImplLookup.access$rawFindImplsAndTraits(ImplLookup.kt:247)
	at org.rust.lang.core.resolve.ImplLookup$findImplsAndTraits$cached$1.invoke(ImplLookup.kt:308)
	at org.rust.lang.core.resolve.ImplLookup$findImplsAndTraits$cached$1.invoke(ImplLookup.kt:308)
	at org.rust.stdext.Cache$Companion$fromConcurrentMap$1.getOrPut(Cache.kt:37)
	at org.rust.lang.core.resolve.ImplLookup.findImplsAndTraits(ImplLookup.kt:308)
	at org.rust.lang.core.resolve.NameResolutionKt.processAssociatedItems(NameResolution.kt:1376)
	at org.rust.lang.core.resolve.NameResolutionKt.processAssociatedItemsWithSelfSubst(NameResolution.kt:1423)
	at org.rust.lang.core.resolve.NameResolutionKt.processTypeQualifiedPathResolveVariants(NameResolution.kt:630)
	at org.rust.lang.core.resolve.NameResolutionKt.processQualifiedPathResolveVariants(NameResolution.kt:488)
	at org.rust.lang.core.resolve.NameResolutionKt.processPathResolveVariants(NameResolution.kt:348)
	at org.rust.lang.core.resolve.ref.RsPathReferenceImplKt$resolvePathRaw$1.invoke(RsPathReferenceImpl.kt:158)
	at org.rust.lang.core.resolve.ref.RsPathReferenceImplKt$resolvePathRaw$1.invoke(RsPathReferenceImpl.kt:157)
	at org.rust.lang.core.resolve.ProcessorsKt.collectResolveVariantsAsScopeEntries(Processors.kt:155)
	at org.rust.lang.core.resolve.ref.RsPathReferenceImplKt.resolvePathRaw(RsPathReferenceImpl.kt:157)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferPathExprType(TypeInferenceWalker.kt:331)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:165)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType$default(TypeInferenceWalker.kt:154)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferCallExprType(TypeInferenceWalker.kt:598)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:171)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.processStatement(TypeInferenceWalker.kt:137)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:108)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:101)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferFnBody(TypeInferenceWalker.kt:96)
	at org.rust.lang.core.types.infer.RsInferenceContext.infer(TypeInference.kt:175)
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn$lambda-0(TypeInference.kt:34)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:74)
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn(TypeInference.kt:34)
	at org.rust.lang.core.types.ExtensionsKt._get_inference_$lambda-0(Extensions.kt:75)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:74)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:81)
	at org.rust.lang.core.types.ExtensionsKt.getType(Extensions.kt:93)
	at org.rust.lang.core.dfa.ControlFlowGraphKt.markNeverTypeAsExit(ControlFlowGraph.kt:357)
	at org.rust.lang.core.dfa.ControlFlowGraphKt.access$markNeverTypeAsExit(ControlFlowGraph.kt:1)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitCallExpr(ControlFlowGraph.kt:282)
	at org.rust.lang.core.psi.impl.RsCallExprImpl.accept(RsCallExprImpl.java:27)
	at org.rust.lang.core.psi.impl.RsCallExprImpl.accept(RsCallExprImpl.java:32)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitElement(ControlFlowGraph.kt:247)
	at org.rust.lang.core.psi.RsVisitor.visitValueArgumentList(RsVisitor.java:780)
	at org.rust.lang.core.psi.impl.RsValueArgumentListImpl.accept(RsValueArgumentListImpl.java:21)
	at org.rust.lang.core.psi.impl.RsValueArgumentListImpl.accept(RsValueArgumentListImpl.java:26)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitExpr(ControlFlowGraph.kt:319)
	at org.rust.lang.core.psi.RsVisitor.visitCallExpr(RsVisitor.java:145)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitCallExpr(ControlFlowGraph.kt:281)
	at org.rust.lang.core.psi.impl.RsCallExprImpl.accept(RsCallExprImpl.java:27)
	at org.rust.lang.core.psi.impl.RsCallExprImpl.accept(RsCallExprImpl.java:32)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitElement(ControlFlowGraph.kt:247)
	at org.rust.lang.core.psi.RsVisitor.visitExpandedElement(RsVisitor.java:836)
	at org.rust.lang.core.psi.RsVisitor.visitStmt(RsVisitor.java:635)
	at org.rust.lang.core.psi.RsVisitor.visitLetDecl(RsVisitor.java:330)
	at org.rust.lang.core.psi.impl.RsLetDeclImpl.accept(RsLetDeclImpl.java:21)
	at org.rust.lang.core.psi.impl.RsLetDeclImpl.accept(RsLetDeclImpl.java:26)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPointVisitor.visitElement(ControlFlowGraph.kt:247)
	at org.rust.lang.core.psi.RsVisitor.visitItemsOwner(RsVisitor.java:864)
	at org.rust.lang.core.psi.RsVisitor.visitBlock(RsVisitor.java:121)
	at org.rust.lang.core.psi.impl.RsBlockImpl.accept(RsBlockImpl.java:27)
	at org.rust.lang.core.psi.impl.RsBlockImpl.accept(RsBlockImpl.java:32)
	at com.intellij.psi.impl.PsiElementBase.acceptChildren(PsiElementBase.java:69)
	at org.rust.lang.core.dfa.ExitPoint$Companion.process(ControlFlowGraph.kt:235)
	at org.rust.ide.inspections.RsExtraSemicolonInspectionKt.inspect(RsExtraSemicolonInspection.kt:38)
	at org.rust.ide.inspections.RsExtraSemicolonInspectionKt.access$inspect(RsExtraSemicolonInspection.kt:1)
	at org.rust.ide.inspections.RsExtraSemicolonInspection$buildVisitor$1.visitFunction(RsExtraSemicolonInspection.kt:30)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:27)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:32)
	at com.intellij.codeInspection.InspectionEngine.acceptElements(InspectionEngine.java:64)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$7(LocalInspectionsPass.java:353)
	at com.intellij.util.AstLoadingFilter.lambda$toComputable$2(AstLoadingFilter.java:172)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:130)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:119)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:109)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$10(LocalInspectionsPass.java:353)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:136)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:149)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:149)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1078)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapInReadActionAndIndicator$1(ApplierCompleter.java:92)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:705)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:647)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
	at com.intellij.concurrency.ApplierCompleter.wrapInReadActionAndIndicator(ApplierCompleter.java:104)
	at com.intellij.concurrency.ApplierCompleter.lambda$compute$0(ApplierCompleter.java:83)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:174)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:183)
	at com.intellij.concurrency.ApplierCompleter.compute(ApplierCompleter.java:83)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
	... 5 more
```

</details>

changelog: Temporary disable parallel macro expansion because it may lead to exceptions