### PR TITLE
CLEAN: Pass stub to `getProcMacroAttributeWithoutResolve`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -687,7 +687,7 @@ fun StubElement<*>.hasMacroIndex(crate: Crate): Boolean {
     if (hasMacroIndexIgnoringProcMacros()) return true
     if (this !is RsAttrProcMacroOwnerStub) return false
     val attr = ProcMacroAttribute.getProcMacroAttributeWithoutResolve(
-        psi as RsAttrProcMacroOwner,
+        this,
         this,
         crate,
         withDerives = true


### PR DESCRIPTION
Internal. Cleanup