### PR TITLE
RES: fix exception in name resolution

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -119,7 +119,7 @@ private fun RsExpr.getValue(crateOrNull: Crate?): String? {
                     when (val variableName = expr.getValue(crate)) {
                         "OUT_DIR" -> crate.outDir?.path
                         else -> {
-                            val toolchain = if (isUnitTestMode) RsToolchainBase.suggest() else project.toolchain
+                            val toolchain = if (isUnitTestMode) RsToolchainBase.suggest() else crate.project.toolchain
                             crate.env[variableName]?.let { toolchain?.toLocalPath(it) }
                         }
                     }


### PR DESCRIPTION
Fixes #8172

I can't make a test because the bug is under `if (!isUnitTestMode)` condition

changelog: Fix analysis in `sixtyfps` crate
