### PR TITLE
TY&RES: resolve an associated type to a trait if we're unsure about the impl

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -606,7 +606,8 @@ class RsTypeInferenceWalker(
             }
         }
         val argExprs = expr.valueArgumentList.exprList
-        val calleeType = lookup.asTyFunction(ty)?.register() ?: unknownTyFunction(argExprs.size)
+        val calleeType = (lookup.asTyFunction(ty)?.register() ?: unknownTyFunction(argExprs.size))
+            .foldWith(associatedTypeNormalizer) as TyFunction
         if (expected != null) ctx.combineTypes(expected, calleeType.retType)
         inferArgumentTypes(calleeType.paramTypes, argExprs)
         return calleeType.retType
@@ -1111,10 +1112,7 @@ class RsTypeInferenceWalker(
             if (!isArrayToSlice(prevType, type)) derefCount++
 
             val outputType = lookup.findIndexOutputType(type, indexType)
-            if (outputType != null
-                // TODO fix resolve in `impl<T, I, const N: usize> Index<I> for [T; N]` and remove this line
-                && (outputType.value != TyUnknown || type !is TyArray)
-            ) {
+            if (outputType != null) {
                 result = outputType.register()
                 break
             }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionTest.kt
@@ -62,27 +62,23 @@ class RsPathCompletionTest : RsCompletionTestBase() {
 
     // enable once name resolution of <Foo as Trait>::function is fixed
     @ProjectDescriptor(WithWorkspaceAndStdLibProjectDescriptor::class)
-    fun `test do not complete paths in path trait impl`() {
-        expect<IllegalStateException> {
-            checkNoCompletionByFileTree("""
-        //- crate-a/main.rs
-            use std::path::Path;
-            trait Foo {
-                fn new(x: &str) -> i32;
-            }
-            impl Foo for Path {
-                fn new(x: &str) -> i32 {
-                    123
-                }
-            }
-            fn main() {
-                <Path as Foo>::new("fo/*caret*/");
-            }
-        //- foo.rs
-            pub struct Foo;
-        """)
+    fun `test do not complete paths in path trait impl`() = checkNoCompletionByFileTree("""
+    //- crate-a/main.rs
+        use std::path::Path;
+        trait Foo {
+            fn new(x: &str) -> i32;
         }
-    }
+        impl Foo for Path {
+            fn new(x: &str) -> i32 {
+                123
+            }
+        }
+        fn main() {
+            <Path as Foo>::new("fo/*caret*/");
+        }
+    //- foo.rs
+        pub struct Foo;
+    """)
 
     @ProjectDescriptor(WithWorkspaceAndStdLibProjectDescriptor::class)
     fun `test complete paths in pathbuf constructor`() = doSingleCompletionByFileTree("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -802,38 +802,6 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }                    //^
     """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
 
-    fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 1)`() = checkByCode("""
-        struct S;
-        trait Trait1<T> { type Item; }
-        trait Trait2<T>: Trait1<T> { fn foo() -> i32; }
-
-        impl Trait1<i32> for S {
-            type Item = i32;
-        }       //X
-        impl Trait1<u8> for S {
-            type Item = u8;
-        }
-        impl Trait2<i32> for S {
-            fn foo() -> Self::Item { unreachable!() }
-        }                   //^
-    """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
-
-    fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 2)`() = checkByCode("""
-        struct S;
-        trait Trait1<T=u8> { type Item; }
-        trait Trait2<T>: Trait1<T> { fn foo() -> i32; }
-
-        impl Trait1<i32> for S {
-            type Item = i32;
-        }       //X
-        impl Trait1 for S {
-            type Item = u8;
-        }
-        impl Trait2<i32> for S {
-            fn foo() -> Self::Item { unreachable!() }
-        }                   //^
-    """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
-
     fun `test explicit UFCS-like type-qualified path`() = checkByCode("""
         struct S;
         impl S {
@@ -863,48 +831,5 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         fn main() {
             X.foo();
         }   //^
-    """)
-
-    fun `test non-UFCS associated type in type alias with bound`() = checkByCode("""
-        trait Trait {
-            type Item;
-        }      //X
-        type Alias<T: Trait> = T::Item;
-                                //^
-    """)
-
-    fun `test associated type in type alias with bound`() = checkByCode("""
-        trait Trait {
-            type Item;
-        }      //X
-        type Alias<T: Trait> = <T as Trait>::Item;
-                                           //^
-    """)
-
-    fun `test associated type in type alias without bound`() = checkByCode("""
-        trait Trait {
-            type Item;
-        }      //X
-        type Alias<T> = <T as Trait>::Item;
-                                    //^
-    """)
-
-    fun `test nested associated type in type alias without bound`() = checkByCode("""
-        trait Trait {
-            type Item;
-        }      //X
-        type Alias1<Q> = <<Q as Trait>::Item as Trait>::Item;
-                                                      //^
-    """)
-
-    fun `test nested associated type in type alias without bound 2`() = checkByCode("""
-        trait Trait {
-            type Item: Trait2;
-        }
-        trait Trait2 {
-            type Item;
-        }      //X
-        type Alias1<Q> = <<Q as Trait>::Item as Trait2>::Item;
-                                                       //^
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
@@ -535,4 +535,13 @@ class RsNumericLiteralTypeInferenceTest : RsTypificationTestBase() {
             0.0.foo();
         } //^ f32
     """)
+
+    fun `test integer literal with returning associated type`() = testExpr("""
+        struct S;
+        trait T { type Item; }
+        impl T for S { type Item = u8; }
+        fn foo() -> <S as T>::Item {
+            0
+        } //^ u8
+    """)
 }


### PR DESCRIPTION
Fixes #7302
Fixes #4475
Fixes #6547
Fixes #5897
Fixes #3987
Fixes #5483

Consider this code:

```rust
pub trait Trait<T> { 
    type Item; 
}       //X
struct S;            
impl Trait<i32> for S { 
    type Item = (); 
}
impl Trait<u8> for S { 
    type Item = ();
}

pub type Alias<T> = <S as Trait<T>>::Item;
                                    //^
```

Previously we had multiresolve on `<S as Trait<T>>::Item` path. Now we just resolve it to the trait. The `impl` will be selected later during type inference (in a place where the concrete impl is really needed for type inference).

This also fixes the same as #8033 (#7865), but in a different way