### PR TITLE
RES: prefer enum variant over associated items

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -325,7 +325,9 @@ class ImplLookup(
                 implsAndTraits += fnTraits.map { TraitImplSource.Object(it) }
             }
             is TyAnon -> {
-                ty.getTraitBoundsTransitively().mapTo(implsAndTraits) { TraitImplSource.Object(it.element) }
+                ty.getTraitBoundsTransitively()
+                    .distinctBy { it.element }
+                    .mapTo(implsAndTraits) { TraitImplSource.Object(it.element) }
                 RsImplIndex.findFreeImpls(project) { implsAndTraits += TraitImplSource.ExplicitImpl(it); false }
             }
             is TyProjection -> {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
@@ -51,14 +51,14 @@ class RsCompletionSortingTest : RsTestBase() {
 
     fun `test enum variants before associated constants`() = doTest("""
         enum E { A, B }
-        trait T { const A: i32; }
-        impl T for E { const A: i32 = 0; }
+        trait T { const C: i32; }
+        impl T for E { const C: i32 = 0; }
 
         fn main() { E::/*caret*/ }
     """, listOf(
         RsEnumVariant::class to "A",
         RsEnumVariant::class to "B",
-        RsConstant::class to "A"
+        RsConstant::class to "C"
     ))
 
     fun `test inherent impl methods before trait impl methods`() = doTest("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1317,4 +1317,58 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             T::Item::bar();
         }          //^
     """)
+
+    fun `test a enum variant wins an associated type in a struct literal context`() = checkByCode("""
+        trait Trait { type Foo; }
+        impl<T> Trait for T { type Foo = (); }
+        enum E {
+            Foo {},
+            //X
+            Bar {}
+        }
+        fn main() {
+            let _ = E::Foo {};
+        }            //^
+    """)
+
+    fun `test a enum variant wins an associated type in a pattern context`() = checkByCode("""
+        trait Trait { type Foo; }
+        impl<T> Trait for T { type Foo = (); }
+        enum E {
+            Foo {},
+            //X
+            Bar {}
+        }
+        fn main() {
+            let a = E::Foo {};
+            if let E::Foo {} = a {}
+        }           //^
+    """)
+
+    fun `test a enum variant wins an associated function in a function call context`() = checkByCode("""
+        trait Trait { fn Foo(a: i32); }
+        impl<T> Trait for T { fn Foo(a: i32) {} }
+        enum E {
+            Foo(i32),
+            //X
+            Bar()
+        }
+        fn main123() {
+            let a = E::Foo(1);
+        }            //^
+    """)
+
+    fun `test a enum variant wins an associated function in a pattern context`() = checkByCode("""
+        trait Trait { fn Foo(a: i32); }
+        impl<T> Trait for T { fn Foo(a: i32) {} }
+        enum E {
+            Foo(i32),
+            //X
+            Bar()
+        }
+        fn main123() {
+            let a = E::Foo(1);
+            if let E::Foo(_) = a {}
+        }           //^
+    """)
 }


### PR DESCRIPTION
Fixes #7464

```rust
trait Trait { type Foo; }
impl<T> Trait for T { type Foo = (); }
enum E {
    Foo {},
    Bar {}
}
fn main() {
    let a = E::Foo {}; // This Foo is a enum variant
    if let E::Foo {} = a {} // This Foo is a enum variant
} 
```

```rust
trait Trait { fn Foo(a: i32); }
impl<T> Trait for T { fn Foo(a: i32) {} }
enum E {
    Foo(i32),
    Bar()
}
fn main() {
    let a = E::Foo(1); // This Foo is a enum variant
    if let E::Foo(_) = a {} // This Foo is a enum variant
}
```
