### PR TITLE
RES: fix search scopes for generated code

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
@@ -47,8 +47,25 @@ class CargoLibrary(
     override fun getPresentableText(): String = if (version != null) "$name $version" else name
 }
 
+class GeneratedCodeFakeLibrary(private val sourceRoots: Set<VirtualFile>) : SyntheticLibrary() {
+    override fun equals(other: Any?): Boolean {
+        return other is GeneratedCodeFakeLibrary && other.sourceRoots == sourceRoots
+    }
+
+    override fun hashCode(): Int = sourceRoots.hashCode()
+    override fun getSourceRoots(): Collection<VirtualFile> = sourceRoots
+    override fun isShowInExternalLibrariesNode(): Boolean = false
+
+    companion object {
+        fun create(cargoProject: CargoProject): GeneratedCodeFakeLibrary? {
+            val generatedRoots = cargoProject.workspace?.packages.orEmpty().mapNotNullTo(HashSet()) { it.outDir }
+            return if (generatedRoots.isEmpty()) null else GeneratedCodeFakeLibrary(generatedRoots)
+        }
+    }
+}
+
 class RsAdditionalLibraryRootsProvider : AdditionalLibraryRootsProvider() {
-    override fun getAdditionalProjectLibraries(project: Project): Collection<CargoLibrary> {
+    override fun getAdditionalProjectLibraries(project: Project): Collection<SyntheticLibrary> {
         checkReadAccessAllowed()
         return project.cargoProjects.allProjects
             .smartFlatMap { it.ideaLibraries }
@@ -65,7 +82,7 @@ private fun <U, V> Collection<U>.smartFlatMap(transform: (U) -> Collection<V>): 
         else -> this.flatMap(transform)
     }
 
-private val CargoProject.ideaLibraries: Collection<CargoLibrary>
+private val CargoProject.ideaLibraries: Collection<SyntheticLibrary>
     get() {
         val workspace = workspace ?: return emptyList()
         val stdlibPackages = mutableListOf<CargoWorkspace.Package>()
@@ -83,6 +100,7 @@ private val CargoProject.ideaLibraries: Collection<CargoLibrary>
             for (pkg in dependencyPackages) {
                 pkg.toCargoLibrary()?.let(this::add)
             }
+            GeneratedCodeFakeLibrary.create(this@ideaLibraries)?.let(::add)
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/indexing/RsIndexableSetContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/indexing/RsIndexableSetContributor.kt
@@ -8,7 +8,6 @@ package org.rust.lang.core.indexing
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.indexing.IndexableSetContributor
-import org.rust.cargo.project.model.cargoProjects
 import org.rust.lang.core.macros.macroExpansionManagerIfCreated
 
 class RsIndexableSetContributor : IndexableSetContributor() {
@@ -17,9 +16,6 @@ class RsIndexableSetContributor : IndexableSetContributor() {
     override fun getAdditionalProjectRootsToIndex(project: Project): Set<VirtualFile> {
         val additionalProjectRootsToIndex = hashSetOf<VirtualFile>()
 
-        project.cargoProjects.allProjects.forEach { cargoProject ->
-            cargoProject.workspace?.packages.orEmpty().mapNotNullTo(additionalProjectRootsToIndex) { it.outDir }
-        }
         project.macroExpansionManagerIfCreated?.indexableDirectory?.let {
             additionalProjectRootsToIndex += it
         }


### PR DESCRIPTION
In #8012 we started using `IndexableSetContributor` to provide locations that should be indexed. But this solution changes the scope of generated files. As a result, any code that uses index search with `GlobalSearchScope.allScope(project)` or `RsWithMacrosProjectScope` scopes doesn't process code from generated files. For example, it breaks `impl` block search during type inference

These changes use `AdditionalLibraryRootsProvider` to create a fake library from generated code. It restores the previous search scope for generated code and makes index search work as before

Fixes #8057

Since it's a fix of #8012, no changelog section here