### PR TITLE
CI: fix `cargo-generate` binary caching on Windows CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -182,7 +182,9 @@ jobs:
               with:
                   path: |
                       ~/.cargo/bin/evcxr
+                      ~/.cargo/bin/evcxr.exe
                       ~/.cargo/bin/cargo-generate
+                      ~/.cargo/bin/cargo-generate.exe
                       ~/.cargo/.crates.toml
                       ~/.cargo/.crates2.json
                   key: ${{ runner.os }}-cache-cargo-binaries-${{ matrix.rust-version }}-${{ github.run_id }} # https://github.com/actions/cache/issues/342#issuecomment-673371329


### PR DESCRIPTION
Improves #7778

The bug is that `Install cargo-generate` step takes about 8m in every CI run on windows

![image](https://user-images.githubusercontent.com/3221931/142828146-349d1716-37df-4b09-995e-86c6daaecea4.png)
