### PR TITLE
Exit points highlighting: Handle cfg-disabled blocks

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
@@ -338,8 +338,13 @@ private class ExitPointVisitor(
 
     private val RsExpr.isInTailPosition: Boolean
         get() {
+            // Ignore the expression if any of its ancestors are cfg-disabled
+            if (!existsAfterExpansion) return false
+
             for (ancestor in ancestors) {
                 when (ancestor) {
+                    // RsExprStmt may actually be RsExpr because of its rightSiblings' cfg attributes
+                    is RsExprStmt -> return ancestor.semicolon == null
                     is RsFunction, is RsLambdaExpr -> return true
                     is RsStmt, is RsCondition, is RsMatchArmGuard, is RsPat, is RsMacroArgument -> return false
                     else -> {

--- a/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
@@ -343,8 +343,8 @@ private class ExitPointVisitor(
 
             for (ancestor in ancestors) {
                 when (ancestor) {
-                    // RsExprStmt may actually be RsExpr because of its rightSiblings' cfg attributes
-                    is RsExprStmt -> return ancestor.semicolon == null
+                    // RsExprStmt (outside of RsTryExpr) may be RsExpr because of its right siblings' cfg attributes
+                    is RsExprStmt -> return ancestor.semicolon == null && ancestors.none { it is RsTryExpr }
                     is RsFunction, is RsLambdaExpr -> return true
                     is RsStmt, is RsCondition, is RsMatchArmGuard, is RsPat, is RsMacroArgument -> return false
                     else -> {

--- a/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
+++ b/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
@@ -72,6 +72,30 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """)
 
+    fun `test highlight correct cfg block with an arrow`() = doTest("""
+        fn foo() /*caret*/-> u8 {
+            #[cfg(not(undeclared))]
+            { 0 }
+
+            #[cfg(undeclared)]
+            { 1 }
+        }
+
+        fn main() {}
+    """, "0")
+
+    fun `test highlight correct cfg block with an arrow reverse order`() = doTest("""
+        fn foo() /*caret*/-> u8 {
+            #[cfg(undeclared)]
+            { 0 }
+
+            #[cfg(not(undeclared))]
+            { 1 }
+        }
+
+        fn main() {}
+    """, "1")
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test highlight try macro as return`() = doTest("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
+++ b/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
@@ -381,7 +381,6 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """, "?", "return 0")
 
-
     fun `test ? in macro`() = doTest("""
         fn main(){
             macrocall![ ?/*caret*/ ];


### PR DESCRIPTION
This PR applies a hack similar to https://github.com/intellij-rust/intellij-rust/pull/7849 for the handling of expr stmts that are actually exprs because of cfg-disabled right siblings.

Fixes https://github.com/intellij-rust/intellij-rust/issues/7973

changelog: Handle cfg-disabled blocks in exit points highlighting
