### PR TITLE
INSP: New auto-import for UFCS trait methods

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -137,8 +137,11 @@ class AutoImportFix(element: RsElement, private val type: Type) : LocalQuickFixO
                 if (it !is ResolvedPath.AssocItem) return null
                 it.source
             }
-            val candidates = ImportCandidatesCollector.getTraitImportCandidates(project, path, sources)?.toList()
-                ?: return null
+            val candidates = if (path.useAutoImportWithNewResolve) {
+                ImportCandidatesCollector2.getTraitImportCandidates(path, sources)
+            } else {
+                ImportCandidatesCollector.getTraitImportCandidates(project, path, sources)?.toList()
+            } ?: return null
             return Context(ASSOC_ITEM_PATH, candidates)
         }
     }

--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
@@ -101,7 +101,7 @@ object ImportCandidatesCollector2 {
     fun getImportCandidates(scope: RsElement, resolvedMethods: List<MethodResolveVariant>): List<ImportCandidate2>? =
         getTraitImportCandidates(scope, resolvedMethods.map { it.source })
 
-    private fun getTraitImportCandidates(scope: RsElement, sources: List<TraitImplSource>): List<ImportCandidate2>? {
+    fun getTraitImportCandidates(scope: RsElement, sources: List<TraitImplSource>): List<ImportCandidate2>? {
         val traits = ImportCandidatesCollector.collectTraitsToImport(scope, sources)
             ?: return null
         val traitsPaths = traits.mapNotNullToSet { it.asModPath() }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -1664,6 +1664,39 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test import trait default method UFCS 2`() = checkAutoImportFixByFileTree("""
+    //- lib.rs
+        pub trait Trait {
+            fn foo() {}
+        }
+        impl<T> Trait for T {}
+    //- main.rs
+        pub use test_package::Trait;
+
+        mod inner {
+            fn main() {
+                i32::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>();
+            }
+        }
+    """, """
+    //- lib.rs
+        pub trait Trait {
+            fn foo() {}
+        }
+        impl<T> Trait for T {}
+    //- main.rs
+        pub use test_package::Trait;
+
+        mod inner {
+            use test_package::Trait;
+
+            fn main() {
+                i32::foo();
+            }
+        }
+    """)
+
     fun `test import trait default assoc function`() = checkAutoImportFixByText("""
         mod foo {
             pub struct S;


### PR DESCRIPTION
Continuation of #8029 for auto-import traits for UFCS.
Meta issue: #7558

changelog: Improve traits auto-import for [UFCS](https://doc.rust-lang.org/1.7.0/book/ufcs.html) methods