### PR TITLE
TY: correctly infer type of struct with the same name as primitive type

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -106,8 +106,7 @@ class RsHighlightingAnnotator : AnnotatorBase() {
 
         val parent = element.parent
         val reference = element.reference
-        val isPrimitiveType = element is RsPath && TyPrimitive.fromPath(element) != null &&
-            (parent is RsBaseType || parent is RsPath && reference != null && reference.multiResolve().isEmpty())
+        val isPrimitiveType = element is RsPath && TyPrimitive.fromPath(element) != null
 
         return when {
             isPrimitiveType -> RsColor.PRIMITIVE_TYPE

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
@@ -12,6 +12,7 @@ import com.intellij.refactoring.changeSignature.ParameterInfo
 import com.intellij.refactoring.changeSignature.ParameterInfo.NEW_PARAMETER
 import org.rust.ide.refactoring.RsFunctionSignatureConfig
 import org.rust.lang.RsLanguage
+import org.rust.lang.core.macros.setContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.Ty
@@ -152,7 +153,12 @@ class RsChangeFunctionSignatureConfig private constructor(
                 val patText = parameter.pat?.text ?: "_"
                 // The element has to be copied, otherwise suggested refactoring API
                 // would revert the PSI item to its previous state
-                val type = ParameterProperty.fromItem(parameter.typeReference?.copy() as? RsTypeReference)
+                val parameterCopy = (parameter.typeReference?.copy() as? RsTypeReference)
+                    ?.also {
+                        val context = parameter.typeReference?.parent?.context as? RsElement
+                        context?.let { it1 -> it.setContext(it1) }
+                    }
+                val type = ParameterProperty.fromItem(parameterCopy)
                 Parameter(factory, patText, type, index)
             }
             return RsChangeFunctionSignatureConfig(

--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
@@ -12,10 +12,11 @@ import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.util.ProcessingContext
+import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.RsBaseTypeKind
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.returnType
-import org.rust.lang.core.types.ty.TyUnit
+import org.rust.lang.core.psi.ext.kind
 
 class RsKeywordCompletionProvider(
     private vararg val keywords: String
@@ -43,7 +44,9 @@ private fun addInsertionHandler(keyword: String, builder: LookupElementBuilder, 
         in ALWAYS_NEEDS_SPACE -> " "
         "return" -> {
             val fn = parameters.position.ancestorStrict<RsFunction>() ?: return builder
-            if (fn.returnType !is TyUnit) " " else ";"
+            val fnRetType = fn.retType
+            val returnsUnit = fnRetType == null || (fnRetType.typeReference as? RsBaseType)?.kind == RsBaseTypeKind.Unit
+            if (returnsUnit) ";" else " "
         }
         else -> return builder
     }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -6,8 +6,10 @@
 package org.rust.lang.core.types.ty
 
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.infer.TypeFolder
 
@@ -35,9 +37,25 @@ sealed class TyPrimitive : Ty() {
 
     companion object {
         fun fromPath(path: RsPath): TyPrimitive? {
-            if (path.hasColonColon) return null
             val name = path.referenceName ?: return null
 
+            val result = fromName(name) ?: return null
+
+            if (path.hasColonColon || path.typeQual != null) return null
+            val parent = path.parent
+            if (parent !is RsBaseType && parent !is RsPath) return null
+
+            // struct u8;
+            // let a: u8; // this is a struct "u8", not a primitive type "u8"
+            val pathReference = path.reference ?: return null
+            val resolvedTo = pathReference.multiResolve()
+            if (parent is RsBaseType && resolvedTo.any { it !is RsMod }) return null
+            if (parent is RsPath && resolvedTo.isNotEmpty()) return null
+
+            return result
+        }
+
+        private fun fromName(name: String): TyPrimitive? {
             TyInteger.fromName(name)?.let { return it }
             TyFloat.fromName(name)?.let { return it }
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -160,6 +160,14 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
             <VARIABLE>i32</VARIABLE> = 2;
             true
         }
+
+        fn <FUNCTION>not_a_primitive</FUNCTION>() {
+            struct <STRUCT>u8</STRUCT>;
+            mod <MODULE>u16</MODULE> { type <TYPE_ALIAS>T</TYPE_ALIAS> = <PRIMITIVE_TYPE>u16</PRIMITIVE_TYPE>; }
+
+            let <VARIABLE>a</VARIABLE>: <STRUCT>u8</STRUCT> = <STRUCT>u8</STRUCT>;
+            let <VARIABLE>b</VARIABLE>: <MODULE>u16</MODULE>::<TYPE_ALIAS>T</TYPE_ALIAS>;
+        }
     """)
 
     @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -768,4 +768,16 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
             x;
         }
     """, checkWarn = false)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no move when Copy is implemented for struct named as a primitive type`() = checkByText("""
+        struct f64;
+        impl Copy for f64 {}
+
+        fn main() {
+            let a = 1.0;
+            let b = a;
+            let c = a;
+        }
+    """, checkWarn = false)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -506,6 +506,30 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
                  //^ Foo<i32>
     """, WITH_ALIAS_NAMES)
 
+    fun `test primitive when there is a mod with the same name`() = testType("""
+        mod u64 {}
+        type T = u64;
+                 //^ u64
+    """)
+
+    fun `test associated type with name f64`() = testType("""
+        trait Trait { type f64; }
+        struct S;
+        impl Trait for S {
+            type f64 = ();
+        }
+        type A = <S as Trait>::f64;
+                             //^ ()
+    """)
+
+    fun `test unresolved associated type with name f64`() = testType("""
+        trait Trait {}
+        struct S;
+        impl Trait for S {}
+        type A = <S as Trait>::f64;
+                             //^ <unknown>
+    """)
+
     /**
      * Checks the type of the element in [code] pointed to by `//^` marker.
      */


### PR DESCRIPTION
```rust
struct u8;
let a: u8; // this is a struct "u8", not a primitive type "u8"
```

This also fixes several "Use of moved value" inspection false positives. 
Previously, this code contained a false positive "Use of moved value" for the second use of `a` because our trait engine thought that there is an ambiguous impl of trait `Copy` for a primitive type `f64`. But actually, it is not an impl for the primitive type.

```rust
struct f64;
impl Copy for f64 {} // An impl for "struct f64", NOT for a primitive type "f64"

fn main123() {
    let a = 1.0;
    let b = a;
    let c = a; // <-- no move here
}
```
        

Fixes #7755
Fixes #4858
Fixes #7246

changelog: 1) Fix several "Use of moved value" inspection false positives (for example, in `bevy` crate). 2) Correctly infer a type of a struct/enum with the same name as a primitive type.