### PR TITLE
REF: Always use `Self::` when extracting static method

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
@@ -25,7 +25,6 @@ import org.rust.ide.utils.import.RsImportHelper.importTypeReferencesFromTys
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.RsCachedImplItem
-import org.rust.lang.core.types.type
 
 class RsExtractFunctionHandler : RefactoringActionHandler {
     override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
@@ -147,12 +146,8 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
         stmt += if (firstParameter != null && firstParameter.isSelf) {
             "self.${config.name}(${config.argumentsText})"
         } else {
-            val type = when (val owner = config.function.owner) {
-                is RsAbstractableOwner.Impl -> {
-                    owner.impl.typeReference?.text?.let {
-                        if (owner.impl.typeParameterList == null) it else "<$it>"
-                    }
-                }
+            val type = when (config.function.owner) {
+                is RsAbstractableOwner.Impl,
                 is RsAbstractableOwner.Trait -> "Self"
                 else -> null
             }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -293,7 +293,7 @@ class RsExtractFunctionTest : RsTestBase() {
         struct S;
         impl S {
             fn foo() {
-                S::bar();
+                Self::bar();
             }
 
             fn bar() {
@@ -314,7 +314,7 @@ class RsExtractFunctionTest : RsTestBase() {
         struct S<T>(T);
         impl<T> S<T> {
             fn foo() {
-                <S<T>>::bar();
+                Self::bar();
             }
 
             fn bar() {
@@ -465,7 +465,7 @@ class RsExtractFunctionTest : RsTestBase() {
         impl S {
             fn foo(self) {
                 let test = 10i32;
-                S::bar(test);
+                Self::bar(test);
             }
 
             fn bar(test: i32) {
@@ -487,7 +487,7 @@ class RsExtractFunctionTest : RsTestBase() {
         struct S;
         impl S {
             fn foo() {
-                S::bar();
+                Self::bar();
             }
 
             pub fn bar() {
@@ -519,7 +519,7 @@ class RsExtractFunctionTest : RsTestBase() {
 
         impl Bar for S {
             fn foo() {
-                S::bar();
+                Self::bar();
             }
         }
 
@@ -556,7 +556,7 @@ class RsExtractFunctionTest : RsTestBase() {
 
         impl Bar for S {
             fn foo() {
-                S::bar();
+                Self::bar();
             }
         }
 
@@ -1709,7 +1709,7 @@ class RsExtractFunctionTest : RsTestBase() {
 
         impl<T, E> Trait for Result<T, E> where (T, E): Trait2 {
             fn fn_bar() {
-                <Result<T, E>>::bar();
+                Self::bar();
             }
         }
 
@@ -1743,7 +1743,7 @@ class RsExtractFunctionTest : RsTestBase() {
 
         impl<T> Trait for Foo<T> where T: Trait2 {
             fn foo(&self) {
-                <Foo<T>>::bar();
+                Self::bar();
             }
         }
 
@@ -1775,7 +1775,7 @@ class RsExtractFunctionTest : RsTestBase() {
 
         impl<'a, T> Trait for Foo<'a, T> where T: Trait2<'a> {
             fn foo(&self) {
-                <Foo<'a, T>>::bar();
+                Self::bar();
             }
         }
 


### PR DESCRIPTION
This will create a slightly more concise method call.

Requested by @krojew in https://github.com/intellij-rust/intellij-rust/issues/7232
Part of https://github.com/intellij-rust/intellij-rust/issues/2183

changelog: Use `Self::` instead of fully qualified name for method call when extracting static method
