### PR TITLE
fix: Use a last resort to try and find toolchains when their binaries are links

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/wsl/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/wsl/Utils.kt
@@ -6,6 +6,7 @@
 package org.rust.cargo.toolchain.wsl
 
 import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.execution.wsl.WslPath
 import java.nio.file.Path
 
 fun WSLDistribution.expandUserHome(path: String): String {
@@ -14,6 +15,15 @@ fun WSLDistribution.expandUserHome(path: String): String {
     return "$userHome${path.substring(1)}"
 }
 
-fun Path.hasExecutableOnWsl(toolName: String): Boolean = pathToExecutableOnWsl(toolName).toFile().isFile
+fun Path.hasExecutableOnWsl(toolName: String): Boolean {
+    val wslExecutable = pathToExecutableOnWsl(toolName)
+    return wslExecutable.toFile().isFile || wslExecutable.isWslExecutable()
+}
 
 fun Path.pathToExecutableOnWsl(toolName: String): Path = resolve(toolName)
+
+fun Path.isWslExecutable(): Boolean {
+    val wslPath = WslPath.parseWindowsUncPath(this.toString())?: return false
+    val output = wslPath.distribution.executeOnWsl(1000, "test", "-x", wslPath.linuxPath)
+    return output.exitCode == 0
+}

--- a/src/main/kotlin/org/rust/cargo/util/ToolchainUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/ToolchainUtil.kt
@@ -5,6 +5,7 @@
 
 package org.rust.cargo.util
 
+import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.openapi.util.SystemInfo
 import org.rust.stdext.isExecutable
 import java.nio.file.Path
@@ -12,6 +13,6 @@ import java.nio.file.Path
 fun Path.hasExecutable(toolName: String): Boolean = pathToExecutable(toolName).isExecutable()
 
 fun Path.pathToExecutable(toolName: String): Path {
-    val exeName = if (SystemInfo.isWindows) "$toolName.exe" else toolName
+    val exeName = if (SystemInfo.isWindows && !WslDistributionManager.isWslPath(this.toString())) "$toolName.exe" else toolName
     return resolve(exeName).toAbsolutePath()
 }


### PR DESCRIPTION
changelog: Try a last a resort to detect toolchain binaries on WSL when they are linked

This should fix #7311


When  `org.rust.cargo.toolchain.wsl.UtilsKt#hasExecutableOnWsl` is called it tries to call `pathToExecutableOnWsl(toolName).toFile().isFile` where `toolName` is `\\wsl$\Arch\usr\bin\rustc` (in my case) and on arch it is a link, as you can see here:
```
PS C:\Users\santo\src\intellij-rust> dir \\wsl$\Arch\usr\bin\rustc


    Directory: \\wsl$\Arch\usr\bin


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-----l         11/9/2021   3:40 PM             15 rustc
```
and any function like isFile, isDirectory, canRead, canExecute, and canWrite all return false, as if in jdk's WindowsPath, that is not valid at all.
So as a last resort, in case a file is pointed in wsl but could not be found, I tried to instantiate WslPath and use its distribution to try and check if that is a valid executable