### PR TITLE
UI: Render const generics in quick docs and inline hints

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/type/RsExpressionTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsExpressionTypeProvider.kt
@@ -84,7 +84,7 @@ class RsExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
         else -> error("Unexpected element type: $element")
     }
 
-    private fun renderTy(ty: Ty): String = ty.render(skipUnchangedDefaultTypeArguments = false)
+    private fun renderTy(ty: Ty): String = ty.render(skipUnchangedDefaultGenericArguments = false)
 
     private fun renderAndAlignTypes(type: Ty, adjustedType: AdjustedType): Pair<String, String> {
         val (l1, _, l3) = alignTypes(renderTy(type), renderTy(adjustedType.derefTy), renderTy(adjustedType.finalTy))

--- a/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
@@ -8,17 +8,22 @@ package org.rust.ide.hints.type
 import com.intellij.codeInsight.hints.presentation.InlayPresentation
 import com.intellij.codeInsight.hints.presentation.PresentationFactory
 import org.rust.ide.presentation.shortPresentableText
+import org.rust.lang.core.psi.RsConstParameter
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.RsTypeParameter
+import org.rust.lang.core.psi.ext.constParameters
+import org.rust.lang.core.psi.ext.startOffset
 import org.rust.lang.core.psi.ext.typeParameters
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.Kind
 import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.CtConstParameter
+import org.rust.lang.core.types.consts.CtUnknown
 import org.rust.lang.core.types.consts.CtValue
 import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.*
+import org.rust.lang.utils.evaluation.evaluate
 
 @Suppress("UnstableApiUsage")
 class RsTypeHintsPresentationFactory(
@@ -107,18 +112,17 @@ class RsTypeHintsPresentationFactory(
         val typeDeclaration = type.item
         val typeNamePresentation = factory.psiSingleReference(text(adtName)) { typeDeclaration }
         val typeArguments = type.typeArguments.zip(type.item.typeParameters)
-
-        return withGenericsTypeHint(typeNamePresentation, typeArguments, type.constArguments, level)
+        val constArguments = type.constArguments.zip(type.item.constParameters)
+        return withGenericsTypeHint(typeNamePresentation, typeArguments, constArguments, level)
     }
 
     private fun aliasTypeHint(boundElement: BoundElement<RsTypeAlias>, level: Int): InlayPresentation {
         val alias = boundElement.element
-
         val adtName = alias.name
         val typeNamePresentation = factory.psiSingleReference(text(adtName)) { alias }
         val typeArguments = alias.typeParameters.map { (boundElement.subst[it] ?: TyUnknown) to it }
-
-        return withGenericsTypeHint(typeNamePresentation, typeArguments, emptyList(), level)
+        val constArguments = alias.constParameters.map { (boundElement.subst[it] ?: CtUnknown) to it }
+        return withGenericsTypeHint(typeNamePresentation, typeArguments, constArguments, level)
     }
 
     private fun projectionTypeHint(type: TyProjection, level: Int): InlayPresentation {
@@ -145,18 +149,19 @@ class RsTypeHintsPresentationFactory(
     private fun withGenericsTypeHint(
         typeNamePresentation: InlayPresentation,
         typeArguments: List<Pair<Ty, RsTypeParameter>>,
-        constArguments: List<Const>,
+        constArguments: List<Pair<Const, RsConstParameter>>,
         level: Int
     ): InlayPresentation {
         val userVisibleKindArguments = mutableListOf<Kind>()
-        for ((argument, parameter) in typeArguments) {
-            if (!showObviousTypes && isDefaultTypeParameter(argument, parameter)) {
-                // don't show default types
-                continue
+
+        val genericArguments = (typeArguments + constArguments).sortedBy { (_, param) -> param.startOffset }
+        for ((argument, parameter) in genericArguments) {
+            if (!showObviousTypes) {
+                when {
+                    argument is Ty && parameter is RsTypeParameter && isDefaultTypeParameter(argument, parameter) -> continue
+                    argument is Const && parameter is RsConstParameter && isDefaultConstParameter(argument, parameter) -> continue
+                }
             }
-            userVisibleKindArguments.add(argument)
-        }
-        for (argument in constArguments) {
             userVisibleKindArguments.add(argument)
         }
 
@@ -170,6 +175,7 @@ class RsTypeHintsPresentationFactory(
             )
             return listOf(typeNamePresentation, collapsible).join()
         }
+
         return typeNamePresentation
     }
 
@@ -244,15 +250,24 @@ class RsTypeHintsPresentationFactory(
     ): InlayPresentation {
         val traitPresentation = factory.psiSingleReference(text(trait.element.name)) { trait.element }
 
-        val typeParametersPresentations = mutableListOf<InlayPresentation>()
-        for (parameter in trait.element.typeParameters) {
-            val argument = trait.subst[parameter] ?: continue
-            if (!showObviousTypes && isDefaultTypeParameter(argument, parameter)) {
-                // don't show default types
-                continue
+        val genericParametersPresentations = mutableListOf<InlayPresentation>()
+        val genericParameters = with(trait.element) { typeParameters + constParameters }.sortedBy { it.startOffset }
+        for (parameter in genericParameters) {
+            val argument = when (parameter) {
+                is RsTypeParameter -> {
+                    val argument = trait.subst[parameter] ?: continue
+                    if (!showObviousTypes && isDefaultTypeParameter(argument, parameter)) continue
+                    argument
+                }
+                is RsConstParameter -> {
+                    val argument = trait.subst[parameter] ?: continue
+                    if (!showObviousTypes && isDefaultConstParameter(argument, parameter)) continue
+                    argument
+                }
+                else -> continue
             }
             val parameterPresentation = hint(argument, level + 1)
-            typeParametersPresentations.add(parameterPresentation)
+            genericParametersPresentations.add(parameterPresentation)
         }
 
         val assocTypesPresentations = mutableListOf<InlayPresentation>()
@@ -272,7 +287,7 @@ class RsTypeHintsPresentationFactory(
             }
         }
 
-        val innerPresentations = typeParametersPresentations + assocTypesPresentations
+        val innerPresentations = genericParametersPresentations + assocTypesPresentations
 
         return if (innerPresentations.isEmpty()) {
             traitPresentation
@@ -294,6 +309,12 @@ class RsTypeHintsPresentationFactory(
 
     private fun isDefaultTypeParameter(argument: Ty, parameter: RsTypeParameter): Boolean =
         argument.isEquivalentTo(parameter.typeReference?.normType)
+
+    private fun isDefaultConstParameter(argument: Const, parameter: RsConstParameter): Boolean {
+        val expectedTy = parameter.typeReference?.type ?: TyUnknown
+        val defaultValue = parameter.expr?.evaluate(expectedTy)
+        return defaultValue !is CtUnknown && argument == defaultValue
+    }
 
     private fun isDefaultTypeAlias(argument: Ty, alias: RsTypeAlias): Boolean =
         argument.isEquivalentTo(alias.typeReference?.normType)

--- a/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
@@ -311,7 +311,7 @@ class RsTypeHintsPresentationFactory(
         argument.isEquivalentTo(parameter.typeReference?.normType)
 
     private fun isDefaultConstParameter(argument: Const, parameter: RsConstParameter): Boolean {
-        val expectedTy = parameter.typeReference?.type ?: TyUnknown
+        val expectedTy = parameter.typeReference?.normType ?: TyUnknown
         val defaultValue = parameter.expr?.evaluate(expectedTy)
         return defaultValue !is CtUnknown && argument == defaultValue
     }

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -211,6 +211,11 @@ open class RsPsiRenderer(
                         sb.append(": ")
                         appendTypeReference(sb, type)
                     }
+                    val defaultValue = expr
+                    if (defaultValue != null) {
+                        sb.append(" = ")
+                        appendConstExpr(sb, defaultValue)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -24,7 +24,6 @@ import org.rust.lang.core.types.regions.ReStatic
 import org.rust.lang.core.types.regions.ReUnknown
 import org.rust.lang.core.types.regions.Region
 import org.rust.lang.core.types.ty.*
-import org.rust.lang.core.types.type
 import org.rust.lang.utils.evaluation.evaluate
 import org.rust.stdext.withPrevious
 
@@ -288,7 +287,7 @@ private data class TypeRenderer(
                         parameter.typeReference?.normType?.isEquivalentTo(subst[parameter]) == true -> continue
                     parameter is RsConstParameter &&
                         parameter.expr != null &&
-                        parameter.expr?.evaluate(parameter.typeReference?.type ?: TyUnknown) == subst[parameter] -> continue
+                        parameter.expr?.evaluate(parameter.typeReference?.normType ?: TyUnknown) == subst[parameter] -> continue
                     else  -> nonDefaultParamFound = true
                 }
             }

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -24,6 +24,8 @@ import org.rust.lang.core.types.regions.ReStatic
 import org.rust.lang.core.types.regions.ReUnknown
 import org.rust.lang.core.types.regions.Region
 import org.rust.lang.core.types.ty.*
+import org.rust.lang.core.types.type
+import org.rust.lang.utils.evaluation.evaluate
 import org.rust.stdext.withPrevious
 
 private const val MAX_SHORT_TYPE_LEN = 50
@@ -41,7 +43,7 @@ fun Ty.render(
     includeTypeArguments: Boolean = true,
     includeLifetimeArguments: Boolean = false,
     useAliasNames: Boolean = true,
-    skipUnchangedDefaultTypeArguments: Boolean = true
+    skipUnchangedDefaultGenericArguments: Boolean = true
 ): String = TypeRenderer(
     context = context,
     unknown = unknown,
@@ -54,7 +56,7 @@ fun Ty.render(
     includeTypeArguments = includeTypeArguments,
     includeLifetimeArguments = includeLifetimeArguments,
     useAliasNames = useAliasNames,
-    skipUnchangedDefaultTypeArguments = skipUnchangedDefaultTypeArguments
+    skipUnchangedDefaultGenericArguments = skipUnchangedDefaultGenericArguments
 ).render(this, level)
 
 fun Ty.renderInsertionSafe(
@@ -64,7 +66,7 @@ fun Ty.renderInsertionSafe(
     includeTypeArguments: Boolean = true,
     includeLifetimeArguments: Boolean = false,
     useAliasNames: Boolean = true,
-    skipUnchangedDefaultTypeArguments: Boolean = true
+    skipUnchangedDefaultGenericArguments: Boolean = true
 ): String = TypeRenderer(
     context = context,
     unknown = "_",
@@ -77,7 +79,7 @@ fun Ty.renderInsertionSafe(
     includeTypeArguments = includeTypeArguments,
     includeLifetimeArguments = includeLifetimeArguments,
     useAliasNames = useAliasNames,
-    skipUnchangedDefaultTypeArguments = skipUnchangedDefaultTypeArguments
+    skipUnchangedDefaultGenericArguments = skipUnchangedDefaultGenericArguments
 ).render(this, level)
 
 val Ty.shortPresentableText: String
@@ -100,7 +102,7 @@ private data class TypeRenderer(
     val includeTypeArguments: Boolean,
     val includeLifetimeArguments: Boolean,
     val useAliasNames: Boolean,
-    val skipUnchangedDefaultTypeArguments: Boolean
+    val skipUnchangedDefaultGenericArguments: Boolean
 ) {
     fun render(ty: Ty, level: Int): String {
         require(level >= 0)
@@ -279,13 +281,15 @@ private data class TypeRenderer(
         val renderedList = mutableListOf<String>()
         var nonDefaultParamFound = false
         for (parameter in declaration.getGenericParameters().asReversed()) {
-            if (skipUnchangedDefaultTypeArguments && !nonDefaultParamFound) {
-                if (parameter is RsTypeParameter &&
-                    parameter.typeReference != null &&
-                    parameter.typeReference?.normType?.isEquivalentTo(subst[parameter]) == true) {
-                    continue
-                } else {
-                    nonDefaultParamFound = true
+            if (skipUnchangedDefaultGenericArguments && !nonDefaultParamFound) {
+                when {
+                    parameter is RsTypeParameter &&
+                        parameter.typeReference != null &&
+                        parameter.typeReference?.normType?.isEquivalentTo(subst[parameter]) == true -> continue
+                    parameter is RsConstParameter &&
+                        parameter.expr != null &&
+                        parameter.expr?.evaluate(parameter.typeReference?.type ?: TyUnknown) == subst[parameter] -> continue
+                    else  -> nonDefaultParamFound = true
                 }
             }
 

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -108,8 +108,6 @@ object RsImportHelper {
     private fun collectImportSubjectsFromTypeReferences(
         context: RsElement,
         result: MutableSet<RsQualifiedNamedElement>,
-        useAliases: Boolean,
-        skipUnchangedDefaultGenericArguments: Boolean
     ) {
         context.accept(object : RsVisitor() {
             override fun visitPath(path: RsPath) {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -49,7 +49,7 @@ abstract class Ty(override val flags: TypeFlags = 0) : Kind, TypeFoldable<Ty> {
     /**
      * User visible string representation of a type
      */
-    final override fun toString(): String = render(useAliasNames = false, skipUnchangedDefaultTypeArguments = false)
+    final override fun toString(): String = render(useAliasNames = false, skipUnchangedDefaultGenericArguments = false)
 
     /**
      * Use it instead of [equals] if you want to check that the types are the same from the Rust perspective.

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -943,6 +943,13 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='definition'><pre>type parameter <b>T</b></pre></div>
     """)
 
+    fun `test const parameter`() = doTest("""
+        fn foo<const N: usize>() { unimplemented!() }
+                   //^
+    """, """
+        <div class='definition'><pre>const parameter <b>N</b>: usize</pre></div>
+    """)
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test type parameter with single bound`() = doTest("""
         use std::borrow::Borrow;
@@ -979,6 +986,14 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
              //^
     """, """
         <div class='definition'><pre>type parameter <b>T</b> = <a href="psi_element://RandomState">RandomState</a></pre></div>
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test const parameter with default value`() = doTest("""
+        fn foo<const N: usize = 0>() { unimplemented!() }
+                   //^
+    """, """
+        <div class='definition'><pre>const parameter <b>N</b>: usize = 0</pre></div>
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)

--- a/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
@@ -18,6 +18,12 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
         }
     """)
 
+    fun `test array`() = checkByText("""
+        fn main() {
+            let s<hint text="[:  [[ [i32 ;  3] ]]]"/> = [1, 2, 3];
+        }
+    """)
+
     fun `test let stmt without expression`() = checkByText("""
         struct S;
         fn main() {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
 import org.rust.*
+import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.refactoring.extractFunction.ExtractFunctionUi
 import org.rust.ide.refactoring.extractFunction.RsExtractFunctionConfig
 import org.rust.ide.refactoring.extractFunction.withMockExtractFunctionUi
@@ -1252,6 +1253,26 @@ class RsExtractFunctionTest : RsTestBase() {
         }
 
         fn foo(s: S<u32>) -> S<u32> {
+            s
+        }
+    """, "foo")
+
+    fun `test extract a function with unset default const parameter`() = doTest("""
+        struct S<const N: usize, const M: usize = 1>([i32; M]);
+
+        fn main() {
+            let s: S<0> = S::<0>([1, 2, 3]);
+            <selection>s</selection>;
+        }
+    """, """
+        struct S<const N: usize, const M: usize = 1>([i32; M]);
+
+        fn main() {
+            let s: S<0> = S::<0>([1, 2, 3]);
+            foo(s);
+        }
+
+        fn foo(s: S<0>) -> S<0> {
             s
         }
     """, "foo")

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -1191,6 +1191,28 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test implement function with const generic defaults`() = doTest("""
+        trait T {
+            fn f<const N: usize = 1>();
+        }
+        struct S;
+        impl T for S {
+            /*caret*/
+        }
+    """, listOf(
+        ImplementMemberSelection("f<const N: usize = 1>()", byDefault = true, isSelected = true),
+    ), """
+        trait T {
+            fn f<const N: usize = 1>();
+        }
+        struct S;
+        impl T for S {
+            fn f<const N: usize = 1>() {
+                <selection>todo!()</selection>
+            }
+        }
+    """)
+
     fun `test do not implement methods already present`() = doTest("""
         trait T {
             fn f1();

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -702,9 +702,9 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
             typeAtCaret.rawType
         }
         val renderedTy = when (renderMode) {
-            DEFAULT -> ty.render(useAliasNames = false, skipUnchangedDefaultTypeArguments = false)
-            WITH_LIFETIMES -> ty.renderInsertionSafe(includeLifetimeArguments = true, skipUnchangedDefaultTypeArguments = false)
-            WITH_ALIAS_NAMES -> ty.render(useAliasNames = true, skipUnchangedDefaultTypeArguments = false)
+            DEFAULT -> ty.render(useAliasNames = false, skipUnchangedDefaultGenericArguments = false)
+            WITH_LIFETIMES -> ty.renderInsertionSafe(includeLifetimeArguments = true, skipUnchangedDefaultGenericArguments = false)
+            WITH_ALIAS_NAMES -> ty.render(useAliasNames = true, skipUnchangedDefaultGenericArguments = false)
         }
         check(renderedTy == expectedType) {
             "$renderedTy != $expectedType"

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
@@ -46,7 +46,7 @@ abstract class RsTypificationTestBase : RsTestBase() {
         val (expr, data) = findElementAndDataInEditor<RsExpr>()
         val expectedTypes = data.split("|").map(String::trim)
 
-        val type = expr.type.render(skipUnchangedDefaultTypeArguments = false, useAliasNames = false)
+        val type = expr.type.render(skipUnchangedDefaultGenericArguments = false, useAliasNames = false)
         check(type in expectedTypes) {
             "Type mismatch. Expected one of $expectedTypes, found: $type. $description"
         }


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6943.

Relates to https://github.com/intellij-rust/intellij-rust/issues/3985.

Depends on https://github.com/intellij-rust/intellij-rust/pull/8144 and https://github.com/intellij-rust/intellij-rust/pull/8145.

changelog: Render const generics in quick docs and inline hints
