### PR TITLE
Update Rust ML ranking provider to 0.2.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -540,7 +540,7 @@ project(":ml-completion") {
         plugins.set(listOf(mlCompletionPlugin))
     }
     dependencies {
-        implementation("org.jetbrains.intellij.deps.completion:completion-ranking-rust:0.2.2")
+        implementation("org.jetbrains.intellij.deps.completion:completion-ranking-rust:0.2.3")
         implementation(project(":"))
         testImplementation(project(":", "testOutput"))
     }


### PR DESCRIPTION
No major changes. A version file `version.txt` has been added to the metadata.