### PR TITLE
Fix warnings in logs due to incorrect check for `Eq` trait implementation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -977,7 +977,7 @@ class ImplLookup(
     fun isSized(ty: Ty): Boolean = ty.isTraitImplemented(items.Sized)
     fun isDebug(ty: Ty): Boolean = ty.isTraitImplemented(items.Debug)
     fun isDefault(ty: Ty): Boolean = ty.isTraitImplemented(items.Default)
-    fun isEq(ty: Ty, rhsType: Ty = ty): Boolean = ty.isTraitImplemented(items.Eq, rhsType)
+    fun isEq(ty: Ty): Boolean = ty.isTraitImplemented(items.Eq)
     fun isPartialEq(ty: Ty, rhsType: Ty = ty): Boolean = ty.isTraitImplemented(items.PartialEq, rhsType)
     fun isIntoIterator(ty: Ty): Boolean = ty.isTraitImplemented(items.IntoIterator)
     fun isAnyFn(ty: Ty): Boolean = isFn(ty) || isFnOnce(ty) || isFnMut(ty)


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/pull/7897.
