### PR TITLE
INSP: remove spurious unreachable warnings for match exprs with no arms

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
@@ -603,7 +603,16 @@ class CFGBuilder(
 
         val prevGuards = ArrayDeque<CFGNode>()
 
-        matchExpr.arms.forEach { arm ->
+        val arms = matchExpr.arms
+        if (arms.isEmpty()) {
+            // The only case where a match with no arms is valid is when the discriminant is
+            // an empty type (!, empty enum etc), but the unreachability in this case is handled
+            // by the type-based CFG analysis/
+            // In all other cases no match arms mean only that the user hasn't typed them yet, so
+            // we add a dummy edge to avoid breaking the CFG (otherwise everything after the match
+            // would be unreachable).
+            addContainedEdge(discriminantExit, exprExit)
+        } else arms.forEach { arm ->
             val armExit = addDummyNode()
             val guard = arm.matchArmGuard
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspectionTest.kt
@@ -229,4 +229,66 @@ class RsUnreachableCodeInspectionTest : RsInspectionsTestBase(RsUnreachableCodeI
             <warning descr="Unreachable code">()</warning>
         }
     """)
+
+    fun `test incomplete match expr reachable`() = checkByText("""
+        fn main() {
+            let x = match 3 {
+
+            };
+            return;
+        }
+    """)
+
+    fun `test incomplete match stmt reachable`() = checkByText("""
+        enum Foo { A(u32), B }
+        fn main() {
+            match f() {
+
+            };
+            return;
+        }
+        fn f() -> Foo { loop {} }
+    """)
+
+    fun `test incomplete match with noreturn branch`() = checkByText("""
+        enum Foo { A(u32), B }
+        fn main() {
+            match f() {
+                Foo::B => loop {},
+            };
+            <warning descr="Unreachable code">return;</warning>
+        }
+        fn f() -> Foo { loop {} }
+    """)
+
+    fun `test incomplete match with noreturn discriminant 1`() = checkByText("""
+        fn main() {
+            <warning descr="Unreachable code">let x = match (loop {}) { };
+            return;</warning>
+        }
+    """)
+
+    fun `test incomplete match with noreturn discriminant 2`() = checkByText("""
+        fn main() {
+            <warning descr="Unreachable code">let x = match (return) { };
+            return;</warning>
+        }
+    """)
+
+    fun `test incomplete match with noreturn discriminant 3`() = checkByText("""
+        fn main() {
+            loop {
+                <warning descr="Unreachable code">let x = match (break) { };
+                return;</warning>
+            }
+        }
+    """)
+
+    fun `test incomplete match with noreturn discriminant 4`() = checkByText("""
+        fn f() -> ! { }
+        fn main() {
+            <warning descr="Unreachable code">let x = match f() { };
+            return;</warning>
+        }
+    """)
 }


### PR DESCRIPTION
We add a dummy CFG edge from the discriminant of the match to its output in this case, since adding a match arm with basically any return type would make the above CFG path possible. This avoids spurious "unreachable expr/stmt" warnings when the user types a new match block.

If the user adds at least one explicit arm, then the dataflow will be analysed properly (it's possible to add first a noreturn arm, while the other arms would be expected to return a value, but this is an easily understandable rare edge case which I don't think requires any special treatment).

The only case when a match with no arms is valid and indeed signifies unreachability is when the discriminant has the type with no values (e.g. ! or `enum Foo {}`), but this case can only be properly handled after type inference, not at the CFG level. It is also a very rare case which shouldn't cause problems for the common case of simply typing out the match expression.

Fixes #7670.

changelog: remove spurious "unreachable expression" warnings from match expressions with no arms
