### PR TITLE
CI: respect Cargo.lock of installed binaries

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -197,7 +197,7 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: install
-                  args: evcxr_repl
+                  args: evcxr_repl --locked
 
             - name: Install cargo-generate
               # BACKCOMPAT: zeroize dependency requires Rust 1.51.0 or newer
@@ -205,7 +205,7 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: install
-                  args: cargo-generate
+                  args: cargo-generate --locked
 
             - name: Check environment
               run: |


### PR DESCRIPTION
`cargo install` doesn't respect `Cargo.lock` by default (see https://github.com/rust-lang/cargo/issues/7169). And after `proc-macro2 1.0.33` release, we started to use it to compile `cargo-generate`. And because of combination of "old" nightly that we used on CI and some bug in `proc-macro2 1.0.32` that was fixed in `proc-macro2 1.0.33`, compilation of `cargo-generate` started to fail

I've just added `--lock` flag to respect `Cargo.lock`