### PR TITLE
GRD: make 2021.3 platform default for development

### DIFF
--- a/gradle-213.properties
+++ b/gradle-213.properties
@@ -5,9 +5,9 @@ ideaVersion=IU-213.5744-EAP-CANDIDATE-SNAPSHOT
 clionVersion=CL-213.5744-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/8195-toml/versions
-tomlPluginVersion=213.5744.3
+tomlPluginVersion=213.5744.178
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=213.5744.18
+nativeDebugPluginVersion=213.5744.122
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPluginVersion=213-SNAPSHOT
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
 # Supported platforms: 212, 213
-platformVersion=212
+platformVersion=213
 # Supported IDEs: idea, clion
 baseIDE=idea
 


### PR DESCRIPTION
changelog: Make 2021.3 platform default for development