### PR TITLE
Enable disabling parameter list folding

### DIFF
--- a/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingOptionsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingOptionsProvider.kt
@@ -16,6 +16,7 @@ class RsCodeFoldingOptionsProvider :
         val settings = instance
         if (settings != null) {
             checkBox("One-line methods", settings::collapsibleOneLineMethods)
+            checkBox("Enable folding function parameter lists", settings::foldableParameterLists)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingSettings.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingSettings.kt
@@ -11,9 +11,9 @@ import com.intellij.openapi.components.ServiceManager
 abstract class RsCodeFoldingSettings {
 
     abstract var collapsibleOneLineMethods: Boolean
+    abstract var foldableParameterLists: Boolean
 
     companion object {
         val instance: RsCodeFoldingSettings get() = ServiceManager.getService(RsCodeFoldingSettings::class.java)
     }
 }
-

--- a/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
@@ -105,7 +105,7 @@ class RsFoldingBuilder : CustomFoldingBuilder(), DumbAware {
         }
 
         override fun visitValueParameterList(o: RsValueParameterList) {
-            if (o.valueParameterList.isEmpty()) return
+            if (o.valueParameterList.isEmpty() || !RsCodeFoldingSettings.instance.foldableParameterLists) return
             foldBetween(o, o.firstChild, o.lastChild)
         }
 

--- a/src/main/kotlin/org/rust/ide/folding/impl/RsCodeFoldingSettingsImpl.kt
+++ b/src/main/kotlin/org/rust/ide/folding/impl/RsCodeFoldingSettingsImpl.kt
@@ -15,6 +15,7 @@ import org.rust.ide.folding.RsCodeFoldingSettings
 class RsCodeFoldingSettingsImpl : RsCodeFoldingSettings(), PersistentStateComponent<RsCodeFoldingSettingsImpl> {
 
     override var collapsibleOneLineMethods: Boolean = true
+    override var foldableParameterLists: Boolean = true
 
     override fun getState(): RsCodeFoldingSettingsImpl = this
 


### PR DESCRIPTION
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

Currently, function parameter lists are foldable by default. This is a useful feature but can be intrusive if you are using the ideavim plugin which has a keybinding to recursively fold all children nodes. This PR adds an option to disable this folding region in the settings. The default option is still true so this would not affect the behavior of folding unless the checkbox is manually un-ticked.

![image](https://user-images.githubusercontent.com/40536127/143766938-25e993e4-cbc1-4e34-a628-028892de0b15.png)

changelog: Add option in settings to disable folding of function parameter lists



