### PR TITLE
T: Fix and enable pretty-printers tests for 213 builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -564,8 +564,6 @@ project(":ml-completion") {
 }
 
 task("runPrettyPrintersTests") {
-    // https://github.com/intellij-rust/intellij-rust/issues/8028
-    enabled = platformVersion < 213 || !isFamily(FAMILY_UNIX)
     doLast {
         val lldbPath = when {
             // TODO: Use `lldb` Python module from CLion distribution

--- a/pretty_printers_tests/src/main.rs
+++ b/pretty_printers_tests/src/main.rs
@@ -96,7 +96,9 @@ fn test(debugger: Debugger, path: String) -> Result<(), ()> {
     let src_dir = Path::new(&settings.test_dir);
     let src_paths: Vec<_> = read_dir(src_dir)
         .unwrap_or_else(|_| panic!("Tests not found!"))
-        .map(|file| file.unwrap().path().as_os_str().to_owned())
+        .map(|file| file.unwrap().path())
+        .map(|path| fs::canonicalize(path))
+        .map(|canonical_path| canonical_path.unwrap().as_os_str().to_owned())
         .collect();
 
     let mut status = Ok(());


### PR DESCRIPTION
Fixes #8028.

Previously, relative paths were used when adding breakpoints in LLDB (by `breakpoint set --file PATH --line LINE` command), leading to unresolved breakpoints and corresponding "Unable to resolve breakpoint to any actual locations" warnings (only on 213 builds, presumably after LLDB upgrade). Now canonical paths are used instead.
