### PR TITLE
INT: Simplify negation of boolean literals

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsBooleanExpUtils.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsBooleanExpUtils.kt
@@ -8,7 +8,8 @@ package org.rust.lang.utils
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ComparisonOp.*
-import org.rust.lang.core.psi.ext.EqualityOp.*
+import org.rust.lang.core.psi.ext.EqualityOp.EQ
+import org.rust.lang.core.psi.ext.EqualityOp.EXCLEQ
 import org.rust.lang.core.psi.ext.operatorType
 
 fun RsBinaryExpr.negateToString(): String {
@@ -42,6 +43,12 @@ fun PsiElement.negate(): PsiElement {
 
         this is RsParenExpr || this is RsPathExpr || this is RsCallExpr ->
             psiFactory.createExpression("!$text")
+
+        this is RsLitExpr -> when (boolLiteral?.text) {
+            "false" -> psiFactory.createExpression("true")
+            "true" -> psiFactory.createExpression("false")
+            else -> error("unreachable")
+        }
 
         else ->
             psiFactory.createExpression("!($text)")

--- a/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
@@ -77,6 +77,16 @@ class InvertIfIntentionTest : RsIntentionTestBase(InvertIfIntention::class) {
         }
     """)
 
+    fun `test bool literal inversion`() = doAvailableTest("""
+        fn foo() {
+            if/*caret*/ true { Ok(()) } else { Err(()) }
+        }
+    """, """
+        fn foo() {
+            if false { Err(()) } else { Ok(()) }
+        }
+    """)
+
     fun `test simple inversion strange formatting`() = doAvailableTest("""
         fn foo() {
             if/*caret*/ 2 == 2 {


### PR DESCRIPTION
We need negation of expression in some intentions (e.g. `Invert if condition`). Previsously we negate `true` boolean literal as `!(true)`. With this PR negation will be just `false`. This is mostly useful while debugging our intentions (since it is rarely to have `if true ...` in real code)

changelog: Simplify negation of boolean literal (e.g. in `Invert if condition` intention)
