### PR TITLE
GRD: force headless mode for `buildEventsScheme` task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -344,6 +344,8 @@ project(":plugin") {
     task<RunIdeTask>("buildEventsScheme") {
         dependsOn(tasks.prepareSandbox)
         args("buildEventsScheme", "--outputFile=${buildDir.resolve("eventScheme.json").absolutePath}", "--pluginId=org.rust.lang")
+        // Force headless mode to be able to run command on CI
+        systemProperty("java.awt.headless", "true")
 
         // BACKCOMPAT: 2021.2
         enabled = platformVersion >= 213


### PR DESCRIPTION
Otherwise, it fails on CI