### PR TITLE
T: fix `TestUnitTestRustcCacheService`

### DIFF
--- a/src/main/kotlin/org/rust/cargo/util/TestUnitTestRustcCacheService.kt
+++ b/src/main/kotlin/org/rust/cargo/util/TestUnitTestRustcCacheService.kt
@@ -22,7 +22,7 @@ class TestUnitTestRustcCacheService : UnitTestRustcCacheService {
         cacheIf: () -> Boolean,
         computation: () -> T
     ): T {
-        if (rustcVersion == null) return computation()
+        if (rustcVersion == null || !cacheIf()) return computation()
         return cache.getOrPut(rustcVersion to cls) { Optional.ofNullable(computation()) }.orNull() as T
     }
 }


### PR DESCRIPTION
Test cache service was introduced in #7713. But after some refactoring during review, `!cacheIf()` call was missed in test implementation.
This change restores this call. Otherwise, some tests fail

bors r+