### PR TITLE
TOML: Enable crates local index on stable

### DIFF
--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -18,7 +18,7 @@
         <experimentalFeature id="org.rust.macros.proc" percentOfUsers="0">
             <description>Enables procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="0">
+        <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="100">
             <description>Enables crates local index</description>
         </experimentalFeature>
     </extensions>

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -37,18 +37,20 @@
                          enabledByDefault="true"
                          level="WARNING"
                          implementationClass="org.rust.toml.inspections.CrateNotFoundInspection"/>
+
+        <!-- Version-related inspections are disabled for now due to false-positives -->
         <localInspection language="TOML"
                          displayName="Invalid crate version"
                          groupPath="Rust"
                          groupName="Cargo.toml"
-                         enabledByDefault="true"
+                         enabledByDefault="false"
                          level="WARNING"
                          implementationClass="org.rust.toml.inspections.CrateVersionInvalidInspection"/>
         <localInspection language="TOML"
                          displayName="New crate version available"
                          groupPath="Rust"
                          groupName="Cargo.toml"
-                         enabledByDefault="true"
+                         enabledByDefault="false"
                          level="WARNING"
                          implementationClass="org.rust.toml.inspections.NewCrateVersionAvailableInspection"/>
 


### PR DESCRIPTION
Enable `org.rust.crates.local.index` experimental feature for all users on stable and disable version-related inspections for now due to false positives

changelog: Enable crates local index on stable to provide analysis for dependencies inside `Cargo.toml` manifest. Currently, it offers completions for `crates.io` dependencies' names and versions, inspections for non-existent packages in the index, and automatically updates with cargo crates index updates
