### PR TITLE
CI: setup Dependabot for updating `ra_ap_proc_macro_srv`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+    - package-ecosystem: "cargo"
+      directory: "/native-helper"
+      schedule:
+          interval: "daily"
+          time: "04:00" # UTC
+      open-pull-requests-limit: 1
+      labels: [ ]
+      assignees:
+          - "vlad20012"


### PR DESCRIPTION
Setup [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates) that will update `ra_ap_proc_macro_srv` in `native-helper/Cargo.toml`.
Hence we will receive updates quicker and keep compatibility with nightly Rust.
