### PR TITLE
DBG: Suggest private items when completing code in the debugger

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerEditorsExtension.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerEditorsExtension.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.xdebugger.XSourcePosition
 import com.intellij.xdebugger.evaluation.EvaluationMode
 import com.jetbrains.cidr.execution.debugger.CidrDebuggerEditorsExtensionBase
-import org.rust.lang.core.psi.RsExpressionCodeFragment
+import org.rust.lang.core.psi.RsDebuggerExpressionCodeFragment
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 
@@ -21,7 +21,7 @@ class RsDebuggerEditorsExtension : CidrDebuggerEditorsExtensionBase() {
 
     override fun createExpressionCodeFragment(project: Project, text: String, context: PsiElement, mode: EvaluationMode): PsiFile =
         if (context is RsElement) {
-            RsExpressionCodeFragment(project, text, context)
+            RsDebuggerExpressionCodeFragment(project, text, context)
         } else {
             super.createExpressionCodeFragment(project, text, context, mode)
         }

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -494,6 +494,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkReferenceIsPublic(ref: RsReferenceElement, o: RsElement, holder: RsAnnotationHolder) {
+        // Do not annotate usages of private items in debugger
+        if (o.containingFile is RsDebuggerExpressionCodeFragment) {
+            return
+        }
         val reference = ref.reference ?: return
         val highlightedElement = ref.referenceNameElement ?: return
         val referenceName = ref.referenceName ?: return

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -46,7 +46,7 @@ class RustParserDefinition : ParserDefinition {
             injectionListener.evalDebugContext(injectionHost, contextResult)
             val context = contextResult.element ?: return default()
 
-            val fragment = RsExpressionCodeFragment(viewProvider, context)
+            val fragment = RsDebuggerExpressionCodeFragment(viewProvider, context)
             injectionListener.didInject(injectionHost)
 
             return fragment

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
@@ -112,14 +112,19 @@ abstract class RsCodeFragment(
     }
 }
 
-class RsExpressionCodeFragment : RsCodeFragment, RsInferenceContextOwner {
-    constructor(fileViewProvider: FileViewProvider, context: RsElement)
+open class RsExpressionCodeFragment : RsCodeFragment, RsInferenceContextOwner {
+    protected constructor(fileViewProvider: FileViewProvider, context: RsElement)
         : super(fileViewProvider, RsCodeFragmentElementType.EXPR, context)
 
     constructor(project: Project, text: CharSequence, context: RsElement, importTarget: RsItemsOwner? = null)
         : super(project, text, RsCodeFragmentElementType.EXPR, context, importTarget = importTarget)
 
     val expr: RsExpr? get() = childOfType()
+}
+
+class RsDebuggerExpressionCodeFragment : RsExpressionCodeFragment {
+    constructor(fileViewProvider: FileViewProvider, context: RsElement) : super(fileViewProvider, context)
+    constructor(project: Project, text: CharSequence, context: RsElement) : super(project, text, context)
 }
 
 class RsStatementCodeFragment(project: Project, text: CharSequence, context: RsElement)

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -10,9 +10,7 @@ import com.intellij.util.SmartList
 import org.rust.lang.core.completion.RsCompletionContext
 import org.rust.lang.core.completion.collectVariantsForEnumCompletion
 import org.rust.lang.core.completion.createLookupElement
-import org.rust.lang.core.psi.RsEnumItem
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.MethodResolveVariant
 import org.rust.lang.core.types.BoundElement
@@ -301,6 +299,10 @@ fun processAllWithSubst(
 }
 
 fun filterCompletionVariantsByVisibility(context: RsElement, processor: RsResolveProcessor): RsResolveProcessor {
+    // Do not filter out private items in debugger
+    if (context.containingFile is RsDebuggerExpressionCodeFragment) {
+        return processor
+    }
     val mod = context.containingMod
     return createProcessor(processor.name) {
         val element = it.element

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
@@ -5,10 +5,14 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.openapi.project.Project
+import com.intellij.psi.util.parentOfType
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
+import org.rust.lang.core.psi.RsCodeFragment
+import org.rust.lang.core.psi.ext.RsElement
 import org.rust.openapiext.Testmark
 
 abstract class RsAnnotationTestBase : RsTestBase() {
@@ -119,5 +123,20 @@ abstract class RsAnnotationTestBase : RsTestBase() {
 
         myFixture.configureFromTempProjectFile(testFilePath)
         myFixture.testHighlighting(false, checkInfo, false)
+    }
+
+    protected fun checkByCodeFragment(
+        @Language("Rust") context: String,
+        fragment: String,
+        fragmentConstructor: (Project, String, RsElement) -> RsCodeFragment,
+        checkWarn: Boolean = true,
+        checkInfo: Boolean = false,
+        checkWeakWarn: Boolean = false
+    ) {
+        InlineFile(context).withCaret()
+        val contextElement = myFixture.file.findElementAt(myFixture.caretOffset)?.parentOfType<RsElement>()!!
+        val codeFragment = fragmentConstructor(project, fragment, contextElement)
+        myFixture.configureFromExistingVirtualFile(codeFragment.virtualFile)
+        myFixture.testHighlighting(checkWarn, checkInfo, checkWeakWarn)
     }
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -9,6 +9,8 @@ import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.macros.MacroExpansionScope
+import org.rust.lang.core.psi.RsDebuggerExpressionCodeFragment
+import org.rust.lang.core.psi.RsExpressionCodeFragment
 
 class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
@@ -4576,4 +4578,22 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl T for S { <error descr="Unnecessary visibility qualifier [E0449]">pub</error> type Item = S; }
         extern { pub type ItemForeign; }
     """)
+
+    fun `test do not annotate usage of private field in debugger code fragment`() = checkByCodeFragment("""
+        mod my {
+            pub struct Foo { inner: i32 }
+        }
+        fn bar(foo: my::Foo) {
+            /*caret*/;
+        }
+    """, """foo.inner""", ::RsDebuggerExpressionCodeFragment)
+
+    fun `test annotate usage of private field in expr code fragment`() = checkByCodeFragment("""
+        mod my {
+            pub struct Foo { inner: i32 }
+        }
+        fn bar(foo: my::Foo) {
+            /*caret*/;
+        }
+    """, """foo.<error descr="Field `inner` of struct `my::Foo` is private [E0616]">inner</error>""", ::RsExpressionCodeFragment)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -121,7 +121,7 @@ abstract class RsCompletionTestFixtureBase<IN>(
         prepare(code)
         val lookups = myFixture.completeBasic()
         checkNotNull(lookups) {
-            "Expected completions that contain $variants, but no completions found"
+            "Expected completions that don't contain $variants, but no completions found"
         }
         if (lookups.any { it.render() in variants }) {
             error("Expected completions that don't contain $variants, but got ${lookups.map { it.render() }}")

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.completion
 
+import com.intellij.codeInsight.CodeInsightSettings
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
@@ -95,8 +96,14 @@ abstract class RsCompletionTestFixtureBase<IN>(
         variants: Iterable<String>,
         render: LookupElement.() -> String = { lookupString }
     ) {
-        prepare(code)
-        doContainsCompletion(variants.toSet(), render)
+        val oldAutocomplete = CodeInsightSettings.getInstance().AUTOCOMPLETE_ON_CODE_COMPLETION
+        CodeInsightSettings.getInstance().AUTOCOMPLETE_ON_CODE_COMPLETION = false
+        try {
+            prepare(code)
+            doContainsCompletion(variants.toSet(), render)
+        } finally {
+            CodeInsightSettings.getInstance().AUTOCOMPLETE_ON_CODE_COMPLETION = oldAutocomplete
+        }
     }
 
     fun doContainsCompletion(variants: Set<String>, render: LookupElement.() -> String) {

--- a/src/test/kotlin/org/rust/lang/core/psi/RsCodeFragmentCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsCodeFragmentCompletionTestBase.kt
@@ -1,0 +1,61 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.util.parentOfType
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import org.intellij.lang.annotations.Language
+import org.rust.InlineFile
+import org.rust.RsTestBase
+import org.rust.lang.core.completion.RsCompletionTestFixtureBase
+import org.rust.lang.core.psi.RsCodeFragmentCompletionTestFixture.Data
+import org.rust.lang.core.psi.ext.RsElement
+
+abstract class RsCodeFragmentCompletionTestBase(
+    private val fragmentConstructor: (Project, String, RsElement) -> RsCodeFragment
+) : RsTestBase() {
+
+    private lateinit var completionFixture: RsCodeFragmentCompletionTestFixture
+
+    override fun setUp() {
+        super.setUp()
+        completionFixture = RsCodeFragmentCompletionTestFixture(myFixture, fragmentConstructor)
+        completionFixture.setUp()
+    }
+
+    override fun tearDown() {
+        completionFixture.tearDown()
+        super.tearDown()
+    }
+
+    protected fun checkContainsCompletion(@Language("Rust") context: String, fragment: String, variant: String) {
+        completionFixture.checkContainsCompletion(Data(context, fragment), listOf(variant))
+    }
+
+    protected fun checkNotContainsCompletion(@Language("Rust") context: String, fragment: String, variant: String) {
+        completionFixture.checkNotContainsCompletion(Data(context, fragment), setOf(variant))
+    }
+}
+
+private class RsCodeFragmentCompletionTestFixture(
+    fixture: CodeInsightTestFixture,
+    private val fragmentConstructor: (Project, String, RsElement) -> RsCodeFragment
+) : RsCompletionTestFixtureBase<Data>(fixture) {
+
+    override fun prepare(code: Data) {
+        val (context, fragment) = code
+        InlineFile(myFixture, context, "main.rs").withCaret()
+        check("<caret>" in fragment) {
+            "Please, add `<caret>` marker to\n$fragment"
+        }
+        val contextElement = myFixture.file.findElementAt(myFixture.caretOffset)?.parentOfType<RsElement>()!!
+        val codeFragment = fragmentConstructor(project, fragment, contextElement)
+        myFixture.configureFromExistingVirtualFile(codeFragment.virtualFile)
+    }
+
+    data class Data(val context: String, val fragment: String)
+}

--- a/src/test/kotlin/org/rust/lang/core/psi/RsDebuggerExpressionCodeFragmentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsDebuggerExpressionCodeFragmentCompletionTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+class RsDebuggerExpressionCodeFragmentCompletionTest
+    : RsCodeFragmentCompletionTestBase(::RsDebuggerExpressionCodeFragment) {
+
+    fun `test complete public field`() = checkContainsCompletion("""
+        mod my {
+            pub struct Foo { pub inner: i32 }
+        }
+        fn bar(foo: my::Foo) {
+            /*caret*/;
+        }
+    """, "foo.in<caret>", "inner")
+
+    fun `test complete private field`() = checkContainsCompletion("""
+        mod my {
+            pub struct Foo { inner: i32 }
+        }
+        fn bar(foo: my::Foo) {
+            /*caret*/;
+        }
+    """, "foo.in<caret>", "inner")
+
+    fun `test complete public function`() = checkContainsCompletion("""
+        mod my {
+            pub fn foobar() {}
+        }
+        fn bar() {
+            use my::*;
+            /*caret*/;
+        }
+    """, "foo<caret>", "foobar")
+
+    fun `test complete private function`() = checkContainsCompletion("""
+        mod my {
+            fn foobar() {}
+        }
+        fn bar() {
+            use my::*;
+            /*caret*/;
+        }
+    """, "foo<caret>", "foobar")
+}

--- a/src/test/kotlin/org/rust/lang/core/psi/RsExpressionCodeFragmentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsExpressionCodeFragmentCompletionTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+class RsExpressionCodeFragmentCompletionTest
+    : RsCodeFragmentCompletionTestBase(::RsExpressionCodeFragment) {
+
+    fun `test complete public field`() = checkContainsCompletion("""
+        mod my {
+            pub struct Foo { pub inner: i32 }
+        }
+        fn bar(foo: my::Foo) {
+            /*caret*/;
+        }
+    """, "foo.in<caret>", "inner")
+
+    fun `test do not complete private field`() = checkNotContainsCompletion("""
+        mod my {
+            pub struct Foo { inner: i32 }
+        }
+        fn bar(foo: my::Foo) {
+            /*caret*/;
+        }
+    """, "foo.in<caret>", "inner")
+
+    fun `test complete public function`() = checkContainsCompletion("""
+        mod my {
+            pub fn foobar() {}
+        }
+        fn bar() {
+            use my::*;
+            /*caret*/;
+        }
+    """, "foo<caret>", "foobar")
+
+    fun `test do not complete private function`() = checkNotContainsCompletion("""
+        mod my {
+            fn foobar() {}
+        }
+        fn bar() {
+            use my::*;
+            /*caret*/;
+        }
+    """, "foo<caret>", "foobar")
+}


### PR DESCRIPTION
Fixes #8067.

* Introduce `RsDebuggerExpressionCodeFragment` for debugger code fragments used in Evaluate Expression and LLDB/GDB Console. Previously, more generic `RsExpressionCodeFragment` was used instead
* Do not filter out private items when completing code in the debugger
* Do not annotate usages of private items as errors in the debugger
* Add tests to check that private items are suggested in debugger code fragments completion

<img width="565" alt="Screenshot 2021-11-04 at 10 13 30" src="https://user-images.githubusercontent.com/4854600/140300674-beef60f5-7efb-4762-817f-6d8f7feeda67.png">

changelog: Suggest private items when completing code in the debugger