### PR TITLE
REF: fix extract variable on RsExprStmt and last expr in block

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
@@ -35,6 +35,6 @@ class IntroduceLocalVariableIntention : RsElementBaseIntentionAction<RsExpr>() {
     }
 
     override fun invoke(project: Project, editor: Editor, ctx: RsExpr) {
-        extractExpression(editor, ctx)
+        extractExpression(editor, ctx, postfixLet = false)
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/RsIntroduceVariableHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/RsIntroduceVariableHandler.kt
@@ -34,9 +34,9 @@ class RsIntroduceVariableHandler : RefactoringActionHandler {
                 val helpId = "refactoring.extractVariable"
                 CommonRefactoringUtil.showErrorHint(project, editor, message, title, helpId)
             }
-            1 -> extractExpression(editor, exprs.single())
+            1 -> extractExpression(editor, exprs.single(), postfixLet = false)
             else -> showExpressionChooser(editor, exprs) {
-                extractExpression(editor, it)
+                extractExpression(editor, it, postfixLet = false)
             }
         }
     }

--- a/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
@@ -100,6 +100,6 @@ class LetPostfixTemplate(provider: RsPostfixTemplateProvider) :
     PostfixTemplateWithExpressionSelector(null, "let", "let name = expr;", RsExprParentsSelector(), provider) {
     override fun expandForChooseExpression(expression: PsiElement, editor: Editor) {
         if (expression !is RsExpr) return
-        extractExpression(editor, expression)
+        extractExpression(editor, expression, postfixLet = true)
     }
 }

--- a/src/test/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntentionTest.kt
@@ -79,7 +79,6 @@ class IntroduceLocalVariableIntentionTest : RsIntentionTestBase(IntroduceLocalVa
         }
     """)
 
-    // TODO really should put `i` as a tail expr (leaving semantics the same), looks like a bug in the refactoring
     fun `test tail exp`() = doAvailableTest("""
         fn foo() -> i32 {
             0/*caret*/
@@ -87,6 +86,7 @@ class IntroduceLocalVariableIntentionTest : RsIntentionTestBase(IntroduceLocalVa
     """, """
         fn foo() -> i32 {
             let /*caret*/i = 0;
+            i
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
@@ -9,10 +9,16 @@ import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
 class LetPostfixTemplateTest : RsPostfixTemplateTest(LetPostfixTemplate(RsPostfixTemplateProvider())) {
-    fun `test not expr`() = doTestNotApplicable("""
+    fun `test not expr 1`() = doTestNotApplicable("""
         fn foo() {
             println!("test");.let/*caret*/
         }
+    """)
+
+    fun `test not expr 2`() = doTestNotApplicable("""
+        fn foo() {
+            println!("test");
+        }.let/*caret*/
     """)
 
     fun `test simple expr`() = doTest("""
@@ -22,6 +28,18 @@ class LetPostfixTemplateTest : RsPostfixTemplateTest(LetPostfixTemplate(RsPostfi
     """, """
         fn foo() {
             let /*caret*/i = 4;
+        }
+    """)
+
+    fun `test incomplete expr`() = doTest("""
+        fn foo() {
+            4.let/*caret*/
+            bar();
+        }
+    """, """
+        fn foo() {
+            let /*caret*/i = 4;
+            bar();
         }
     """)
 


### PR DESCRIPTION
This involves a change to the tests. The old behaviour was breaking code since it changed the returned value of the block from T to (), and breaking code is bad. It's also trivially easy to change the returned value after refactoring to a more complex expression, since only a single identifier should be returned.

This commit also includes a fix for extracting several occurrences of an expression. Previously if we extracted an RsExprStmt, then the logic would short-circuit and extract only it, ignoring the possibility of other occurrences.

Fixes #8099
Fixes #8095
Fixes #8082
Fixes #8091

changelog: fix ["Extract variable"](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-refactorings.html#extractvar-refactoring) refactoring on expression statements and return values
