### PR TITLE
RES: Fix handling $crate inside detached files

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -23,6 +23,7 @@ import org.rust.lang.core.resolve.Namespace
 import org.rust.lang.core.resolve2.ImportType.GLOB
 import org.rust.lang.core.resolve2.ImportType.NAMED
 import org.rust.lang.core.resolve2.PartialResolvedImport.*
+import org.rust.lang.core.resolve2.util.DollarCrateMap
 import org.rust.lang.core.resolve2.util.createDollarCrateHelper
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.openapiext.*
@@ -503,7 +504,7 @@ class MacroCallInfo(
      * `srcOffset` - [CratePersistentId]
      * `dstOffset` - index of [MACRO_DOLLAR_CRATE_IDENTIFIER] in [body]
      */
-    val dollarCrateMap: RangeMap = RangeMap.EMPTY,
+    val dollarCrateMap: DollarCrateMap = DollarCrateMap.EMPTY,
 
     /**
      * Non-null in the case of attribute procedural macro if we can fall back that item

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -16,7 +16,6 @@ import org.rust.lang.RsConstants
 import org.rust.lang.RsFileType
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.macros.MacroCallBody
-import org.rust.lang.core.macros.RangeMap
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.RsMod
@@ -25,6 +24,7 @@ import org.rust.lang.core.psi.ext.variants
 import org.rust.lang.core.resolve.namespaces
 import org.rust.lang.core.resolve.processModDeclResolveVariants
 import org.rust.lang.core.resolve2.util.DollarCrateHelper
+import org.rust.lang.core.resolve2.util.DollarCrateMap
 import org.rust.lang.core.stubs.*
 import org.rust.openapiext.fileId
 import org.rust.openapiext.findFileByMaybeRelativePath
@@ -294,10 +294,10 @@ private class ModCollector(
         val bodyHash = call.bodyHash
         if (bodyHash == null && call.path.last() != "include") return
         val path = dollarCrateHelper?.convertPath(call.path, call.pathOffsetInExpansion) ?: call.path
-        val dollarCrateMap = dollarCrateHelper?.getRangeMap(
+        val dollarCrateMap = dollarCrateHelper?.getDollarCrateMap(
             call.bodyStartOffsetInExpansion,
             call.bodyEndOffsetInExpansion
-        ) ?: RangeMap.EMPTY
+        ) ?: DollarCrateMap.EMPTY
         val macroIndex = parentMacroIndex.append(call.macroIndexInParent)
         context.context.macroCalls += MacroCallInfo(
             modData,
@@ -315,10 +315,10 @@ private class ModCollector(
         val (body, bodyHash) = call.lowerBody(project, crate) ?: return
         val macroIndex = parentMacroIndex.append(call.macroIndexInParent)
         val path = dollarCrateHelper?.convertPath(call.attrPath, call.attrPathStartOffsetInExpansion) ?: call.attrPath
-        val dollarCrateMap = dollarCrateHelper?.getRangeMap(
+        val dollarCrateMap = dollarCrateHelper?.getDollarCrateMap(
             call.bodyStartOffsetInExpansion,
             call.bodyEndOffsetInExpansion
-        ) ?: RangeMap.EMPTY
+        ) ?: DollarCrateMap.EMPTY
         val originalItem = call.originalItem?.let {
             val visItem = convertToVisItem(it, isModOrEnum = false, forceCfgDisabledVisibility = false)
             Triple(visItem, it.namespaces, it.procMacroKind)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -854,4 +854,26 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
             func();
         } //^ detached/inner.rs
     """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve in detached file ($crate)`() = stubOnlyResolve("""
+    //- detached.rs
+        mod inner {
+            pub fn func() {}
+        }        //X
+
+        macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
+        macro_rules! gen {
+            () => {
+                as_is! {
+                    use $ crate::inner::func;
+                }
+            }
+        }
+        gen!();
+
+        fn main() {
+            func();
+        } //^ detached.rs
+    """)
 }


### PR DESCRIPTION
Fixes exception

<details>

```
java.lang.IllegalArgumentException: srcOffset should be >= 0; got: -2169
	at org.rust.lang.core.macros.MappedTextRange.<init>(RangeMap.kt:100)
	at org.rust.lang.core.resolve2.util.DollarCrateHelper.getRangeMap(DollarCrateUtil.kt:91)
	at org.rust.lang.core.resolve2.ModCollector.collectProcMacroCall(ModCollector.kt:318)
	at org.rust.lang.core.resolve2.ModCollectorBase.collectCustomDeriveProcMacroCall-18vbGDs(ModCollectorBase.kt:272)
	at org.rust.lang.core.resolve2.ModCollectorBase.collectElement(ModCollectorBase.kt:76)
	at org.rust.lang.core.resolve2.ModCollectorBase.collectElements(ModCollectorBase.kt:52)
	at org.rust.lang.core.resolve2.ModCollectorBase.access$collectElements(ModCollectorBase.kt:31)
	at org.rust.lang.core.resolve2.ModCollectorBase$Companion.collectMod(ModCollectorBase.kt:332)
	at org.rust.lang.core.resolve2.ModCollector.collectMod(ModCollector.kt:118)
	at org.rust.lang.core.resolve2.ModCollectorKt.collectExpandedElements(ModCollector.kt:78)
	at org.rust.lang.core.resolve2.DefCollector.recordExpansion(DefCollector.kt:369)
	at org.rust.lang.core.resolve2.DefCollector.expandMacrosInParallel(DefCollector.kt:349)
	at org.rust.lang.core.resolve2.DefCollector.expandMacros(DefCollector.kt:314)
	at org.rust.lang.core.resolve2.DefCollector.collect(DefCollector.kt:80)
	at org.rust.lang.core.resolve2.FacadeBuildDefMapKt.buildDefMap(FacadeBuildDefMap.kt:43)
	at org.rust.lang.core.resolve2.DetachedDefMapKt$getDetachedDefMap$1.invoke(DetachedDefMap.kt:77)
	at org.rust.lang.core.resolve2.DetachedDefMapKt$getDetachedDefMap$1.invoke(DetachedDefMap.kt:75)
	at org.rust.openapiext.UtilsKt.getCachedOrCompute(utils.kt:417)
	at org.rust.lang.core.resolve2.DetachedDefMapKt.getDetachedDefMap(DetachedDefMap.kt:75)
	at org.rust.lang.core.resolve2.DetachedDefMapKt.getModInfoInDetachedCrate(DetachedDefMap.kt:27)
	at org.rust.lang.core.resolve2.DetachedDefMapKt.getDetachedModInfo(DetachedDefMap.kt:23)
	at org.rust.lang.core.resolve2.FacadeResolveKt.getModInfo(FacadeResolve.kt:475)
	at org.rust.lang.core.resolve2.FacadeResolveKt.processMacros(FacadeResolve.kt:119)
	at org.rust.lang.core.resolve.MacroResolver.tryProcessAllMacrosUsingNewResolve(NameResolution.kt:1063)
	at org.rust.lang.core.resolve.MacroResolver.psiBasedProcessScopesInLexicalOrderUpward(NameResolution.kt:985)
	at org.rust.lang.core.resolve.MacroResolver.processScopesInLexicalOrderUpward(NameResolution.kt:980)
	at org.rust.lang.core.resolve.MacroResolver.processMacrosInLexicalOrderUpward(NameResolution.kt:959)
	at org.rust.lang.core.resolve.MacroResolver.access$processMacrosInLexicalOrderUpward(NameResolution.kt:949)
	at org.rust.lang.core.resolve.MacroResolver$Companion.processMacrosInLexicalOrderUpward(NameResolution.kt:1079)
	at org.rust.lang.core.resolve.NameResolutionKt.processMacroCallVariantsInScope(NameResolution.kt:933)
	at org.rust.lang.core.resolve.NameResolutionKt$processMacroCallPathResolveVariants$resolved$1.invoke(NameResolution.kt:883)
	at org.rust.lang.core.resolve.NameResolutionKt$processMacroCallPathResolveVariants$resolved$1.invoke(NameResolution.kt:882)
	at org.rust.lang.core.resolve.ProcessorsKt.pickFirstResolveEntry(Processors.kt:175)
	at org.rust.lang.core.resolve.NameResolutionKt.processMacroCallPathResolveVariants(NameResolution.kt:882)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl$Resolver$invoke$1.invoke(RsMacroPathReferenceImpl.kt:66)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl$Resolver$invoke$1.invoke(RsMacroPathReferenceImpl.kt:65)
	at org.rust.lang.core.resolve.ProcessorsKt.pickFirstResolveEntry(Processors.kt:175)
	at org.rust.lang.core.resolve.ProcessorsKt.pickFirstResolveVariant(Processors.kt:160)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl$Resolver.invoke(RsMacroPathReferenceImpl.kt:65)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl$Resolver.invoke(RsMacroPathReferenceImpl.kt:63)
	at org.rust.lang.core.resolve.ref.RsResolveCache.resolveWithCaching$lambda-1$lambda-0(RsResolveCache.kt:101)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:114)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:44)
	at org.rust.lang.core.resolve.ref.RsResolveCache.resolveWithCaching(RsResolveCache.kt:101)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl.resolve(RsMacroPathReferenceImpl.kt:55)
	at org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl.resolve(RsMacroPathReferenceImpl.kt:38)
	at org.rust.ide.inspections.lints.RsDeprecationInspection$buildVisitor$1.visitElement(RsDeprecationInspection.kt:29)
	at org.rust.lang.core.psi.RsVisitor.visitPathReferenceElement(RsVisitor.java:903)
	at org.rust.lang.core.psi.RsVisitor.visitPath(RsVisitor.java:605)
	at org.rust.lang.core.psi.impl.RsPathImpl.accept(RsPathImpl.java:27)
	at org.rust.lang.core.psi.impl.RsPathImpl.accept(RsPathImpl.java:32)
	at com.intellij.codeInspection.InspectionEngine.acceptElements(InspectionEngine.java:72)
	at com.intellij.codeInspection.InspectionEngine.createVisitorAndAcceptElements(InspectionEngine.java:47)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.doInspectInjectedPsi(LocalInspectionsPass.java:987)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$inspectInjectedPsi$17(LocalInspectionsPass.java:548)
	at com.intellij.concurrency.JobLauncherImpl.lambda$processImmediatelyIfTooFew$2(JobLauncherImpl.java:140)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:624)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:698)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:646)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:623)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:66)
	at com.intellij.concurrency.JobLauncherImpl.lambda$processImmediatelyIfTooFew$3(JobLauncherImpl.java:136)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:839)
	at com.intellij.concurrency.JobLauncherImpl.processImmediatelyIfTooFew(JobLauncherImpl.java:147)
	at com.intellij.concurrency.JobLauncherImpl.invokeConcurrentlyUnderProgress(JobLauncherImpl.java:47)
	at com.intellij.concurrency.JobLauncher.invokeConcurrentlyUnderProgress(JobLauncher.java:49)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.inspectInjectedPsi(LocalInspectionsPass.java:551)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.inspect(LocalInspectionsPass.java:228)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.collectInformationWithProgress(LocalInspectionsPass.java:127)
	at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:84)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:56)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:414)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1084)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:407)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:624)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:698)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:646)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:623)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:66)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:406)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:382)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:174)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:181)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:380)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:184)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

</details>

inside detached file if there is a macro call with `$crate` in its body, e.g.:
```rust
mod inner {
    pub fn func() {}
}        //X

macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
macro_rules! gen {
    () => {
        as_is! {
            use $ crate::inner::func;
        }
    }
}
gen!();

fn main() {
    func();
} //^ detached.rs
```

changelog: Fix handling `$crate` inside detached files
