### PR TITLE
TY: Take into account const generics defaults in const evaluation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -1133,7 +1133,7 @@ private sealed class SelectionCandidate {
 
 private fun prepareSubstAndTraitRefRaw(
     ctx: RsInferenceContext,
-    generics: List<TyTypeParameter>,
+    typeGenerics: List<TyTypeParameter>,
     constGenerics: List<CtConstParameter>,
     formalSelfTy: Ty,
     formalTrait: BoundElement<RsTraitItem>,
@@ -1141,17 +1141,12 @@ private fun prepareSubstAndTraitRefRaw(
     recursionDepth: Int
 ): Triple<Substitution, TraitRef, List<Obligation>> {
     val subst = Substitution(
-        typeSubst = generics.associateWith { ctx.typeVarForParam(it) },
+        typeSubst = typeGenerics.associateWith { ctx.typeVarForParam(it) },
         constSubst = constGenerics.associateWith { ctx.constVarForParam(it) }
     )
-    val boundSubst = formalTrait.substitute(subst).subst.mapTypeValues { (k, v) ->
-        if (k == v && k.parameter is TyTypeParameter.Named) {
-            // Default type parameter values `trait Tr<T=Foo> {}`
-            k.parameter.parameter.typeReference?.type?.substitute(subst) ?: v
-        } else {
-            v
-        }
-    }.substituteInValues(mapOf(TyTypeParameter.self() to selfTy).toTypeSubst())
+    val boundSubst = formalTrait.substitute(subst)
+        .subst
+        .substituteInValues(mapOf(TyTypeParameter.self() to selfTy).toTypeSubst())
     val (normSelfTy, obligations) = ctx.normalizeAssociatedTypesIn(formalSelfTy.substitute(subst), recursionDepth)
     return Triple(subst, TraitRef(normSelfTy, BoundElement(formalTrait.element, boundSubst)), obligations)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/Substitution.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Substitution.kt
@@ -55,6 +55,9 @@ open class Substitution(
     fun typeParameterByName(name: String): TyTypeParameter? =
         typeSubst.keys.find { it.toString() == name }
 
+    fun constParameterByName(name: String): CtConstParameter? =
+        constSubst.keys.find { it.toString() == name }
+
     fun substituteInValues(map: Substitution): Substitution =
         Substitution(
             typeSubst.mapValues { (_, value) -> value.substitute(map) },

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -10,6 +10,7 @@ import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.*
+import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.infer.TypeFoldable
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
@@ -78,6 +79,10 @@ enum class Mutability {
 
 fun Ty.getTypeParameter(name: String): TyTypeParameter? {
     return typeParameterValues.typeParameterByName(name)
+}
+
+fun Ty.getConstParameter(name: String): CtConstParameter? {
+    return typeParameterValues.constParameterByName(name)
 }
 
 val Ty.isSelf: Boolean

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1706,6 +1706,14 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ S<i32>
     """)
 
+    fun `test default const argument is not used in expression context 1`() = testExpr("""
+        struct S<const N: usize = 1>;
+        fn main() {
+            let a = S;
+            a;
+        } //^ S<<unknown>>
+    """)
+
     fun `test default type argument is not used in expression context 2`() = testExpr("""
         struct S<T = X>(T);
         struct X;
@@ -1716,6 +1724,18 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = S::new(1);
             a;
         } //^ S<i32>
+    """)
+
+    fun `test default const argument is not used in expression context 2`() = testExpr("""
+        struct S<const N: usize = 1>;
+        impl<const N: usize> S<N> {
+            fn new() -> S<N> { S }
+        }
+
+        fn main() {
+            let a = S::new();
+            a;
+        } //^ S<<unknown>>
     """)
 
     fun `test default type argument is used in expression context`() = testExpr("""
@@ -1729,6 +1749,17 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ S<i32, ()>
     """)
 
+    fun `test default const argument is used in expression context`() = testExpr("""
+        struct S<const N: usize, const M: usize = 1>;
+        impl<const N: usize> S<N, 1> {
+            fn id(self) -> Self { unimplemented!() }
+        }
+        fn main() {
+            let s = S::<0>.id();
+            s;
+        } //^ S<0, 1>
+    """)
+
     fun `test default type argument is not used in pat context`() = testExpr("""
         struct S<T = X>(T);
         struct X;
@@ -1736,6 +1767,14 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let S(a) = S(1);
             a;
         } //^ i32
+    """)
+
+    fun `test default const argument is not used in pat context`() = testExpr("""
+        struct S<const N: usize = 1>([i32; N]);
+        fn main() {
+            let S(a) = S([1, 2, 3]);
+            a;
+        } //^ [i32; 3]
     """)
 
     fun `test default type argument is used in type context 1`() = testExpr("""
@@ -1746,12 +1785,26 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ S<X>
     """)
 
+    fun `test default const argument is used in type context 1`() = testExpr("""
+        struct S<const N: usize = 1>;
+        fn foo(s: S) {
+            s;
+        } //^ S<1>
+    """)
+
     fun `test default type argument is used in type context 2`() = testExpr("""
         struct S<T1 = X, T2 = Y>(T1, T2);
         struct X; struct Y;
         fn foo(s: S<u8>) {
             s;
         } //^ S<u8, Y>
+    """)
+
+    fun `test default const argument is used in type context 2`() = testExpr("""
+        struct S<const N1: usize = 1, const N2: usize = 2>;
+        fn foo(s: S<0>) {
+            s;
+        } //^ S<0, 2>
     """)
 
     fun `test type argument is unknown if not passed`() = testExpr("""
@@ -1986,5 +2039,28 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = foo(S);
             a;
         } //^ X
+    """)
+
+    fun `test trait impl with default type parameter value`() = testExpr("""
+        struct X;
+        trait Tr<T = X> { fn foo(&self) -> T { todo!() } }
+        struct S;
+        impl Tr for S {}
+        fn foo() {
+            let a = S.foo();
+            a;
+        } //^ X
+    """)
+
+    fun `test trait impl with default const parameter value`() = testExpr("""
+        trait Tr<const T: usize = 1> { fn foo(&self) -> [i32; T] { todo!() } }
+
+        struct S;
+        impl Tr for S {}
+
+        fn foo() {
+            let a = S.foo();
+            a;
+        } //^ [i32; 1]
     """)
 }


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/issues/3985.

changelog: Take into account const generics defaults in const evaluation
