### PR TITLE
RES: Use new resolve inside detached files

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
@@ -119,7 +119,7 @@ private fun ImportContext2.convertToCandidates(itemsPaths: List<ItemUsePath>): L
         .mapValues { (item, paths) -> filterForSingleItem(paths, item) }
         .flatMap { (item, paths) ->
             val itemsPsi = item
-                .toPsi(rootDefMap, project)
+                .toPsi(rootInfo)
                 .filterIsInstance<RsQualifiedNamedElement>()
                 .let { list ->
                     if (pathInfo != null) {
@@ -314,8 +314,8 @@ private data class ItemWithNamespace(val path: ModPath, val isModOrEnum: Boolean
     override fun toString(): String = "$path ($namespace)"
 }
 
-private fun ItemWithNamespace.toPsi(defMap: CrateDefMap, project: Project): List<RsNamedElement> =
-    VisItem(path, Visibility.Public, isModOrEnum).toPsi(defMap, project, namespace)
+private fun ItemWithNamespace.toPsi(info: RsModInfo): List<RsNamedElement> =
+    VisItem(path, Visibility.Public, isModOrEnum).toPsi(info, namespace)
 
 private fun filterForSingleItem(paths: List<ItemUsePath>, item: ItemWithNamespace): List<ItemUsePath> =
     filterForSingleCrate(paths, item)

--- a/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
@@ -52,15 +52,17 @@ data class ImportContext private constructor(
 }
 
 class ImportContext2 private constructor(
-    val project: Project,
+    /** Info of mod in which auto-import or completion is called */
+    val rootInfo: RsModInfoBase.RsModInfo,
     /** Mod in which auto-import or completion is called */
     val rootMod: RsMod,
-    val rootModData: ModData,
-    /** DefMap of [rootModData] */
-    val rootDefMap: CrateDefMap,
 
     val pathInfo: PathInfo?,
 ) {
+    val project: Project get() = rootInfo.project
+    val rootModData: ModData get() = rootInfo.modData
+    val rootDefMap: CrateDefMap get() = rootInfo.defMap
+
     companion object {
         fun from(path: RsPath, isCompletion: Boolean): ImportContext2? =
             from(path, PathInfo.from(path, isCompletion))
@@ -68,13 +70,7 @@ class ImportContext2 private constructor(
         fun from(context: RsElement, pathInfo: PathInfo? = null): ImportContext2? {
             val rootMod = context.containingMod
             val info = getModInfo(rootMod) as? RsModInfoBase.RsModInfo ?: return null
-            return ImportContext2(
-                project = info.project,
-                rootMod = rootMod,
-                rootModData = info.modData,
-                rootDefMap = info.defMap,
-                pathInfo = pathInfo,
-            )
+            return ImportContext2(info, rootMod, pathInfo)
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
@@ -30,8 +30,8 @@ interface Crate : UserDataHolderEx {
     val id: CratePersistentId?
     val edition: CargoWorkspace.Edition
 
-    val cargoProject: CargoProject
-    val cargoWorkspace: CargoWorkspace
+    val cargoProject: CargoProject?
+    val cargoWorkspace: CargoWorkspace?
     val cargoTarget: CargoWorkspace.Target?
     val kind: CargoWorkspace.TargetKind
     val origin: PackageOrigin
@@ -90,8 +90,7 @@ interface Crate : UserDataHolderEx {
      */
     val normName: String
 
-    @JvmDefault
-    val project: Project get() = cargoProject.project
+    val project: Project
 
     /**
      * A procedural macro compiler artifact (compiled binary).

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.crate.impl
 
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.UserDataHolderBase
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.CfgOptions
@@ -59,7 +60,8 @@ class CargoBasedCrate(
     override val env: Map<String, String> get() = cargoTarget.pkg.env
     override val outDir: VirtualFile? get() = cargoTarget.pkg.outDir
 
-    override val rootMod: RsFile? get() = rootModFile?.toPsiFile(cargoProject.project)?.rustFile
+    override val rootMod: RsFile? get() = rootModFile?.toPsiFile(project)?.rustFile
+    override val project: Project get() = cargoProject.project
 
     override val origin: PackageOrigin get() = cargoTarget.pkg.origin
     override val edition: CargoWorkspace.Edition get() = cargoTarget.edition

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/DoctestCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/DoctestCrate.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.crate.impl
 
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.UserDataHolderBase
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.CfgOptions
@@ -28,9 +29,9 @@ class DoctestCrate(
     override val reverseDependencies: List<Crate> get() = emptyList()
 
     override val id: CratePersistentId? get() = null
-    override val cargoProject: CargoProject get() = parentCrate.cargoProject
+    override val cargoProject: CargoProject? get() = parentCrate.cargoProject
     override val cargoTarget: CargoWorkspace.Target? get() = null
-    override val cargoWorkspace: CargoWorkspace get() = parentCrate.cargoWorkspace
+    override val cargoWorkspace: CargoWorkspace? get() = parentCrate.cargoWorkspace
     override val kind: CargoWorkspace.TargetKind get() = CargoWorkspace.TargetKind.Test
 
     override val cfgOptions: CfgOptions get() = CfgOptions.EMPTY
@@ -45,6 +46,7 @@ class DoctestCrate(
     override val areDoctestsEnabled: Boolean get() = false
     override val presentableName: String get() = parentCrate.presentableName + "-doctest"
     override val normName: String get() = parentCrate.normName + "_doctest"
+    override val project: Project get() = parentCrate.project
     override val procMacroArtifact: CargoWorkspaceData.ProcMacroArtifact? get() = null
 
     override fun toString(): String = "Doctest in ${parentCrate.cargoTarget?.name}"
@@ -57,7 +59,7 @@ class DoctestCrate(
                 DoctestCrate(parentCrate, doctestModule, dependencies)
             } else {
                 // A doctest located in the stdlib is depending on all stdlib crates
-                val stdCrates = parentCrate.cargoProject.project.crateGraph.topSortedCrates
+                val stdCrates = parentCrate.project.crateGraph.topSortedCrates
                     .filter { it.origin == PackageOrigin.STDLIB }
                     .map { Crate.Dependency(it.normName, it) }
                     .distinctBy { it.normName }

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/FakeDetachedCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/FakeDetachedCrate.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.crate.impl
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.UserDataHolderBase
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.CargoProject
@@ -22,7 +23,7 @@ class FakeDetachedCrate(
     override val rootMod: RsFile,
     override val id: CratePersistentId,
     override val dependencies: Collection<Crate.Dependency>,
-) : Crate {
+) : UserDataHolderBase(), Crate {
     override val flatDependencies: LinkedHashSet<Crate> = dependencies.flattenTopSortedDeps()
 
     override val reverseDependencies: List<Crate> get() = emptyList()

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/FakeDetachedCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/FakeDetachedCrate.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.crate.impl
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.CfgOptions
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspaceData
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.psi.RsFile
+
+/** Fake crate for [RsFile] outside of module tree. */
+class FakeDetachedCrate(
+    override val rootMod: RsFile,
+    override val id: CratePersistentId,
+    override val dependencies: Collection<Crate.Dependency>,
+) : Crate {
+    override val flatDependencies: LinkedHashSet<Crate> = dependencies.flattenTopSortedDeps()
+
+    override val reverseDependencies: List<Crate> get() = emptyList()
+
+    override val cargoProject: CargoProject? get() = null
+    override val cargoTarget: CargoWorkspace.Target? get() = null
+    override val cargoWorkspace: CargoWorkspace? get() = null
+    override val kind: CargoWorkspace.TargetKind get() = CargoWorkspace.TargetKind.Test
+
+    override val cfgOptions: CfgOptions get() = CfgOptions.EMPTY
+    override val features: Map<String, FeatureState> get() = emptyMap()
+    override val evaluateUnknownCfgToFalse: Boolean get() = true
+    override val env: Map<String, String> get() = emptyMap()
+    override val outDir: VirtualFile? get() = null
+
+    override val rootModFile: VirtualFile? get() = rootMod.virtualFile
+    override val origin: PackageOrigin get() = PackageOrigin.WORKSPACE
+    override val edition: CargoWorkspace.Edition get() = CargoWorkspace.Edition.values().last()
+    override val areDoctestsEnabled: Boolean get() = false
+    override val presentableName: String get() = "Fake for ${rootModFile?.path}"
+    override val normName: String get() = "__fake__"
+    override val project: Project get() = rootMod.project
+    override val procMacroArtifact: CargoWorkspaceData.ProcMacroArtifact? get() = null
+
+    override fun toString(): String = presentableName
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiElement
 import org.rust.lang.RsConstants
 import org.rust.lang.RsFileType
 import org.rust.lang.core.psi.RsFile
@@ -14,7 +15,7 @@ import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.RsModItem
 import org.rust.openapiext.findFileByMaybeRelativePath
 
-interface RsMod : RsQualifiedNamedElement, RsItemsOwner, RsVisible {
+interface RsMod : RsQualifiedNamedElement, RsItemsOwner, RsVisible, PsiElement {
     /**
      *  Returns a parent module (`super::` in paths).
      *
@@ -106,7 +107,7 @@ val RsMod.childModules: List<RsMod>
         }
 
 fun RsMod.getChildModule(name: String): RsMod? =
-    childModules.find { it.modName == name }
+    expandedItemsCached.named[name]?.filterIsInstance<RsMod>()?.singleOrNull()
 
 fun commonParentMod(mod1: RsMod, mod2: RsMod): RsMod? {
     val superMods1 = mod1.superMods.asReversed()

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1727,7 +1727,7 @@ fun findPrelude(element: RsElement): RsMod? {
 private fun findPreludeUsingNewResolve(element: RsElement): RsMod? {
     val info = getModInfo(element.containingMod) as? RsModInfo ?: return null
     val prelude = info.defMap.prelude ?: return null
-    return prelude.toRsMod(element.project).singleOrNull()
+    return prelude.toRsMod(info).singleOrNull()
 }
 
 // Implicit extern crate from stdlib

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -113,10 +113,8 @@ class CrateDefMap(
     fun getModData(mod: RsMod): ModData? {
         if (mod is RsFile) {
             val virtualFile = mod.originalFile.virtualFile ?: return null
+            if (virtualFile !is VirtualFileWithId) return null
             val fileInfo = fileInfos[virtualFile.fileId]
-            // TODO: Exception here does not fail [RsBuildDefMapTest]
-            // Note: we don't expand cfg-disabled macros (it can contain mod declaration)
-            testAssert({ fileInfo != null || !mod.isDeeplyEnabledByCfg }, { "todo" })
             return fileInfo?.modData
         }
         val parentMod = mod.`super` ?: return null
@@ -265,7 +263,7 @@ class ModData(
     val isDeeplyEnabledByCfgOuter: Boolean,
     val isEnabledByCfgInner: Boolean,
     /** id of containing file */
-    val fileId: FileId,
+    val fileId: FileId?,
     // TODO: Possible optimization - store as Array<String>
     /** Starts with :: */
     val fileRelativePath: String,
@@ -274,6 +272,8 @@ class ModData(
     val hasPathAttribute: Boolean,
     val hasMacroUse: Boolean,
     val isEnum: Boolean = false,
+    /** Normal cargo crate with physical crate root, etc */
+    val isNormalCrate: Boolean = true,
     /** Only for debug */
     val crateDescription: String,
 ) {
@@ -319,7 +319,11 @@ class ModData(
 
     lateinit var asVisItem: VisItem
 
-    var directoryContainedAllChildFiles: FileId = ownedDirectoryId ?: parent!!.directoryContainedAllChildFiles
+    var directoryContainedAllChildFiles: FileId? = if (isNormalCrate) {
+        ownedDirectoryId ?: parent!!.directoryContainedAllChildFiles
+    } else {
+        null
+    }
 
     /**
      * Means that mod declaration has path attribute or any parent inline mod
@@ -390,7 +394,7 @@ class ModData(
         val persistentFS = PersistentFS.getInstance()
         val childFile = persistentFS.findFileById(childFileId) ?: return
         val childDirectory = childFile.parent ?: return
-        val containedDirectory = persistentFS.findFileById(directoryContainedAllChildFiles) ?: return
+        val containedDirectory = persistentFS.findFileById(directoryContainedAllChildFiles ?: return) ?: return
         if (!VfsUtil.isAncestor(containedDirectory, childDirectory, false)) {
             VfsUtil.getCommonAncestor(containedDirectory, childDirectory)?.let {
                 directoryContainedAllChildFiles = it.fileId

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefMapsBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefMapsBuilder.kt
@@ -108,7 +108,7 @@ class DefMapsBuilder(
                 it to dependencyDefMap
             }
             .toMap(hashMapOf())
-        val defMap = buildDefMap(crate, allDependenciesDefMaps, poolForMacros, indicator)
+        val defMap = buildDefMap(crate, allDependenciesDefMaps, poolForMacros, indicator, isNormalCrate = true)
         defMapService.setDefMap(crateId, defMap)
         if (defMap != null) {
             builtDefMaps[crate] = defMap

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DetachedDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DetachedDefMap.kt
@@ -1,0 +1,97 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.impl.FakeDetachedCrate
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsModItem
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.getChildModule
+import org.rust.openapiext.getCachedOrCompute
+
+fun Project.getDetachedModInfo(scope: RsMod): RsModInfoBase {
+    val rootMod = scope.containingFile as? RsFile ?: return RsModInfoBase.InfoNotFound
+    val crate = FakeDetachedCrate(rootMod, DefMapService.getDetachedCrateNextId(), dependencies = emptyList())
+    return getModInfoInDetachedCrate(scope, crate)
+}
+
+private fun Project.getModInfoInDetachedCrate(scope: RsMod, crate: Crate): RsModInfoBase {
+    val defMap = defMapService.getDetachedDefMap(crate) ?: return RsModInfoBase.InfoNotFound
+    val dataPsiHelper = DetachedFileDataPsiHelper(crate.rootMod ?: return RsModInfoBase.InfoNotFound, defMap)
+    val modData = dataPsiHelper.psiToData(scope) ?: return RsModInfoBase.InfoNotFound
+    return RsModInfoBase.RsModInfo(this, defMap, modData, crate, dataPsiHelper)
+}
+
+private class DetachedFileDataPsiHelper(
+    private val root: RsFile,
+    private val defMap: CrateDefMap
+) : DataPsiHelper {
+    override fun psiToData(scope: RsMod): ModData? {
+        return when {
+            scope.containingFile != root -> null
+            scope == root -> defMap.root
+            scope is RsModItem -> {
+                val superMod = scope.`super` ?: return null
+                val superModData = psiToData(superMod) ?: return null
+                superModData.childModules[scope.modName]
+            }
+            else -> null
+        }
+    }
+
+    override fun dataToPsi(data: ModData): RsMod? {
+        return when {
+            data.crate != defMap.crate -> null
+            data == defMap.root -> root
+            else -> {
+                val superModData = data.parent ?: return null
+                val superMod = dataToPsi(superModData) ?: return null
+                superMod.getChildModule(data.name)
+            }
+        }
+    }
+}
+
+private fun DefMapService.getDetachedDefMap(crate: Crate): CrateDefMap? {
+    check(crate.id != null)
+    val crateRoot = crate.rootMod ?: return null
+
+    val allDependenciesDefMaps = crate.getAllDependenciesDefMaps()
+
+    val dependenciesStamps = allDependenciesDefMaps.map {
+        val holder = getDefMapHolder(it.value.crate)
+        holder.modificationCount
+    }
+    val dependencies = dependenciesStamps + crateRoot.modificationStamp
+
+    return getCachedOrCompute(crateRoot, DEF_MAP_KEY, dependencies) {
+        val indicator = ProgressManager.getGlobalProgressIndicator() ?: EmptyProgressIndicator()
+        buildDefMap(crate, allDependenciesDefMaps, pool = null, indicator, isNormalCrate = false)
+            ?: error("null detached DefMap")
+    }
+}
+
+private val DEF_MAP_KEY: Key<Pair<CrateDefMap, List<Long>>> = Key.create("DEF_MAP_KEY")
+
+private fun Crate.getAllDependenciesDefMaps(): Map<Crate, CrateDefMap> {
+    val allDependencies = flatDependencies
+    val ids = allDependencies.mapNotNull { it.id }
+    val crateById = allDependencies.associateBy { it.id }
+    val defMapById = project.defMapService.getOrUpdateIfNeeded(ids)
+    return defMapById.mapNotNull { (crateId, defMap) ->
+        val crate = crateById[crateId]
+        if (crate != null && defMap != null) {
+            crate to defMap
+        } else {
+            null
+        }
+    }.toMap(hashMapOf())
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeMetaInfo.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeMetaInfo.kt
@@ -17,13 +17,13 @@ data class NamedItem(val name: String, val item: RsNamedElement)
 
 /** List of items added to [context] by glob import to [this] */
 fun RsMod.exportedItems(context: RsMod): List<NamedItem> {
-    val (project, defMap, modData) = getModInfo(this) as? RsModInfo ?: return emptyList()
+    val info = getModInfo(this) as? RsModInfo ?: return emptyList()
     val contextInfo = getModInfo(context) as? RsModInfo ?: return emptyList()
-    return modData
+    return info.modData
         .getVisibleItems { it.isVisibleFromMod(contextInfo.modData) }
         .flatMap { (name, perNs) ->
             perNs.allVisItems().flatMap { (visItem, namespace) ->
-                val items = visItem.toPsi(defMap, project, namespace)
+                val items = visItem.toPsi(info, namespace)
                 items.map { NamedItem(name, it) }
             }
         }
@@ -41,7 +41,7 @@ private fun PerNs.allVisItems(): Array<Pair<VisItem, Namespace>> =
  */
 fun RsMod.getDirectoryContainedAllChildFiles(): VirtualFile? {
     val (_, _, modData) = getModInfo(this) as? RsModInfo ?: return null
-    return PersistentFS.getInstance().findFileById(modData.directoryContainedAllChildFiles)
+    return PersistentFS.getInstance().findFileById(modData.directoryContainedAllChildFiles ?: return null)
 }
 
 fun CrateDefMap.hasTransitiveGlobImport(source: RsMod, target: RsMod): Boolean {

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
@@ -33,27 +33,33 @@ import kotlin.system.measureTimeMillis
  * If process is cancelled ([ProcessCanceledException]), then only part of defMaps could be updated,
  * other defMaps will be updated in next call to [getOrUpdateIfNeeded].
  */
-fun DefMapService.getOrUpdateIfNeeded(crate: CratePersistentId): CrateDefMap? {
-    check(project.isNewResolveEnabled)
-    val holder = getDefMapHolder(crate)
+fun DefMapService.getOrUpdateIfNeeded(crate: CratePersistentId): CrateDefMap? =
+    getOrUpdateIfNeeded(listOf(crate))[crate]
 
-    if (holder.hasLatestStamp()) return holder.defMap
+fun DefMapService.getOrUpdateIfNeeded(crates: List<CratePersistentId>): Map<CratePersistentId, CrateDefMap?> {
+    check(project.isNewResolveEnabled)
+    val holders = crates.map(::getDefMapHolder)
+
+    fun List<DefMapHolder>.defMaps() = associate { it.crateId to it.defMap }
+    if (holders.all { it.hasLatestStamp() }) return holders.defMaps()
 
     checkReadAccessAllowed()
     checkIsSmartMode(project)
     return defMapsBuildLock.withLockAndCheckingCancelled {
         check(defMapsBuildLock.holdCount == 1) { "Can't use resolve while building CrateDefMap" }
-        if (holder.hasLatestStamp()) return@withLockAndCheckingCancelled holder.defMap
+        if (holders.all { it.hasLatestStamp() }) return@withLockAndCheckingCancelled holders.defMaps()
 
         val pool = Executors.newWorkStealingPool()
         try {
             val indicator = ProgressManager.getGlobalProgressIndicator() ?: EmptyProgressIndicator()
             // TODO: Invoke outside of read action ?
-            DefMapUpdater(crate, this, pool, indicator, multithread = true).run()
-            if (hasDefMapFor(crate)) {
-                holder.checkHasLatestStamp()
+            DefMapUpdater(crates, this, pool, indicator, multithread = true).run()
+            for (holder in holders) {
+                if (hasDefMapFor(holder.crateId)) {
+                    holder.checkHasLatestStamp()
+                }
             }
-            holder.defMap
+            holders.defMaps()
         } finally {
             pool.shutdown()
             MacroExpansionSharedCache.getInstance().flush()
@@ -79,14 +85,14 @@ private fun doUpdateDefMapForAllCrates(
     pool: ExecutorService,
     indicator: ProgressIndicator,
     multithread: Boolean,
-    rootCrateId: CratePersistentId? = null
+    rootCrateIds: List<CratePersistentId>? = null
 ) {
     val dumbService = DumbService.getInstance(project)
     val defMapService = project.defMapService
     runReadActionInSmartMode(dumbService) {
         defMapService.defMapsBuildLock.withLockAndCheckingCancelled {
             check(defMapService.defMapsBuildLock.holdCount == 1)
-            DefMapUpdater(rootCrateId, defMapService, pool, indicator, multithread).run()
+            DefMapUpdater(rootCrateIds, defMapService, pool, indicator, multithread).run()
         }
     }
 }
@@ -111,7 +117,7 @@ fun Project.forceRebuildDefMapForCrate(crateId: CratePersistentId) {
             defMapService.scheduleRebuildDefMap(crateId)
         }
     }
-    doUpdateDefMapForAllCrates(this, newSameThreadExecutorService(), EmptyProgressIndicator(), multithread = false, crateId)
+    doUpdateDefMapForAllCrates(this, newSameThreadExecutorService(), EmptyProgressIndicator(), multithread = false, listOf(crateId))
 }
 
 fun Project.getAllDefMaps(): List<CrateDefMap> = crateGraph.topSortedCrates.mapNotNull {
@@ -122,9 +128,9 @@ fun Project.getAllDefMaps(): List<CrateDefMap> = crateGraph.topSortedCrates.mapN
 private class DefMapUpdater(
     /**
      * If null, DefMap is updated for all crates.
-     * Otherwise for [rootCrateId] and all it dependencies.
+     * Otherwise for [rootCrateIds] and all its dependencies.
      */
-    rootCrateId: CratePersistentId?,
+    rootCrateIds: List<CratePersistentId>?,
     private val defMapService: DefMapService,
     private val pool: ExecutorService,
     private val indicator: ProgressIndicator,
@@ -136,9 +142,12 @@ private class DefMapUpdater(
     private val topSortedCrates: List<Crate> = defMapService.project.crateGraph.topSortedCrates
 
     /** Crates to check for update */
-    private val crates: Collection<Crate> = run {
-        val rootCrate = rootCrateId?.let { id -> topSortedCrates.find { it.id == id } }
-        if (rootCrate != null) rootCrate.flatDependencies + rootCrate else topSortedCrates
+    private val crates: Collection<Crate> = if (rootCrateIds == null) {
+        topSortedCrates
+    } else {
+        val rootCrates = rootCrateIds.mapNotNull { id -> topSortedCrates.find { it.id == id } }
+        val crates = rootCrates.flatMapTo(hashSetOf()) { it.flatDependencies } + rootCrates
+        crates.topSort(topSortedCrates)
     }
     private var numberUpdatedCrates: Int = 0
 

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
@@ -166,7 +166,7 @@ class CfgEvaluator(
                 PackageOrigin.STDLIB, PackageOrigin.STDLIB_DEPENDENCY -> False
 
                 PackageOrigin.DEPENDENCY -> ThreeValuedLogic.fromBoolean(
-                    crate.cargoTarget?.pkg?.let { !RsCfgNotTestIndex.hasCfgNotTest(crate.cargoProject.project, it) } ?: false
+                    crate.cargoTarget?.pkg?.let { !RsCfgNotTestIndex.hasCfgNotTest(crate.project, it) } ?: false
                 )
 
                 // TODO Provide cfg(test) switching for workspace packages

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -796,4 +796,62 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
         pub use foo::*;
     """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve in detached file`() = stubOnlyResolve("""
+    //- detached.rs
+        macro foo() {}
+            //X
+        fn main() {
+            foo!();
+        } //^ detached.rs
+    """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve in detached file (to inline mod)`() = stubOnlyResolve("""
+    //- detached.rs
+        mod inner {
+            pub fn func() {}
+        }        //X
+        use inner::func;
+        fn main() {
+            func();
+        } //^ detached.rs
+    """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve in detached file (in inline mod)`() = stubOnlyResolve("""
+    //- detached.rs
+        mod inner {
+            fn func() {}
+             //X
+            fn main() {
+                func();
+            } //^ detached.rs
+        }
+    """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve in detached file (from inline mod)`() = stubOnlyResolve("""
+    //- detached.rs
+        fn func() {}
+         //X
+        mod inner {
+            fn main() {
+                super::func();
+            }        //^ detached.rs
+        }
+    """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve in detached file (in inner mod)`() = stubOnlyResolve("""
+    //- detached.rs
+        mod inner;
+    //- detached/inner.rs
+        fn func() {}
+         //X
+        fn main() {
+            func();
+        } //^ detached/inner.rs
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
@@ -234,7 +234,7 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
 
         pub struct S<const N1: usize>;
 
-    //- mod.rs
+    //- lib.rs
         mod foo;
 
         fn bar<const N2: usize>() -> foo::S<{ N2 }> { foo::S }
@@ -249,7 +249,7 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
 
         pub trait T<const N1: usize> {}
 
-    //- mod.rs
+    //- lib.rs
         mod foo;
 
         impl <const N2: usize> foo::T<{ N2 }> for foo::S {}
@@ -272,7 +272,7 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
             U=u32
         >(&'a [R; A], &'b [T; B], &'c [U; C]);
 
-    //- mod.rs
+    //- lib.rs
         mod foo;
 
         fn main() {
@@ -287,7 +287,7 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
         #![feature(const_generics)]
         pub struct S<const N1: usize>;
         pub fn bar<const N2: usize>() -> S<N2> { S }
-    //- mod.rs
+    //- lib.rs
         mod foo;
         const C: usize = 42;
         fn main() {


### PR DESCRIPTION
changelog: Use new name resolution engine inside detached files (without crate root). This e.g. allows resolving [macros 2.0](https://rust-lang.github.io/rfcs/1584-macros.html) in such files
