### PR TITLE
ANN: adjust format macro annotator for `panic` macro on 2021 edition

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -10,6 +10,7 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.colors.RsColor
 import org.rust.ide.injected.isDoctestInjection
@@ -513,8 +514,12 @@ private fun getFormatMacroCtx(formatMacro: RsMacroCall): Pair<Int, List<RsFormat
         "format",
         "format_args",
         "format_args_nl" -> 0
-        // panic macro handle any literal (even with `{}`) if it's single argument
-        "panic" -> if (formatMacroArgs.size < 2) null else 0
+        // panic macro handles any literal (even with `{}`) if it's single argument in 2015 and 2018 editions,
+        // but starting with edition 2021 the first string literal is always format string
+        "panic" -> {
+            val edition = formatMacro.containingCrate?.edition ?: Edition.EDITION_2018
+            if (formatMacroArgs.size < 2 && edition < Edition.EDITION_2021) null else 0
+        }
         "write",
         "writeln" -> 1
         else -> null

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.annotator
 
-import org.rust.ExpandMacros
-import org.rust.MockRustcVersion
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.*
+import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.colors.RsColor
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
@@ -520,9 +518,27 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test panic with single literal`() = checkErrors("""
         fn main() {
             panic!("{}");
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2021)
+    fun `test panic macro 2021`() = checkErrors("""
+        use std::fmt;
+
+        struct S;
+        impl fmt::Display for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+
+        fn main() {
+            panic!("<error descr="Invalid reference to positional argument 0 (no arguments were given)">{}</error>");
+            panic!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+            panic!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER> <error descr="Invalid reference to positional argument 1 (there is 1 argument)">{}</error>", S);
+            panic!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S, <error descr="Argument never used">S</error>);
         }
     """)
 


### PR DESCRIPTION
Starting with edition 2021, `panic` macro uses the same rules to format string literal as other format macros, i.e. it doesn't eat any single string literal argument without errors.
This change just adjusts our annotator to new compiler rules

See https://doc.rust-lang.org/stable/edition-guide/rust-2021/panic-macro-consistency.html

Part of #6902

changelog: Highlight errors in single string literal argument of `panic` macro according [new rules](https://doc.rust-lang.org/stable/edition-guide/rust-2021/panic-macro-consistency.html) in 2021 edition 
