### PR TITLE
INSP&ACT: Take into account const generics in `Wrong generic arguments number` inspection and corresponding quick fixes

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
@@ -68,7 +68,7 @@ class RsWrongGenericArgumentsNumberInspection : RsLocalInspectionTool() {
         val problemText = "Wrong number of $argumentName arguments: expected $errorText, found $actualArgs"
         val fixes = getFixes(declaration, element, actualArgs, expectedTotalParams)
 
-        RsDiagnostic.WrongGenericArgumentsNumber(element, problemText, fixes).addToHolder(holder)
+        RsDiagnostic.WrongNumberOfGenericArguments(element, problemText, fixes).addToHolder(holder)
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
@@ -6,15 +6,13 @@
 package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
-import org.rust.ide.inspections.fixes.AddTypeArguments
-import org.rust.ide.inspections.fixes.RemoveTypeArguments
+import org.rust.ide.inspections.fixes.AddGenericArguments
+import org.rust.ide.inspections.fixes.RemoveGenericArguments
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.RsElement
-import org.rust.lang.core.psi.ext.RsGenericDeclaration
-import org.rust.lang.core.psi.ext.constParameters
-import org.rust.lang.core.psi.ext.typeParameters
+import org.rust.lang.core.psi.ext.*
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
+import org.rust.openapiext.createSmartPointer
 
 /**
  * Inspection that detects the E0107 error.
@@ -35,28 +33,27 @@ class RsWrongGenericArgumentsNumberInspection : RsLocalInspectionTool() {
     private fun checkTypeArguments(holder: RsProblemsHolder, element: RsElement) {
         val (actualArguments, declaration) = getTypeArgumentsAndDeclaration(element) ?: return
 
-        val actualTypeArgs = actualArguments?.typeReferenceList?.size ?: 0
-        val expectedTotalTypeParams = declaration.typeParameters.size
-        val expectedRequiredTypeParams = declaration.typeParameters.count { it.typeReference == null }
-
-        val actualConstArgs = actualArguments?.exprList?.size ?: 0
-        val expectedTotalConstParams = declaration.constParameters.size
-
+        val actualTypeArgs = actualArguments?.typeArguments.orEmpty().size
+        val actualConstArgs = actualArguments?.constArguments.orEmpty().size
         val actualArgs = actualTypeArgs + actualConstArgs
+
+        val expectedTotalTypeParams = declaration.typeParameters.size
+        val expectedTotalConstParams = declaration.constParameters.size
         val expectedTotalParams = expectedTotalTypeParams + expectedTotalConstParams
-        val maxExpectedRequiredParams = expectedRequiredTypeParams + expectedTotalConstParams
-        val minExpectedRequiredParams = when (element.parent) {
+
+        if (actualArgs == expectedTotalParams) return
+
+        val expectedRequiredParams = declaration.requiredGenericParameters.size
+        val minRequiredParams = when (element.parent) {
             is RsBaseType, is RsTraitRef -> 0
             else -> 1
         }
 
-        if (actualArgs == expectedTotalParams) return
-
         val errorText = when {
             actualArgs > expectedTotalParams ->
-                if (maxExpectedRequiredParams != expectedTotalParams) "at most $expectedTotalParams" else "$expectedTotalParams"
-            actualArgs in minExpectedRequiredParams until maxExpectedRequiredParams ->
-                if (maxExpectedRequiredParams != expectedTotalParams) "at least $maxExpectedRequiredParams" else "$expectedTotalParams"
+                if (expectedRequiredParams != expectedTotalParams) "at most $expectedTotalParams" else "$expectedTotalParams"
+            actualArgs in minRequiredParams until expectedRequiredParams ->
+                if (expectedRequiredParams != expectedTotalParams) "at least $expectedRequiredParams" else "$expectedTotalParams"
             else -> return
         }
 
@@ -69,18 +66,22 @@ class RsWrongGenericArgumentsNumberInspection : RsLocalInspectionTool() {
         }
 
         val problemText = "Wrong number of $argumentName arguments: expected $errorText, found $actualArgs"
-        val fixes = getFixes(element, actualTypeArgs, expectedTotalTypeParams)
+        val fixes = getFixes(declaration, element, actualArgs, expectedTotalParams)
 
-        RsDiagnostic.WrongNumberOfTypeArguments(element, problemText, fixes).addToHolder(holder)
+        RsDiagnostic.WrongGenericArgumentsNumber(element, problemText, fixes).addToHolder(holder)
     }
 }
 
-private fun getFixes(element: RsElement, actualArgs: Int, expectedTotalParams: Int): List<LocalQuickFix> =
-    when {
-        actualArgs > expectedTotalParams -> listOf(RemoveTypeArguments(expectedTotalParams, actualArgs))
-        actualArgs < expectedTotalParams -> listOf(AddTypeArguments(element))
-        else -> emptyList()
-    }
+private fun getFixes(
+    declaration: RsGenericDeclaration,
+    element: RsElement,
+    actualArgs: Int,
+    expectedTotalParams: Int
+): List<LocalQuickFix> = when {
+    actualArgs > expectedTotalParams -> listOf(RemoveGenericArguments(expectedTotalParams, actualArgs))
+    actualArgs < expectedTotalParams -> listOf(AddGenericArguments(declaration.createSmartPointer(), element))
+    else -> emptyList()
+}
 
 fun getTypeArgumentsAndDeclaration(pathOrMethodCall: RsElement): Pair<RsTypeArgumentList?, RsGenericDeclaration>? {
     val (arguments, resolved) = when (pathOrMethodCall) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsOrderInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsOrderInspection.kt
@@ -55,7 +55,7 @@ class RsWrongGenericArgumentsOrderInspection : RsLocalInspectionTool() {
             } else {
                 emptyList()
             }
-            RsDiagnostic.WrongGenericArgumentsNumber(arg, text, fixes).addToHolder(holder)
+            RsDiagnostic.WrongOrderOfGenericArguments(arg, text, fixes).addToHolder(holder)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddGenericArguments.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddGenericArguments.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPsiElementPointer
 import org.rust.ide.inspections.getTypeArgumentsAndDeclaration
 import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.RsElementTypes.COMMA
@@ -17,16 +18,15 @@ import org.rust.lang.core.psi.RsElementTypes.LT
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsTypeArgumentList
-import org.rust.lang.core.psi.RsTypeReference
-import org.rust.lang.core.psi.ext.RsElement
-import org.rust.lang.core.psi.ext.elementType
-import org.rust.lang.core.psi.ext.getNextNonCommentSibling
-import org.rust.lang.core.psi.ext.requiredGenericParameters
+import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.createSmartPointer
 
-class AddTypeArguments(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
-    override fun getText(): String = "Add missing type arguments"
-    override fun getFamilyName() = text
+class AddGenericArguments(
+    private val declaration: SmartPsiElementPointer<RsGenericDeclaration>,
+    element: RsElement
+) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    override fun getText(): String = "Add missing $argumentsName"
+    override fun getFamilyName() = "Add missing generic arguments"
 
     override fun invoke(
         project: Project,
@@ -36,29 +36,40 @@ class AddTypeArguments(element: RsElement) : LocalQuickFixAndIntentionActionOnPs
         endElement: PsiElement
     ) {
         val element = startElement as? RsElement ?: return
-        val inserted = insertTypeArgumentsIfNeeded(element) ?: return
+        val inserted = insertGenericArgumentsIfNeeded(element) ?: return
         editor?.buildAndRunTemplate(element, inserted.map { it.createSmartPointer() })
     }
+
+    private val argumentsName: String
+        get() {
+            val element = declaration.element ?: return "generic arguments"
+            return when {
+                element.typeParameters.isNotEmpty() && element.constParameters.isNotEmpty() -> "generic arguments"
+                element.typeParameters.isNotEmpty() -> "type arguments"
+                element.constParameters.isNotEmpty() -> "const arguments"
+                else -> "generic arguments"
+            }
+        }
 }
 
 /**
- * Inserts type arguments if they are needed and returns a list of inserted type arguments.
+ * Inserts type arguments if they are needed and returns a list of inserted generic arguments.
  */
-fun insertTypeArgumentsIfNeeded(pathOrMethodCall: RsElement): List<RsTypeReference>? {
+fun insertGenericArgumentsIfNeeded(pathOrMethodCall: RsElement): List<RsElement>? {
     val (typeArguments, declaration) = getTypeArgumentsAndDeclaration(pathOrMethodCall) ?: return null
 
     val requiredParameters = declaration.requiredGenericParameters
     if (requiredParameters.isEmpty()) return null
 
-    val argumentCount = typeArguments?.typeReferenceList?.size ?: 0
+    val argumentCount = (typeArguments?.typeReferenceList?.size ?: 0) + (typeArguments?.exprList?.size ?: 0)
     if (argumentCount >= requiredParameters.size) return null
 
     val factory = RsPsiFactory(pathOrMethodCall.project)
-    val missingTypes = requiredParameters.drop(argumentCount).map { it.name ?: "_" }
+    val missingParams = requiredParameters.drop(argumentCount).map { it.name ?: "_" }
 
     val replaced = if (typeArguments != null) {
         var anchor = with(typeArguments) {
-            typeReferenceList.lastOrNull() ?: lifetimeList.lastOrNull() ?: lt
+            (lifetimeList + typeReferenceList + exprList).maxByOrNull { it.startOffset } ?: lt
         }
         val nextSibling = anchor.getNextNonCommentSibling()
         val addCommaAfter = nextSibling?.isComma == true
@@ -66,7 +77,7 @@ fun insertTypeArgumentsIfNeeded(pathOrMethodCall: RsElement): List<RsTypeReferen
             anchor = nextSibling
         }
 
-        for (type in missingTypes) {
+        for (type in missingParams) {
             if (anchor.elementType != LT && !anchor.isComma) {
                 anchor = typeArguments.addAfter(factory.createComma(), anchor)
             }
@@ -79,13 +90,13 @@ fun insertTypeArgumentsIfNeeded(pathOrMethodCall: RsElement): List<RsTypeReferen
 
         typeArguments
     } else {
-        val newArgumentList = factory.createTypeArgumentList(missingTypes)
+        val newArgumentList = factory.createTypeArgumentList(missingParams)
 
         // this can only happen for type references (base types/trait refs)
         if (pathOrMethodCall !is RsPath) return null
         pathOrMethodCall.addAfter(newArgumentList, pathOrMethodCall.identifier) as RsTypeArgumentList
     }
-    return replaced.typeReferenceList.drop(argumentCount)
+    return (replaced.typeReferenceList + replaced.exprList).sortedBy { it.startOffset }.drop(argumentCount)
 }
 
 private val PsiElement.isComma: Boolean

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveGenericArguments.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveGenericArguments.kt
@@ -13,13 +13,13 @@ import org.rust.lang.core.psi.RsTypeArgumentList
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.deleteWithSurroundingComma
 import org.rust.lang.core.psi.ext.getNextNonCommentSibling
+import org.rust.lang.core.psi.ext.startOffset
 
-class RemoveTypeArguments(
+class RemoveGenericArguments(
     private val startIndex: Int,
     private val endIndex: Int
 ) : LocalQuickFix {
-
-    override fun getFamilyName() = "Remove redundant type arguments"
+    override fun getFamilyName() = "Remove redundant generic arguments"
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
         val element = descriptor.psiElement as? RsElement ?: return
@@ -28,10 +28,10 @@ class RemoveTypeArguments(
     }
 
     private fun RsTypeArgumentList.removeTypeParameters() {
-        val count = endIndex - startIndex
-        for (i in 0 until count) {
-            typeReferenceList[startIndex].deleteWithSurroundingComma()
-        }
+        (typeReferenceList + exprList)
+            .sortedBy { it.startOffset }
+            .subList(startIndex, endIndex)
+            .forEach { it.deleteWithSurroundingComma() }
         // If the type argument list is empty, delete it
         if (lt.getNextNonCommentSibling() == gt) {
             delete()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsGenericDeclaration.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsGenericDeclaration.kt
@@ -24,5 +24,11 @@ val RsGenericDeclaration.lifetimeParameters: List<RsLifetimeParameter>
 val RsGenericDeclaration.constParameters: List<RsConstParameter>
     get() = typeParameterList?.constParameterList.orEmpty()
 
-val RsGenericDeclaration.requiredGenericParameters: List<RsTypeParameter>
-    get() = typeParameters.filter { it.typeReference == null }
+val RsGenericDeclaration.requiredGenericParameters: List<RsGenericParameter>
+    get() = genericParameters.filter {
+        when (it) {
+            is RsTypeParameter -> it.typeReference == null
+            is RsConstParameter -> it.expr == null
+            else -> false
+        }
+    }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1048,6 +1048,19 @@ sealed class RsDiagnostic(
         }
     }
 
+    class WrongOrderOfGenericArguments(
+        element: PsiElement,
+        private val errorText: String,
+        private val fixes: List<LocalQuickFix>
+    ) : RsDiagnostic(element) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            E0747,
+            errorText,
+            fixes = fixes
+        )
+    }
+
     class ImplForNonAdtError(
         element: PsiElement
     ) : RsDiagnostic(element) {
@@ -1165,19 +1178,6 @@ sealed class RsDiagnostic(
             ERROR,
             E0741,
             "$typeName doesn't derive both `PartialEq` and `Eq`"
-        )
-    }
-
-    class WrongGenericArgumentsNumber(
-        element: PsiElement,
-        private val errorText: String,
-        private val fixes: List<LocalQuickFix>
-    ) : RsDiagnostic(element) {
-        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
-            ERROR,
-            E0747,
-            errorText,
-            fixes = fixes
         )
     }
 

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1033,7 +1033,7 @@ sealed class RsDiagnostic(
         }
     }
 
-    class WrongNumberOfTypeArguments(
+    class WrongNumberOfGenericArguments(
         element: PsiElement,
         private val errorText: String,
         private val fixes: List<LocalQuickFix>

--- a/src/test/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspectionTest.kt
@@ -242,7 +242,7 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
-    fun `test fix no type arguments struct`() = checkFixByText("Remove redundant type arguments", """
+    fun `test fix no type arguments struct`() = checkFixByText("Remove redundant generic arguments", """
         struct Foo0;
         impl <error>Foo0/*caret*/<u8></error> {}
     """, """
@@ -250,7 +250,7 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         impl Foo0 {}
     """)
 
-    fun `test fix no type arguments method`() = checkFixByText("Remove redundant type arguments", """
+    fun `test fix no type arguments method`() = checkFixByText("Remove redundant generic arguments", """
         struct Test;
 
         impl Test {
@@ -274,7 +274,7 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
-    fun `test fix no type function call`() = checkFixByText("Remove redundant type arguments", """
+    fun `test fix no type function call`() = checkFixByText("Remove redundant generic arguments", """
         fn foo() {}
 
         fn main() {
@@ -303,7 +303,7 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
-    fun `test fix struct with multiple type arguments`() = checkFixByText("Remove redundant type arguments", """
+    fun `test fix struct with multiple type arguments`() = checkFixByText("Remove redundant generic arguments", """
         struct Foo<T, U> { t: T, u: U }
         struct Err {
             err1: <error descr="Wrong number of type arguments: expected 2, found 4 [E0107]">Foo<u32, i32, u32, u32/*caret*/></error>,
@@ -315,7 +315,19 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
-    fun `test fix struct with default type arguments`() = checkFixByText("Remove redundant type arguments", """
+    fun `test fix struct with multiple const arguments`() = checkFixByText("Remove redundant generic arguments", """
+        struct Foo<const N: i32, const M: i32>(i32);
+        struct Err {
+            err1: <error descr="Wrong number of const arguments: expected 2, found 4 [E0107]">Foo<1, 2, 3, 4/*caret*/></error>,
+        }
+    """, """
+        struct Foo<const N: i32, const M: i32>(i32);
+        struct Err {
+            err1: Foo<1, 2>,
+        }
+    """)
+
+    fun `test fix struct with default type arguments`() = checkFixByText("Remove redundant generic arguments", """
         struct Foo<T, U = i32> { t: T, u: U }
         struct Err {
             err1: <error descr="Wrong number of type arguments: expected at most 2, found 4 [E0107]">Foo<u32, i32, u32, u32/*caret*/></error>,
@@ -347,6 +359,18 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
             S.foo::<i32>(1, 2);
             S.foo::<i32, i32>(1, 2);
             S.<error descr="Wrong number of type arguments: expected at most 2, found 3 [E0107]">foo::<i32, i32, i32>(1, 2)</error>;
+        }
+    """)
+
+    fun `test fix struct with default const arguments`() = checkFixByText("Remove redundant generic arguments", """
+        struct Foo<const N: i32, const M: i32 = 1>(i32);
+        struct Err {
+            err1: <error descr="Wrong number of const arguments: expected at most 2, found 4 [E0107]">Foo<0, 1, 2, 3/*caret*/></error>,
+        }
+    """, """
+        struct Foo<const N: i32, const M: i32 = 1>(i32);
+        struct Err {
+            err1: Foo<0, 1>,
         }
     """)
 
@@ -450,10 +474,10 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
-    fun `test add arguments keep const generics`() = checkFixByText("Add missing type arguments", """
+    fun `test add arguments keep const generics`() = checkFixByText("Add missing generic arguments", """
         #![feature(const_generics)]
 
-        trait S<A, B, const N: usize> {
+        trait S<A, const N: usize, B> {
         }
 
         fn main() {
@@ -462,11 +486,11 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
     """, """
         #![feature(const_generics)]
 
-        trait S<A, B, const N: usize> {
+        trait S<A, const N: usize, B> {
         }
 
         fn main() {
-            let x: S<u32, B, 0>;
+            let x: S<u32, 0, B>;
         }
     """)
 
@@ -475,6 +499,14 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
 
         fn main() {
             let x: S<u32, u32>;
+        }
+    """)
+
+    fun `test add arguments ignore const parameters with a default`() = checkFixIsUnavailable("Add missing const arguments", """
+        struct S<const A: i32, const B: i32 = 1, const C: i32 = 2>(i32);
+
+        fn main() {
+            let x: S<0, 1>;
         }
     """)
 
@@ -564,7 +596,7 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
-    fun `test remove type arguments with lifetime 1`() = checkFixByText("Remove redundant type arguments", """
+    fun `test remove type arguments with lifetime 1`() = checkFixByText("Remove redundant generic arguments", """
         struct B<'a, T>(&'a T);
 
         struct C<'a> {
@@ -578,7 +610,7 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
-    fun `test remove type arguments with lifetime 2`() = checkFixByText("Remove redundant type arguments", """
+    fun `test remove type arguments with lifetime 2`() = checkFixByText("Remove redundant generic arguments", """
         struct B<'a>(&'a u32);
 
         struct C<'a> {
@@ -592,13 +624,13 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
-    fun `test remove type arguments with const argument 1`() = checkFixByText("Remove redundant type arguments", """
+    fun `test remove type arguments with const argument 1`() = checkFixByText("Remove redundant generic arguments", """
         #![feature(const_generics)]
 
         struct B<T, const N: i32>(T);
 
         struct C {
-            a: <error descr="Wrong number of generic arguments: expected 2, found 3 [E0107]">B<u32, i32, 1>/*caret*/</error>
+            a: <error descr="Wrong number of generic arguments: expected 2, found 3 [E0107]">B<u32, 1, i32>/*caret*/</error>
         }
     """, """
         #![feature(const_generics)]
@@ -610,13 +642,13 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
-    fun `test remove type arguments with const argument 2`() = checkFixByText("Remove redundant type arguments", """
+    fun `test remove type arguments with const argument 2`() = checkFixByText("Remove redundant generic arguments", """
         #![feature(const_generics)]
 
         struct B<const N: i32>;
 
         struct C {
-            a: <error descr="Wrong number of generic arguments: expected 1, found 2 [E0107]">B<i32, 1>/*caret*/</error>
+            a: <error descr="Wrong number of generic arguments: expected 1, found 2 [E0107]">B<1, i32>/*caret*/</error>
         }
     """, """
         #![feature(const_generics)]

--- a/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
@@ -137,21 +137,41 @@ class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::cla
         }
     """)
 
-    fun `test trait with method and 2 type parameters`() = doAvailableTestWithLiveTemplate("""
-        trait Foo<A, B> {
-            fn foo(&self) -> (A, B);
+    fun `test trait with 1 const parameter`() = doAvailableTestWithLiveTemplate("""
+        trait Foo<const N: usize> {
+            fn foo(&self) -> [i32; N];
         }
 
         struct S/*caret*/;
-    """, "Foo\t\ti32\tu8\t", """
-        trait Foo<A, B> {
-            fn foo(&self) -> (A, B);
+    """, "Foo\t\t1\t", """
+        trait Foo<const N: usize> {
+            fn foo(&self) -> [i32; N];
         }
 
         struct S;
 
-        impl Foo<i32, u8/*caret*/> for S {
-            fn foo(&self) -> (i32, u8) {
+        impl Foo<1/*caret*/> for S {
+            fn foo(&self) -> [i32; 1] {
+                todo!()
+            }
+        }
+    """)
+
+    fun `test trait with method and 2 generic parameters`() = doAvailableTestWithLiveTemplate("""
+        trait Foo<A, const N: usize> {
+            fn foo(&self) -> [A; N];
+        }
+
+        struct S/*caret*/;
+    """, "Foo\t\ti32\t1\t", """
+        trait Foo<A, const N: usize> {
+            fn foo(&self) -> [A; N];
+        }
+
+        struct S;
+
+        impl Foo<i32, 1/*caret*/> for S {
+            fn foo(&self) -> [i32; 1] {
                 todo!()
             }
         }


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/issues/3985.

Depends on https://github.com/intellij-rust/intellij-rust/pull/8144 and https://github.com/intellij-rust/intellij-rust/pull/8145.

changelog: Take into account const generics in `Wrong generic arguments number` inspection and corresponding quick fixes
