### PR TITLE
RES: Correctly disambiguate unit struct vs const to struct

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -157,7 +157,7 @@ fun processItemDeclarations(
         if (isAtLeastEdition2018 && !scope.isCrateRoot) {
             val crateRoot = scope.crateRoot
             if (crateRoot != null) {
-                val result = processWithShadowingAndUpdateScope(directlyDeclaredNames, originalProcessor) { shadowingProcessor ->
+                val result = processWithShadowingAndUpdateScope(directlyDeclaredNames, ns, originalProcessor) { shadowingProcessor ->
                     crateRoot.processExpandedItemsExceptImplsAndUses { item ->
                         if (item is RsExternCrateItem) {
                             processExternCrateItem(item, shadowingProcessor, true)
@@ -173,7 +173,7 @@ fun processItemDeclarations(
         // "extern_prelude" feature. Extern crate names can be resolved as if they were in the prelude.
         // See https://blog.rust-lang.org/2018/10/25/Rust-1.30.0.html#module-system-improvements
         // See https://github.com/rust-lang/rust/pull/54404/
-        val result = processWithShadowingAndUpdateScope(directlyDeclaredNames, originalProcessor) { shadowingProcessor ->
+        val result = processWithShadowingAndUpdateScope(directlyDeclaredNames, ns, originalProcessor) { shadowingProcessor ->
             val isCompletion = ipm == ItemProcessingMode.WITH_PRIVATE_IMPORTS_N_EXTERN_CRATES_COMPLETION
             processExternCrateResolveVariants(
                 scope,
@@ -215,7 +215,7 @@ fun processItemDeclarations(
         } ?: continue
 
         val found = recursionGuard(mod, {
-            processWithShadowing(directlyDeclaredNames, originalProcessor) { shadowingProcessor ->
+            processWithShadowing(directlyDeclaredNames, ns, originalProcessor) { shadowingProcessor ->
                 processItemOrEnumVariantDeclarations(
                     mod,
                     ns,

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsConstArgumentResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsConstArgumentResolveTest.kt
@@ -94,6 +94,15 @@ class RsConstArgumentResolveTest : RsResolveTestBase() {
         }       //^
     """)
 
+    fun `test type is preferred in an upper scope (unit struct)`() = checkByCode("""
+        struct N;
+             //X
+        fn bar<T>() {}
+        fn foo<const N: i32>() {
+            bar::<N>();
+        }       //^
+    """)
+
     // Method call arguments:
 
     fun `test disambiguate type argument in method call`() = checkByCode("""


### PR DESCRIPTION
```rust
struct N;
     //X
fn bar<T>() {}
fn foo<const N: i32>() {
    bar::<N>();
}       //^
```