### PR TITLE
MACRO: fix expansion of proc macros with a float literal in a body

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -106,6 +106,6 @@ class ProcMacroExpander(
     }
 
     companion object {
-        const val EXPANDER_VERSION: Int = 2
+        const val EXPANDER_VERSION: Int = 3
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/tt/TokenTreeParserTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/tt/TokenTreeParserTest.kt
@@ -224,8 +224,16 @@ class TokenTreeParserTest : RsTestBase() {
           IDENT   _ 1
     """)
 
+    fun `test 35`() = doTest("1.0 foo bar", """
+        SUBTREE $
+          LITERAL 1.0 0
+          IDENT   foo 1
+          IDENT   bar 2
+    """)
+
     fun doTest(code: String, expected: String) {
         val subtree = project.createRustPsiBuilder(code).parseSubtree().subtree
+        assertEquals(subtree, FlatTree.fromSubtree(subtree).toTokenTree())
         assertEquals(expected.trimIndent(), subtree.toDebugString())
     }
 }


### PR DESCRIPTION
Fixes #7049
