### PR TITLE
TY: fix type inference for break from a nested expression block

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -848,7 +848,7 @@ class RsTypeInferenceWalker(
                             returningTypes += child.expr?.let(ctx::getExprType) ?: TyUnit.INSTANCE
                         }
                     }
-                    is RsLabeledExpression -> {
+                    is RsLooplikeExpr -> {
                         if (label != null) {
                             collectReturningTypes(child, true)
                         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -124,6 +124,76 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         fn foo(s: S<u32>) {}
     """)
 
+    fun `test labeled block expr nested 1`() = testExpr("""
+        fn main() {
+            let x = 'a: {
+                {
+                    break 'a 1u32;
+                }
+            };
+            x;
+          //^ u32
+        }
+    """)
+
+    fun `test labeled block expr nested 2`() = testExpr("""
+        fn main() {
+            let x = 'a: {
+                'b: {
+                    break 'a 1u32;
+                }
+            };
+            x;
+          //^ u32
+        }
+    """)
+
+    fun `test labeled block expr nested 3`() = testExpr("""
+        fn main() {
+            let x = 'a: {
+                'b: {
+                    break 'b 1u32;
+                }
+            };
+            x;
+          //^ u32
+        }
+    """)
+
+    fun `test labeled block expr nested 4`() = testExpr("""
+        fn main() {
+            let x = 'a: {
+                'b: {
+                    break 1u32;
+                }
+            };
+            x;
+          //^ !
+        }
+    """)
+
+    fun `test labeled block expr nested 5`() = testExpr("""
+        fn main() {
+            let x = 'a: {
+                loop {
+                    break 1u32;
+                }
+            };
+            x;
+          //^ u32
+        }
+    """)
+
+    fun `test labeled block expr nested 6`() = testExpr("""
+        fn main() {
+            let x = 'a: {
+                loop { }
+            };
+            x;
+          //^ !
+        }
+    """)
+
     fun `test try block expr (option)`() = testExpr("""
         #[lang = "core::option::Option"]
         enum Option<T> { None, Some(T) }
@@ -429,6 +499,36 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             };
             x;
           //^ i32
+        }
+    """)
+
+    fun `test loop with inner block`() = testExpr("""
+        fn main() {
+            let x = loop {
+                { break "bar"; }
+            };
+            x;
+          //^ &str
+        }
+    """)
+
+    fun `test loop with inner nested block`() = testExpr("""
+        fn main() {
+            let x = loop {
+                let _ = { break true; };
+            };
+            x;
+          //^ bool
+        }
+    """)
+
+    fun `test loop with inner nested labeled block`() = testExpr("""
+        fn main() {
+            let x = loop {
+                let _ = 'a: { break 'a true; };
+            };
+            x;
+          //^ !
         }
     """)
 


### PR DESCRIPTION
Fixes #7502.
Fixes #7695.

Previously type inference incorrectly treated nested expression blocks as nested loops, which would mean that breaks with no specified label from within nested blocks was treated as a non-returning break from a nested loop, so that the break value type was correctly propagated only when explicitly breaking by label.

changelog: Fixed type inference for breaks out of the loop nested within expression blocks
