### PR TITLE
Remove get, set and with patterns from RsSelfConventionInspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
@@ -47,10 +47,6 @@ class RsSelfConventionInspection : RsLocalInspectionTool() {
             SelfConvention("is_", listOf(SelfSignature.BY_REF, SelfSignature.NO_SELF)),
             SelfConvention("to_", listOf(SelfSignature.BY_MUT_REF), postfix = "_mut"),
             SelfConvention("to_", listOf(SelfSignature.BY_REF, SelfSignature.BY_VAL)),
-            SelfConvention("get_", listOf(SelfSignature.BY_MUT_REF), postfix = "_mut"),
-            SelfConvention("get_", listOf(SelfSignature.BY_REF)),
-            SelfConvention("set_", listOf(SelfSignature.BY_MUT_REF)),
-            SelfConvention("with_", listOf(SelfSignature.BY_VAL, SelfSignature.BY_MUT_REF, SelfSignature.NO_SELF))
         )
     }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
@@ -8,9 +8,6 @@ package org.rust.ide.inspections
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
-/**
- * Tests for Self Convention inspection
- */
 class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionInspection::class) {
     fun `test from`() = checkByText("""
         struct Foo;
@@ -62,42 +59,6 @@ class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionIns
         impl Foo {
             fn is_awesome(<warning descr="methods called `is_*` usually take self by reference or no self; consider choosing a less ambiguous name">self</warning>) {}
             fn is_awesome_ref(&self) {}
-        }
-    """)
-
-    fun `test get`() = checkByText("""
-        struct Foo;
-        impl Foo {
-            fn get_a(<warning descr="methods called `get_*` usually take self by reference; consider choosing a less ambiguous name">self</warning>) {}
-            fn get_b(&self) {}
-            fn get_c(<warning descr="methods called `get_*` usually take self by reference; consider choosing a less ambiguous name">&mut self</warning>) {}
-        }
-    """)
-
-    fun `test get mut`() = checkByText("""
-        struct Foo;
-        impl Foo {
-            fn get_a_mut(<warning descr="methods called `get_*_mut` usually take self by mutable reference; consider choosing a less ambiguous name">self</warning>) {}
-            fn get_b_mut(<warning descr="methods called `get_*_mut` usually take self by mutable reference; consider choosing a less ambiguous name">&self</warning>) {}
-            fn get_c_mut(&mut self) {}
-        }
-    """)
-
-    fun `test set`() = checkByText("""
-        struct Foo;
-        impl Foo {
-            fn set_foo(<warning descr="methods called `set_*` usually take self by mutable reference; consider choosing a less ambiguous name">&self</warning>) {}
-            fn set_bar(&mut self) {}
-        }
-    """)
-
-    fun `test with`() = checkByText("""
-        struct Foo;
-        impl Foo {
-            fn with_foo(<warning descr="methods called `with_*` usually take self by value or self by mutable reference or no self; consider choosing a less ambiguous name">&self</warning>) {}
-            fn with_bar(&mut self) {}
-            fn with_baz(self) {}
-            fn with_constructor() {}
         }
     """)
 


### PR DESCRIPTION
The `self` convention inspection had a lot of annoying false positives with the `get`, `set` and `with` patterns (https://github.com/intellij-rust/intellij-rust/issues/7475#issuecomment-976434220, https://github.com/intellij-rust/intellij-rust/issues/7475). These patterns are used in pretty much all `self` scenarios in the wild, as found out by @afetisov (https://github.com/intellij-rust/intellij-rust/pull/7557#issuecomment-883506073, https://github.com/intellij-rust/intellij-rust/pull/7557#issuecomment-884224559). I already wanted to remove them in the last PR that modified the convention (https://github.com/intellij-rust/intellij-rust/pull/7557#issuecomment-884227697), but didn't get to it.

This PR removes all `get`, `set` and `with` patterns from the convention. Now the convention almost exactly mirrors `Clippy` (https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention), which is as it should be IMO.

changelog: Remove `set`, `get` and `with` name patterns from the `self` convention inspection. This should reduce the number of false positives produced and it also moves the inspection closer to the corresponding `Clippy` inspection `wrong_self_convention`.