### PR TITLE
Fix untrusted notifications in Cargo projects

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
@@ -18,7 +18,7 @@ import org.rust.RsBundle
 import org.rust.cargo.CargoConstants
 import org.rust.cargo.icons.CargoIcons
 import org.rust.cargo.project.model.guessAndSetupRustProject
-import org.rust.ide.security.isOldTrustedProjectApiAvailable
+import org.rust.ide.security.isNewTrustedProjectApiAvailable
 import javax.swing.Icon
 
 class CargoProjectOpenProcessor : ProjectOpenProcessor() {
@@ -39,13 +39,13 @@ class CargoProjectOpenProcessor : ProjectOpenProcessor() {
         // if they trust project before opening, i.e. we don't need to check it manually.
         // Moreover, the corresponding API was changed, so we should avoid using old API
         // not to produce runtime errors
-        if (isOldTrustedProjectApiAvailable) {
+        if (!isNewTrustedProjectApiAvailable) {
             choice = confirmOpeningUntrustedProject(basedir, listOf(RsBundle.message("cargo")))
             if (choice == OpenUntrustedProjectChoice.CANCEL) return null
         }
 
         return PlatformProjectOpenProcessor.getInstance().doOpenProject(basedir, projectToClose, forceNewFrame)?.also {
-            if (isOldTrustedProjectApiAvailable) {
+            if (!isNewTrustedProjectApiAvailable) {
                 it.setTrusted(choice == OpenUntrustedProjectChoice.IMPORT)
             }
             StartupManager.getInstance(it).runWhenProjectIsInitialized { guessAndSetupRustProject(it) }

--- a/src/main/kotlin/org/rust/ide/notifications/RsUntrustedNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/RsUntrustedNotificationProvider.kt
@@ -17,6 +17,7 @@ import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.EditorNotifications
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.isCargoToml
+import org.rust.ide.security.isNewTrustedProjectApiAvailable
 import org.rust.lang.core.psi.isRustFile
 
 class RsUntrustedNotificationProvider : EditorNotifications.Provider<EditorNotificationPanel>(), DumbAware {
@@ -26,6 +27,7 @@ class RsUntrustedNotificationProvider : EditorNotifications.Provider<EditorNotif
     @Suppress("UnstableApiUsage")
     override fun createNotificationPanel(file: VirtualFile, fileEditor: FileEditor, project: Project): EditorNotificationPanel? {
         if (project.isTrusted()) return null
+        if (isNewTrustedProjectApiAvailable) return null
         if (!(file.isRustFile || file.isCargoToml)) return null
 
         val cargoProjects = project.cargoProjects

--- a/src/main/kotlin/org/rust/ide/security/RsTrustChangeNotifier.kt
+++ b/src/main/kotlin/org/rust/ide/security/RsTrustChangeNotifier.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.ui.EditorNotifications
 import org.rust.cargo.project.model.cargoProjects
 
+// BACKCOMPAT: 2021.3. Replace with implementation of `com.intellij.ide.impl.TrustStateListener`
 @Suppress("UnstableApiUsage")
 class RsTrustChangeNotifier : TrustChangeNotifier {
     override fun projectTrusted(project: Project) {

--- a/src/main/kotlin/org/rust/ide/security/trustedProjectUtils.kt
+++ b/src/main/kotlin/org/rust/ide/security/trustedProjectUtils.kt
@@ -5,18 +5,38 @@
 
 package org.rust.ide.security
 
-import com.intellij.ide.impl.OpenUntrustedProjectChoice
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+
+private val LOG = Logger.getInstance(":org.rust.ide.security.TrustedProjectUtils")
 
 // Starting with 2021.3.1 and 2021.2.4 some project trusted API was changed,
 // so let's check if old API is available not to produce runtime errors
 //
 // BACKCOMPAT: 2021.3
-val isOldTrustedProjectApiAvailable: Boolean by lazy {
+val isNewTrustedProjectApiAvailable: Boolean get() = whenProjectTrustedFunction != null
+
+fun whenProjectTrusted(parentDisposable: Disposable, listener: (Project) -> Unit) {
+    if (whenProjectTrustedFunction == null) {
+        LOG.warn("`com.intellij.ide.impl.whenProjectTrusted` is not available")
+    }
+    whenProjectTrustedFunction?.invoke(parentDisposable, listener)
+}
+
+// Reflection based wrapper over `com.intellij.ide.impl.whenProjectTrusted` function
+private val whenProjectTrustedFunction: ((Disposable, (Project) -> Unit) -> Unit)? by lazy {
     try {
-        @Suppress("UnstableApiUsage")
-        OpenUntrustedProjectChoice.IMPORT.name
-        true
-    } catch (e: NoSuchFieldError) {
-        false
+        val trustedProjectClass = Class.forName("com.intellij.ide.impl.TrustedProjects")
+        val method = trustedProjectClass.getMethod("whenProjectTrusted", Disposable::class.java, Function1::class.java);
+        { parentDisposable, listener ->
+            try {
+                method.invoke(null, parentDisposable, listener)
+            } catch (e: Throwable) {
+                LOG.error(e)
+            }
+        }
+    } catch (ignore: Throwable) {
+        null
     }
 }


### PR DESCRIPTION
Coming versions of IntelliJ IDE (more specifically 2021.2.4 and 2021.3.1) will bring changes in untrusted editor notification.
Now, if a project is opened in safe mode, IDE will show the corresponding editor notification in all files itself. That leads to double editor notification since the plugin shows its own notification as well.

<img width="782" alt="Screen Shot 2021-11-24 at 16 51 58" src="https://user-images.githubusercontent.com/2539310/143281497-36fbe0c7-62cc-47df-a3f5-9090289b02d7.png">


These changes prepare the plugin for platform changes, and now the editor notification about untrusted project will be shown only once. Also, they fix `trust project` action in the notification that doesn't work with stable plugin builds because of changes in the platform (`TrustChangeNotifier` was renamed to `TrustStateListener`)



changelog: Prepare plugin for upcoming changes in untrusted editor notification
