### PR TITLE
Unused imports inspection: support usages in serde attribute strings

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -200,9 +200,8 @@ enum class KnownDerivableTrait(
 
     /** Hardcoded trait impl vs proc macro expansion usage */
     fun shouldUseHardcodedTraitDerive(): Boolean {
-        // Use hardcoded impls for all known derives except `failure::Fail` (if proc macro expansion
-        // is enabled). We always hardcode `serde` due to performance reasons
-        return this != Fail || !ProcMacroApplicationService.isEnabled()
+        // We don't use hardcoded impls for non-std derives if proc macro expansion is enabled
+        return isStd || !ProcMacroApplicationService.isEnabled()
     }
 
     companion object {

--- a/src/test/kotlin/org/rust/NewResolve.kt
+++ b/src/test/kotlin/org/rust/NewResolve.kt
@@ -5,7 +5,6 @@
 
 package org.rust
 
-import com.intellij.findAnnotationInstance
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import junit.framework.TestCase

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -344,16 +344,7 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
     private fun getVirtualFileByName(path: String): VirtualFile? =
         LocalFileSystem.getInstance().findFileByPath(path)
 
-    protected inline fun <reified X : Throwable> expect(f: () -> Unit) {
-        try {
-            f()
-        } catch (e: Throwable) {
-            if (e is X)
-                return
-            throw e
-        }
-        fail("No ${X::class.java} was thrown during the test")
-    }
+    protected inline fun <reified X : Throwable> expect(f: () -> Unit) = org.rust.expect<X>(f)
 
     @Suppress("TestFunctionName")
     protected fun InlineFile(@Language("Rust") code: String, name: String = "main.rs"): InlineFile {

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -6,7 +6,6 @@
 package org.rust
 
 import com.intellij.codeInsight.template.impl.TemplateManagerImpl
-import com.intellij.findAnnotationInstance
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.util.Disposer

--- a/src/test/kotlin/org/rust/RustcVersion.kt
+++ b/src/test/kotlin/org/rust/RustcVersion.kt
@@ -5,7 +5,6 @@
 
 package org.rust
 
-import com.intellij.findAnnotationInstance
 import com.intellij.util.text.SemVer
 import junit.framework.TestCase
 import org.rust.cargo.project.model.CargoProject

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -5,7 +5,6 @@
 
 package org.rust.cargo
 
-import com.intellij.findAnnotationInstance
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.RecursionManager

--- a/src/test/kotlin/org/rust/ide/annotator/AnnotationTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/AnnotationTestFixtureBase.kt
@@ -8,7 +8,6 @@ package org.rust.ide.annotator
 import com.intellij.codeInsight.daemon.impl.HighlightVisitor
 import com.intellij.codeInsight.daemon.impl.SeveritiesProvider
 import com.intellij.codeInspection.InspectionProfileEntry
-import com.intellij.findAnnotationInstance
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.ExtensionTestUtil
@@ -16,6 +15,7 @@ import com.intellij.testFramework.InspectionTestUtil
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.impl.BaseFixture
 import junit.framework.TestCase
+import org.rust.findAnnotationInstance
 import org.rust.openapiext.Testmark
 import kotlin.reflect.KClass
 

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterTestBase.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.formatter
 
-import com.intellij.findAnnotationInstance
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.psi.formatter.FormatterTestCase
 import com.intellij.util.ThrowableRunnable
@@ -14,6 +13,7 @@ import org.junit.internal.runners.JUnit38ClassRunner
 import org.junit.runner.RunWith
 import org.rust.IgnoreInPlatform
 import org.rust.TestCase
+import org.rust.findAnnotationInstance
 import kotlin.reflect.KMutableProperty0
 
 @RunWith(JUnit38ClassRunner::class) // TODO: drop the annotation when issue with Gradle test scanning go away

--- a/src/test/kotlin/org/rust/utils.kt
+++ b/src/test/kotlin/org/rust/utils.kt
@@ -11,3 +11,14 @@ import junit.framework.TestCase
 /** Tries to find the specified annotation on the current test method and then on the current class */
 inline fun <reified T : Annotation> TestCase.findAnnotationInstance(): T? =
     javaClass.getMethod(name).getAnnotation(T::class.java) ?: javaClass.getAnnotation(T::class.java)
+
+inline fun <reified X : Throwable> expect(f: () -> Unit) {
+    try {
+        f()
+    } catch (e: Throwable) {
+        if (e is X)
+            return
+        throw e
+    }
+    RsTestBase.fail("No ${X::class.java} was thrown during the test")
+}

--- a/src/test/kotlin/org/rust/utils.kt
+++ b/src/test/kotlin/org/rust/utils.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package com.intellij
+package org.rust
 
 import junit.framework.TestCase
 

--- a/src/test/kotlin/org/rustSlowTests/RsUnusedImportWithToolchainInspectionTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsUnusedImportWithToolchainInspectionTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests
+
+import org.junit.ComparisonFailure
+import org.rust.ExpandMacros
+import org.rust.MinRustcVersion
+import org.rust.WithExperimentalFeatures
+import org.rust.expect
+import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
+import org.rust.ide.experiments.RsExperiments.PROC_MACROS
+import org.rust.ide.inspections.RsWithToolchainInspectionTestBase
+import org.rust.ide.inspections.lints.RsUnusedImportInspection
+import org.rust.lang.core.macros.MacroExpansionScope
+
+@MinRustcVersion("1.46.0")
+class RsUnusedImportWithToolchainInspectionTest : RsWithToolchainInspectionTestBase<Unit>(RsUnusedImportInspection::class) {
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
+    fun `test unused imports, usages in serde attribute (current mod)`() = check {
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            serde = { version = "1.0", features = ["derive"] }
+            serde_json = "1.0"
+        """)
+
+        dir("src") {
+            rust("lib.rs", """
+                mod inner {/*caret*/
+                    pub fn func() -> i32 { 1 }
+                }
+                use inner::func;
+
+                #[derive(serde::Deserialize)]
+                struct Foo {
+                    #[serde(default = "func")]
+                    field: i32,
+                }
+            """)
+        }
+    }
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
+    fun `test unused imports, usages in serde attribute (other mod)`() = expect<ComparisonFailure> {
+        check {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+                edition = "2018"
+
+                [dependencies]
+                serde = { version = "1.0", features = ["derive"] }
+                serde_json = "1.0"
+            """)
+
+            dir("src") {
+                rust("lib.rs", """
+                    mod mod1 {/*caret*/
+                        pub fn func() -> i32 { 1 }
+                    }
+                    use mod1::func;
+
+                    mod mod2 {
+                        #[derive(serde::Deserialize)]
+                        struct Foo {
+                            #[serde(default = "super::func")]
+                            field: i32,
+                        }
+                    }
+                """)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Now `serde` macros `Serialise` and `Deserialize` are expanded with proc macro expander and not hardcoded. This allows to support usages of imports in serde string attributes like [`#[serde(default = "path")]`](https://serde.rs/field-attrs.html#default--path)
```rust
#[derive(serde::Deserialize)]
struct Foo {
    #[serde(default = "func")]
    field: i32,
}
```

For now, usages are searched in the current mod only

Meta issue: #2158

changelog: Support usages in `serde` string attributes like [`#[serde(default = "path")]`](https://serde.rs/field-attrs.html#default--path) in unused imports inspection
