### PR TITLE
RES: Fix updating DefMap when adding `#![no_std]`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -109,7 +109,8 @@ private class ModCollector(
 
     fun collectMod(mod: StubElement<out RsMod>, propagateLegacyMacros: Boolean = false) {
         val visitor = if (hashCalculator != null) {
-            val hashVisitor = hashCalculator.getVisitor(crate, modData.fileRelativePath)
+            val stdlibAttributes = defMap.stdlibAttributes.takeIf { modData.isNormalCrate && modData.isCrateRoot }
+            val hashVisitor = hashCalculator.getVisitor(crate, modData.fileRelativePath, stdlibAttributes)
             CompositeModVisitor(hashVisitor, this)
         } else {
             this

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
@@ -386,6 +386,22 @@ class RsDefMapUpdateChangeSingleFileTest : RsDefMapUpdateTestBase() {
         #![cfg(not(intellij_rust))]
     """)
 
+    fun `test add no_std attribute`() = doTestChanged("""
+    """, """
+        #![no_std]
+    """)
+
+    fun `test add no_core attribute`() = doTestChanged("""
+    """, """
+        #![no_core]
+    """)
+
+    fun `test change no_std to no_core attribute`() = doTestChanged("""
+        #![no_std]
+    """, """
+        #![no_core]
+    """)
+
     private fun type(text: String = "a"): () -> Unit = {
         myFixture.type(text)
         PsiDocumentManager.getInstance(project).commitAllDocuments()


### PR DESCRIPTION
changelog: Fixes caching of resolve when adding or removing `#![no_std]` attribute
