### PR TITLE
DBG: Allow loading NatVis files from Rust MSVC toolchain on Windows

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/RustcNatvisFileProvider.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RustcNatvisFileProvider.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger
+
+import com.intellij.openapi.util.registry.Registry
+import com.jetbrains.cidr.execution.debugger.CidrDebugProcess
+import com.jetbrains.cidr.execution.debugger.formatters.natvis.NatvisFileProvider
+import org.rust.cargo.project.settings.toolchain
+import org.rust.debugger.LLDBRenderers.COMPILER
+import org.rust.debugger.runconfig.RsDebugProcessConfigurator
+import org.rust.debugger.settings.RsDebuggerSettings
+import java.io.File
+
+/**
+ * Activates NatVis files from rustc when:
+ * - Rust compiler's renderers are selected as LLDB renderers
+ * - Experimental Rust MSVC support in LLDB is disabled
+*/
+class RustcNatvisFileProvider : NatvisFileProvider {
+    override fun populate(debugProcess: CidrDebugProcess, fileList: MutableList<String>) {
+        val settings = RsDebuggerSettings.getInstance()
+        val isLLDBRustMSVCSupportEnabled = Registry.`is`("org.rust.debugger.lldb.rust.msvc", false)
+
+        if (settings.lldbRenderers == COMPILER && !isLLDBRustMSVCSupportEnabled) {
+            val toolchain = debugProcess.project.toolchain ?: return
+            val cargoProject = RsDebugProcessConfigurator.findCargoProject(debugProcess) ?: return
+            val sysroot = cargoProject.rustcInfo?.sysroot
+                ?.let { toolchain.toRemotePath(it) }
+                ?: return
+            val visualizersDir = File(sysroot).resolve("lib").resolve("rustlib").resolve("etc")
+            val absolutePaths = NatvisFileProvider.listNatvisFilesInDirectory(visualizersDir).map { it.absolutePath }
+            fileList.addAll(absolutePaths)
+        }
+    }
+}

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurator.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurator.kt
@@ -7,11 +7,17 @@ package org.rust.debugger.runconfig
 
 import com.jetbrains.cidr.execution.debugger.CidrDebugProcess
 import com.jetbrains.cidr.execution.debugger.CidrDebugProcessConfigurator
+import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 
 class RsDebugProcessConfigurator : CidrDebugProcessConfigurator {
     override fun configure(process: CidrDebugProcess) {
-        val cargoProject = when {
+        val cargoProject = findCargoProject(process) ?: return
+        RsDebugProcessConfigurationHelper(process, cargoProject).configure()
+    }
+
+    companion object {
+        fun findCargoProject(process: CidrDebugProcess): CargoProject? = when {
             process is RsLocalDebugProcess -> {
                 // In case of Rust project, select the corresponding Cargo project
                 process.runParameters.cargoProject
@@ -24,9 +30,8 @@ class RsDebugProcessConfigurator : CidrDebugProcessConfigurator {
             }
             else -> {
                 // Otherwise, don't configure the debug process for Rust
-                return
+                null
             }
         }
-        RsDebugProcessConfigurationHelper(process, cargoProject).configure()
     }
 }

--- a/debugger/src/main/resources/org.rust.debugger.xml
+++ b/debugger/src/main/resources/org.rust.debugger.xml
@@ -16,6 +16,7 @@
         <lineBreakpointFileTypesProvider implementation="org.rust.debugger.RsLineBreakpointFileTypesProvider"/>
         <debugProcessConfigurator implementation="org.rust.debugger.runconfig.RsDebugProcessConfigurator"/>
         <backendConsoleInjectionHelper implementation="org.rust.debugger.RsBackendConsoleInjectionHelper"/>
+        <formatters.natvis.provider implementation="org.rust.debugger.RustcNatvisFileProvider"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Now, when using MSVC toolchain on Windows, the plugin searches for NatVis files in `$sysroot/lib/rustlib/etc` directory and loads them when:
1. `Enable NatVis renderers for LLDB` is set in `Data Views | C/C++` (enabled by default);
2. `LLDB renderers` option is set to "Rust compiler's renderers";
3. Experimental Rust MSVC support in LLDB is disabled manually.

Note, if only (2) is met, the plugin now does not load any pretty-printers since the MSVC toolchain does not provide regular Python pretty-printers. Previously, the plugin was wrongly trying to load the missing Python pretty-printers.

Also note that (3) is required because NatVis renderers heavily use C++ syntax, which conflicts with the Rust parser used by MSVC LLDB inside Rust frames when experimental Rust MSVC support is enabled.

NatVis files provided by the Rust MSVC toolchain are located at https://github.com/rust-lang/rust/tree/master/src/etc/natvis.

This PR brings initial support for NatVis renderers but leaves Bundled renderers + Experimental Rust MSVC support in LLDB as the default behaviour. However, NatVis is a promising way to render certain Rust types, bringing `Raw View` and support for several extra `liballoc`/`libcore` types. This initial support has room for improvement, and it could be addressed in the future.

A few examples of the difference are shown below.

**Bundled renderers**

<img width="731" alt="Bundled renderers" src="https://user-images.githubusercontent.com/4854600/143222284-df8fc3d9-4f66-48f2-b837-b2733d49bc99.png">

**Rust compiler's renderers (NatVis)**
<img width="731" alt="Rust compiler's renderers" src="https://user-images.githubusercontent.com/4854600/143224759-562565b7-e4b2-499d-abbf-b5733ab28a0d.png">

Part of #5632.

changelog: Allow loading NatVis debugger renderers when using MSVC toolchain on Windows