### PR TITLE
MACRO: fix expansion of proc macros that weirdly mix token spans

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -106,6 +106,6 @@ class ProcMacroExpander(
     }
 
     companion object {
-        const val EXPANDER_VERSION: Int = 3
+        const val EXPANDER_VERSION: Int = 4
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -116,6 +116,22 @@ class RsProcMacroExpansionResolveTest : RsResolveTestBase() {
         }           //^ unresolved
     """)
 
+    fun `test incorrect spans`() = checkByCode("""
+        use test_proc_macros::function_like_reverse_spans;
+
+        mod foo {
+            pub fn bar() {}
+        }        //X
+
+        function_like_reverse_spans! {
+            use foo:: bar;
+        }// 1   2  34 5  6
+
+        fn main() {
+            bar();
+        } //^
+    """)
+
     fun `test custom derive expands to a struct`() = checkByCode("""
         use test_proc_macros::DeriveStructFooDeclaration;
 

--- a/testData/test-proc-macros/src/lib.rs
+++ b/testData/test-proc-macros/src/lib.rs
@@ -56,6 +56,16 @@ pub fn function_like_do_brace_println_and_process_exit(input: TokenStream) -> To
     std::process::exit(101)
 }
 
+#[proc_macro]
+pub fn function_like_reverse_spans(item: TokenStream) -> TokenStream {
+    let tts = item.into_iter().collect::<Vec<_>>();
+    tts.iter().enumerate().map(|(i, tt)| {
+        let mut tt2 = tt.clone();
+        tt2.set_span(tts[tts.len() - 1 - i].span());
+        tt2
+    }).collect::<TokenStream>()
+}
+
 #[proc_macro_derive(DeriveImplForFoo)]
 pub fn derive_impl_for_foo(_item: TokenStream) -> TokenStream {
    "impl Foo { fn foo(&self) -> Bar {} }".parse().unwrap()


### PR DESCRIPTION
This fixes the expansion of `yew::html` macro.

Fixes #7049