### PR TITLE
INSP: Fix renaming mod declaration by "Module naming convention"

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RenameFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RenameFix.kt
@@ -6,12 +6,13 @@
 package org.rust.ide.inspections.fixes
 
 import com.intellij.codeInspection.LocalQuickFixOnPsiElement
-import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNamedElement
 import com.intellij.refactoring.RefactoringFactory
+import org.rust.lang.core.psi.RsModDeclItem
+import org.rust.openapiext.nonBlocking
 
 /**
  * Fix that renames the given element.
@@ -28,7 +29,9 @@ class RenameFix(
     override fun getFamilyName() = "Rename element"
 
     override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) =
-        invokeLater {
-            RefactoringFactory.getInstance(project).createRename(startElement, newName).run()
-        }
+        project.nonBlocking({
+            (startElement as? RsModDeclItem)?.reference?.resolve() ?: startElement
+        }, {
+            RefactoringFactory.getInstance(project).createRename(it, newName).run()
+        })
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceConstant/RsIntroduceConstantHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceConstant/RsIntroduceConstantHandler.kt
@@ -18,7 +18,10 @@ import com.intellij.refactoring.util.CommonRefactoringUtil
 import org.rust.ide.refactoring.*
 import org.rust.ide.utils.import.RsImportHelper
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.getAllVisibleBindings
+import org.rust.lang.core.psi.ext.getLocalVariableVisibleBindings
+import org.rust.lang.core.psi.ext.isConst
 import org.rust.openapiext.nonBlocking
 import org.rust.openapiext.runWriteCommandAction
 
@@ -28,7 +31,7 @@ class RsIntroduceConstantHandler : RefactoringActionHandler {
         val exprs = findCandidateExpressionsToExtract(editor, file)
 
         // isExtractable uses resolve, so we must not call it from EDT
-        nonBlocking(project, {
+        project.nonBlocking({
             exprs.filter { it.isExtractable() }
         }) {
             if (!editor.isDisposed) {
@@ -127,7 +130,7 @@ private fun extractExpression(editor: Editor, expr: RsExpr) {
     showOccurrencesChooser(editor, expr, occurrences) { occurrencesToReplace ->
         showInsertionChooser(editor, expr) { candidate ->
             val project = editor.project ?: return@showInsertionChooser
-            nonBlocking(project, {
+            project.nonBlocking({
                 findExistingBindings(candidate, occurrences)
             }) { bindings ->
                 replaceWithConstant(expr, occurrencesToReplace, candidate, bindings, editor)

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -419,7 +419,8 @@ fun <T, D> getCachedOrCompute(
     return value
 }
 
-inline fun <R> nonBlocking(project: Project, crossinline block: () -> R, crossinline uiContinuation: (R) -> Unit) {
+/** Intended to be invoked from EDT */
+inline fun <R> Project.nonBlocking(crossinline block: () -> R, crossinline uiContinuation: (R) -> Unit) {
     if (isUnitTestMode) {
         val result = block()
         uiContinuation(result)
@@ -427,8 +428,8 @@ inline fun <R> nonBlocking(project: Project, crossinline block: () -> R, crossin
         ReadAction.nonBlocking(Callable {
             block()
         })
-            .inSmartMode(project)
-            .expireWith(RsPluginDisposable.getInstance(project))
+            .inSmartMode(this)
+            .expireWith(RsPluginDisposable.getInstance(this))
             .finishOnUiThread(ModalityState.current()) { result ->
                 uiContinuation(result)
             }.submit(AppExecutorUtil.getAppExecutorService())

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
@@ -57,4 +57,40 @@ class RsModuleNamingInspectionTest : RsInspectionsTestBase(RsModuleNamingInspect
     fun `test module not support case`() = checkByText("""
         mod 模块名 {}
     """)
+
+    fun `test mod decl 1`() = checkFixByFileTreeWithoutHighlighting("Rename to `foo`", """
+    //- main.rs
+        fn main() {
+            Foo::func();
+        }
+        mod Foo/*caret*/;
+    //- Foo.rs
+        pub fn func() {}
+    """, """
+    //- main.rs
+        fn main() {
+            foo::func();
+        }
+        mod foo/*caret*/;
+    //- foo.rs
+        pub fn func() {}
+    """)
+
+    fun `test mod decl 2`() = checkFixByFileTreeWithoutHighlighting("Rename to `foo`", """
+    //- main.rs
+        fn main() {
+            Foo::func();
+        }
+        mod Foo/*caret*/;
+    //- Foo/mod.rs
+        pub fn func() {}
+    """, """
+    //- main.rs
+        fn main() {
+            foo::func();
+        }
+        mod foo/*caret*/;
+    //- foo/mod.rs
+        pub fn func() {}
+    """)
 }


### PR DESCRIPTION
Fixes #8120

changelog: Fix renaming mod declaration by "Module naming convention" inspection
