### PR TITLE
REF: Enable suggested signature refactoring for trait methods

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
@@ -49,7 +49,8 @@ sealed class ParameterProperty<T: RsElement> {
     class Empty<T: RsElement> : ParameterProperty<T>()
     class Invalid<T: RsElement>(override val text: String) : ParameterProperty<T>()
     class Valid<T: RsElement>(override val item: T) : ParameterProperty<T>() {
-        override val text: String = item.text
+        override val text: String
+            get() = item.text
     }
 
     open val text: String = ""
@@ -149,7 +150,9 @@ class RsChangeFunctionSignatureConfig private constructor(
             val factory = RsPsiFactory(function.project)
             val parameters = function.rawValueParameters.mapIndexed { index, parameter ->
                 val patText = parameter.pat?.text ?: "_"
-                val type = ParameterProperty.fromItem(parameter.typeReference)
+                // The element has to be copied, otherwise suggested refactoring API
+                // would revert the PSI item to its previous state
+                val type = ParameterProperty.fromItem(parameter.typeReference?.copy() as? RsTypeReference)
                 Parameter(factory, patText, type, index)
             }
             return RsChangeFunctionSignatureConfig(

--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringExecution.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringExecution.kt
@@ -43,7 +43,6 @@ class RsSuggestedRefactoringExecution(support: RsSuggestedRefactoringSupport) : 
         val oldSignature = data.oldSignature
         val newSignature = data.newSignature
 
-
         // We need to mark "new" parameters with the new parameter index and find parameters swaps.
         var newParameterIndex = 0
         val parameters = newSignature.parameters.zip(config.parameters).map { (signatureParameter, parameter) ->

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsChangeSignatureSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsChangeSignatureSuggestedRefactoringTest.kt
@@ -20,7 +20,7 @@ class RsChangeSignatureSuggestedRefactoringTest : RsSuggestedRefactoringTestBase
         fn foo()/*caret*/ {}
     """) { myFixture.type(" -> u32") }
 
-    fun `test unavailable when changing parameter type`() = doUnavailableTest("""
+    fun `test unavailable when changing function parameter type`() = doUnavailableTest("""
         fn foo(a: /*caret*/u32) {}
     """) {
         myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
@@ -641,6 +641,48 @@ New:
     """.trimIndent())
         }
     }
+
+    fun `test change trait method parameter type`() = doTestChangeSignature("""
+        trait Trait {
+            fn foo(&self, a: /*caret*/u32);
+        }
+        struct S;
+        impl Trait for S {
+            fn foo(&self, a: u32) {}
+        }
+    """, """
+        trait Trait {
+            fn foo(&self, a: i32);
+        }
+        struct S;
+        impl Trait for S {
+            fn foo(&self, a: i32) {}
+        }
+    """, "foo", {
+        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
+        myFixture.type("i")
+    }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'a'
+    ': '
+    'u32' (modified)
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'a'
+    ': '
+    'i32' (modified)
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
 
     private fun withMockedDefaultValues(expressions: List<RsExpr>, action: () -> Unit) {
         val originalValue = _suggestedChangeSignatureNewParameterValuesForTests

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringTest.kt
@@ -46,8 +46,8 @@ abstract class RsSuggestedRefactoringTestBase : RsTestBase() {
     }
 
     protected fun doTestChangeSignature(
-        initialText: String,
-        textAfterRefactoring: String,
+        @Language("Rust") initialText: String,
+        @Language("Rust") textAfterRefactoring: String,
         usagesName: String,
         editingAction: () -> Unit,
         expectedPresentation: String? = null


### PR DESCRIPTION
Follow-up and partial revert of https://github.com/intellij-rust/intellij-rust/pull/8042 (based on [this](https://github.com/intellij-rust/intellij-rust/pull/8042#issuecomment-967006776) comment).

I included some comments in the code that explain why some more changes needed to be made.

changelog: Enable suggested signature refactoring when a type of a trait method parameter changes.