### PR TITLE
RES: Fix identity attribute proc macro on another proc macro definition

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -147,6 +147,7 @@ private class ModCollector(
         val perNs = PerNs.from(visItem, item.namespaces)
         onAddItem(modData, name, perNs, visItem.visibility)
 
+        /** See also [DefCollector.tryTreatAsIdentityMacro] */
         if (item.procMacroKind != null) {
             modData.procMacros[name] = item.procMacroKind
         }
@@ -320,7 +321,7 @@ private class ModCollector(
         ) ?: RangeMap.EMPTY
         val originalItem = call.originalItem?.let {
             val visItem = convertToVisItem(it, isModOrEnum = false, forceCfgDisabledVisibility = false)
-            visItem to it.namespaces
+            Triple(visItem, it.namespaces, it.procMacroKind)
         }
         context.context.macroCalls += MacroCallInfo(
             modData,

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -227,7 +227,7 @@ class ModCollectorBase private constructor(
         val attrPathSegments = attrPath.getPathWithAdjustedDollarCrate() ?: return
 
         val originalItem = if (item is RsNamedStub && RsProcMacroPsiUtil.canFallBackAttrMacroToOriginalItem(item)) {
-            lowerSimpleItem(item)?.takeIf { it.procMacroKind == null }
+            lowerSimpleItem(item)
         } else {
             null
         }

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -70,6 +70,7 @@ object WithStdlibWithSymlinkRustProjectDescriptor : WithCustomStdlibRustProjectD
  * Constructs a project with dependency `testData/test-proc-macros`
  */
 object WithProcMacroRustProjectDescriptor : WithProcMacros(DefaultDescriptor)
+object WithProcMacroAndDependencyRustProjectDescriptor : WithProcMacros(WithDependencyRustProjectDescriptor)
 
 open class RustProjectDescriptorBase : LightProjectDescriptor() {
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -7,6 +7,8 @@ package org.rust.lang.core.resolve
 
 import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
+import org.rust.ide.experiments.RsExperiments.PROC_MACROS
 
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -603,5 +605,20 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
         #[attr_hardcoded_not_a_macro]
           //^ ...test-proc-macros/src/lib.rs
         fn main() {}
+    """)
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroAndDependencyRustProjectDescriptor::class)
+    fun `test hardcoded not a macro on proc macro definition`() = stubOnlyResolve("""
+    //- dep-proc-macro/lib.rs
+        #[test_proc_macros::attr_hardcoded_not_a_macro]
+        #[proc_macro]
+        pub fn example_proc_macro(input: TokenStream) -> TokenStream {
+            input
+        }
+    //- lib.rs
+        fn main() {
+            dep_proc_macro::example_proc_macro!();
+        }                 //^ dep-proc-macro/lib.rs
     """)
 }


### PR DESCRIPTION
Fixes #8178

changelog: Fixes resolve of proc macros from [`yew`](https://docs.rs/yew/latest/yew/) crate, such as `yew::html!`
