### PR TITLE
ACT: Render parentheses for type references in `Implement Members` refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -239,8 +239,14 @@ open class RsPsiRenderer(
         }
     }
 
-    open fun appendTypeReference(sb: StringBuilder, ref: RsTypeReference) {
-        when (val type = ref.skipParens()) {
+    open fun appendTypeReference(sb: StringBuilder, type: RsTypeReference) {
+        when (type) {
+            is RsParenType -> {
+                sb.append("(")
+                type.typeReference?.let { appendTypeReference(sb, it) }
+                sb.append(")")
+            }
+
             is RsTupleType -> {
                 val types = type.typeReferenceList
                 if (types.size == 1) {
@@ -317,10 +323,7 @@ open class RsPsiRenderer(
             is RsMacroType -> {
                 appendPath(sb, type.macroCall.path)
                 sb.append("!(")
-                val macroBody = type.macroCall.macroBody
-                if (macroBody != null) {
-                    sb.append(macroBody)
-                }
+                type.macroCall.macroBody?.let { sb.append(it) }
                 sb.append(")")
             }
         }

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -1774,6 +1774,30 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test type reference parentheses`() = doTest("""
+        trait T {}
+        trait Foo {
+            fn foo() -> &(dyn T + 'static);
+        }
+        struct S;
+        impl Foo for S {
+            /*caret*/
+        }
+    """, listOf(
+        ImplementMemberSelection("foo() -> &(dyn T + 'static)", byDefault = true)
+    ), """
+        trait T {}
+        trait Foo {
+            fn foo() -> &(dyn T + 'static);
+        }
+        struct S;
+        impl Foo for S {
+            fn foo() -> &(dyn T + 'static) {
+                todo!()
+            }
+        }
+    """)
+
     private data class ImplementMemberSelection(val member: String, val byDefault: Boolean, val isSelected: Boolean = byDefault)
 
     private fun doTest(


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/8050.

changelog: Render parentheses for type references in `Implement Members` refactoring