### PR TITLE
COMP: Fix out-of-scope completion in doctest injections

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import org.rust.ide.injected.isDoctestInjection
 import org.rust.ide.inspections.import.AutoImportFix.Type.*
 import org.rust.ide.utils.import.*
 import org.rust.lang.core.psi.*
@@ -97,7 +96,7 @@ class AutoImportFix(element: RsElement, private val type: Type) : LocalQuickFixO
             }
 
             val superPath = path.rootPath()
-            val candidates = if (project.useAutoImportWithNewResolve && !path.isDoctestInjection) run {
+            val candidates = if (path.useAutoImportWithNewResolve) run {
                 val importContext = ImportContext2.from(path, isCompletion = false) ?: return@run emptyList()
                 ImportCandidatesCollector2.getImportCandidates(importContext, referenceName)
             } else {

--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.util.registry.RegistryValue
 import com.intellij.util.containers.MultiMap
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.util.AutoInjectedCrates
+import org.rust.ide.injected.isDoctestInjection
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CrateGraphService
 import org.rust.lang.core.crate.CratePersistentId
@@ -27,7 +28,8 @@ import org.rust.lang.core.resolve2.*
 import org.rust.stdext.mapToSet
 
 private val AUTO_IMPORT_USING_NEW_RESOLVE: RegistryValue = Registry.get("org.rust.auto.import.using.new.resolve")
-val Project.useAutoImportWithNewResolve: Boolean get() = isNewResolveEnabled && AUTO_IMPORT_USING_NEW_RESOLVE.asBoolean()
+private val Project.useAutoImportWithNewResolve: Boolean get() = isNewResolveEnabled && AUTO_IMPORT_USING_NEW_RESOLVE.asBoolean()
+val RsElement.useAutoImportWithNewResolve: Boolean get() = project.useAutoImportWithNewResolve && !isDoctestInjection
 
 /**
  * ## High-level description

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -17,6 +17,7 @@ import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.ProcessingContext
 import com.intellij.util.containers.MultiMap
+import org.rust.ide.injected.isDoctestInjection
 import org.rust.ide.refactoring.RsNamesValidator
 import org.rust.ide.settings.RsCodeInsightSettings
 import org.rust.ide.utils.import.*
@@ -192,7 +193,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         val project = parameters.originalFile.project
 
         val context = RsCompletionContext(path, expectedTy, isSimplePath = true)
-        val candidates = if (project.useAutoImportWithNewResolve) run {
+        val candidates = if (path.useAutoImportWithNewResolve) run {
             val importContext = ImportContext2.from(path, isCompletion = true) ?: return@run emptyList()
             ImportCandidatesCollector2.getCompletionCandidates(importContext, result.prefixMatcher, processedPathElements)
         } else {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -12,13 +12,13 @@ import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.openapiext.Testmark
 
-abstract class RsCompletionTestBase : RsTestBase() {
+abstract class RsCompletionTestBase(private val defaultFileName: String = "main.rs") : RsTestBase() {
 
     protected lateinit var completionFixture: RsCompletionTestFixture
 
     override fun setUp() {
         super.setUp()
-        completionFixture = RsCompletionTestFixture(myFixture)
+        completionFixture = RsCompletionTestFixture(myFixture, defaultFileName)
         completionFixture.setUp()
     }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsDoctestInjectionCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsDoctestInjectionCompletionTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+class RsDoctestInjectionCompletionTest : RsCompletionTestBase("lib.rs") {
+
+    fun `test simple`() = doSingleCompletion("""
+        /// ```
+        /// fn foo() {}
+        /// fn main() {
+        ///     fo/*caret*/
+        /// }
+        /// ```
+        fn func() {}
+    """, """
+        /// ```
+        /// fn foo() {}
+        /// fn main() {
+        ///     foo()/*caret*/
+        /// }
+        /// ```
+        fn func() {}
+    """)
+
+    fun `test out of scope same crate`() = expect<IllegalStateException> {
+    doSingleCompletion("""
+        /// ```
+        /// mod inner {
+        ///     pub fn foo() {}
+        /// }
+        /// fn main() {
+        ///     fo/*caret*/
+        /// }
+        /// ```
+        fn func() {}
+    """, """
+        /// ```
+        /// use inner::foo;
+        /// mod inner {
+        ///     pub fn foo() {}
+        /// }
+        /// fn main() {
+        ///     foo()/*caret*/
+        /// }
+        /// ```
+        fn func() {}
+    """)
+    }
+
+    // TODO: Fix formatting & insert import at top level
+    fun `test out of scope different crate`() = doSingleCompletion("""
+        /// ```
+        /// fn main() {
+        ///     fo/*caret*/
+        /// }
+        /// ```
+        fn func() {}
+        pub fn foo() {}
+    """, """
+        /// ```
+        /// fn main() {
+        ///     use test_package::foo;
+        /// foo()/*caret*/
+        /// }
+        /// ```
+        fn func() {}
+        pub fn foo() {}
+    """)
+}


### PR DESCRIPTION
Introduced in #7914 

No changelog since this is a fix for #7914
