### PR TITLE
INSP: Add "simplify if with constant condition" inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspection.kt
@@ -1,0 +1,104 @@
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.util.prevLeaf
+import org.rust.ide.inspections.fixes.SubstituteTextFix
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.consts.asBool
+import org.rust.lang.utils.evaluation.evaluate
+
+/** See also [RsRedundantElseInspection]. */
+class RsConstantConditionIfInspection : RsLocalInspectionTool() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
+        object : RsVisitor() {
+            override fun visitIfExpr(ifExpr: RsIfExpr) {
+                val condition = ifExpr.condition ?: return
+                if (condition.pat != null) return
+                val conditionValue = condition.expr?.evaluate()?.asBool() ?: return
+
+                val isUsedAsExpression = ifExpr.isUsedAsExpression()
+                val isInsideCascadeIf = ifExpr.parent is RsElseBranch
+                val fix = if (!conditionValue && ifExpr.elseBranch == null) {
+                    if (isUsedAsExpression && !isInsideCascadeIf) return
+                    createDeleteElseBranchFix(ifExpr, isInsideCascadeIf)
+                } else {
+                    SimplifyFix(conditionValue, isUsedAsExpression, isInsideCascadeIf)
+                }
+
+                holder.registerProblem(condition, "Condition is always ''$conditionValue''", fix)
+            }
+        }
+
+    private fun createDeleteElseBranchFix(ifExpr: RsIfExpr, isInsideCascadeIf: Boolean): SubstituteTextFix {
+        val ifRange = ifExpr.rangeWithPrevSpace
+        val deletionRange = if (isInsideCascadeIf) {
+            val parentElse = (ifExpr.parent as RsElseBranch).`else`
+            val elseRange = parentElse.rangeWithPrevSpace(parentElse.prevLeaf())
+            elseRange.union(ifRange)
+        } else {
+            ifRange
+        }
+        return SubstituteTextFix.delete(
+            "Delete expression",
+            ifExpr.containingFile,
+            deletionRange
+        )
+    }
+}
+
+private class SimplifyFix(
+    private val conditionValue: Boolean,
+    private val isUsedAsExpression: Boolean,
+    private val isInsideCascadeIf: Boolean,
+) : LocalQuickFix {
+    override fun getFamilyName(): String = name
+
+    override fun getName(): String = "Simplify expression"
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val ifExpr = descriptor.psiElement.ancestorStrict<RsIfExpr>() ?: return
+
+        // `if false {} else if ... {} else ...`
+        ifExpr.elseBranch?.ifExpr?.let { elseIfExpr ->
+            if (!conditionValue) {
+                ifExpr.replace(elseIfExpr)
+                return
+            }
+        }
+
+        val branch = (if (conditionValue) ifExpr.block else ifExpr.elseBranch?.block) ?: return
+        val branchFirst = branch.lbrace.getNextNonWhitespaceSibling()!!
+        val branchLast = branch.rbrace.getPrevNonWhitespaceSibling()!!
+        if (isUsedAsExpression) {
+            val canUnwrapBlock = branchFirst == branchLast && !isInsideCascadeIf
+            val replaceWith = when {
+                canUnwrapBlock -> branchFirst
+                isInsideCascadeIf -> branch
+                else -> branch.wrapAsBlockExpr()
+            }
+            val replaced = ifExpr.replace(replaceWith)
+            descriptor.findExistingEditor()?.caretModel?.moveToOffset(replaced.startOffset)
+        } else {
+            if (branchFirst != branch.rbrace) {
+                ifExpr.parent.addRangeAfter(branchFirst, branchLast, ifExpr)
+            }
+            ifExpr.delete()
+        }
+    }
+}
+
+private fun RsIfExpr.isUsedAsExpression(): Boolean =
+    when (val parent = parent) {
+        is RsExprStmt -> false
+        is RsBlock -> this != parent.expr
+        else -> true
+    }
+
+private fun RsBlock.wrapAsBlockExpr(): RsBlockExpr {
+    val blockExpr = RsPsiFactory(project).createBlockExpr("")
+    blockExpr.block.replace(this)
+    return blockExpr
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
@@ -6,6 +6,10 @@
 package org.rust.ide.inspections
 
 import com.intellij.codeInspection.*
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
@@ -102,4 +106,11 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
             holder.registerProblem(element, message, highlightType, rangeInElement, *fixes)
         }
     }
+}
+
+fun ProblemDescriptor.findExistingEditor(): Editor? {
+    ApplicationManager.getApplication().assertReadAccessAllowed()
+    val file = (this as? ProblemDescriptorBase)?.containingFile ?: return null
+    val document = FileDocumentManager.getInstance().getDocument(file) ?: return null
+    return EditorFactory.getInstance().getEditors(document).firstOrNull()
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
@@ -12,12 +12,12 @@ import org.rust.lang.core.FeatureAvailability
 import org.rust.lang.core.LET_ELSE
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.types.consts.asBool
-import org.rust.lang.utils.evaluation.evaluate
 
 /**
  * Detects redundant `else` statements preceded by an irrefutable pattern.
  * Quick fix: Remove `else`
+ *
+ * See also [RsConstantConditionIfInspection].
  */
 class RsRedundantElseInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Redundant else"
@@ -67,13 +67,8 @@ class RsRedundantElseInspection : RsLocalInspectionTool() {
 
         private val RsCondition.isRedundant: Boolean
             get() {
-                val patList = patList
-                return if (patList != null) {
-                    patList.all { pat -> pat.isIrrefutable }
-                } else {
-                    val expr = expr ?: return false
-                    expr.evaluate().asBool() == true
-                }
+                val patList = patList ?: return false
+                return patList.all { pat -> pat.isIrrefutable }
             }
     }
 }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -483,6 +483,11 @@
                          implementationClass="org.rust.ide.inspections.RsSimplifyBooleanExpressionInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
+                         displayName="Condition of 'if' expression is constant"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RsConstantConditionIfInspection"/>
+
+        <localInspection language="Rust" groupName="Rust"
                          displayName="No mutable required"
                          enabledByDefault="false" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsVariableMutableInspection"/>

--- a/src/main/resources/inspectionDescriptions/RsConstantConditionIf.html
+++ b/src/main/resources/inspectionDescriptions/RsConstantConditionIf.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Reports <code>if</code> expressions that have <code>true</code> or <code>false</code> constant literal condition and can be simplified.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspectionTest.kt
@@ -1,0 +1,302 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.rust.MockEdition
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
+
+@MockEdition(Edition.EDITION_2018)
+class RsConstantConditionIfInspectionTest : RsInspectionsTestBase(RsConstantConditionIfInspection::class) {
+
+    fun `test always true, empty branches`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {} else {}
+        }
+    """, """
+        fn main() {}
+    """)
+
+    fun `test always false, empty branches`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''false''">/*caret*/false</warning> {} else {}
+        }
+    """, """
+        fn main() {}
+    """)
+
+    fun `test always true, simple branches`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                println!("1");
+            } else {
+                println!("2");
+            }
+        }
+    """, """
+        fn main() {
+            println!("1");
+        }
+    """)
+
+    fun `test always false, simple branches`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''false''">/*caret*/false</warning> {
+                println!("1");
+            } else {
+                println!("2");
+            }
+        }
+    """, """
+        fn main() {
+            println!("2");
+        }
+    """)
+
+    fun `test always true, complex branches`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                println!("1");
+                println!("1");
+            } else {
+                println!("2");
+                println!("2");
+            }
+        }
+    """, """
+        fn main() {
+            println!("1");
+            println!("1");
+        }
+    """)
+
+    fun `test always false, complex branches`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''false''">/*caret*/false</warning> {
+                println!("1");
+                println!("1");
+            } else {
+                println!("2");
+                println!("2");
+            }
+        }
+    """, """
+        fn main() {
+            println!("2");
+            println!("2");
+        }
+    """)
+
+    fun `test always true, without else`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                1;
+            }
+        }
+    """, """
+        fn main() {
+            1;
+        }
+    """)
+
+    fun `test always false, without else`() = checkFixByText("Delete expression", """
+        fn main() {
+            if <warning descr="Condition is always ''false''">/*caret*/false</warning> {
+                1;
+            }
+        }
+    """, """
+        fn main() {
+        }
+    """)
+
+    fun `test used as expression, simple branch`() = checkFixByText("Simplify expression", """
+        fn main() {
+            let _ = if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                1
+            } else {
+                2
+            };
+        }
+    """, """
+        fn main() {
+            let _ = 1;
+        }
+    """)
+
+    fun `test used as expression, complex branch`() = checkFixByText("Simplify expression", """
+        fn main() {
+            let _ = if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                println!("1");
+                1
+            } else {
+                2
+            };
+        }
+    """, """
+        fn main() {
+            let _ = {
+                println!("1");
+                1
+            };
+        }
+    """)
+
+    fun `test cascade if, first true`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                1;
+            } else if a {
+                2;
+            } else {
+                3;
+            }
+        }
+    """, """
+        fn main() {
+            /*caret*/1;
+        }
+    """)
+
+    fun `test cascade if, first false`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''false''">/*caret*/false</warning> {
+                1;
+            } else if a {
+                2;
+            } else {
+                3;
+            }
+        }
+    """, """
+        fn main() {
+            /*caret*/if a {
+                2;
+            } else {
+                3;
+            }
+        }
+    """)
+
+    fun `test cascade if, middle true`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if a {
+                1;
+            } else if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                2;
+            } else if b {
+                3;
+            } else {
+                4;
+            }
+        }
+    """, """
+        fn main() {
+            if a {
+                1;
+            } else /*caret*/{
+                2;
+            }
+        }
+    """)
+
+    fun `test cascade if, middle false`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if a {
+                1;
+            } else if <warning descr="Condition is always ''false''">/*caret*/false</warning> {
+                2;
+            } else if b {
+                3;
+            } else {
+                4;
+            }
+        }
+    """, """
+        fn main() {
+            if a {
+                1;
+            } else /*caret*/if b {
+                3;
+            } else {
+                4;
+            }
+        }
+    """)
+
+    fun `test cascade if, last true`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if a {
+                1;
+            } else if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                2;
+            } else {
+                3;
+            }
+        }
+    """, """
+        fn main() {
+            if a {
+                1;
+            } else /*caret*/{
+                2;
+            }
+        }
+    """)
+
+    fun `test cascade if, last false`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if a {
+                1;
+            } else if <warning descr="Condition is always ''false''">/*caret*/false</warning> {
+                2;
+            } else {
+                3;
+            }
+        }
+    """, """
+        fn main() {
+            if a {
+                1;
+            } else /*caret*/{
+                3;
+            }
+        }
+    """)
+
+    fun `test cascade if, last without else true`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if a {
+                1;
+            } else if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                2;
+            }
+        }
+    """, """
+        fn main() {
+            if a {
+                1;
+            } else /*caret*/{
+                2;
+            }
+        }
+    """)
+
+    fun `test cascade if, last without else false`() = checkFixByText("Delete expression", """
+        fn main() {
+            if a {
+                1;
+            } else if <warning descr="Condition is always ''false''">/*caret*/false</warning> {
+                2;
+            }
+        }
+    """, """
+        fn main() {
+            if a {
+                1;
+            }/*caret*/
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/RsRedundantElseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsRedundantElseInspectionTest.kt
@@ -188,15 +188,6 @@ class RsRedundantElseInspectionTest : RsInspectionsTestBase(RsRedundantElseInspe
         }
     """)
 
-    fun `test boolean constant`() = checkByText("""
-        fn main() {
-            if true {
-            } <warning descr="Redundant `else`">else</warning> {
-                let a = 5;
-            }
-        }
-    """)
-
     @MockRustcVersion("1.56.0")
     fun `test let else (feature unavailable)`() = checkByText("""
         fn main() {


### PR DESCRIPTION
We have `RedundantElseInspection` which works for irrefutable patterns and always true `if`-conditions. This PR adds new inspection which works for both always true and always false `if`-conditions. And `RedundantElseInspection` now checks only irrefutable patterns. 

![](https://user-images.githubusercontent.com/6505554/139441929-2b6aea03-1973-47a8-a45c-6f166022a803.gif)

changelog: Add "simplify if with constant condition" inspection
