### PR TITLE
MACRO: hardcode that stdlib can't have proc macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ProcMacroAttribute.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ProcMacroAttribute.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.psi
 
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.macros.proc.ProcMacroApplicationService
 import org.rust.lang.core.psi.ext.*
@@ -126,6 +127,13 @@ sealed class ProcMacroAttribute<out T : RsMetaItemPsiOrStub> {
             }
 
             val crate = explicitCrate ?: owner.containingCrate ?: return None
+
+            // Stdlib uses many unstable built-in attributes that change frequently, and We may not be able to update
+            // the `RS_BUILTIN_ATTRIBUTES` list in time. Let's just assume that stdlib can't have proc macros
+            if (crate.origin == PackageOrigin.STDLIB || crate.origin == PackageOrigin.STDLIB_DEPENDENCY) {
+                return None
+            }
+
             val customAttributes = explicitCustomAttributes ?: CustomAttributes.fromCrate(crate)
 
             owner.getQueryAttributes(crate, stub, outerAttrsOnly = true).metaItems.forEachIndexed { index, meta ->


### PR DESCRIPTION
Fixes #7992

Stdlib uses many unstable built-in attributes that change frequently, and We may not be able to update the `RS_BUILTIN_ATTRIBUTES` list in time. Let's just assume that stdlib can't have proc macros