### PR TITLE
REF: Support indirect self-references in move refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
@@ -67,6 +67,8 @@ class RsMoveReferenceInfo(
 ) {
     val pathNew: RsPath? get() = pathNewAccessible ?: pathNewFallback
     val isInsideUseDirective: Boolean get() = pathOldOriginal.ancestorStrict<RsUseItem>() != null
+
+    override fun toString(): String = "'${pathOld.text}' → '${target.qualifiedName}'"
 }
 
 /**

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -1782,7 +1782,7 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
-    fun `test self references to inner mod`() = doTest("""
+    fun `test self references to inner mod (absolute path)`() = doTest("""
     //- lib.rs
         mod mod1 {
             mod foo1/*caret*/ {
@@ -1800,6 +1800,30 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
             }
 
             fn foo2() { foo1::func(); }
+        }
+    """)
+
+    fun `test self references to inner mod (using import)`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            use foo1::func;
+            mod foo1/*caret*/ {
+                pub fn func() {}
+            }
+            fn foo2/*caret*/() { func(); }
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        mod mod1 {}
+        mod mod2 {
+            use foo1::func;
+
+            pub mod foo1 {
+                pub fn func() {}
+            }
+
+            fn foo2() { func(); }
         }
     """)
 


### PR DESCRIPTION
Fixes #7884

changelog: Support indirect self-references in [`Move` refactoring](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-refactorings.html#move-refactoring) (`Refactor | Move` or <kbd>F6</kbd>)
