### PR TITLE
CI: Remove workflows with old resolve

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -135,7 +135,6 @@ jobs:
                 rust-version: [ 1.55.0, nightly-2021-08-17 ]
                 base-ide: [ idea, clion ]
                 platform-version: [ 212, 213 ]
-                resolve-engine: [ resolve-new ]
                 # it's enough to verify plugin structure only once per platform version
                 verify-plugin: [ false ]
                 include:
@@ -144,13 +143,6 @@ jobs:
                       rust-version: 1.41.0
                       base-ide: idea
                       platform-version: 212
-                      resolve-engine: resolve-old
-                      verify-plugin: true
-                    - os: ubuntu-18.04
-                      rust-version: 1.55.0
-                      base-ide: idea
-                      platform-version: 212
-                      resolve-engine: resolve-old
                       verify-plugin: true
 
         runs-on: ${{ matrix.os }}
@@ -226,10 +218,6 @@ jobs:
                   echo "ORG_GRADLE_PROJECT_ideaVersion=IU-2021.2" >> $GITHUB_ENV
                   echo "ORG_GRADLE_PROJECT_clionVersion=CL-2021.2" >> $GITHUB_ENV
                   echo "ORG_GRADLE_PROJECT_nativeDebugPluginVersion=212.4746.2" >> $GITHUB_ENV
-
-            - name: Set up env variable for old resolve
-              if: matrix.resolve-engine == 'resolve-old'
-              run: echo "INTELLIJ_RUST_FORCE_USE_OLD_RESOLVE=" >> $GITHUB_ENV
 
             - name: Set up test env variables
               run: echo "RUST_SRC_WITH_SYMLINK=$HOME/.rust-src" >> $GITHUB_ENV

--- a/src/test/kotlin/org/rust/NewResolve.kt
+++ b/src/test/kotlin/org/rust/NewResolve.kt
@@ -15,10 +15,6 @@ import org.rust.openapiext.TestmarkPred
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class UseNewResolve
-
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
 annotation class UseOldResolve
 
 fun TestmarkPred.ignoreInNewResolve(project: Project): TestmarkPred {
@@ -32,9 +28,6 @@ fun TestmarkPred.ignoreInNewResolve(project: Project): TestmarkPred {
 
 fun TestCase.setupResolveEngine(project: Project, testRootDisposable: Disposable) {
     val defMap = project.defMapService
-    findAnnotationInstance<UseNewResolve>()?.let {
-        defMap.setNewResolveEnabled(testRootDisposable, true)
-    }
     findAnnotationInstance<UseOldResolve>()?.let {
         defMap.setNewResolveEnabled(testRootDisposable, false)
     }

--- a/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
@@ -113,7 +113,6 @@ class RsShowMacroExpansionActionsTest : RsTestBase() {
         compile_error!("");
     """)
 
-    @UseNewResolve
     @MinRustcVersion("1.46.0")
     @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
@@ -129,7 +128,6 @@ class RsShowMacroExpansionActionsTest : RsTestBase() {
         fn foo() {}
     """)
 
-    @UseNewResolve
     @MinRustcVersion("1.46.0")
     @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -969,7 +969,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         macro_rules! foo { () => {} }
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test no duplicates with import E0252 private item`() = checkErrors("""
         mod mod1 {

--- a/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
@@ -31,7 +31,6 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
         }</CFG_DISABLED_CODE>
     """)
 
-    @UseNewResolve
     @MinRustcVersion("1.46.0")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
@@ -46,7 +45,6 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MinRustcVersion("1.46.0")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionErrorAnnotatorTest.kt
@@ -6,14 +6,10 @@
 package org.rust.ide.annotator
 
 import org.rust.ProjectDescriptor
-import org.rust.UseNewResolve
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.colors.RsColor
 
-// `asm` macro was converted to macro 2.0 since 1.55.0
-// and the plugin can resolve macro 2.0 only when new name resolution engine is enabled
-@UseNewResolve
 class RsUnsafeExpressionErrorAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class) {
     override fun setUp() {
         super.setUp()

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/QualifyPathFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/QualifyPathFixTest.kt
@@ -5,12 +5,13 @@
 
 package org.rust.ide.inspections.fixes
 
-import org.rust.*
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsUnresolvedReferenceInspection
 
-@UseNewResolve
 class QualifyPathFixTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
     fun `test function call`() = checkFixByText("Qualify path to `foo::bar`", """
         mod foo {

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/RemoveImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/RemoveImportFixTest.kt
@@ -5,11 +5,9 @@
 
 package org.rust.ide.inspections.fixes
 
-import org.rust.UseNewResolve
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsUnusedImportInspection
 
-@UseNewResolve
 class RemoveImportFixTest : RsInspectionsTestBase(RsUnusedImportInspection::class) {
     fun `test remove use item in the middle`() = checkFixByText("Remove unused import", """
         struct A;

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -5,11 +5,13 @@
 
 package org.rust.ide.inspections.import
 
-import org.rust.*
+import org.rust.MinRustcVersion
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.utils.import.Testmarks
 
-@UseNewResolve
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
 class AutoImportFixStdTest : AutoImportFixTestBase() {
     fun `test import item from std crate`() = checkAutoImportFixByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -9,7 +9,6 @@ import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.utils.import.Testmarks
 
-@UseNewResolve
 class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import struct`() = checkAutoImportFixByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -12,7 +12,6 @@ import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.lang.core.macros.MacroExpansionScope
 
-@UseNewResolve
 class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspection::class) {
     fun `test unused import`() = checkByText("""
         mod foo {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
@@ -10,7 +10,6 @@ import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.lints.RsUnusedImportInspection
 
-@UseNewResolve  // because of RsUnusedImportInspection
 @WithEnabledInspections(RsUnusedImportInspection::class)
 class RsImportOptimizerTest: RsTestBase() {
 
@@ -546,7 +545,6 @@ class RsImportOptimizerTest: RsTestBase() {
         fn usage(p1: bbb::S, p2: mem::S, p3: string:S, p4: io::S) {}
     """)
 
-    @UseNewResolve
     fun `test remove unused use item`() = doTest("""
         struct S;
 
@@ -559,7 +557,6 @@ class RsImportOptimizerTest: RsTestBase() {
         mod foo {}
     """)
 
-    @UseNewResolve
     fun `test remove unused use speck at the beginning`() = doTest("""
         struct S;
 
@@ -574,7 +571,6 @@ class RsImportOptimizerTest: RsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test remove unused use speck in the middle`() = doTest("""
         struct S;
 
@@ -589,7 +585,6 @@ class RsImportOptimizerTest: RsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test remove multiple unused use specks`() = doTest("""
         struct S1;
         struct S2;
@@ -606,7 +601,6 @@ class RsImportOptimizerTest: RsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test remove unused use speck at the end`() = doTest("""
         struct S;
 
@@ -621,7 +615,6 @@ class RsImportOptimizerTest: RsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test remove empty group after unused specks are removed`() = doTest("""
         struct S1;
         struct S2;
@@ -636,7 +629,6 @@ class RsImportOptimizerTest: RsTestBase() {
         mod foo {}
     """)
 
-    @UseNewResolve
     fun `test remove multiple unused use items`() = doTest("""
         struct S1;
         struct S2;
@@ -652,7 +644,6 @@ class RsImportOptimizerTest: RsTestBase() {
         mod foo {}
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test do not remove cfg-disabled import`() = checkNotChanged("""

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -9,7 +9,6 @@ import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.lints.RsUnusedImportInspection
 
-@UseNewResolve  // because of RsUnusedImportInspection
 @WithEnabledInspections(RsUnusedImportInspection::class)
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
@@ -915,7 +914,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test copy usual imports from old mod`() = doTest("""
     //- lib.rs
         mod mod1 {
@@ -993,7 +991,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test outside reference to function in old mod when move from crate root`() = doTest("""
     //- lib.rs
         fn foo/*caret*/() { bar(); }
@@ -1552,7 +1549,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @UseNewResolve
     fun `test outside reference to items from stdlib`() = doTest("""
     //- lib.rs
         mod mod1 {
@@ -1575,7 +1571,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @UseNewResolve
     fun `test outside reference to Arc from stdlib`() = doTest("""
     //- lib.rs
         mod mod1 {
@@ -1683,7 +1678,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test self references from inner mod 1`() = doTest("""
     //- lib.rs
         mod mod1 {
@@ -1720,7 +1714,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test self references from inner mod 2`() = doTest("""
     //- lib.rs
         mod mod1 {
@@ -1789,7 +1782,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test self references to inner mod`() = doTest("""
     //- lib.rs
         mod mod1 {
@@ -2074,7 +2066,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test inside references, should add import for grandparent mod`() = doTest("""
     //- lib.rs
         mod inner1 {
@@ -2811,7 +2802,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod2/*target*/ {}
     """)
 
-    @UseNewResolve
     fun `test outside references with import alias`() = doTest("""
     //- lib.rs
         mod foo {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -7,7 +7,6 @@ package org.rust.lang.core.completion
 
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
-import org.rust.UseNewResolve
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
@@ -165,7 +164,6 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test public item reexported with restricted visibility 1`() = checkNoCompletion("""
         pub mod inner1 {
@@ -179,7 +177,6 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test public item reexported with restricted visibility 2`() = checkContainsCompletion("bar2", """
         pub mod inner1 {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -644,7 +644,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test complete macro2`() = doSingleCompletion("""
         macro foo() {}
         fn main() {
@@ -657,7 +656,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test complete macro2 in use statement`() = doSingleCompletion("""
         pub mod bar {
             pub macro foo() {}
@@ -1093,7 +1091,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         pub fn func() {}
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test completion cfg-disabled item 2`() = doSingleCompletionByFileTree("""

--- a/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
@@ -5,9 +5,7 @@
 
 package org.rust.lang.core.completion
 
-import org.rust.UseNewResolve
 
-@UseNewResolve
 class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
     fun `test constant`() = doFirstCompletion("""
         trait Foo {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.completion
 
 import org.intellij.lang.annotations.Language
-import org.rust.UseNewResolve
 
 class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
     fun `test expr 1`() = doTest("""
@@ -33,7 +32,6 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
         }
     """, setOf("iii"), setOf("i32"))
 
-    @UseNewResolve
     fun `test expr (macro 2)`() = doTest("""
         macro my_macro($ e:expr, foo) {
             1

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionFromIndexTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionFromIndexTest.kt
@@ -7,8 +7,11 @@ package org.rust.lang.core.completion
 
 import com.intellij.codeInsight.lookup.LookupElementPresentation
 import org.intellij.lang.annotations.Language
-import org.rust.*
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.hasCaretMarker
 import org.rust.ide.settings.RsCodeInsightSettings
 import org.rust.lang.core.completion.RsCommonCompletionProvider.Testmarks
 import org.rust.openapiext.Testmark
@@ -377,7 +380,6 @@ class RsPathCompletionFromIndexTest : RsCompletionTestBase() {
         }
     }
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro`() = doTestByFileTree("""
     //- lib.rs
@@ -395,7 +397,6 @@ class RsPathCompletionFromIndexTest : RsCompletionTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2`() = doTestByFileTree("""
     //- lib.rs
@@ -415,7 +416,6 @@ class RsPathCompletionFromIndexTest : RsCompletionTestBase() {
 
     // TODO parse top-level identifier as RsPath
     // e.g. `lazy_static`
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro with same name as dependency`() = expect<IllegalStateException> {
         doTestByFileTree("""
@@ -431,7 +431,6 @@ class RsPathCompletionFromIndexTest : RsCompletionTestBase() {
     """)
     }
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro as type reference`() = doTestByFileTree("""
     //- lib.rs

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallUnderCfgTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallUnderCfgTest.kt
@@ -86,7 +86,6 @@ class RsMacroCallUnderCfgTest : RsTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockCargoFeatures("feature_foo")
     fun `test macro call in cfg disabled nested mod`() = checkResolvedOnlyWhenFeatureIsEnabledByTree("feature_foo", """
     //- foo.rs

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacro2ExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacro2ExpansionTest.kt
@@ -7,11 +7,9 @@ package org.rust.lang.core.macros.decl
 
 import org.rust.MinRustcVersion
 import org.rust.ProjectDescriptor
-import org.rust.UseNewResolve
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.macros.RsMacroExpansionTestBase
 
-@UseNewResolve
 class RsMacro2ExpansionTest : RsMacroExpansionTestBase() {
     fun `test function-like body`() = doTest("""
         macro foo ($ i:ident) {

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphBuilderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphBuilderTest.kt
@@ -7,7 +7,6 @@ package org.rust.lang.core.macros.decl
 
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
-import org.rust.UseNewResolve
 import org.rust.lang.core.psi.ext.RsMacroDefinitionBase
 import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.lang.core.psi.ext.graph
@@ -34,7 +33,6 @@ class RsMacroGraphBuilderTest : RsTestBase() {
         END
     """)
 
-    @UseNewResolve
     fun `test one rule simple (macro 2)`() = check("""
         macro my_macro($ e:expr) {
             1

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphWalkerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphWalkerTest.kt
@@ -8,7 +8,6 @@ package org.rust.lang.core.macros.decl
 import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
-import org.rust.UseNewResolve
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.*
@@ -40,7 +39,6 @@ class RsMacroGraphWalkerTest : RsTestBase() {
         }
     """, hashSetOf(FragmentKind.Expr, FragmentKind.Ident))
 
-    @UseNewResolve
     fun `test simple (macro 2)`() = check("""
         macro my_macro($ e:expr) {
             1

--- a/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
@@ -19,7 +19,6 @@ import org.rust.stdext.singleOrFilter
 /**
  * A test for detecting proc macro attributes on items. See [ProcMacroAttribute]
  */
-@UseNewResolve
 @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
 @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
 class ProcMacroAttributeTest : RsTestBase() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -682,7 +682,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     // Goal of these two tests is to check that there are no exceptions during building CrateDefMap.
     // Actual resolve result is not important, because proper multiresolve is not yet supported in new resolve.
     @ExpandMacros
-    @UseNewResolve
     @MockAdditionalCfgOptions("intellij_rust")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import inside expanded shadowed mod 1`() = stubOnlyResolve("""
@@ -709,7 +708,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
 
     // From https://github.com/tokio-rs/tokio/blob/97c2c4203cd7c42960cac895987c43a17dff052e/tokio/src/process/mod.rs#L132-L134
     @ExpandMacros
-    @UseNewResolve
     @MockAdditionalCfgOptions("intellij_rust")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import inside expanded shadowed mod 2`() = stubOnlyResolve("""
@@ -753,7 +751,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
 
     // We check that there are no exceptions during building CrateDefMap (actual resolve result is not important)
     @ExpandMacros
-    @UseNewResolve
     @MockAdditionalCfgOptions("intellij_rust")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import to mod shadowed by expanded mod`() = checkByCode("""
@@ -887,7 +884,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }                      //^ dep-lib/not_test.rs
      """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test file level cfg attribute 1`() = stubOnlyResolve("""
@@ -907,7 +903,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         pub fn func() {}
      """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test file level cfg attribute 2`() = stubOnlyResolve("""
@@ -973,7 +968,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         pub fn func() {}
      """)
 
-    @UseNewResolve
     @MockAdditionalCfgOptions("intellij_rust")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test cfg-disabled item is resolved from cfg-disabled function 1`() = stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
@@ -8,7 +8,6 @@ package org.rust.lang.core.resolve
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
 import org.rust.MockEdition
-import org.rust.UseNewResolve
 import org.rust.cargo.project.workspace.CargoWorkspace
 
 class RsIncludeMacroResolveTest : RsResolveTestBase() {
@@ -188,7 +187,6 @@ class RsIncludeMacroResolveTest : RsResolveTestBase() {
         pub struct Foo;
     """)
 
-    @UseNewResolve
     @ExpandMacros
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro call in included file 1`() = checkResolve("""
@@ -202,7 +200,6 @@ class RsIncludeMacroResolveTest : RsResolveTestBase() {
         //^ main.rs
     """)
 
-    @UseNewResolve
     @ExpandMacros
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro call in included file 2`() = checkResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -914,7 +914,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         } //^ unresolved
     """)
 
-    @UseNewResolve
     fun `test legacy textual macro reexported as macro 2`() = checkByCode("""
         mod inner {
             #[macro_export]
@@ -966,7 +965,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         } //^
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test propagate expanded macro def to grandparent mod`() = checkByCode("""
         mod inner {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.resolve
 
 import org.rust.MockEdition
-import org.rust.UseNewResolve
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ignoreInNewResolve
 
@@ -281,7 +280,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
     """)
 
     // TODO
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in nested mod (reexport)`() = expect<IllegalStateException> {
         checkByCode("""
@@ -297,7 +295,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         """)
     }
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in nested mod (import)`() = checkByCode("""
         mod inner {
@@ -314,7 +311,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in nested mod (macro call)`() = checkByCode("""
         mod inner {
@@ -330,7 +326,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
              //^
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in crate root (reexport)`() = checkByCode("""
         #[macro_export]
@@ -342,7 +337,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
               //^
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in crate root (import)`() = checkByCode("""
         #[macro_export]
@@ -357,7 +351,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in crate root (macro call fqn)`() = checkByCode("""
         #[macro_export]
@@ -371,7 +364,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
              //^
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in crate root (macro call)`() = checkByCode("""
         #[macro_export]
@@ -385,7 +377,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         //^
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test propagate expanded macro def`() = checkByCode("""
         mod outer {
@@ -408,7 +399,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
     """)
 
     // From https://github.com/seed-rs/seed/blob/d9935ee25148c151931160d188d5f0e67c746cba/src/shortcuts.rs#L9-L45
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test generate two macro defs with same name`() = checkByCode("""
         mod outer {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
@@ -8,7 +8,6 @@ package org.rust.lang.core.resolve
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
 import org.rust.MockEdition
-import org.rust.UseNewResolve
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.lang.core.psi.ext.RsReferenceElement
 
@@ -48,7 +47,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test use multi reference, duplicated function`() = doTest("""
         mod m {
             pub fn foo() {}
@@ -60,7 +58,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
         } //^
     """)
 
-    @UseNewResolve
     fun `test use multi reference, duplicated struct`() = doTest("""
         mod m {
             pub struct Foo {}
@@ -72,7 +69,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }         //^
     """)
 
-    @UseNewResolve
     fun `test use multi reference, duplicated unit struct`() = doTest("""
         mod m {
             pub struct Foo;
@@ -84,7 +80,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }         //^
     """)
 
-    @UseNewResolve
     fun `test use multi reference, duplicated enum variant`() = doTest("""
         enum E { A, A }
         use E::A;
@@ -93,7 +88,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }         //^
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test use multi reference, item in duplicated inline mod`() = doTest("""
         mod m {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -248,7 +248,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro inside import 3`() = stubOnlyResolve("""
     //- main.rs
@@ -261,7 +260,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo { () => {} }
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro inside import 4`() = stubOnlyResolve("""
     //- main.rs
@@ -411,7 +409,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import wins extern crate import`() = stubOnlyResolve("""
     //- main.rs
@@ -429,7 +426,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo { () => {}; }
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test import wins macro from prelude`() = stubOnlyResolve("""
@@ -499,7 +495,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test import macro by multi-segment path without extern crate 1`() = stubOnlyResolve("""
     //- lib.rs
         use dep_lib_target;
@@ -514,7 +509,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test import macro by multi-segment path without extern crate 2`() = stubOnlyResolve("""
     //- lib.rs
         use dep_lib_target;
@@ -531,7 +525,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     fun `test import macro by qualified path with aliased extern crate`() = stubOnlyResolve("""
     //- lib.rs
         extern crate dep_lib_target as aliased;
@@ -545,7 +538,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro reexported as macro 2`() = stubOnlyResolve("""
     //- lib.rs
@@ -558,7 +550,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         pub use foo_ as foo;
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (same mod)`() = stubOnlyResolve("""
     //- lib.rs
@@ -569,7 +560,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }           //X
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (different mod same crate)`() = stubOnlyResolve("""
     //- lib.rs
@@ -580,7 +570,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }           //X
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (different crate)`() = stubOnlyResolve("""
     //- main.rs
@@ -591,7 +580,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                 //X
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (inside function body)`() = expect<IllegalStateException> {
         stubOnlyResolve("""
@@ -604,7 +592,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         """)
     }
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (import)`() = stubOnlyResolve("""
     //- main.rs
@@ -617,7 +604,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                 //X
     """)
 
-    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (unresolved in textual scope)`() = stubOnlyResolve("""
     //- lib.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -11,7 +11,6 @@ import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
 import org.rust.lang.core.macros.MacroExpansionScope
 
-@UseNewResolve
 @MinRustcVersion("1.46.0")
 @MockEdition(EDITION_2018)
 @ExpandMacros(MacroExpansionScope.WORKSPACE)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -268,7 +268,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
         struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve custom derive by qualified path with re-export 1`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_derive(ProcMacroName)]
@@ -281,7 +280,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve custom derive by qualified path with re-export 2`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_derive(ProcMacroName)]
@@ -296,7 +294,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve attribute macro by qualified path with re-export 1`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_attribute]
@@ -309,7 +306,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve attribute macro by qualified path with re-export 2`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_attribute]
@@ -336,7 +332,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
               //^ dep-proc-macro/lib.rs
     """)
 
-    @UseNewResolve
     fun `test resolve bang proc macro from macro call through macro_use with rename`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro]
@@ -403,7 +398,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
     """)
 
     // TODO fix name resolution order
-    @UseNewResolve
     fun `test resolve bang proc macro through macro_use to the last extern crate 4`() = expect<IllegalStateException> {
     stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
@@ -469,7 +463,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve attr proc macro from macro call through macro_use with rename`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_attribute]
@@ -485,7 +478,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve custom derive proc macro from macro call through macro_use`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_derive(ProcMacroName)]
@@ -499,7 +491,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test custom derive proc macro is not resolved to decl macro through macro_use 1`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_derive(ProcMacroName)]
@@ -516,7 +507,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test custom derive proc macro is not resolved to decl macro through macro_use 2`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_derive(ProcMacroName)]
@@ -536,7 +526,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve custom derive proc macro from macro call through macro_use with rename`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_derive(ProcMacroName)]
@@ -552,7 +541,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve custom derive through macro_use to the last extern crate 1`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_derive(ProcMacroName)]
@@ -571,7 +559,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve custom derive through macro_use to the last extern crate 2`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_derive(ProcMacroName)]
@@ -590,7 +577,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             struct S;
     """)
 
-    @UseNewResolve
     fun `test resolve custom derive through macro_use to the last extern crate 3`() = stubOnlyResolve("""
         //- dep-proc-macro/lib.rs
             #[proc_macro_derive(ProcMacroName)]

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -276,7 +276,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }   //^ ...libcore/macros/mod.rs|...core/src/macros/mod.rs
     """)
 
-    @UseNewResolve // macro 2.0 since rust 1.55
     fun `test asm macro`() = stubOnlyResolve("""
     //- main.rs
         #![feature(asm)]

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
@@ -33,7 +33,6 @@ class RsStdlibResolveTestEdition2018 : RsResolveTestBase() {
           //^ ...core/src/lib.rs|...core/lib.rs
     """)
 
-    @UseNewResolve
     fun `test alloc crate unresolved without extern crate`() = stubOnlyResolve("""
     //- main.rs
         use alloc::rc::Rc;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.resolve
 
 import org.rust.MockEdition
-import org.rust.UseNewResolve
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ignoreInNewResolve
 
@@ -555,7 +554,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         mod b;
     """)
 
-    @UseNewResolve
     fun `test resolve macro multi file 4`() = stubOnlyResolve("""
     //- b.rs
         #![macro_use]
@@ -779,7 +777,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test item reexported from 'pub(crate)' mod in dependency crate`() = stubOnlyResolve("""
     //- main.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.resolve
 
 import org.rust.MockEdition
-import org.rust.UseNewResolve
 import org.rust.UseOldResolve
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.stdext.BothEditions
@@ -755,7 +754,6 @@ class RsUseResolveTest : RsResolveTestBase() {
         } //^
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test complex cyclic chain with glob imports and aliases`() = checkByCode("""
         mod a {
@@ -860,7 +858,6 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @UseNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test two usual imports with same name in different namespaces`() = checkByCode("""
         mod a {

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapMacroIndexConsistencyTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapMacroIndexConsistencyTest.kt
@@ -15,7 +15,6 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.toPsiFile
 import org.rust.stdext.withPrevious
 
-@UseNewResolve
 @MinRustcVersion("1.46.0")
 @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
 class RsDefMapMacroIndexConsistencyTest : RsTestBase() {

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
@@ -11,10 +11,8 @@ import com.intellij.psi.PsiDocumentManager
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
 import org.rust.MockAdditionalCfgOptions
-import org.rust.UseNewResolve
 
-/** Tests whether or not [CrateDefMap] should be updated after file modification */
-@UseNewResolve
+/** Tests whether [CrateDefMap] should be updated after file modification */
 @ExpandMacros  // needed to enable precise modification tracker
 class RsDefMapUpdateChangeSingleFileTest : RsDefMapUpdateTestBase() {
 

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateCreateNewFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateCreateNewFileTest.kt
@@ -9,12 +9,10 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.psi.PsiDirectory
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
-import org.rust.UseNewResolve
 import org.rust.fileTreeFromText
 import org.rust.openapiext.toPsiDirectory
 
-/** Tests whether or not [CrateDefMap] should be updated after creation of new file */
-@UseNewResolve
+/** Tests whether [CrateDefMap] should be updated after creation of new file */
 @ExpandMacros
 class RsDefMapUpdateCreateNewFileTest : RsDefMapUpdateTestBase() {
 

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
@@ -15,7 +15,6 @@ import org.rust.lang.core.psi.rustStructureModificationTracker
 import org.rust.lang.core.resolve2.CrateInfo.*
 
 /** Tests which exactly [CrateDefMap]s are updated when we modify some crate and then run resolve in some other crate */
-@UseNewResolve
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
 class RsMultipleDefMapsUpdateTest : RsTestBase() {
 

--- a/src/test/kotlin/org/rustPerformanceTests/RsBuildDefMapTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsBuildDefMapTest.kt
@@ -7,7 +7,6 @@ package org.rustPerformanceTests
 
 import com.intellij.openapi.util.Disposer
 import com.sun.management.HotSpotDiagnosticMXBean
-import org.rust.UseNewResolve
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.resolve2.getAllDefMaps
@@ -15,7 +14,6 @@ import java.lang.management.ManagementFactory
 
 private const val DUMP_HEAP: Boolean = false
 
-@UseNewResolve
 class RsBuildDefMapTest : RsRealProjectTestBase() {
 
     fun `test build rustc`() = doTest(RUSTC)

--- a/src/test/kotlin/org/rustPerformanceTests/RsProfileBuildDefMapTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsProfileBuildDefMapTest.kt
@@ -5,10 +5,8 @@
 
 package org.rustPerformanceTests
 
-import org.rust.UseNewResolve
 import org.rust.lang.core.resolve2.forceRebuildDefMapForAllCrates
 
-@UseNewResolve
 class RsProfileBuildDefMapTest : RsPerformanceTestBase() {
 
     fun `test rustc`() = doTest(RUSTC)

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/RsDefMapSoftReferenceTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/RsDefMapSoftReferenceTest.kt
@@ -6,7 +6,6 @@
 package org.rustSlowTests.lang.resolve
 
 import org.intellij.lang.annotations.Language
-import org.rust.UseNewResolve
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.resolve.RsResolveTestBase
@@ -15,7 +14,6 @@ import org.rust.lang.core.resolve2.DefMapService
 import org.rust.lang.core.resolve2.defMapService
 
 /** See [DefMapService.defMaps] for details */
-@UseNewResolve
 class RsDefMapSoftReferenceTest : RsResolveTestBase() {
 
     fun test() = doTest("""


### PR DESCRIPTION
The old name resolution is [deprecated](https://github.com/intellij-rust/intellij-rust/pull/7844), so I think it is reasonable to keep testing on CI only with the new engine.