### PR TITLE
CARGO: prevent some runtime errors in future IDE versions

### DIFF
--- a/src/main/kotlin/org/rust/ide/security/trustedProjectUtils.kt
+++ b/src/main/kotlin/org/rust/ide/security/trustedProjectUtils.kt
@@ -1,0 +1,22 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.security
+
+import com.intellij.ide.impl.OpenUntrustedProjectChoice
+
+// Starting with 2021.3.1 and 2021.2.4 some project trusted API was changed,
+// so let's check if old API is available not to produce runtime errors
+//
+// BACKCOMPAT: 2021.3
+val isOldTrustedProjectApiAvailable: Boolean by lazy {
+    try {
+        @Suppress("UnstableApiUsage")
+        OpenUntrustedProjectChoice.IMPORT.name
+        true
+    } catch (e: NoSuchFieldError) {
+        false
+    }
+}


### PR DESCRIPTION
Project trusted API will be changed in coming IDE versions (2021.3.1 and 2021.2.4).
Two main changes:
- IDE will ask if users trust project on the first project opening for every project so we don't need to do it in the plugin
- some corresponding API will be changed so we shouldn't call it at all to avoid runtime errors

These changes introduce `isOldTrustedProjectApiAvailable` property to indicate if old API is available and adjust `CargoProjectOpenProcessor` implementation

changelog: Prevent future runtime errors during project opening because of incompatibility changes in future IDE versions
