### PR TITLE
TY&ANN: Fix false positive E0277 `Sized` is not satisfied

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -819,7 +819,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         val typeRef = impl.typeReference ?: return
         val type = typeRef.type
         val supertraits = trait.typeParamBounds?.polyboundList?.mapNotNull { it.bound } ?: return
-        val lookup = typeRef.implLookup
+        val lookup = impl.implLookup
 
         val selfSubst = mapOf(TyTypeParameter.self() to type).toTypeSubst()
         val substitution = (impl.implementedTrait?.subst ?: emptySubstitution).substituteInValues(selfSubst) + selfSubst
@@ -1642,8 +1642,9 @@ private fun checkTypesAreSized(holder: RsAnnotationHolder, fn: RsFunction) {
     if (arguments.isEmpty() && retType == null) return
 
     val owner = fn.owner
+    val lookup = ImplLookup.relativeTo(fn)
 
-    fun isError(ty: Ty): Boolean = !ty.isSized() &&
+    fun isError(ty: Ty): Boolean = !lookup.isSized(ty) &&
         // '?Sized' type parameter types in abstract trait method is not an error
         !(owner is RsAbstractableOwner.Trait && fn.isAbstract)
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -1178,9 +1178,6 @@ class RsTypeParameterStub(
 ) : RsAttributeOwnerStubBase<RsTypeParameter>(parent, elementType),
     RsNamedStub {
 
-    val isSized: Boolean
-        get() = BitUtil.isSet(flags, IS_SIZED_MASK)
-
     object Type : RsStubElementType<RsTypeParameterStub, RsTypeParameter>("TYPE_PARAMETER") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsTypeParameterStub(
@@ -1200,14 +1197,8 @@ class RsTypeParameterStub(
             RsTypeParameterImpl(stub, this)
 
         override fun createStub(psi: RsTypeParameter, parentStub: StubElement<*>?): RsTypeParameterStub {
-            var flags = RsAttributeOwnerStub.extractFlags(psi)
-            flags = BitUtil.set(flags, IS_SIZED_MASK, psi.isSized)
-            return RsTypeParameterStub(parentStub, this, psi.name, flags)
+            return RsTypeParameterStub(parentStub, this, psi.name, RsAttributeOwnerStub.extractFlags(psi))
         }
-    }
-
-    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
-        private val IS_SIZED_MASK: Int = nextBitMask()
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/RsPsiSubstitution.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RsPsiSubstitution.kt
@@ -13,10 +13,7 @@ import org.rust.lang.core.types.consts.CtUnknown
 import org.rust.lang.core.types.infer.resolve
 import org.rust.lang.core.types.infer.substitute
 import org.rust.lang.core.types.regions.ReEarlyBound
-import org.rust.lang.core.types.ty.Ty
-import org.rust.lang.core.types.ty.TyTuple
-import org.rust.lang.core.types.ty.TyTypeParameter
-import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.ty.*
 import org.rust.lang.utils.evaluation.PathExprResolver
 import org.rust.lang.utils.evaluation.evaluate
 
@@ -55,7 +52,11 @@ fun RsPsiSubstitution.toSubst(resolver: PathExprResolver? = PathExprResolver.def
             }
             is RsPsiSubstitution.TypeValue.OptionalAbsent -> paramTy
             is RsPsiSubstitution.TypeValue.Present.InAngles -> value.value.type
-            is RsPsiSubstitution.TypeValue.Present.FnSugar -> TyTuple(value.inputArgs.map { it?.type ?: TyUnknown })
+            is RsPsiSubstitution.TypeValue.Present.FnSugar -> if (value.inputArgs.isNotEmpty()) {
+                TyTuple(value.inputArgs.map { it?.type ?: TyUnknown })
+            } else {
+                TyUnit.INSTANCE
+            }
             RsPsiSubstitution.TypeValue.RequiredAbsent -> TyUnknown
         }
         paramTy to valueTy

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -6,16 +6,13 @@
 package org.rust.lang.core.types.ty
 
 import org.rust.ide.presentation.render
-import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.RsTypeAlias
-import org.rust.lang.core.psi.ext.fields
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.*
 import org.rust.lang.core.types.infer.TypeFoldable
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
-import org.rust.lang.core.types.infer.substitute
 import org.rust.stdext.dequeOf
 import java.util.*
 
@@ -81,45 +78,6 @@ enum class Mutability {
 
 fun Ty.getTypeParameter(name: String): TyTypeParameter? {
     return typeParameterValues.typeParameterByName(name)
-}
-
-/**
- * See `org.rust.lang.core.type.RsImplicitTraitsTest`
- */
-fun Ty.isSized(): Boolean {
-    val ancestors = mutableSetOf(this)
-
-    fun Ty.isSizedInner(): Boolean {
-        return when (this) {
-            is TyNumeric,
-            is TyBool,
-            is TyChar,
-            is TyUnit,
-            is TyNever,
-            is TyReference,
-            is TyPointer,
-            is TyArray,
-            is TyFunction -> true
-
-            is TyStr, is TySlice, is TyTraitObject -> false
-
-            is TyTypeParameter -> isSized
-
-            is TyAdt -> {
-                val item = item as? RsStructItem ?: return true
-                val typeRef = item.fields.lastOrNull()?.typeReference
-                val type = typeRef?.type?.substitute(typeParameterValues) ?: return true
-                if (!ancestors.add(type)) return true
-                type.isSizedInner()
-            }
-
-            is TyTuple -> types.last().isSizedInner()
-
-            else -> true
-        }
-    }
-
-    return isSizedInner()
 }
 
 val Ty.isSelf: Boolean

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
@@ -10,11 +10,16 @@ import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.mergeFlags
+import org.rust.openapiext.testAssert
 
 data class TyTuple(
     val types: List<Ty>,
     override val aliasedBy: BoundElement<RsTypeAlias>? = null
 ) : Ty(mergeFlags(types)) {
+
+    init {
+        testAssert { types.isNotEmpty() }
+    }
 
     override fun superFoldWith(folder: TypeFolder): Ty =
         TyTuple(types.map { it.foldWith(folder) }, aliasedBy?.foldWith(folder))

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1515,13 +1515,26 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     """)
 
     fun `test function args should implement Sized trait E0277`() = checkErrors("""
+        #[lang = "sized"] trait Sized {}
         fn foo1(bar: <error descr="the trait bound `[u8]: std::marker::Sized` is not satisfied [E0277]">[u8]</error>) {}
         fn foo2(bar: i32) {}
     """)
 
     fun `test function return type should implement Sized trait E0277`() = checkErrors("""
+        #[lang = "sized"] trait Sized {}
         fn foo1() -> <error descr="the trait bound `[u8]: std::marker::Sized` is not satisfied [E0277]">[u8]</error> { unimplemented!() }
         fn foo2() -> i32 { unimplemented!() }
+    """)
+
+    fun `test type parameter with Sized bound on member function is Sized E0277`() = checkErrors("""
+        #[lang = "sized"] trait Sized {}
+        struct Foo<T>(T);
+        impl<T: ?Sized> Foo<T> {
+            fn foo() -> T where T: Sized { unimplemented!() }
+        }
+        impl<T: ?Sized> Foo<T> {
+            fn foo() -> T where T: Sized { unimplemented!() }
+        }
     """)
 
     fun `test trait method without body can have arg with '?Sized' type E0277`() = checkErrors("""
@@ -1546,10 +1559,9 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         trait Bar where Self: Sized {
             fn foo() -> (Self, Self) { unimplemented!() }
         }
-        // TODO
-//        trait Baz {
-//            fn foo() -> (Self, Self) where Self: Sized { unimplemented!() }
-//        }
+        trait Baz {
+            fn foo() -> (Self, Self) where Self: Sized { unimplemented!() }
+        }
     """)
 
     fun `test supertrait is not implemented E0277 simple trait`() = checkErrors("""

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.intellij.lang.annotations.Language
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
@@ -37,4 +38,20 @@ class ConvertToSizedTypeFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         trait Foo {}
         fn foo() -> Box<Foo> { unimplemented!() }
     """)
+
+    private fun checkFixByText(
+        fixName: String,
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+    ) {
+        super.checkFixByText(
+            fixName,
+            "#[lang = \"sized\"] trait Sized {}\n" + before.trimIndent(),
+            "#[lang = \"sized\"] trait Sized {}\n" + after.trimIndent(),
+            checkWarn = true,
+            checkInfo = false,
+            checkWeakWarn = false,
+            testmark = null
+        )
+    }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
@@ -217,6 +217,7 @@ class RsTypeAwareCompletionTest : RsCompletionTestBase() {
     """)
 
     fun `test impl for 'Sized' type parameter is not completed for trait object`() = checkNotContainsCompletion("bar", """
+        #[lang = "sized"] trait Sized {}
         trait Foo { fn foo(&self); fn foo2(&self); }
         trait Bar { fn bar(&self); }
         impl<T> Bar for T {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -133,7 +133,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         }
     """, TypeInferenceMarks.methodPickCheckBounds)
 
-    fun `test trait bound satisfied for trait`() = checkByCode("""
+    fun `test trait bound satisfied for dyn trait`() = checkByCode("""
         #[lang = "sized"]
         trait Sized {}
         trait Tr1 { fn some_fn(&self) {} }
@@ -145,7 +145,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         struct S<T: ?Sized> { value: T }
         impl<T: Bound1 + ?Sized> Tr1 for S<T> { }
         impl<T: Bound2 + ?Sized> Tr2 for S<T> { }
-        fn f(v: &S<ChildOfBound2>) {
+        fn f(v: &S<dyn ChildOfBound2>) {
             v.some_fn();
             //^
         }
@@ -167,6 +167,22 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
                 t.some_fn();
                 //^
             }
+        }
+    """, TypeInferenceMarks.methodPickCheckBounds)
+
+    fun `test Sized trait bound satisfied`() = checkByCode("""
+        #[lang = "sized"] trait Sized {}
+        trait Tr1 { fn some_fn(&self) {} }
+        trait Tr2 { fn some_fn(&self) {} }
+                     //X
+        trait Bound1 {}
+        struct S<T: ?Sized> { value: T }
+        impl<T> Tr1 for S<T> { }
+        impl<T: ?Sized> Tr2 for S<T> { }
+        trait Dyn {}
+        fn f(v: &S<dyn Dyn>) {
+            v.some_fn();
+            //^
         }
     """, TypeInferenceMarks.methodPickCheckBounds)
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -112,6 +112,18 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
                          //^ !Sized
     """)
 
+    fun `test type parameter with Sized bound on impl member function is Sized`() = doTest("""
+        impl<T: ?Sized> Box<T> {
+            fn foo() -> Box<T> where T: Sized { unimplemented!() }
+        }                 //^ Sized
+    """)
+
+    fun `test type parameter with Sized bound on triat member function is Sized`() = doTest("""
+        trait Tra<T: ?Sized> {
+            fn foo() -> T where T: Sized { todo!() }
+        }             //^ Sized
+    """)
+
     fun `test Self is ?Sized by default`() = doTest("""
         trait Foo {
             fn foo(self: Self);


### PR DESCRIPTION
Fixes #6991
Fixes #2530

Previously we had a false positive E0277 in this example:

```rust
struct Foo<T>(T);
impl<T: ?Sized> Foo<T> {
    fn foo() -> T where T: Sized { unimplemented!() }
}
```

![image](https://user-images.githubusercontent.com/3221931/145051893-1d587270-0ba8-4dc0-ae19-de03e0a925c1.png)

This fixes 40 false-positives in stdlib and 21 false-positives in tokio

changelog: 1) Fix false positive E0277 `trait bound Sized is not satisfied` 2) Take into account `Sized`/`?Sized` trait bounds during name resolution and completion
