### PR TITLE
REF: fix Extract Variable interaction with closures

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
@@ -402,6 +402,58 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
         }
     """, replaceAll = true)
 
+    fun `test lambda scoping 1`() = doTest("""
+        fn main() {
+            let _ = <selection>false</selection>;
+            || false;
+        }
+    """, emptyList(), 0, """
+        fn main() {
+            let x = false;
+            let _ = x;
+            || x;
+        }
+    """, replaceAll = true)
+
+    fun `test lambda scoping 2`() = doTest("""
+        fn main() {
+            let _ = false;
+            || <selection>false</selection>;
+        }
+    """, emptyList(), 0, """
+        fn main() {
+            let x = false;
+            let _ = x;
+            || x;
+        }
+    """, replaceAll = true)
+
+    fun `test lambda scoping 3`() = doTest("""
+        fn main() {
+            || false;
+            let _ = <selection>false</selection>;
+        }
+    """, emptyList(), 0, """
+        fn main() {
+            let x = false;
+            || x;
+            let _ = x;
+        }
+    """, replaceAll = true)
+
+    fun `test lambda scoping 4`() = doTest("""
+        fn main() {
+            || <selection>false</selection>;
+            let _ = false;
+        }
+    """, emptyList(), 0, """
+        fn main() {
+            let x = false;
+            || x;
+            let _ = x;
+        }
+    """, replaceAll = true)
+
     fun `test lambda has no braces with match expr`() = doTest("""
         fn main() {
             Some(1).map(|x| match <selection>x</selection> {


### PR DESCRIPTION
Closes #8229 

Previously refactoring didn't consider whether the extracted subexpression of a closure is also used somewhere outside of the closure. This lead to the binding created within the scope of the closure, while the occurrences were replaced regardless of the scope. We move the binding inside of the closure body only if all extracted expressions are within its scope.

changelog: "Introduce local variable" no longer moves the new binding into closure bodies if it is used outside of them
