### PR TITLE
ANN: don't produce super trait is not implemented (E0277) for non fully known types

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -818,6 +818,8 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         val traitRef = impl.traitRef ?: return
         val typeRef = impl.typeReference ?: return
         val type = typeRef.type
+        // If type is not fully known, the plugin should produce some another error, like E0412
+        if (type.containsTyOfClass(TyUnknown::class.java)) return
         val supertraits = trait.typeParamBounds?.polyboundList?.mapNotNull { it.bound } ?: return
         val lookup = typeRef.implLookup
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1658,6 +1658,21 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl<T> Baz for T {}
     """)
 
+    fun `test no E0277 for unknown type`() = checkErrors("""
+        trait Foo {}
+        trait Bar: Foo {}
+
+        impl Bar for S {}
+    """)
+
+    fun `test no E0277 for not fully known type`() = checkErrors("""
+        trait Foo {}
+        trait Bar: Foo {}
+        struct S<T>(T);
+        impl <T: Foo> Foo for S<T> {}
+        impl Bar for S<Q> {}
+    """)
+
     @MockRustcVersion("1.27.1")
     fun `test crate visibility feature E0658`() = checkErrors("""
         <error descr="`crate` visibility modifier is experimental [E0658]">crate</error> struct Foo;


### PR DESCRIPTION
Previously, the plugin showed [E0277](https://doc.rust-lang.org/error-index.html#E0277) even if the type is not fully known (or even unknown at all).
For example,

```rust
trait Foo {}
trait Bar: Foo {}
impl Bar for S {} // <-- `S` is unknown here
```
It contradicts with compiler errors. The compiler produces something like `` error[E0412]: cannot find type `S` in this scope ``. Moreover, it creates quite weird error messages with `?` in type

![image](https://user-images.githubusercontent.com/2539310/144868627-4f5d3194-edc3-4711-b74d-78102fba8aad.png)

Now, the plugin checks that all trait bound is implemented only for fully known types.

changelog: Don't produce [E0277](https://doc.rust-lang.org/error-index.html#E0277) errors for non fully-known types
