### PR TITLE
TY&RES: resolve explicit type-qualified associated types in type aliases

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -864,4 +864,47 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             X.foo();
         }   //^
     """)
+
+    fun `test non-UFCS associated type in type alias with bound`() = checkByCode("""
+        trait Trait {
+            type Item;
+        }      //X
+        type Alias<T: Trait> = T::Item;
+                                //^
+    """)
+
+    fun `test associated type in type alias with bound`() = checkByCode("""
+        trait Trait {
+            type Item;
+        }      //X
+        type Alias<T: Trait> = <T as Trait>::Item;
+                                           //^
+    """)
+
+    fun `test associated type in type alias without bound`() = checkByCode("""
+        trait Trait {
+            type Item;
+        }      //X
+        type Alias<T> = <T as Trait>::Item;
+                                    //^
+    """)
+
+    fun `test nested associated type in type alias without bound`() = checkByCode("""
+        trait Trait {
+            type Item;
+        }      //X
+        type Alias1<Q> = <<Q as Trait>::Item as Trait>::Item;
+                                                      //^
+    """)
+
+    fun `test nested associated type in type alias without bound 2`() = checkByCode("""
+        trait Trait {
+            type Item: Trait2;
+        }
+        trait Trait2 {
+            type Item;
+        }      //X
+        type Alias1<Q> = <<Q as Trait>::Item as Trait2>::Item;
+                                                       //^
+    """)
 }


### PR DESCRIPTION
Fixes #7865

I found that it's possible to use `<T as Trait>` syntax in type aliases when `T` does not have the corresponding bound `Trait`.

```rust
trait Trait {
    type Item;
}
type Alias<T> = <T as Trait>::Item;
```

Previously, `<T as Trait>::Item` was unresolved.

changelog: Fix name resolution of explicit type-qualified associated types in type aliases (like `type Alias<T> = <T as Trait>::Item;`). This fixes type inference in `hecs` crate
