### PR TITLE
INSP: Support usages in attr proc macros in unused imports inspection

### DIFF
--- a/src/main/kotlin/org/rust/openapiext/psi.kt
+++ b/src/main/kotlin/org/rust/openapiext/psi.kt
@@ -12,8 +12,13 @@ import com.intellij.psi.impl.source.tree.CompositeElement
 import com.intellij.psi.search.PsiElementProcessor
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.containers.ContainerUtil
+import org.rust.lang.core.psi.ProcMacroAttribute
 import org.rust.lang.core.psi.RsMacroCall
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.ext.RsAttrProcMacroOwner
+import org.rust.lang.core.psi.ext.RsPossibleMacroCall
+import org.rust.lang.core.psi.ext.expansion
+import org.rust.lang.core.psi.ext.macroName
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.stdext.exhaustive
 
@@ -101,6 +106,9 @@ private class RsWithMacrosRecursiveElementWalkingVisitor(
         private set
 
     override fun visitElement(element: PsiElement) {
+        val procMacroAttribute = (element as? RsAttrProcMacroOwner)?.procMacroAttributeWithDerives
+        if (tryProcessAttrProcMacro(procMacroAttribute)) return
+
         when (processor.execute(element)) {
             TreeStatus.VISIT_CHILDREN -> {
                 if (element is RsMacroCall && shouldExpandMacro(element)) {
@@ -108,7 +116,7 @@ private class RsWithMacrosRecursiveElementWalkingVisitor(
                 } else {
                     super.visitElement(element)
                 }
-                tryProcessDeriveProcMacro(element)
+                tryProcessDeriveProcMacro(procMacroAttribute)
             }
             TreeStatus.SKIP_CHILDREN -> return
             TreeStatus.ABORT -> {
@@ -137,12 +145,17 @@ private class RsWithMacrosRecursiveElementWalkingVisitor(
         }
     }
 
-    private fun tryProcessDeriveProcMacro(element: PsiElement) {
-        if (element !is RsStructOrEnumItemElement) return
-        for (deriveMetaItem in element.deriveMetaItems) {
-            if (deriveMetaItem.canBeMacroCall) {
-                processMacro(deriveMetaItem)
-            }
+    private fun tryProcessAttrProcMacro(procMacroAttribute: ProcMacroAttribute<RsMetaItem>?): Boolean {
+        if (procMacroAttribute !is ProcMacroAttribute.Attr) return false
+        super.visitElement(procMacroAttribute.attr)
+        processMacro(procMacroAttribute.attr)
+        return true
+    }
+
+    private fun tryProcessDeriveProcMacro(procMacroAttribute: ProcMacroAttribute<RsMetaItem>?) {
+        if (procMacroAttribute !is ProcMacroAttribute.Derive) return
+        for (derive in procMacroAttribute.derives) {
+            processMacro(derive)
         }
     }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -474,6 +474,21 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
+    @MinRustcVersion("1.46.0")
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test usage inside attribute proc macro expansion`() = checkByText("""
+        struct Foo;
+        mod foo {
+            use test_proc_macros::attr_replace_with_attr;
+            use crate::Foo;
+            #[attr_replace_with_attr(fn bar(_: Foo) {})]
+            fn func() {}
+        }
+    """)
+
     fun `test deny lint`() = checkByText("""
         #![deny(unused_imports)]
 


### PR DESCRIPTION
For now, usages are searched in the current mod only

Meta issue: #2158

changelog: Support usages in attribute proc macros in unused imports inspection