### PR TITLE
Use crate search scope for non-library crates

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.search.GlobalSearchScopes
 import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.SearchScope
 import com.intellij.psi.util.PsiTreeUtil
+import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.macros.findMacroCallExpandedFrom
 import org.rust.lang.core.macros.isExpandedFromIncludeMacro
 import org.rust.lang.core.psi.ext.*
@@ -98,7 +99,11 @@ object RsPsiImplUtil {
         restrictedVis: RsVisibility
     ): SearchScope? {
         val restrictedMod = when (val visibility = restrictedVis.intersect(element.visibility)) {
-            RsVisibility.Public -> return null
+            RsVisibility.Public -> {
+                val crate = containingMod.containingCrate ?: return null
+                if (crate.kind is CargoWorkspace.TargetKind.Lib) return null
+                crate.rootMod ?: return null
+            }
             RsVisibility.Private -> containingMod
             is RsVisibility.Restricted -> visibility.inMod
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
@@ -95,4 +95,47 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
         macro_rules! bar { () => {}; }
                    //X
     """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve to inline mod`() = stubOnlyResolve("""
+    //- lib.rs
+        /// ```
+        /// mod inner {
+        ///     pub fn func() {}
+        /// }
+        /// use inner::func;
+        /// fn main() {
+        ///     func();
+        /// } //^ ...lib.rs
+        /// ```
+        fn foo() {}
+    """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve in inline mod`() = stubOnlyResolve("""
+    //- lib.rs
+        /// ```
+        /// mod inner {
+        ///     fn func() {}
+        ///     fn main() {
+        ///         func();
+        ///     } //^ ...lib.rs
+        /// }
+        /// ```
+        fn foo() {}
+    """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve to super mod`() = stubOnlyResolve("""
+    //- lib.rs
+        /// ```
+        /// fn func() {}
+        /// mod inner {
+        ///     fn main() {
+        ///         super::func();
+        ///     }        //^ ...lib.rs
+        /// }
+        /// ```
+        fn foo() {}
+    """)
 }


### PR DESCRIPTION
We have function `RsPsiImplUtil#getDeclarationUseScope(RsVisible)` which returns scope in which we should find usages of passed element. This function returns `null` for public items, which roughly means that usages can be anywhere. But items of binary and other non-library crates can be used only within crates.

changelog: Slightly optimize find usages for public items in binary crates