### PR TITLE
REF: Fix extract function refactoring for argument of `println!` macro

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1786,6 +1786,36 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """, "bar")
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test extract println! argument expression`() = doTest("""
+        fn main() {
+            println!("{}", <selection>1 + 2</selection>);
+        }
+    """, """
+        fn main() {
+            println!("{}", bar());
+        }
+
+        fn bar() -> i32 {
+            1 + 2
+        }
+    """, "bar")
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test extract vec! argument expression`() = doTest("""
+        fn main() {
+            vec![<selection>1 + 2</selection>];
+        }
+    """, """
+        fn main() {
+            vec![bar()];
+        }
+
+        fn bar() -> i32 {
+            1 + 2
+        }
+    """, "bar")
+
     private fun doTest(
         @Language("Rust") code: String,
         @Language("Rust") excepted: String,


### PR DESCRIPTION
Fixes #7104

changelog: Fix [`Extract function`](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-refactorings.html#extractmethod-refactoring) refactoring (<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd>) for argument of `println!` macro
