### PR TITLE
L10N: Add `@Nls` and `@NlsContexts` annotations if needed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,7 @@ change. Common tags are:
   * GRD for build changes
   * T for tests
   * DOC for documentation
+  * L10N for changes related to localization
 </details>
 
 Try to keep the summary line of a commit message under 72 characters.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -325,6 +325,9 @@ project(":plugin") {
 
             // Uncomment to enable FUS testing mode
             // jvmArgs("-Dfus.internal.test.mode=true")
+
+            // Uncomment to enable localization testing mode
+            // jvmArgs("-Didea.l10n=true")
         }
 
         withType<PatchPluginXmlTask> {

--- a/debugger/src/main/kotlin/org/rust/debugger/PrettyPrinters.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/PrettyPrinters.kt
@@ -5,13 +5,14 @@
 
 package org.rust.debugger
 
+import com.intellij.openapi.util.NlsContexts.ListItem
 import org.rust.openapiext.RsPathManager
 
 val PP_PATH: String get() = RsPathManager.prettyPrintersDir().toString()
 const val LLDB_LOOKUP: String = "lldb_lookup"
 const val GDB_LOOKUP: String = "gdb_lookup"
 
-enum class LLDBRenderers(private val description: String) {
+enum class LLDBRenderers(@Suppress("UnstableApiUsage") @ListItem private val description: String) {
     NONE("No renderers"),
     COMPILER("Rust compiler's renderers"),
     BUNDLED("Bundled renderers");

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -8,6 +8,7 @@ package org.rust.debugger.runconfig
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.util.NlsContexts.NotificationContent
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.text.SemVer
@@ -171,7 +172,7 @@ class RsDebugProcessConfigurationHelper(
         executeInterpreterCommand(threadId, frameIndex, command)
     }
 
-    private fun checkSysroot(sysroot: String?, message: String): String? {
+    private fun checkSysroot(sysroot: String?, @Suppress("UnstableApiUsage") @NotificationContent message: String): String? {
         if (sysroot == null) {
             project.showBalloon(message, NotificationType.WARNING)
         }

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
@@ -12,6 +12,8 @@ import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.util.NlsContexts.Button
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.xdebugger.XDebugProcess
 import com.intellij.xdebugger.XDebugProcessStarter
@@ -93,7 +95,11 @@ object RsDebugRunnerUtils {
         return false
     }
 
-    private fun showDialog(project: Project, message: String, action: String): Int {
+    private fun showDialog(
+        project: Project,
+        @Suppress("UnstableApiUsage") @DialogMessage message: String,
+        @Suppress("UnstableApiUsage") @Button action: String
+    ): Int {
         return Messages.showDialog(
             project,
             message,

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsConfigurableBase.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsConfigurableBase.kt
@@ -8,13 +8,16 @@ package org.rust.cargo.project.configurable
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.ConfigurableName
 import com.intellij.util.PlatformUtils
-import org.jetbrains.annotations.Nls
 import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.rustSettings
 
-abstract class RsConfigurableBase(protected val project: Project, @Nls displayName: String) :
-    BoundConfigurable(displayName) {
+@Suppress("UnstableApiUsage")
+abstract class RsConfigurableBase(
+    protected val project: Project,
+    @ConfigurableName displayName: String
+) : BoundConfigurable(displayName) {
 
     protected val state: RustProjectSettingsService.State = project.rustSettings.settingsState
 

--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.roots.ContentEntry
+import com.intellij.openapi.util.NlsContexts.Tooltip
 import com.intellij.openapi.util.UserDataHolderEx
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
@@ -111,7 +112,7 @@ interface CargoProject : UserDataHolderEx {
     sealed class UpdateStatus(private val priority: Int) {
         object UpToDate : UpdateStatus(0)
         object NeedsUpdate : UpdateStatus(1)
-        class UpdateFailed(val reason: String) : UpdateStatus(2)
+        class UpdateFailed(@Suppress("UnstableApiUsage") @Tooltip val reason: String) : UpdateStatus(2)
 
         fun merge(status: UpdateStatus): UpdateStatus = if (priority >= status.priority) this else status
     }

--- a/src/main/kotlin/org/rust/cargo/project/model/ProcessProgressListener.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/ProcessProgressListener.kt
@@ -5,9 +5,11 @@
 
 package org.rust.cargo.project.model
 
+import com.intellij.build.events.BuildEventsNls
 import com.intellij.execution.process.ProcessListener
 
+@Suppress("UnstableApiUsage")
 interface ProcessProgressListener : ProcessListener {
-    fun error(title: String, message: String)
-    fun warning(title: String, message: String)
+    fun error(@BuildEventsNls.Title title: String, @BuildEventsNls.Message message: String)
+    fun warning(@BuildEventsNls.Title title: String, @BuildEventsNls.Message message: String)
 }

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -11,6 +11,7 @@ import com.intellij.build.BuildContentDescriptor
 import com.intellij.build.BuildDescriptor
 import com.intellij.build.DefaultBuildDescriptor
 import com.intellij.build.SyncViewManager
+import com.intellij.build.events.BuildEventsNls
 import com.intellij.build.events.MessageEvent
 import com.intellij.build.progress.BuildProgress
 import com.intellij.build.progress.BuildProgressDescriptor
@@ -489,11 +490,17 @@ private class SyncCargoBuildAdapter(
     }
 }
 
-private fun CargoSyncTask.SyncContext.error(title: String, message: String) {
+private fun CargoSyncTask.SyncContext.error(
+    @BuildEventsNls.Title title: String,
+    @BuildEventsNls.Message message: String
+) {
     syncProgress.message(title, message, MessageEvent.Kind.ERROR, null)
 }
 
-private fun CargoSyncTask.SyncContext.warning(title: String, message: String) {
+private fun CargoSyncTask.SyncContext.warning(
+    @BuildEventsNls.Title title: String,
+    @BuildEventsNls.Message message: String
+) {
     syncProgress.message(title, message, MessageEvent.Kind.WARNING, null)
 }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
@@ -15,6 +15,7 @@ import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
@@ -65,6 +66,8 @@ abstract class RsExecutableRunner(
         val artifact = artifacts.firstOrNull()
         val binaries = artifact?.executables.orEmpty()
 
+        @Suppress("UnstableApiUsage")
+        @DialogMessage
         fun checkErrors(items: List<Any>, itemName: String): String? = when {
             items.isEmpty() -> "Can't find a $itemName."
             items.size > 1 -> "More than one $itemName was produced. " +
@@ -125,7 +128,7 @@ abstract class RsExecutableRunner(
         project.showErrorDialog(toolchainError.message)
     }
 
-    private fun Project.showErrorDialog(message: String) {
+    private fun Project.showErrorDialog(@Suppress("UnstableApiUsage") @DialogMessage message: String) {
         Messages.showErrorDialog(this, message, errorMessageTitle)
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -17,6 +17,7 @@ import com.intellij.execution.ui.RunContentManager
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import org.jdom.Element
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
@@ -125,7 +126,7 @@ fun addFormatJsonOption(additionalArguments: MutableList<String>, formatOption: 
 
 sealed class BuildResult {
     data class Binaries(val paths: List<String>) : BuildResult()
-    sealed class ToolchainError(val message: String) : BuildResult() {
+    sealed class ToolchainError(@Suppress("UnstableApiUsage") @DialogMessage val message: String) : BuildResult() {
         // TODO: move into bundle
         object UnsupportedMSVC : ToolchainError("MSVC toolchain is not supported. Please use GNU toolchain.")
         object UnsupportedGNU : ToolchainError("GNU toolchain is not supported. Please use MSVC toolchain.")

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -14,6 +14,7 @@ import com.intellij.execution.testframework.actions.ConsolePropertiesProvider
 import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.util.execution.ParametersListUtil
@@ -180,7 +181,7 @@ open class CargoCommandConfiguration(
         val ok: Ok? get() = this as? Ok
 
         companion object {
-            fun error(message: String) = Err(RuntimeConfigurationError(message))
+            fun error(@Suppress("UnstableApiUsage") @DialogMessage message: String) = Err(RuntimeConfigurationError(message))
         }
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -24,6 +24,8 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.util.NlsContexts
+import com.intellij.openapi.util.NlsContexts.DialogTitle
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import org.rust.cargo.runconfig.*
@@ -47,7 +49,7 @@ import java.nio.file.Paths
  */
 abstract class RsAsyncRunner(
     private val executorId: String,
-    private val errorMessageTitle: String
+    @Suppress("UnstableApiUsage") @DialogTitle private val errorMessageTitle: String
 ) : AsyncProgramRunner<RunnerSettings>() {
     override fun canRun(executorId: String, profile: RunProfile): Boolean {
         if (executorId != this.executorId || profile !is CargoCommandConfiguration ||
@@ -226,7 +228,7 @@ abstract class RsAsyncRunner(
         return promise
     }
 
-    protected fun Project.showErrorDialog(message: String) {
+    protected fun Project.showErrorDialog(@Suppress("UnstableApiUsage") @NlsContexts.DialogMessage message: String) {
         Messages.showErrorDialog(this, message, errorMessageTitle)
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.openapi.util.NlsContexts.Label
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -183,7 +184,8 @@ class CargoCommandConfigurationEditor(project: Project)
         labeledRow("Back&trace:", backtraceMode) { backtraceMode() }
     }
 
-    private fun LayoutBuilder.labeledRow(labelText: String, component: JComponent, init: Row.() -> Unit) {
+    @Suppress("UnstableApiUsage")
+    private fun LayoutBuilder.labeledRow(@Label labelText: String, component: JComponent, init: Row.() -> Unit) {
         val label = Label(labelText)
         label.labelFor = component
         row(label) { init() }

--- a/src/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchainFlavor.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchainFlavor.kt
@@ -9,6 +9,7 @@ import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.execution.wsl.WSLUtil
 import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.util.NlsContexts.ProgressTitle
 import com.intellij.util.io.isDirectory
 import org.rust.cargo.toolchain.flavors.RsToolchainFlavor
 import org.rust.ide.experiments.RsExperiments.WSL_TOOLCHAIN
@@ -67,7 +68,10 @@ fun WSLDistribution.getHomePathCandidates(): Sequence<Path> = sequence {
     }
 }
 
-private fun <T> compute(title: String, getter: () -> T): T = if (isDispatchThread) {
+private fun <T> compute(
+    @Suppress("UnstableApiUsage") @ProgressTitle title: String,
+    getter: () -> T
+): T = if (isDispatchThread) {
     val project = ProjectManager.getInstance().defaultProject
     project.computeWithCancelableProgress(title, getter)
 } else {

--- a/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
+++ b/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
@@ -17,6 +17,8 @@ import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.installAndEnable
+import com.intellij.openapi.util.NlsContexts.Button
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.util.PlatformUtils.*
 import org.rust.cargo.runconfig.RsDefaultProgramRunnerBase
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
@@ -107,8 +109,10 @@ class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
             }
         };
 
-        abstract val message: String
-        abstract val actionName: String
+        @Suppress("UnstableApiUsage")
+        abstract val message: @DialogMessage String
+        @Suppress("UnstableApiUsage")
+        abstract val actionName: @Button String
         abstract fun doOkAction(project: Project, pluginId: PluginId)
     }
 }

--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.highlighter.EditorHighlighter
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.util.NlsContexts.PopupTitle
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleManager
@@ -40,7 +41,7 @@ import javax.swing.JPanel
 /** Data class to group title and expansions of macro to show them in the view. */
 data class MacroExpansionViewDetails(
     val macroToExpand: RsPossibleMacroCall,
-    val title: String,
+    @Suppress("UnstableApiUsage") @PopupTitle val title: String,
     val expansion: MacroExpansion
 )
 
@@ -90,6 +91,8 @@ private fun expandMacroForView(macroToExpand: RsPossibleMacroCall, expandRecursi
     )
 }
 
+@Suppress("UnstableApiUsage")
+@PopupTitle
 private fun getMacroExpansionViewTitle(macroToExpand: RsPossibleMacroCall, expandRecursively: Boolean): String {
     val path = macroToExpand.path?.text
     val name = when (val kind = macroToExpand.kind) {

--- a/src/main/kotlin/org/rust/ide/annotator/RsAnnotationHolder.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsAnnotationHolder.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.annotator
 
 import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInspection.util.InspectionMessage
 import com.intellij.lang.annotation.AnnotationBuilder
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.AnnotationSession
@@ -15,31 +16,31 @@ import org.rust.lang.core.psi.ext.existsAfterExpansion
 
 class RsAnnotationHolder(val holder: AnnotationHolder) {
 
-    fun createErrorAnnotation(element: PsiElement, message: String?, vararg fixes: IntentionAction) {
+    fun createErrorAnnotation(element: PsiElement, @InspectionMessage message: String?, vararg fixes: IntentionAction) {
         newErrorAnnotation(element, message, *fixes)?.create()
     }
 
-    fun createWeakWarningAnnotation(element: PsiElement, message: String?, vararg fixes: IntentionAction) {
+    fun createWeakWarningAnnotation(element: PsiElement, @InspectionMessage message: String?, vararg fixes: IntentionAction) {
         newWeakWarningAnnotation(element, message, *fixes)?.create()
     }
 
     fun newErrorAnnotation(
         element: PsiElement,
-        message: String?,
+        @InspectionMessage message: String?,
         vararg fixes: IntentionAction
     ): AnnotationBuilder? =
         newAnnotation(element, HighlightSeverity.ERROR, message, *fixes)
 
     fun newWeakWarningAnnotation(
         element: PsiElement,
-        message: String?,
+        @InspectionMessage message: String?,
         vararg fixes: IntentionAction
     ): AnnotationBuilder? = newAnnotation(element, HighlightSeverity.WEAK_WARNING, message, *fixes)
 
     fun newAnnotation(
         element: PsiElement,
         severity: HighlightSeverity,
-        message: String?,
+        @InspectionMessage message: String?,
         vararg fixes: IntentionAction
     ): AnnotationBuilder? {
         if (!element.existsAfterExpansion) return null

--- a/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.annotator
 
 import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.util.InspectionMessage
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
@@ -94,7 +95,7 @@ private class RedundantParenthesisVisitor(private val holder: RsAnnotationHolder
         if (o.parent !is RsParenExpr) o.expr.warnIfParens("Redundant parentheses in expression")
     }
 
-    private fun RsExpr?.warnIfParens(message: String) {
+    private fun RsExpr?.warnIfParens(@InspectionMessage message: String) {
         if (this !is RsParenExpr || !canWarn(this)) return
         holder.createWeakWarningAnnotation(this, message, RemoveRedundantParenthesesFix(this))
     }

--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.codeInspection.util.InspectionMessage
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
@@ -175,7 +176,11 @@ private class ParseContext(val sourceMap: IntArray, val offset: Int, val paramet
             .shiftRight(offset)
 }
 
-private data class ErrorAnnotation(val range: TextRange, val error: String, val isTraitError: Boolean = false)
+private data class ErrorAnnotation(
+    val range: TextRange,
+    @InspectionMessage val error: String,
+    val isTraitError: Boolean = false
+)
 
 private val formatParser = Regex("""\{\{|}}|(\{([^}]*)}?)|(})""")
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -7,6 +7,7 @@ package org.rust.ide.annotator
 
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.util.InspectionMessage
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
@@ -364,19 +365,27 @@ private fun require(el: PsiElement?, holder: AnnotationHolder, message: String, 
             .range(highlightElements.combinedRange!!).create()
     }
 
-private fun deny(el: PsiElement?, holder: AnnotationHolder, message: String, vararg highlightElements: PsiElement?): Unit? =
-    if (el == null) null
-    else {
-        holder.newAnnotation(HighlightSeverity.ERROR, message)
-            .range(highlightElements.combinedRange ?: el.textRange).create()
-    }
+private fun deny(
+    el: PsiElement?,
+    holder: AnnotationHolder,
+    @InspectionMessage message: String,
+    vararg highlightElements: PsiElement?
+) {
+    if (el == null) return
+    holder.newAnnotation(HighlightSeverity.ERROR, message)
+        .range(highlightElements.combinedRange ?: el.textRange).create()
+}
 
-private inline fun <reified T : RsElement> denyType(el: PsiElement?, holder: AnnotationHolder, message: String, vararg highlightElements: PsiElement?): Unit? =
-    if (el !is T) null
-    else {
-        holder.newAnnotation(HighlightSeverity.ERROR, message)
-            .range(highlightElements.combinedRange ?: el.textRange).create()
-    }
+private inline fun <reified T : RsElement> denyType(
+    el: PsiElement?,
+    holder: AnnotationHolder,
+    @InspectionMessage message: String,
+    vararg highlightElements: PsiElement?
+) {
+    if (el !is T) return
+    holder.newAnnotation(HighlightSeverity.ERROR, message)
+        .range(highlightElements.combinedRange ?: el.textRange).create()
+}
 
 private val Array<out PsiElement?>.combinedRange: TextRange?
     get() = if (isEmpty())

--- a/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.codeInspection.util.InspectionMessage
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
@@ -135,7 +136,7 @@ class RsUnsafeExpressionAnnotator : AnnotatorBase() {
         return parent is RsBlockExpr || (parent is RsFunction && parent.isActuallyUnsafe)
     }
 
-    private fun AnnotationHolder.createUnsafeAnnotation(textRange: TextRange, message: String) {
+    private fun AnnotationHolder.createUnsafeAnnotation(textRange: TextRange, @InspectionMessage message: String) {
         if (isBatchMode) return
         val color = RsColor.UNSAFE_CODE
         val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION

--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -9,12 +9,14 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.HighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.options.colors.AttributesDescriptor
+import com.intellij.openapi.util.NlsContexts.AttributeDescriptor
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
 
 /**
  * See [RsColorSettingsPage] and [org.rust.ide.highlight.RsHighlighter]
  */
-enum class RsColor(humanName: String, default: TextAttributesKey? = null) {
+@Suppress("UnstableApiUsage")
+enum class RsColor(@AttributeDescriptor humanName: String, default: TextAttributesKey? = null) {
     VARIABLE("Variables//Default", Default.IDENTIFIER),
     MUT_BINDING("Variables//Mutable binding", Default.IDENTIFIER),
     FIELD("Variables//Field", Default.INSTANCE_FIELD),

--- a/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
@@ -109,12 +109,11 @@ class RsExternalLinterInspection : GlobalSimpleInspectionTool() {
         }
     }
 
-    override fun getDisplayName(): String = DISPLAY_NAME
+    override fun getDisplayName(): String = "External Linter"
 
     override fun getShortName(): String = SHORT_NAME
 
     companion object {
-        const val DISPLAY_NAME: String = "External Linter"
         const val SHORT_NAME: String = "RsExternalLinter"
 
         private val ANALYZED_FILES: Key<MutableSet<RsFile>> = Key.create("ANALYZED_FILES")

--- a/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.codeInspection.util.InspectionMessage
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
@@ -66,7 +67,7 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
     val project: Project get() = holder.project
     val isOnTheFly: Boolean get() = holder.isOnTheFly
 
-    fun registerProblem(element: PsiElement, descriptionTemplate: String, vararg fixes: LocalQuickFix?) {
+    fun registerProblem(element: PsiElement, @InspectionMessage descriptionTemplate: String, vararg fixes: LocalQuickFix?) {
         if (element.existsAfterExpansion) {
             holder.registerProblem(element, descriptionTemplate, *fixes)
         }
@@ -74,7 +75,7 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
 
     fun registerProblem(
         element: PsiElement,
-        descriptionTemplate: String,
+        @InspectionMessage descriptionTemplate: String,
         highlightType: ProblemHighlightType,
         vararg fixes: LocalQuickFix
     ) {
@@ -89,7 +90,7 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
         }
     }
 
-    fun registerProblem(element: PsiElement, rangeInElement: TextRange, message: String, vararg fixes: LocalQuickFix?) {
+    fun registerProblem(element: PsiElement, rangeInElement: TextRange, @InspectionMessage message: String, vararg fixes: LocalQuickFix?) {
         if (element.existsAfterExpansion) {
             holder.registerProblem(element, rangeInElement, message, *fixes)
         }
@@ -97,7 +98,7 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
 
     fun registerProblem(
         element: PsiElement,
-        message: String,
+        @InspectionMessage message: String,
         highlightType: ProblemHighlightType,
         rangeInElement: TextRange,
         vararg fixes: LocalQuickFix?

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/SubstituteTextFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/SubstituteTextFix.kt
@@ -7,6 +7,7 @@ package org.rust.ide.inspections.fixes
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.util.IntentionName
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
@@ -21,7 +22,7 @@ import org.rust.openapiext.document
  * @param substitution The text that will be placed starting from `range.startOffset`. If `null`, no text will be inserted.
  */
 class SubstituteTextFix private constructor(
-    private val fixName: String = "Substitute",
+    @IntentionName private val fixName: String = "Substitute",
     file: PsiFile,
     range: TextRange,
     private val substitution: String?
@@ -44,13 +45,13 @@ class SubstituteTextFix private constructor(
     }
 
     companion object {
-        fun delete(fixName: String, file: PsiFile, range: TextRange) =
+        fun delete(@IntentionName fixName: String, file: PsiFile, range: TextRange) =
             SubstituteTextFix(fixName, file, range, null)
 
-        fun insert(fixName: String, file: PsiFile, offsetInElement: Int, text: String) =
+        fun insert(@IntentionName fixName: String, file: PsiFile, offsetInElement: Int, text: String) =
             SubstituteTextFix(fixName, file, TextRange(offsetInElement, offsetInElement), text)
 
-        fun replace(fixName: String, file: PsiFile, range: TextRange, text: String) =
+        fun replace(@IntentionName fixName: String, file: PsiFile, range: TextRange, text: String) =
             SubstituteTextFix(fixName, file, range, text)
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.inspections.lints
 
 import com.intellij.codeInspection.*
+import com.intellij.codeInspection.util.InspectionMessage
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiComment
@@ -26,7 +27,7 @@ abstract class RsLintInspection : RsLocalInspectionTool() {
 
     protected fun RsProblemsHolder.registerLintProblem(
         element: PsiElement,
-        descriptionTemplate: String,
+        @InspectionMessage descriptionTemplate: String,
         lintHighlightingType: RsLintHighlightingType = RsLintHighlightingType.DEFAULT,
         fixes: List<LocalQuickFix> = emptyList()
     ) {
@@ -35,7 +36,7 @@ abstract class RsLintInspection : RsLocalInspectionTool() {
 
     protected fun RsProblemsHolder.registerLintProblem(
         element: PsiElement,
-        descriptionTemplate: String,
+        @InspectionMessage descriptionTemplate: String,
         rangeInElement: TextRange,
         lintHighlightingType: RsLintHighlightingType = RsLintHighlightingType.DEFAULT,
         fixes: List<LocalQuickFix> = emptyList()

--- a/src/main/kotlin/org/rust/ide/intentions/ChopListIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ChopListIntention.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInspection.util.IntentionName
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
@@ -19,7 +20,7 @@ import org.rust.lang.core.psi.ext.startOffset
 abstract class ChopListIntentionBase<TList : RsElement, TElement : RsElement>(
     listClass: Class<TList>,
     elementClass: Class<TElement>,
-    intentionText: String
+    @IntentionName intentionText: String
 ) : ListIntentionBase<TList, TElement>(listClass, elementClass, intentionText) {
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): TList? {
         val list = element.listContext ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/JoinListIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/JoinListIntention.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInspection.util.IntentionName
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
@@ -20,7 +21,7 @@ import org.rust.lang.core.psi.ext.startOffset
 abstract class JoinListIntentionBase<TList : RsElement, TElement : RsElement>(
     listClass: Class<TList>,
     elementClass: Class<TElement>,
-    intentionText: String,
+    @IntentionName intentionText: String,
     private val prefix: String = "",
     private val suffix: String = ""
 ) : ListIntentionBase<TList, TElement>(listClass, elementClass, intentionText) {

--- a/src/main/kotlin/org/rust/ide/intentions/ListIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ListIntention.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInspection.util.IntentionName
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
@@ -16,7 +17,7 @@ import org.rust.lang.core.psi.ext.*
 abstract class ListIntentionBase<TList : RsElement, TElement : RsElement>(
     private val listClass: Class<TList>,
     private val elementClass: Class<TElement>,
-    intentionText: String
+    @IntentionName intentionText: String
 ) : RsElementBaseIntentionAction<TList>() {
 
     init {

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsLineMarkerInfoUtils.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsLineMarkerInfoUtils.kt
@@ -8,6 +8,7 @@ package org.rust.ide.lineMarkers
 import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.openapi.util.NlsContexts.Tooltip
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import javax.swing.Icon
@@ -19,7 +20,7 @@ object RsLineMarkerInfoUtils {
         icon: Icon,
         navHandler: GutterIconNavigationHandler<PsiElement>?,
         alignment: GutterIconRenderer.Alignment,
-        messageProvider: () -> String
+        @Suppress("UnstableApiUsage") messageProvider: () -> @Tooltip String
     ): LineMarkerInfo<PsiElement> {
         return LineMarkerInfo(element, range, icon, { messageProvider() }, navHandler, alignment, messageProvider)
     }

--- a/src/main/kotlin/org/rust/ide/newProject/RsPackageNameValidator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsPackageNameValidator.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.newProject
 
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.openapi.util.SystemInfo
 
 /**
@@ -35,6 +36,8 @@ object RsPackageNameValidator {
         "com8", "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"
     )
 
+    @Suppress("UnstableApiUsage")
+    @DialogMessage
     fun validate(name: String, isBinary: Boolean): String? = when {
         name.isEmpty() -> "Package name can't be empty"
         name in KEYWORDS_BLACKLIST || name == "test" -> "The name `$name` cannot be used as a crate name"

--- a/src/main/kotlin/org/rust/ide/newProject/RsProjectTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsProjectTemplate.kt
@@ -5,20 +5,22 @@
 
 package org.rust.ide.newProject
 
+import com.intellij.openapi.util.NlsContexts.ListItem
 import org.rust.ide.icons.RsIcons
 import javax.swing.Icon
 
-sealed class RsProjectTemplate(val name: String, val isBinary: Boolean, val icon: Icon) {
+sealed class RsProjectTemplate(@Suppress("UnstableApiUsage") @ListItem val name: String, val isBinary: Boolean, val icon: Icon) {
     fun validateProjectName(crateName: String): String? = RsPackageNameValidator.validate(crateName, isBinary)
 }
 
-sealed class RsGenericTemplate(name: String, isBinary: Boolean) : RsProjectTemplate(name, isBinary, RsIcons.RUST) {
+sealed class RsGenericTemplate(@Suppress("UnstableApiUsage") @ListItem name: String, isBinary: Boolean) : RsProjectTemplate(name, isBinary, RsIcons.RUST) {
     object CargoBinaryTemplate : RsGenericTemplate("Binary (application)", true)
     object CargoLibraryTemplate : RsGenericTemplate("Library", false)
 }
 
 open class RsCustomTemplate(
-    name: String, val url: String
+    @Suppress("UnstableApiUsage") @ListItem name: String,
+    val url: String
 ) : RsProjectTemplate(name, false, RsIcons.CARGO_GENERATE) {
     object ProcMacroTemplate : RsCustomTemplate("Procedural Macro", "https://github.com/intellij-rust/rust-procmacro-quickstart-template")
     object WasmPackTemplate : RsCustomTemplate("WebAssembly Lib", "https://github.com/intellij-rust/wasm-pack-template")

--- a/src/main/kotlin/org/rust/ide/notifications/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/Utils.kt
@@ -13,16 +13,21 @@ import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.*
 import com.intellij.openapi.wm.WindowManager
 import org.rust.RsBundle
 
-fun Project.showBalloon(content: String, type: NotificationType, action: AnAction? = null) {
+fun Project.showBalloon(
+    @Suppress("UnstableApiUsage") @NotificationContent content: String,
+    type: NotificationType,
+    action: AnAction? = null
+) {
     showBalloon("", content, type, action)
 }
 
 fun Project.showBalloon(
-    title: String,
-    content: String,
+    @Suppress("UnstableApiUsage") @NotificationTitle title: String,
+    @Suppress("UnstableApiUsage") @NotificationContent content: String,
     type: NotificationType,
     action: AnAction? = null,
     listener: NotificationListener? = null
@@ -34,12 +39,12 @@ fun Project.showBalloon(
     Notifications.Bus.notify(notification, this)
 }
 
-fun showBalloonWithoutProject(content: String, type: NotificationType) {
+fun showBalloonWithoutProject(@Suppress("UnstableApiUsage") @NotificationContent content: String, type: NotificationType) {
     val notification = RsNotifications.pluginNotifications().createNotification(content, type)
     Notifications.Bus.notify(notification)
 }
 
-fun Project.setStatusBarText(text: String) {
+fun Project.setStatusBarText(@Suppress("UnstableApiUsage") @StatusBarText text: String) {
     val statusBar = WindowManager.getInstance().getStatusBar(this)
     statusBar?.info = text
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsInPlaceVariableIntroducer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsInPlaceVariableIntroducer.kt
@@ -7,6 +7,7 @@ package org.rust.ide.refactoring
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.Command
 import com.intellij.openapi.util.Pair
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
@@ -17,7 +18,7 @@ class RsInPlaceVariableIntroducer(
     elementToRename: PsiNamedElement,
     editor: Editor,
     project: Project,
-    title: String,
+    @Suppress("UnstableApiUsage") @Command title: String,
     private val additionalElementsToRename: List<PsiElement> = emptyList()
 ) : InplaceVariableIntroducer<PsiElement>(elementToRename, editor, project, title, emptyArray(), null) {
     override fun collectAdditionalElementsToRename(stringUsages: MutableList<Pair<PsiElement, TextRange>>) {

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.fileTypes.LanguageFileType
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.psi.PsiCodeFragment
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -320,6 +321,8 @@ private class ChangeSignatureDialog(project: Project, descriptor: SignatureDescr
         isValid = validateAndUpdateData() == null
     }
 
+    @Suppress("UnstableApiUsage")
+    @DialogMessage
     private fun validateAndUpdateData(): String? {
         val factory = RsPsiFactory(config.function.project)
 

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.refactoring.RefactoringBundle
@@ -65,7 +66,11 @@ class RsChangeSignatureHandler : ChangeSignatureHandler {
         }
     }
 
-    private fun showCannotRefactorErrorHint(project: Project, editor: Editor, message: String) {
+    private fun showCannotRefactorErrorHint(
+        project: Project,
+        editor: Editor,
+        @Suppress("UnstableApiUsage") @DialogMessage message: String
+    ) {
         CommonRefactoringUtil.showErrorHint(project, editor,
             RefactoringBundle.getCannotRefactorMessage(message),
             RefactoringBundle.message("changeSignature.refactoring.name"),
@@ -78,6 +83,8 @@ class RsChangeSignatureHandler : ChangeSignatureHandler {
             return checkFunction(function) == null
         }
 
+        @Suppress("UnstableApiUsage")
+        @DialogMessage
         private fun checkFunction(function: RsFunction): String? {
             if (function.containingCrate?.origin != PackageOrigin.WORKSPACE) {
                 return "Cannot change signature of function in a foreign crate"

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
@@ -12,6 +12,7 @@ import com.intellij.lang.LanguageCodeInsightActionHandler
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.DialogTitle
 import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsImplItem
@@ -115,5 +116,5 @@ abstract class BaseGenerateHandler : LanguageCodeInsightActionHandler {
         editor: Editor
     )
 
-    protected abstract val dialogTitle: String
+    protected abstract val dialogTitle: @Suppress("UnstableApiUsage") @DialogTitle String
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/ui.kt
@@ -10,6 +10,7 @@ import com.intellij.codeInsight.generation.MemberChooserObject
 import com.intellij.codeInsight.generation.MemberChooserObjectBase
 import com.intellij.ide.util.MemberChooser
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.DialogTitle
 import org.jetbrains.annotations.TestOnly
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsStructItem
@@ -21,7 +22,7 @@ fun showStructMemberChooserDialog(
     project: Project,
     structItem: RsStructItem,
     fields: List<StructMember>,
-    title: String
+    @Suppress("UnstableApiUsage") @DialogTitle title: String
 ): List<StructMember>? {
     val chooser = if (isUnitTestMode) {
         MOCK ?: error("You should set mock ui via `withMockStructMemberChooserUi`")
@@ -58,7 +59,9 @@ interface StructMemberChooserUi {
     fun selectMembers(project: Project, all: List<RsStructMemberChooserObject>): List<RsStructMemberChooserObject>?
 }
 
-private class DialogStructMemberChooserUi(private val title: String) : StructMemberChooserUi {
+private class DialogStructMemberChooserUi(
+    @Suppress("UnstableApiUsage") @DialogTitle private val title: String
+) : StructMemberChooserUi {
     override fun selectMembers(project: Project, all: List<RsStructMemberChooserObject>): List<RsStructMemberChooserObject>? {
         val dialogTitle = title
         val chooser = MemberChooser(all.toTypedArray(), true, true, project).apply {

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionHandler.kt
@@ -11,6 +11,7 @@ import com.intellij.lang.refactoring.InlineActionHandler
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.RefactoringBundle
@@ -72,7 +73,7 @@ class RsInlineFunctionHandler : InlineActionHandler() {
     override fun canInlineElement(element: PsiElement): Boolean =
         element is RsFunction && element.navigationElement is RsFunction
 
-    private fun errorHint(project: Project, editor: Editor, message: String) {
+    private fun errorHint(project: Project, editor: Editor, @Suppress("UnstableApiUsage") @DialogMessage message: String) {
         CommonRefactoringUtil.showErrorHint(
             project,
             editor,

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
@@ -8,6 +8,7 @@ package org.rust.ide.refactoring.inlineFunction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
@@ -58,7 +59,8 @@ class RsInlineFunctionProcessor(
     }
 
     override fun preprocessUsages(refUsages: Ref<Array<UsageInfo>>): Boolean {
-        val conflicts = MultiMap<PsiElement, String>()
+        @Suppress("UnstableApiUsage")
+        val conflicts = MultiMap<PsiElement, @DialogMessage String>()
         refUsages.get().forEach { usage ->
             val caller = usage.element?.ancestors?.filter { it is RsCallExpr || it is RsDotExpr }?.firstOrNull()
             val exprAncestor = usage.element?.ancestorOrSelf<RsStmt>() ?: usage.element?.ancestorOrSelf<RsExpr>()
@@ -89,6 +91,8 @@ class RsInlineFunctionProcessor(
         return showConflicts(conflicts, refUsages.get())
     }
 
+    @Suppress("UnstableApiUsage")
+    @DialogMessage
     private fun checkCallerConflicts(function: RsFunction, caller: PsiElement): String? {
         val funcArguments = (function.copy() as RsFunction).valueParameters
         var callArguments = when (caller) {

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineUtils.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineUtils.kt
@@ -7,6 +7,7 @@ package org.rust.ide.refactoring
 
 import com.intellij.openapi.editor.ex.EditorSettingsExternalizable
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.ListItem
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.RefactoringBundle
 import com.intellij.refactoring.inline.InlineOptionsWithSearchSettingsDialog
@@ -76,7 +77,10 @@ abstract class RsInlineDialog(
     }
 }
 
-class RsInlineUsageViewDescriptor(val element: PsiElement, val header: String) : UsageViewDescriptor {
+class RsInlineUsageViewDescriptor(
+    val element: PsiElement,
+    @Suppress("UnstableApiUsage") @ListItem val header: String
+) : UsageViewDescriptor {
     override fun getCommentReferencesText(usagesCount: Int, filesCount: Int) =
         RefactoringBundle.message("comments.elements.header",
             UsageViewBundle.getOccurencesString(usagesCount, filesCount))

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueHandler.kt
@@ -10,6 +10,7 @@ import com.intellij.lang.Language
 import com.intellij.lang.refactoring.InlineActionHandler
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.RefactoringBundle
@@ -148,7 +149,7 @@ sealed class InlineValueMode {
     object InlineAllAndRemoveOriginal : InlineValueMode()
 }
 
-private fun showErrorHint(project: Project, editor: Editor, message: String) {
+private fun showErrorHint(project: Project, editor: Editor, @Suppress("UnstableApiUsage") @DialogMessage message: String) {
     CommonRefactoringUtil.showErrorHint(
         project,
         editor,

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesDialog.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.showOkCancelDialog
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.RefactoringBundle
@@ -121,7 +122,7 @@ class RsMoveFilesOrDirectoriesDialog(
         return result == Messages.OK
     }
 
-    private fun showError(message: String?) {
+    private fun showError(@Suppress("UnstableApiUsage") @DialogMessage message: String?) {
         val title = RefactoringBundle.message("error.title")
         CommonRefactoringUtil.showErrorMessage(title, message, "refactoring.moveFile", project)
     }

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsDialog.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -189,7 +190,7 @@ class RsMoveTopLevelItemsDialog(
         }
     }
 
-    private fun showErrorMessage(message: String?) {
+    private fun showErrorMessage(@Suppress("UnstableApiUsage") @DialogMessage message: String?) {
         val title = message("error.title")
         CommonRefactoringUtil.showErrorMessage(title, message, null, project)
     }

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsProcessor.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.refactoring.move
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
@@ -40,7 +41,7 @@ class RsMoveTopLevelItemsProcessor(
         return commonProcessor.findUsages()
     }
 
-    private fun checkNoItemsWithSameName(conflicts: MultiMap<PsiElement, String>) {
+    private fun checkNoItemsWithSameName(@Suppress("UnstableApiUsage") conflicts: MultiMap<PsiElement, @DialogMessage String>) {
         if (!searchForReferences) return
 
         val targetModItems = targetMod.expandedItemsExceptImplsAndUses

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.impl.source.DummyHolder
@@ -146,7 +147,10 @@ class RsMoveCommonProcessor(
         }
     }
 
-    fun preprocessUsages(usages: Array<UsageInfo>, conflicts: MultiMap<PsiElement, String>): Boolean {
+    fun preprocessUsages(
+        usages: Array<UsageInfo>,
+        @Suppress("UnstableApiUsage") conflicts: MultiMap<PsiElement, @DialogMessage String>
+    ): Boolean {
         val title = message("refactoring.preprocess.usages.progress")
         return try {
             /**

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveConflictsDetector.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveConflictsDetector.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.refactoring.move.common
 
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.util.RefactoringUIUtil
@@ -21,7 +22,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 
 class RsMoveConflictsDetector(
-    private val conflicts: MultiMap<PsiElement, String>,
+    @Suppress("UnstableApiUsage") private val conflicts: MultiMap<PsiElement, @DialogMessage String>,
     private val elementsToMove: List<ElementToMove>,
     private val sourceMod: RsMod,
     private val targetMod: RsMod
@@ -251,7 +252,11 @@ class RsMoveConflictsDetector(
     }
 }
 
-fun addVisibilityConflict(conflicts: MultiMap<PsiElement, String>, reference: RsElement, target: RsElement) {
+fun addVisibilityConflict(
+    @Suppress("UnstableApiUsage") conflicts: MultiMap<PsiElement, @DialogMessage String>,
+    reference: RsElement,
+    target: RsElement
+) {
     val referenceDescription = RefactoringUIUtil.getDescription(reference.containingMod, true)
     val targetDescription = RefactoringUIUtil.getDescription(target, true)
     val message = "$referenceDescription uses $targetDescription which will be inaccessible after move"

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveTraitMethodsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveTraitMethodsProcessor.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.refactoring.move.common
 
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.psi.PsiElement
 import com.intellij.util.containers.MultiMap
 import org.rust.ide.refactoring.move.common.RsMoveUtil.isInsideMovedElements
@@ -30,7 +31,10 @@ class RsMoveTraitMethodsProcessor(
     private val pathHelper: RsMovePathHelper
 ) {
 
-    fun preprocessOutsideReferences(conflicts: MultiMap<PsiElement, String>, elementsToMove: List<ElementToMove>) {
+    fun preprocessOutsideReferences(
+        @Suppress("UnstableApiUsage") conflicts: MultiMap<PsiElement, @DialogMessage String>,
+        elementsToMove: List<ElementToMove>
+    ) {
         val references = getReferencesToTraitAssocItems(elementsToMove)
         preprocessReferencesToTraitAssocItems(
             references,
@@ -40,7 +44,10 @@ class RsMoveTraitMethodsProcessor(
         )
     }
 
-    fun preprocessInsideReferences(conflicts: MultiMap<PsiElement, String>, elementsToMove: List<ElementToMove>) {
+    fun preprocessInsideReferences(
+        @Suppress("UnstableApiUsage") conflicts: MultiMap<PsiElement, @DialogMessage String>,
+        elementsToMove: List<ElementToMove>
+    ) {
         val traitsToMove = elementsToMove
             .filterIsInstance<ItemToMove>()
             .map { it.item }
@@ -59,7 +66,7 @@ class RsMoveTraitMethodsProcessor(
 
     private fun preprocessReferencesToTraitAssocItems(
         references: List<RsReferenceElement>,
-        conflicts: MultiMap<PsiElement, String>,
+        @Suppress("UnstableApiUsage") conflicts: MultiMap<PsiElement, @DialogMessage String>,
         findTraitUsePath: (RsTraitItem) -> String?,
         shouldProcessTrait: (RsTraitItem) -> Boolean
     ) {

--- a/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
+++ b/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core
 
 import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.util.InspectionMessage
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.psi.PsiElement
 import com.intellij.util.text.SemVer
@@ -96,7 +97,7 @@ class CompilerFeature(
         holder: RsAnnotationHolder,
         startElement: PsiElement,
         endElement: PsiElement?,
-        message: String,
+        @InspectionMessage message: String,
         vararg fixes: LocalQuickFix
     ) {
         getDiagnostic(startElement, endElement, message, *fixes)?.addToHolder(holder)

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.macros.errors
 
+import org.jetbrains.annotations.Nls
 import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.macros.MacroExpansionContext
 import org.rust.lang.core.psi.RsProcMacroKind
@@ -37,6 +38,7 @@ sealed class GetMacroExpansionError {
 
     // Can't expand the macro because ...
     // Failed to expand the macro because ...
+    @Nls
     fun toUserViewableMessage(): String = when(this) {
         MacroExpansionIsDisabled -> "macro expansion is disabled in project settings"
         MacroExpansionEngineIsNotReady -> "macro expansion engine is not ready"

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -10,11 +10,13 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.util.InspectionMessage
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts.Tooltip
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.text.StringUtil.pluralize
 import com.intellij.psi.PsiElement
@@ -1464,8 +1466,8 @@ enum class Severity {
 class PreparedAnnotation(
     val severity: Severity,
     val errorCode: RsErrorCode?,
-    val header: String,
-    val description: String = "",
+    @Suppress("UnstableApiUsage") @InspectionMessage val header: String,
+    @Suppress("UnstableApiUsage") @Tooltip val description: String = "",
     val fixes: List<LocalQuickFix> = emptyList(),
     val textAttributes: TextAttributesKey? = null
 )

--- a/src/main/kotlin/org/rust/openapiext/ui.kt
+++ b/src/main/kotlin/org/rust/openapiext/ui.kt
@@ -17,6 +17,7 @@ import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.ui.TextComponentAccessor
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.NlsContexts.DialogTitle
 import com.intellij.ui.DocumentAdapter
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.Label
@@ -54,7 +55,7 @@ class UiDebouncer(
 
 fun pathToDirectoryTextField(
     disposable: Disposable,
-    title: String,
+    @Suppress("UnstableApiUsage") @DialogTitle title: String,
     onTextChanged: () -> Unit = {}
 ): TextFieldWithBrowseButton =
     pathTextField(
@@ -66,7 +67,7 @@ fun pathToDirectoryTextField(
 
 fun pathToRsFileTextField(
     disposable: Disposable,
-    title: String,
+    @DialogTitle title: String,
     project: Project,
     onTextChanged: () -> Unit = {}
 ): TextFieldWithBrowseButton =
@@ -82,7 +83,7 @@ fun pathToRsFileTextField(
 fun pathTextField(
     fileChooserDescriptor: FileChooserDescriptor,
     disposable: Disposable,
-    title: String,
+    @DialogTitle title: String,
     onTextChanged: () -> Unit = {}
 ): TextFieldWithBrowseButton {
 

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -39,6 +39,7 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.*
+import com.intellij.openapi.util.NlsContexts.ProgressTitle
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
@@ -257,14 +258,20 @@ inline fun testAssert(action: () -> Boolean, lazyMessage: () -> Any) {
 fun <T> runWithCheckCanceled(callable: () -> T): T =
     ApplicationUtil.runWithCheckCanceled(callable, ProgressManager.getInstance().progressIndicator)
 
-fun <T> Project.computeWithCancelableProgress(title: String, supplier: () -> T): T {
+fun <T> Project.computeWithCancelableProgress(
+    @Suppress("UnstableApiUsage") @ProgressTitle title: String,
+    supplier: () -> T
+): T {
     if (isUnitTestMode) {
         return supplier()
     }
     return ProgressManager.getInstance().runProcessWithProgressSynchronously<T, Exception>(supplier, title, true, this)
 }
 
-fun Project.runWithCancelableProgress(title: String, process: () -> Unit): Boolean {
+fun Project.runWithCancelableProgress(
+    @Suppress("UnstableApiUsage") @ProgressTitle title: String,
+    process: () -> Unit
+): Boolean {
     if (isUnitTestMode) {
         process()
         return true


### PR DESCRIPTION
It should provide more context for `Java | Internationalization | Hardcoded strings` inspection and improve its output, i.e. simplify future changes related to hardcoded string literal extraction into message bundles

Preparation for #8009

changelog: Annotate some code with `@Nls` and `@NlsContexts` annotations