### PR TITLE
Added the option to format code with nightly Rust.

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
@@ -13,5 +13,6 @@ class RustfmtConfigurable(project: Project) : RsConfigurableBase(project, "Rustf
     override fun createPanel(): DialogPanel = panel {
         row { checkBox("Use rustfmt instead of built-in formatter", state::useRustfmt) }
         row { checkBox("Run rustfmt on Save", state::runRustfmtOnSave) }
+        row { checkBox("Run rustfmt with nightly", state::runRustfmtWithNightly) }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -52,6 +52,7 @@ interface RustProjectSettingsService {
         var doctestInjectionEnabled: Boolean = true,
         var useRustfmt: Boolean = false,
         var runRustfmtOnSave: Boolean = false,
+        var runRustfmtWithNightly: Boolean = false,
     ) {
         @get:Transient
         @set:Transient
@@ -109,6 +110,7 @@ interface RustProjectSettingsService {
     val doctestInjectionEnabled: Boolean
     val useRustfmt: Boolean
     val runRustfmtOnSave: Boolean
+    val runRustfmtWithNightly: Boolean
 
     @Suppress("DEPRECATION")
     @Deprecated("Use toolchain property")

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -63,6 +63,7 @@ class RustProjectSettingsServiceImpl(
     override val doctestInjectionEnabled: Boolean get() = _state.doctestInjectionEnabled
     override val useRustfmt: Boolean get() = _state.useRustfmt
     override val runRustfmtOnSave: Boolean get() = _state.runRustfmtOnSave
+    override val runRustfmtWithNightly: Boolean get() = _state.runRustfmtWithNightly
 
     @Suppress("OverridingDeprecatedMember", "DEPRECATION")
     override fun getToolchain(): RsToolchain? = _state.toolchain?.let(RsToolchain::from)

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/SerializationUtils.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/SerializationUtils.kt
@@ -29,6 +29,7 @@ const val MACRO_EXPANSION_ENGINE: String = "macroExpansionEngine"
 const val DOCTEST_INJECTION_ENABLED: String = "doctestInjectionEnabled"
 const val USE_RUSTFMT: String = "useRustfmt"
 const val RUN_RUSTFMT_ON_SAVE: String = "runRustfmtOnSave"
+const val USE_RUSTFMT_WITH_NIGHTLY: String = "runRustfmtWithNightly"
 const val USE_SKIP_CHILDREN: String = "useSkipChildren"
 
 // Legacy properties needed for migration

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
@@ -11,8 +11,10 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.project.guessProjectForFile
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.CargoCommandLine
@@ -41,7 +43,14 @@ class Rustfmt(toolchain: RsToolchainBase) : RustupComponent(NAME, toolchain) {
         val file = document.virtualFile ?: return null
         if (file.isNotRustFile || !file.isValid) return null
 
+        val project = guessProjectForFile(file) ?: return null
+        val runRustfmtWithNightly = project.rustSettings.runRustfmtWithNightly
+
         val arguments = buildList<String> {
+            if (runRustfmtWithNightly) {
+                add("+nightly")
+            }
+
             add("--emit=stdout")
 
             val configPath = findConfigPathRecursively(file.parent, stopAt = cargoProject.workingDirectory)

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -39,6 +39,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
               <option name="toolchainHomeDirectory" value="/" />
               <option name="useOffline" value="true" />
               <option name="useRustfmt" value="true" />
+              <option name="runRustfmtWithNightly" value="true" />
               <option name="version" value="2" />
             </RustProjectSettings>
         """.trimIndent()
@@ -60,6 +61,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         assertEquals(false, service.doctestInjectionEnabled)
         assertEquals(true, service.useRustfmt)
         assertEquals(true, service.runRustfmtOnSave)
+        assertEquals(true, service.runRustfmtWithNightly)
     }
 
     fun `test update from version 1`() {


### PR DESCRIPTION
Usually I use a `stable` toolchain, but `nightly` supports more formatting options, so I added an option to use `rustfmt` in `nightly` even if the current toolchain is `stable`.

This PR just adds the `+nightly` parameter when executing `cargo fmt`.

changelog: Added the option to format code with nightly Rust.
