### PR TITLE
INSP: Add `#[repr(...)]` quick fix for E0308 error

### DIFF
--- a/src/main/kotlin/org/rust/ide/fixes/ChangeReprAttributeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ChangeReprAttributeFix.kt
@@ -1,0 +1,88 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.psi.RsEnumItem
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsVariantDiscriminant
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyInteger
+
+/**
+ * ```
+ * enum Foo {
+ *     FooVariant = 1u16 // Error: expected `isize`, found `u16`
+ * }
+ * ```
+ *
+ * =>
+ *
+ * ```
+ * #[repr(u16)]
+ * enum Foo {
+ *     FooVariant = 1u16
+ * }
+ * ```
+ */
+class ChangeReprAttributeFix(
+    element: RsElement,
+    enumName: String,
+    private val actualTy: String
+) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    private val _text: String = run {
+        "Change representation of enum `$enumName` to `#[repr($actualTy)]`"
+    }
+
+    override fun getText(): String = _text
+    override fun getFamilyName(): String = "Change `repr` attribute"
+
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        val owner = findEnumOwner(startElement) as? RsDocAndAttributeOwner ?: return
+        val reprAttributes = owner.queryAttributes.reprAttributes.toList()
+        val newOuterAttribute = RsPsiFactory(project).createOuterAttr("repr($actualTy)")
+
+        when (reprAttributes.size) {
+            // create the repr attribute
+            0 -> owner.addBefore(newOuterAttribute, owner.firstChild)
+            // replace the repr attribute
+            1 -> reprAttributes.single().replace(newOuterAttribute.metaItem)
+            // multiple #[repr(...)] attributes are disallowed by "conflicting_repr_hints" hard lint
+            else -> return
+        }
+    }
+
+    companion object {
+        private fun findEnumOwner(element: PsiElement): RsEnumItem? {
+            return if (element is RsExpr && element.context is RsVariantDiscriminant) {
+                element.contextStrict()
+            } else {
+                null
+            }
+        }
+
+        fun createIfCompatible(element: RsElement, actualTy: Ty): ChangeReprAttributeFix? {
+            if (element.containingCrate.origin != PackageOrigin.WORKSPACE) return null
+            if (actualTy !is TyInteger) return null
+            val enumOwner = findEnumOwner(element) ?: return null
+            val enumName = enumOwner.name ?: ""
+            return ChangeReprAttributeFix(element, enumName, actualTy.name)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -102,6 +102,11 @@ sealed class RsDiagnostic(
                         if (retFix != null) {
                             add(retFix)
                         }
+
+                        val reprFix = ChangeReprAttributeFix.createIfCompatible(element, actualTy)
+                        if (reprFix != null) {
+                            add(reprFix)
+                        }
                     }
 
                     val parent = element.parent

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReprAttributeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReprAttributeFixTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.typecheck
+
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.RsTypeCheckInspection
+
+class ChangeReprAttributeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
+    fun `test add repr on enum`() = checkFixByText("Change representation of enum `Foo` to `#[repr(u16)]`", """
+        enum Foo {
+            FooVariant = <error>1u16/*caret*/</error>
+        }
+    """, """
+        #[repr(u16)]
+        enum Foo {
+            FooVariant = 1u16
+        }
+    """)
+
+    fun `test change repr on enum`() = checkFixByText("Change representation of enum `Foo` to `#[repr(u16)]`", """
+        #[repr(u8)]
+        enum Foo {
+            FooVariant = <error>1u16/*caret*/</error>
+        }
+    """, """
+        #[repr(u16)]
+        enum Foo {
+            FooVariant = 1u16
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test change cfg_attr repr on enum`() = checkFixByText("Change representation of enum `Foo` to `#[repr(u16)]`", """
+        #[cfg_attr(intellij_rust, repr(u8))]
+        enum Foo {
+            FooVariant = <error>1u16/*caret*/</error>
+        }
+    """, """
+        #[cfg_attr(intellij_rust, repr(u16))]
+        enum Foo {
+            FooVariant = 1u16
+        }
+    """)
+
+    fun `test aliased types`() = checkFixByText("Change representation of enum `Foo` to `#[repr(u8)]`", """
+        type A = u8;
+
+        enum Foo {
+            FooVariant = <error>1 as A/*caret*/</error>
+        }
+    """, """
+        type A = u8;
+
+        #[repr(u8)]
+        enum Foo {
+            FooVariant = 1 as A
+        }
+    """)
+
+    fun `test don't offer the fix for non-integral types`() = checkFixIsUnavailable("Change representation of enum `Foo` to `#[repr(char)]`", """
+        enum Foo {
+            FooVariant = <error>'a'/*caret*/</error>
+        }
+    """)
+
+    fun `test don't offer the fix for nested expressions`() = checkFixIsUnavailable("Change representation of enum `Foo` to `#[repr(u8)]`", """
+        enum Foo {
+            FooVariant = {
+                let x: isize = <error>1u8/*caret*/</error>;
+                2
+            }
+        }
+    """)
+}


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/7894.

changelog: Add a quick fix for [type mismatch E0308](https://doc.rust-lang.org/error-index.html#E0308) error that adds a `#[repr(...)]` attribute to a enum:

```rust
enum Foo {
    FooVariant = 1u16 // Error: expected `isize`, found `u16`
}
```

=>

```rust
#[repr(u16)]
enum Foo {
    FooVariant = 1u16
}
```