### PR TITLE
REF: do not use resolve in RsChangeFunctionSignatureConfig::create

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
@@ -147,7 +147,7 @@ class RsChangeFunctionSignatureConfig private constructor(
     companion object {
         fun create(function: RsFunction): RsChangeFunctionSignatureConfig {
             val factory = RsPsiFactory(function.project)
-            val parameters = function.valueParameters.mapIndexed { index, parameter ->
+            val parameters = function.rawValueParameters.mapIndexed { index, parameter ->
                 val patText = parameter.pat?.text ?: "_"
                 val type = ParameterProperty.fromItem(parameter.typeReference)
                 Parameter(factory, patText, type, index)


### PR DESCRIPTION
We do not allow this refactoring on functions with any cfg-disabled parameters, so it should not change anything.

It was causing the following exception:

```
java.lang.Throwable: Slow operations are prohibited on EDT. See SlowOperations.assertSlowOperationsAreAllowed javadoc.
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:182)
	at com.intellij.util.SlowOperations.assertSlowOperationsAreAllowed(SlowOperations.java:110)
	at com.intellij.util.indexing.FileBasedIndexImpl.ensureUpToDate(FileBasedIndexImpl.java:754)
	at com.intellij.psi.stubs.StubIndexImpl.getContainingIds(StubIndexImpl.java:501)
	at com.intellij.psi.stubs.StubIndexImpl.processElements(StubIndexImpl.java:305)
	at com.intellij.psi.stubs.StubIndex.processElements(StubIndex.java:51)
	at org.rust.lang.core.stubs.index.RsIncludeMacroIndex$Companion.makeIndexLookup$lambda-2(RsIncludeMacroIndex.kt:84)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:89)
	at org.rust.openapiext.UtilsKt.recursionGuard$default(utils.kt:88)
	at org.rust.lang.core.stubs.index.RsIncludeMacroIndex$Companion.makeIndexLookup(RsIncludeMacroIndex.kt:77)
	at org.rust.lang.core.stubs.index.RsIncludeMacroIndex$Companion.getIncludedFromInternal(RsIncludeMacroIndex.kt:72)
	at org.rust.lang.core.stubs.index.RsIncludeMacroIndex$Companion.getIncludedFrom$lambda-0(RsIncludeMacroIndex.kt:64)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at org.rust.lang.core.stubs.index.RsIncludeMacroIndex$Companion.getIncludedFrom(RsIncludeMacroIndex.kt:62)
	at org.rust.lang.core.macros.RsExpandedElement$Companion.getContextImpl(RsExpandedElement.kt:36)
	at org.rust.lang.core.macros.RsExpandedElement$Companion.getContextImpl$default(RsExpandedElement.kt:29)
	at org.rust.lang.core.psi.ext.RsFunctionImplMixin.getContext(RsFunction.kt:260)
	at com.intellij.psi.util.PsiTreeUtil.getContextOfType(PsiTreeUtil.java:615)
	at com.intellij.psi.util.PsiTreeUtil.getContextOfType(PsiTreeUtil.java:596)
	at org.rust.lang.core.psi.ext.PsiElementKt.getContextualFile(PsiElement.kt:349)
	at org.rust.lang.core.psi.ext.RsElementKt.getContainingCrate(RsElement.kt:61)
	at org.rust.lang.core.stubs.common.RsAttributeOwnerPsiOrStub.getContainingCrate(PsiOrStubInterfaces.kt:49)
	at org.rust.lang.core.psi.ext.RsDocAndAttributeOwnerKt.evaluateCfg(RsDocAndAttributeOwner.kt:475)
	at org.rust.lang.core.psi.ext.RsDocAndAttributeOwnerKt.evaluateCfg$default(RsDocAndAttributeOwner.kt:464)
	at org.rust.lang.core.psi.ext.RsDocAndAttributeOwnerKt.getExistsAfterExpansionSelf(RsDocAndAttributeOwner.kt:445)
	at org.rust.lang.core.psi.ext.RsFunctionKt.getValueParameters(RsFunction.kt:70)
	at org.rust.ide.refactoring.changeSignature.RsChangeFunctionSignatureConfig$Companion.create(RsChangeSignatureConfig.kt:150)
	at org.rust.ide.refactoring.suggested.RsSuggestedRefactoringExecution.performChangeSignature(RsSuggestedRefactoringExecution.kt:37)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt.performChangeSignature(PerformSuggestedRefactoring.kt:373)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt.access$performChangeSignature(PerformSuggestedRefactoring.kt:1)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt$performSuggestedRefactoring$3$1.invoke(PerformSuggestedRefactoring.kt:103)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt$performSuggestedRefactoring$3$1.invoke(PerformSuggestedRefactoring.kt)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt.performWithDumbEditor(PerformSuggestedRefactoring.kt:313)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt.doRefactor(PerformSuggestedRefactoring.kt:177)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt.access$doRefactor(PerformSuggestedRefactoring.kt:1)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt$performSuggestedRefactoring$3.invoke(PerformSuggestedRefactoring.kt:102)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt$performSuggestedRefactoring$callbacks$6.invoke(PerformSuggestedRefactoring.kt:146)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt$performSuggestedRefactoring$callbacks$6.invoke(PerformSuggestedRefactoring.kt)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt$createAndShowBalloon$1$hideBalloonAndRefactor$$inlined$executeCommand$1.run(actions.kt:14)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:216)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:172)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:162)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:148)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt$createAndShowBalloon$1.invoke(PerformSuggestedRefactoring.kt:391)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt$createAndShowBalloon$6.invoke(PerformSuggestedRefactoring.kt:272)
	at com.intellij.refactoring.suggested.PerformSuggestedRefactoringKt$createAndShowBalloon$6.invoke(PerformSuggestedRefactoring.kt)
	at com.intellij.refactoring.suggested.ChangeSignaturePopup$1.actionPerformed(ChangeSignaturePopup.kt:343)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1967)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2308)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:270)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6652)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3345)
	at java.desktop/java.awt.Component.processEvent(Component.java:6417)
	at java.desktop/java.awt.Container.processEvent(Container.java:2263)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5027)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4859)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4918)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4547)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4488)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2307)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2784)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4859)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:778)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:727)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:751)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:749)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:748)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:885)
	at com.intellij.ide.IdeEventQueue.dispatchMouseEvent(IdeEventQueue.java:814)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:751)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$6(IdeEventQueue.java:441)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:825)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$7(IdeEventQueue.java:440)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:794)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:492)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

changelog: Do not use potentially long-running operations on the UI thread in Change signature refactoring.