### PR TITLE
Auto import: use absolute path for extern crate if needed

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector.kt
@@ -355,9 +355,13 @@ sealed class ImportInfo {
          * Can be null if extern crate item is absent or it is in crate root.
          */
         val depth: Int?,
-        crateRelativePath: String
+        crateRelativePath: String,
+        hasModWithSameNameAsExternCrate: Boolean = false,
     ) : ImportInfo() {
-        override val usePath: String = "$externCrateName::$crateRelativePath"
+        override val usePath: String = run {
+            val absolutePrefix = if (hasModWithSameNameAsExternCrate) "::" else ""
+            "$absolutePrefix$externCrateName::$crateRelativePath"
+        }
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
@@ -132,7 +132,7 @@ private fun ImportContext2.convertToCandidates(itemsPaths: List<ItemUsePath>): L
             itemsPsi.flatMap { itemPsi ->
                 paths.map { path ->
                     val qualifiedItem = QualifiedNamedItem2(itemPsi, path.path, path.crate)
-                    val importInfo = qualifiedItem.toImportInfo(rootDefMap)
+                    val importInfo = qualifiedItem.toImportInfo(rootDefMap, rootModData)
                     ImportCandidate2(qualifiedItem, importInfo)
                 }
             }
@@ -363,7 +363,7 @@ private fun ImportContext2.isUsefulTraitImport(usePath: String): Boolean {
         || element.canBeAccessedByTraitName
 }
 
-private fun QualifiedNamedItem2.toImportInfo(defMap: CrateDefMap): ImportInfo {
+private fun QualifiedNamedItem2.toImportInfo(defMap: CrateDefMap, modData: ModData): ImportInfo {
     val crateName = path.first()
     return if (crateName == "crate") {
         val usePath = path.joinToString("::").let {
@@ -373,7 +373,14 @@ private fun QualifiedNamedItem2.toImportInfo(defMap: CrateDefMap): ImportInfo {
     } else {
         val needInsertExternCrateItem = !defMap.isAtLeastEdition2018 && !defMap.hasExternCrateInCrateRoot(crateName)
         val crateRelativePath = path.copyOfRange(1, path.size).joinToString("::")
-        ImportInfo.ExternCrateImportInfo(containingCrate, crateName, needInsertExternCrateItem, null, crateRelativePath)
+        ImportInfo.ExternCrateImportInfo(
+            crate = containingCrate,
+            externCrateName = crateName,
+            needInsertExternCrateItem = needInsertExternCrateItem,
+            depth = null,
+            crateRelativePath = crateRelativePath,
+            hasModWithSameNameAsExternCrate = crateName in modData.childModules
+        )
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -2886,4 +2886,23 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `func`">func/*caret*/</error>!();
         }
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test use absolute path when extern crate has same name as child mod`() = checkAutoImportFixByFileTree("""
+    //- lib.rs
+        pub fn func() {}
+    //- main.rs
+        mod test_package {}
+        fn main() {
+            <error descr="Unresolved reference: `func`">func/*caret*/</error>();
+        }
+    """, """
+    //- main.rs
+        use ::test_package::func;
+
+        mod test_package {}
+        fn main() {
+            func();
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #7394

changelog: Use absolute import path in auto-import when the scope has child mod with the same name as extern crate
