### PR TITLE
REF: ignore parameter type changes in suggested change signature refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringAvailability.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringAvailability.kt
@@ -42,7 +42,6 @@ class RsSuggestedRefactoringAvailability(
         oldSignature: SuggestedRefactoringSupport.Signature,
         newSignature: SuggestedRefactoringSupport.Signature
     ): Boolean = hasParameterAddedRemovedOrReordered(oldSignature, newSignature) ||
-        hasTypeChanges(oldSignature, newSignature) ||
         hasNameChanges(oldSignature, newSignature)
 }
 

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsChangeSignatureSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsChangeSignatureSuggestedRefactoringTest.kt
@@ -20,6 +20,13 @@ class RsChangeSignatureSuggestedRefactoringTest : RsSuggestedRefactoringTestBase
         fn foo()/*caret*/ {}
     """) { myFixture.type(" -> u32") }
 
+    fun `test unavailable when changing parameter type`() = doUnavailableTest("""
+        fn foo(a: /*caret*/u32) {}
+    """) {
+        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
+        myFixture.type("i")
+    }
+
     fun `test unavailable on inner binding change`() = doUnavailableTest("""
         struct S {
             a: u32


### PR DESCRIPTION
Do not show `Update ... to reflect signature changes` if only a parameter type was changed (as that cannot be reflected by the refactoring anyway).

changelog: The `Change signature` refactoring is no longer offered automatically on function parameter type changes.