### PR TITLE
MACRO: add `async_trait` to the list of hardcoded proc macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
@@ -52,6 +52,7 @@ private val RS_HARDCODED_PROC_MACRO_ATTRIBUTES: Map<String, Map<String, KnownPro
         "count_alloc" to KnownProcMacroKind.IDENTITY,
     ),
     "uefi_macros" to mapOf("entry" to KnownProcMacroKind.CUSTOM_MAIN),
+    "async_trait" to mapOf("async_trait" to KnownProcMacroKind.ASYNC_TRAIT),
 )
 
 fun getHardcodeProcMacroProperties(packageName: String, macroName: String): KnownProcMacroKind {
@@ -114,6 +115,9 @@ enum class KnownProcMacroKind {
      * Also, the macro can produce multiple test functions.
      */
     CUSTOM_TEST_RENAME,
+
+    /** https://crates.io/crates/async-trait */
+    ASYNC_TRAIT,
     ;
 
     val treatAsBuiltinAttr: Boolean


### PR DESCRIPTION
Just skip `#[async_trait]` proc macro expansion and treat it as some unknown attribute.

Fixes #8053
Fixes #8026
Fixes #8072
Fixes #8181
Fixes #8093

But brings #7863 false-positive again :(

changelog: Do not expand `async_trait` procedural macro if proc macro expansion is enabled. This fixes several issues with `async_trait`.