### PR TITLE
REF: handle name collisions in RsIntroduceConstantHandler

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
@@ -20,7 +20,7 @@ import org.rust.lang.core.psi.RsElementTypes.RPAREN
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.childrenWithLeaves
 import org.rust.lang.core.psi.ext.elementType
-import org.rust.lang.core.psi.ext.getVisibleBindings
+import org.rust.lang.core.psi.ext.getLocalVariableVisibleBindings
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.ty.Ty
@@ -47,7 +47,7 @@ class FillFunctionArgumentsFix(element: PsiElement) : LocalQuickFixAndIntentionA
 
         val factory = RsPsiFactory(project)
         val builder = RsDefaultValueBuilder(parent.knownItems, parent.containingMod, factory)
-        val bindings = parent.getVisibleBindings()
+        val bindings = parent.getLocalVariableVisibleBindings()
 
         // We are currently looking for an argument for this parameter
         var parameterIndex = 0

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/InitializeWithDefaultValueFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/InitializeWithDefaultValueFix.kt
@@ -14,7 +14,7 @@ import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestorOrSelf
-import org.rust.lang.core.psi.ext.getVisibleBindings
+import org.rust.lang.core.psi.ext.getLocalVariableVisibleBindings
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.declaration
 import org.rust.lang.core.types.type
@@ -31,7 +31,7 @@ class InitializeWithDefaultValueFix(element: RsElement) : LocalQuickFixAndIntent
         val semicolon = declaration.semicolon ?: return
         val psiFactory = RsPsiFactory(project)
         val initExpr = RsDefaultValueBuilder(declaration.knownItems, declaration.containingMod, psiFactory, true)
-            .buildFor(patBinding.type, (startElement as RsElement).getVisibleBindings())
+            .buildFor(patBinding.type, (startElement as RsElement).getLocalVariableVisibleBindings())
 
         if (declaration.eq == null) {
             declaration.addBefore(psiFactory.createEq(), semicolon)

--- a/src/main/kotlin/org/rust/ide/intentions/DestructureIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/DestructureIntention.kt
@@ -21,9 +21,6 @@ import org.rust.ide.refactoring.findBinding
 import org.rust.ide.utils.import.RsImportHelper.importTypeReferencesFromTy
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.resolve.VALUES
-import org.rust.lang.core.resolve.createProcessor
-import org.rust.lang.core.resolve.processNestedScopesUpwards
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.ty.TyTuple
 import org.rust.lang.core.types.type
@@ -256,16 +253,4 @@ private sealed class ReplaceContext {
         val fieldNames: List<String>,
         val structName: String? = null
     ) : ReplaceContext()
-}
-
-private fun RsElement.getAllVisibleBindings(): Set<String> {
-    val bindings = mutableSetOf<String>()
-    val processor = createProcessor { entry ->
-        val element = entry.element as? RsNameIdentifierOwner ?: return@createProcessor false
-        val name = element.name ?: return@createProcessor false
-        bindings.add(name)
-        false
-    }
-    processNestedScopesUpwards(this, VALUES, processor)
-    return bindings
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsNameSuggestions.kt
@@ -66,7 +66,7 @@ fun Ty.suggestedNames(context: PsiElement, additionalNamesInScope: Set<String> =
     return finalizeNameSelection(context, names, additionalNamesInScope)
 }
 
-private fun freshenName(name: String, usedNames: Set<String>): String {
+fun freshenName(name: String, usedNames: Set<String>): String {
     var newName = name
     var i = 1
     while (i < FRESHEN_LIMIT && usedNames.contains(newName)) {

--- a/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
+++ b/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
@@ -30,7 +30,7 @@ fun addMissingFieldsToStructLiteral(
         body,
         declaration.fields,
         fieldsToAdd,
-        structLiteral.getVisibleBindings()
+        structLiteral.getLocalVariableVisibleBindings()
     )
     editor?.buildAndRunTemplate(body, addedFields.mapNotNull { it.expr?.createSmartPointer() })
 }


### PR DESCRIPTION
This PR adds basic handling of name collisions in `RsIntroduceConstantHandler`.

@dima74 Is there a better way to get all bindings/names at a given place?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7957

changelog: Handle name collisions in Introduce Constant refactoring.