### PR TITLE
MACRO: parse `_` as an identifier in proc macro bodies

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -101,6 +101,6 @@ class ProcMacroExpander(
     }
 
     companion object {
-        const val EXPANDER_VERSION: Int = 1
+        const val EXPANDER_VERSION: Int = 2
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/tt/TokenTreeParser.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/tt/TokenTreeParser.kt
@@ -97,7 +97,7 @@ private class TokenTreeParser(
                 result += Leaf.Literal(tokenText2, allocId(offset, nextWhitespaceOrCommentText()))
             }
             in RS_LITERALS -> result += Leaf.Literal(tokenText, allocId(offset, nextWhitespaceOrCommentText()))
-            in RS_IDENTIFIER_TOKENS -> result += Leaf.Ident(tokenText, allocId(offset, nextWhitespaceOrCommentText()))
+            in PROC_MACRO_IDENTIFIER_TOKENS -> result += Leaf.Ident(tokenText, allocId(offset, nextWhitespaceOrCommentText()))
             QUOTE_IDENTIFIER -> {
                 result += Leaf.Punct(tokenText[0].toString(), Spacing.Joint, allocId(offset, ""))
                 result += Leaf.Ident(tokenText.substring(1), allocId(offset + 1, nextWhitespaceOrCommentText()))
@@ -150,11 +150,16 @@ private class TokenTreeParser(
     }
 }
 
+private val PROC_MACRO_IDENTIFIER_TOKENS = TokenSet.orSet(
+    RS_IDENTIFIER_TOKENS,
+    tokenSetOf(UNDERSCORE)
+)
+
 private val NEXT_TOKEN_ALONE_SET = TokenSet.orSet(
     tokenSetOf(WHITE_SPACE, LBRACK, LBRACE, LPAREN, QUOTE_IDENTIFIER),
     RS_COMMENTS,
     RS_LITERALS,
-    RS_IDENTIFIER_TOKENS,
+    PROC_MACRO_IDENTIFIER_TOKENS,
 )
 
 private val WHITESPACE_OR_COMMENTS = TokenSet.orSet(

--- a/src/test/kotlin/org/rust/lang/core/macros/tt/TokenTreeParserTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/tt/TokenTreeParserTest.kt
@@ -213,6 +213,17 @@ class TokenTreeParserTest : RsTestBase() {
           IDENT   foo 2
     """)
 
+    fun `test 33`() = doTest("_", """
+        SUBTREE $
+          IDENT   _ 0
+    """)
+
+    fun `test 34`() = doTest("._", """
+        SUBTREE $
+          PUNCT   . [alone] 0
+          IDENT   _ 1
+    """)
+
     fun doTest(code: String, expected: String) {
         val subtree = project.createRustPsiBuilder(code).parseSubtree().subtree
         assertEquals(expected.trimIndent(), subtree.toDebugString())


### PR DESCRIPTION
Fixes #8019

changelog: Fix expansion of procedural macros that contain `_` in the macro body