### PR TITLE
UI: fix Rust code completion settings layout

### DIFF
--- a/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
@@ -6,39 +6,11 @@
 package org.rust.ide.settings
 
 import com.intellij.application.options.editor.AutoImportOptionsProvider
-import com.intellij.ui.IdeBorderFactory
-import com.intellij.ui.components.JBCheckBox
-import com.intellij.ui.layout.panel
-import org.rust.openapiext.CheckboxDelegate
-import javax.swing.JComponent
+import com.intellij.openapi.options.ConfigurableBuilder
 
-class RsAutoImportOptions : AutoImportOptionsProvider {
-
-    private val showImportPopupCheckbox: JBCheckBox = JBCheckBox("Show import popup")
-    private var showImportPopup: Boolean by CheckboxDelegate(showImportPopupCheckbox)
-
-    private val importOutOfScopeItemsCheckbox: JBCheckBox = JBCheckBox("Import out-of-scope items on completion")
-    private var importOutOfScopeItems: Boolean by CheckboxDelegate(importOutOfScopeItemsCheckbox)
-
-    override fun createComponent(): JComponent = panel {
-        row { showImportPopupCheckbox() }
-        row { importOutOfScopeItemsCheckbox() }
-    }.apply { border = IdeBorderFactory.createTitledBorder("Rust") }
-
-    override fun isModified(): Boolean {
-        return showImportPopup != RsCodeInsightSettings.getInstance().showImportPopup ||
-            importOutOfScopeItems != RsCodeInsightSettings.getInstance().importOutOfScopeItems
-    }
-
-    override fun apply() {
-        val settings = RsCodeInsightSettings.getInstance()
-        settings.showImportPopup = showImportPopup
-        settings.importOutOfScopeItems = importOutOfScopeItems
-    }
-
-    override fun reset() {
-        val settings = RsCodeInsightSettings.getInstance()
-        showImportPopup = settings.showImportPopup
-        importOutOfScopeItems = settings.importOutOfScopeItems
+class RsAutoImportOptions : ConfigurableBuilder("Rust"), AutoImportOptionsProvider {
+    init {
+        checkBox("Show import popup", RsCodeInsightSettings.getInstance()::showImportPopup)
+        checkBox("Import out-of-scope items on completion", RsCodeInsightSettings.getInstance()::importOutOfScopeItems)
     }
 }

--- a/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
@@ -7,10 +7,18 @@ package org.rust.ide.settings
 
 import com.intellij.application.options.editor.AutoImportOptionsProvider
 import com.intellij.openapi.options.ConfigurableBuilder
+import org.rust.RsBundle
 
-class RsAutoImportOptions : ConfigurableBuilder("Rust"), AutoImportOptionsProvider {
+class RsAutoImportOptions : ConfigurableBuilder(RsBundle.message("settings.rust.auto.import.title")),
+                            AutoImportOptionsProvider {
     init {
-        checkBox("Show import popup", RsCodeInsightSettings.getInstance()::showImportPopup)
-        checkBox("Import out-of-scope items on completion", RsCodeInsightSettings.getInstance()::importOutOfScopeItems)
+        checkBox(
+            RsBundle.message("settings.rust.auto.import.show.popup"),
+            RsCodeInsightSettings.getInstance()::showImportPopup
+        )
+        checkBox(
+            RsBundle.message("settings.rust.auto.import.on.completion"),
+            RsCodeInsightSettings.getInstance()::importOutOfScopeItems
+        )
     }
 }

--- a/src/main/kotlin/org/rust/ide/settings/RsCodeCompletionOptions.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsCodeCompletionOptions.kt
@@ -7,9 +7,14 @@ package org.rust.ide.settings
 
 import com.intellij.application.options.CodeCompletionOptionsCustomSection
 import com.intellij.openapi.options.ConfigurableBuilder
+import org.rust.RsBundle
 
-class RsCodeCompletionConfigurable : ConfigurableBuilder("Rust"), CodeCompletionOptionsCustomSection {
+class RsCodeCompletionConfigurable : ConfigurableBuilder(RsBundle.message("settings.rust.completion.title")),
+                                     CodeCompletionOptionsCustomSection {
     init {
-        checkBox("Suggest out of scope items", RsCodeInsightSettings.getInstance()::suggestOutOfScopeItems)
+        checkBox(
+            RsBundle.message("settings.rust.completion.suggest.out.of.scope.items"),
+            RsCodeInsightSettings.getInstance()::suggestOutOfScopeItems
+        )
     }
 }

--- a/src/main/kotlin/org/rust/ide/settings/RsCodeCompletionOptions.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsCodeCompletionOptions.kt
@@ -6,29 +6,10 @@
 package org.rust.ide.settings
 
 import com.intellij.application.options.CodeCompletionOptionsCustomSection
-import com.intellij.ui.IdeBorderFactory
-import com.intellij.ui.components.JBCheckBox
-import com.intellij.ui.layout.panel
-import org.rust.openapiext.CheckboxDelegate
-import javax.swing.JPanel
+import com.intellij.openapi.options.ConfigurableBuilder
 
-class RsCodeCompletionConfigurable : CodeCompletionOptionsCustomSection {
-    private val suggestOutOfScopeItemsCheckbox: JBCheckBox = JBCheckBox("Suggest out of scope items")
-    private var suggestOutOfScopeItems: Boolean by CheckboxDelegate(suggestOutOfScopeItemsCheckbox)
-
-    override fun createComponent(): JPanel = panel {
-        row { suggestOutOfScopeItemsCheckbox() }
-    }.apply { border = IdeBorderFactory.createTitledBorder("Rust") }
-
-    override fun isModified(): Boolean {
-        return suggestOutOfScopeItems != RsCodeInsightSettings.getInstance().suggestOutOfScopeItems
-    }
-
-    override fun apply() {
-        RsCodeInsightSettings.getInstance().suggestOutOfScopeItems = suggestOutOfScopeItems
-    }
-
-    override fun reset() {
-        suggestOutOfScopeItems = RsCodeInsightSettings.getInstance().suggestOutOfScopeItems
+class RsCodeCompletionConfigurable : ConfigurableBuilder("Rust"), CodeCompletionOptionsCustomSection {
+    init {
+        checkBox("Suggest out of scope items", RsCodeInsightSettings.getInstance()::suggestOutOfScopeItems)
     }
 }

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -87,6 +87,12 @@ refactoring.change.signature.name=Change Signature
 refactoring.change.signature.refactor.super.function=Method {0} implements base method of trait {1}.\nDo you want to refactor the base method?
 refactoring.change.signature.visibility.conflict=The function will not be visible from {0} after the refactoring
 
+settings.rust.auto.import.on.completion=Import out-of-scope items on completion
+settings.rust.auto.import.show.popup=Show import popup
+settings.rust.auto.import.title=Rust
+settings.rust.completion.suggest.out.of.scope.items=Suggest out-of-scope items
+settings.rust.completion.title=Rust
+
 structure.view.show.macro.expanded=Show Items from Macro Expansions
 structure.view.sort.visibility=Sort by Visibility
 


### PR DESCRIPTION
| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2539310/143849368-6e772e55-ec1f-44c7-8b34-1a2b730387f0.png) | ![image](https://user-images.githubusercontent.com/2539310/143849491-490459bf-b10a-4633-9562-bb1bd8ccc0c1.png) |

Also:
- simplify `RsCodeCompletionConfigurable` and `RsAutoImportOptions` using `ConfigurableBuilder` API
- extract user visible strings to message bundle from `RsCodeCompletionConfigurable` and `RsAutoImportOptions

changelog: Fix Rust code completion settings layout
