### PR TITLE
ANN: annotate macro 2.0 definitions as experimental

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -69,6 +69,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             override fun visitLetElseBranch(o: RsLetElseBranch) = checkLetElseBranch(rsHolder, o)
             override fun visitLabel(o: RsLabel) = checkLabel(rsHolder, o)
             override fun visitLifetime(o: RsLifetime) = checkLifetime(rsHolder, o)
+            override fun visitMacro2(o: RsMacro2) = checkMacro2(rsHolder, o)
             override fun visitMatchArmGuard(o: RsMatchArmGuard) = checkMatchArmGuard(rsHolder, o)
             override fun visitModDeclItem(o: RsModDeclItem) = checkModDecl(rsHolder, o)
             override fun visitModItem(o: RsModItem) = checkDuplicates(rsHolder, o)
@@ -116,6 +117,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         }
 
         element.accept(visitor)
+    }
+
+    private fun checkMacro2(holder: RsAnnotationHolder, macro: RsMacro2) {
+        DECL_MACRO.check(holder, macro.macroKw, "`macro`")
     }
 
     private fun checkMetaItem(holder: RsAnnotationHolder, metaItem: RsMetaItem) {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -4427,4 +4427,20 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             name: &'async str,
         }
     """)
+
+    @MockRustcVersion("1.56.0")
+    fun `test macro 2 is experimental 1`() = checkErrors("""
+        pub <error descr="`macro` is experimental [E0658]">macro</error> id($ e:expr) {
+            $ e
+        }
+    """)
+
+    @MockRustcVersion("1.56.0-nightly")
+    fun `test macro 2 is experimental 2`() = checkErrors("""
+        #![feature(decl_macro)]
+
+        pub macro id($ e:expr) {
+            $ e
+        }
+    """)
 }


### PR DESCRIPTION
changelog: Annotate [macro 2.0](https://rust-lang.github.io/rfcs/1584-macros.html) definitions as experimental and provide quick-fix to add `decl_macro` feature on nightly toolchain
