### PR TITLE
INT: Fix "Introduce variable" intention inside match arm

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
@@ -9,10 +9,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.rust.ide.refactoring.introduceVariable.extractExpression
-import org.rust.lang.core.psi.RsBlock
-import org.rust.lang.core.psi.RsExpr
-import org.rust.lang.core.psi.RsExprStmt
-import org.rust.lang.core.psi.RsRetExpr
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestors
 import org.rust.lang.core.types.ty.TyUnit
 import org.rust.lang.core.types.type
@@ -23,10 +20,16 @@ class IntroduceLocalVariableIntention : RsElementBaseIntentionAction<RsExpr>() {
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsExpr? {
         val expr = element.ancestors
-            .takeWhile { it !is RsBlock }
+            .takeWhile {
+                it !is RsBlock && it !is RsMatchExpr && it !is RsLambdaExpr
+            }
             .find {
                 val parent = it.parent
-                parent is RsRetExpr || parent is RsExprStmt || parent is RsBlock && it == parent.expr
+                parent is RsRetExpr
+                    || parent is RsExprStmt
+                    || parent is RsBlock && it == parent.expr
+                    || parent is RsMatchArm && it == parent.expr
+                    || parent is RsLambdaExpr && it == parent.expr
             } as? RsExpr
 
         if (expr?.type is TyUnit) return null

--- a/src/test/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntentionTest.kt
@@ -100,4 +100,51 @@ class IntroduceLocalVariableIntentionTest : RsIntentionTestBase(IntroduceLocalVa
             return i;
         }
     """)
+
+    fun `test match arm expr`() = doAvailableTest("""
+        fn func() -> i32 {
+            match f {
+                true => 1/*caret*/,
+                false => 0,
+            }
+        }
+    """, """
+        fn func() -> i32 {
+            let i = 1;
+            match f {
+                true => i,
+                false => 0,
+            }
+        }
+    """)
+
+    fun `test match arm return expr`() = doAvailableTest("""
+        fn func() -> i32 {
+            match f {
+                true => return 1/*caret*/,
+                false => 0,
+            }
+        }
+    """, """
+        fn func() -> i32 {
+            let i = 1;
+            match f {
+                true => return i,
+                false => 0,
+            }
+        }
+    """)
+
+    fun `test lambda expr`() = doAvailableTest("""
+        fn func() -> i32 {
+            let l = || 1/*caret*/;
+        }
+    """, """
+        fn func() -> i32 {
+            let l = || {
+                let i = 1;
+                i
+            };
+        }
+    """)
 }


### PR DESCRIPTION
"Introduce variable" intention (invoked via Alt+Enter) is a lightweight version of "Introduce variable" refactoring (Invoked via Ctrl+Alt+V). Intention is needed for better discoverability of the feature, and is expected to work in fewer places than refactoring (#5637). This PR fixes intention inside simple match arm, so now arm expression is extracted (and not whole match arm)

```rust
fn func() -> i32 {
    match f {
        true => 1/*caret*/,
        false => 0,
    }
}
```

cc @neonaot 

changelog: Fix "Introduce variable" intention inside match arm
