### PR TITLE
DBG: fix NPE in debugger support in IDEA

### DIFF
--- a/debugger/src/main/resources/META-INF/native-debug-only.xml
+++ b/debugger/src/main/resources/META-INF/native-debug-only.xml
@@ -1,3 +1,10 @@
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
     <xi:include href="/META-INF/debugger-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
+    <extensions defaultExtensionNs="cidr.debugger">
+        <!-- Default implementation not to produce NPE for non-Rust stack frames -->
+        <!-- Workaround for https://github.com/intellij-rust/intellij-rust/issues/8122 -->
+        <!-- BACKCOMPAT: 2021.3 -->
+        <languageSupport language="" implementationClass="org.rust.debugger.lang.RsDebuggerLanguageSupport" order="last"/>
+    </extensions>
 </idea-plugin>


### PR DESCRIPTION
Provide default implementation of `cidr.debugger.languageSupport` extension point.
CLion relies on the existence of default implementation of this EP. And it exists in CLion.
But in IDEA with Native Debugging Support plugin, there is no such implementation by default, so we can get NPE if the platform tries to do something with non-Rust stack frame.

This change is a hack just to avoid NPE. A proper solution will be landed as a fix of https://youtrack.jetbrains.com/issue/CPP-27382

Fixes #8122

changelog: Fix exception during debugging in IDEA 2021.3
