### PR TITLE
Do not offer `Add remaining patterns` fix when matching a non exhaustive enum

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1125,7 +1125,7 @@ sealed class RsDiagnostic(
             E0004,
             "Match must be exhaustive",
             fixes = listOfNotNull(
-                AddRemainingArmsFix(matchExpr, patterns),
+                AddRemainingArmsFix(matchExpr, patterns).takeIf { patterns.isNotEmpty() },
                 AddWildcardArmFix(matchExpr).takeIf { matchExpr.arms.isNotEmpty() }
             )
         )

--- a/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
@@ -728,6 +728,27 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
         }
     """)
 
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test do not offer add remaining arms fix for non-exhaustive enum match in different crate`() = checkFixIsUnavailableByFileTree("Add remaining", """
+        //- dep-lib/lib.rs
+        #[non_exhaustive]
+        pub enum Error {
+            Variant
+        }
+
+        //- main.rs
+        extern crate dep_lib_target;
+        use dep_lib_target::Error;
+
+        fn main() {
+            let error = Error::Variant;
+
+            <error descr="Match must be exhaustive [E0004]">match/*caret*/</error> error {
+                Error::Variant => println!("Variant")
+            }
+        }
+    """)
+
     fun `test empty match simple enum variants`() = checkFixByText("Add remaining patterns", """
         enum FooBar { Foo, Bar }
 


### PR DESCRIPTION
...without any wildcard arm, as it doesn't have any effect:

![non_exhaustive](https://user-images.githubusercontent.com/4539057/144878282-2de964ee-074f-4ef2-8b00-f94383593d26.gif)

The changelog sentence will be a mouthful :D

changelog: Do not offer the `Add remaining patterns fix` when pattern matching on an enum marked with `#[non_exhaustive]` if there are no wildcard arms in the `match` expression.