### PR TITLE
INSP: Fix "simplify if with constant condition" generated PSI

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspectionTest.kt
@@ -144,6 +144,79 @@ class RsConstantConditionIfInspectionTest : RsInspectionsTestBase(RsConstantCond
         }
     """)
 
+    fun `test used as tail expression, simple branch`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                1
+            } else {
+                2
+            }
+        }
+    """, """
+        fn main() {
+            1
+        }
+    """)
+
+    fun `test used as tail expression, complex branch`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                println!("1");
+                1
+            } else {
+                2
+            }
+        }
+    """, """
+        fn main() {
+            println!("1");
+            1
+        }
+    """)
+
+    fun `test if is not last in function 1`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {} else {}
+            println!("3");
+        }
+    """, """
+        fn main() {
+            println!("3");
+        }
+    """)
+
+    fun `test if is not last in function 2`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                println!("1");
+            } else {
+                println!("2");
+            }
+            println!("3");
+        }
+    """, """
+        fn main() {
+            println!("1");
+            println!("3");
+        }
+    """)
+
+    fun `test if is not last in function 3`() = checkFixByText("Simplify expression", """
+        fn main() {
+            if <warning descr="Condition is always ''true''">/*caret*/true</warning> {
+                1
+            } else {
+                2
+            }
+            println!("3");
+        }
+    """, """
+        fn main() {
+            1;
+            println!("3");
+        }
+    """)
+
     fun `test cascade if, first true`() = checkFixByText("Simplify expression", """
         fn main() {
             if <warning descr="Condition is always ''true''">/*caret*/true</warning> {


### PR DESCRIPTION
#8030 generates correct text with invalid PSI in some cases (e.g. `RsExprStmt` inside `RsExprStmt`), which may lead to exceptions. This PR fixes generated PSI.

<details>

```
java.lang.Throwable
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:182)
	at com.intellij.psi.impl.PsiElementBase.notNullChild(PsiElementBase.java:284)
	at org.rust.lang.core.psi.impl.RsExprStmtImpl.getExpr(RsExprStmtImpl.java:33)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.processStatement(TypeInferenceWalker.kt:151)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:108)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:101)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferFnBody(TypeInferenceWalker.kt:96)
	at org.rust.lang.core.types.infer.RsInferenceContext.infer(TypeInference.kt:175)
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn$lambda-0(TypeInference.kt:34)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:89)
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn(TypeInference.kt:34)
	at org.rust.lang.core.types.ExtensionsKt._get_inference_$lambda-0(Extensions.kt:75)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:43)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:74)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:81)
	at org.rust.lang.core.types.ExtensionsKt.getType(Extensions.kt:87)
	at org.rust.ide.hints.type.RsInlayTypeHintsProvider$getCollectorFor$1.presentTypePlaceholders(RsInlayTypeHintsProvider.kt:110)
	at org.rust.ide.hints.type.RsInlayTypeHintsProvider$getCollectorFor$1.presentVariable(RsInlayTypeHintsProvider.kt:89)
	at org.rust.ide.hints.type.RsInlayTypeHintsProvider$getCollectorFor$1.collect(RsInlayTypeHintsProvider.kt:73)
	at com.intellij.codeInsight.hints.CollectorWithSettings.collectHints(InlayHintsUtils.kt:65)
	at com.intellij.codeInsight.hints.InlayHintsPass$doCollectInformation$1.process(InlayHintsPass.kt:46)
	at com.intellij.codeInsight.hints.InlayHintsPass$doCollectInformation$1.process(InlayHintsPass.kt:26)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:136)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1078)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapInReadActionAndIndicator$1(ApplierCompleter.java:92)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:705)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:647)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
	at com.intellij.concurrency.ApplierCompleter.wrapInReadActionAndIndicator(ApplierCompleter.java:104)
	at com.intellij.concurrency.ApplierCompleter.compute(ApplierCompleter.java:86)
	at com.intellij.concurrency.JobLauncherImpl.invokeConcurrentlyUnderProgress(JobLauncherImpl.java:61)
	at com.intellij.codeInsight.hints.InlayHintsPass.doCollectInformation(InlayHintsPass.kt:37)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:56)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:414)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1078)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:407)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:705)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:647)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:406)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:382)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:174)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:183)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:380)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:188)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

</details>