### PR TITLE
T: Make 2021 default edition in tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -137,6 +137,7 @@ jobs:
                 platform-version: [ 212, 213 ]
                 # it's enough to verify plugin structure only once per platform version
                 verify-plugin: [ false ]
+                default-edition-for-tests: [ 2021 ]
                 include:
                     - os: ubuntu-18.04
                       # Don't forget to update condition in `Set up additional env variables` step
@@ -144,6 +145,8 @@ jobs:
                       base-ide: idea
                       platform-version: 212
                       verify-plugin: true
+                      # BACKCOMPAT: 2021 edition needs at least 1.56
+                      default-edition-for-tests: 2018
 
         runs-on: ${{ matrix.os }}
         timeout-minutes: 120
@@ -151,6 +154,7 @@ jobs:
             ORG_GRADLE_PROJECT_baseIDE: ${{ matrix.base-ide }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}
             ORG_GRADLE_PROJECT_compileNativeCode: false
+            DEFAULT_EDITION_FOR_TESTS: ${{ matrix.default-edition-for-tests }}
 
         steps:
             - uses: actions/checkout@v2

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -27,8 +27,9 @@ import org.junit.internal.runners.JUnit38ClassRunner
 import org.junit.runner.RunWith
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.RustcInfo
+import org.rust.cargo.project.model.impl.DEFAULT_EDITION_FOR_TESTS
 import org.rust.cargo.project.model.impl.testCargoProjects
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.cargo.project.workspace.PackageFeature
 import org.rust.cargo.toolchain.RustChannel
 import org.rust.cargo.toolchain.impl.RustcVersion
@@ -104,7 +105,7 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
     }
 
     private fun setupMockEdition() {
-        val edition = findAnnotationInstance<MockEdition>()?.edition ?: CargoWorkspace.Edition.EDITION_2015
+        val edition = findAnnotationInstance<MockEdition>()?.edition ?: DEFAULT_EDITION_FOR_TESTS
         project.testCargoProjects.setEdition(edition, testRootDisposable)
     }
 
@@ -231,13 +232,15 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
         }
 
     private fun runTestEdition2015(testRunnable: ThrowableRunnable<Throwable>) {
-        project.testCargoProjects.setEdition(CargoWorkspace.Edition.EDITION_2015, testRootDisposable)
-        super.runTestRunnable(testRunnable)
+        project.testCargoProjects.withEdition(Edition.EDITION_2015) {
+            super.runTestRunnable(testRunnable)
+        }
     }
 
     private fun runTestEdition2018(testRunnable: ThrowableRunnable<Throwable>) {
-        project.testCargoProjects.setEdition(CargoWorkspace.Edition.EDITION_2018, testRootDisposable)
-        super.runTestRunnable(testRunnable)
+        project.testCargoProjects.withEdition(Edition.EDITION_2018) {
+            super.runTestRunnable(testRunnable)
+        }
     }
 
     protected val fileName: String

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -20,13 +20,14 @@ import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.util.Urls
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.RustcInfo
+import org.rust.cargo.project.model.impl.DEFAULT_EDITION_FOR_TESTS
 import org.rust.cargo.project.model.impl.testCargoProjects
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.workspace.CargoWorkspace
-import org.rust.cargo.project.workspace.CargoWorkspace.*
+import org.rust.cargo.project.workspace.CargoWorkspace.LibKind
+import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.project.workspace.CargoWorkspaceData
-import org.rust.cargo.project.workspace.CargoWorkspaceData.Dependency
-import org.rust.cargo.project.workspace.CargoWorkspaceData.Package
+import org.rust.cargo.project.workspace.CargoWorkspaceData.*
 import org.rust.cargo.project.workspace.CargoWorkspaceData.Target
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.project.workspace.StandardLibrary
@@ -114,11 +115,11 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
                 // don't use `FileUtil.join` here because it uses `File.separator`
                 // which is system dependent although all other code uses `/` as separator
                 Target(source?.let { "$contentRoot/$it" } ?: "", targetName,
-                    TargetKind.Lib(libKind), Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList())
+                    TargetKind.Lib(libKind), DEFAULT_EDITION_FOR_TESTS, doctest = true, requiredFeatures = emptyList())
             ),
             source = source,
             origin = origin,
-            edition = Edition.EDITION_2015,
+            edition = DEFAULT_EDITION_FOR_TESTS,
             features = emptyMap(),
             enabledFeatures = emptySet(),
             cfgOptions = CfgOptions.EMPTY,
@@ -134,28 +135,31 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
         name = name,
         version = "0.0.1",
         targets = listOf(
-            Target("$contentRoot/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB), edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/bin/a.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/bin/a/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/tests/a.rs", name, TargetKind.Test, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/tests/a/main.rs", name, TargetKind.Test, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/bench/a.rs", name, TargetKind.Bench, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/bench/a/main.rs", name, TargetKind.Bench, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/example/a.rs", name, TargetKind.ExampleBin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/example/a/main.rs", name, TargetKind.ExampleBin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/example-lib/a.rs", name, TargetKind.ExampleLib(EnumSet.of(LibKind.LIB)), edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
-            Target("$contentRoot/build.rs", "build_script_build", TargetKind.CustomBuild, edition = Edition.EDITION_2015, doctest = false, requiredFeatures = emptyList())
+            testTarget("$contentRoot/main.rs", name, TargetKind.Bin),
+            testTarget("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB)),
+            testTarget("$contentRoot/bin/a.rs", name, TargetKind.Bin),
+            testTarget("$contentRoot/bin/a/main.rs", name, TargetKind.Bin),
+            testTarget("$contentRoot/tests/a.rs", name, TargetKind.Test),
+            testTarget("$contentRoot/tests/a/main.rs", name, TargetKind.Test),
+            testTarget("$contentRoot/bench/a.rs", name, TargetKind.Bench),
+            testTarget("$contentRoot/bench/a/main.rs", name, TargetKind.Bench),
+            testTarget("$contentRoot/example/a.rs", name, TargetKind.ExampleBin),
+            testTarget("$contentRoot/example/a/main.rs", name, TargetKind.ExampleBin),
+            testTarget("$contentRoot/example-lib/a.rs", name, TargetKind.ExampleLib(EnumSet.of(LibKind.LIB))),
+            testTarget("$contentRoot/build.rs", "build_script_build", TargetKind.CustomBuild, doctest = false),
         ),
         source = null,
         origin = PackageOrigin.WORKSPACE,
-        edition = Edition.EDITION_2015,
+        edition = DEFAULT_EDITION_FOR_TESTS,
         features = emptyMap(),
         enabledFeatures = emptySet(),
         cfgOptions = CfgOptions.EMPTY,
         env = emptyMap(),
         outDirUrl = null
     )
+
+    private fun testTarget(crateRootUrl: String, name: String, kind: TargetKind, doctest: Boolean = true): Target =
+        Target(crateRootUrl, name, kind, DEFAULT_EDITION_FOR_TESTS, doctest, requiredFeatures = emptyList())
 }
 
 open class WithRustup(

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
@@ -23,6 +23,7 @@ import org.jdom.Element
 import org.rust.RsTestBase
 import org.rust.cargo.CargoConstants
 import org.rust.cargo.CfgOptions
+import org.rust.cargo.project.model.impl.DEFAULT_EDITION_FOR_TESTS
 import org.rust.cargo.project.model.impl.testCargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.*
@@ -133,27 +134,27 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
         private val hello = """pub fn hello() -> String { return "Hello, World!".to_string(); }"""
 
         fun bin(name: String, path: String, @Language("Rust") code: String = helloWorld): TestProjectBuilder {
-            addTarget(name, TargetKind.Bin, Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.Bin, DEFAULT_EDITION_FOR_TESTS, path, code)
             return this
         }
 
         fun example(name: String, path: String, @Language("Rust") code: String = helloWorld): TestProjectBuilder {
-            addTarget(name, TargetKind.ExampleBin, Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.ExampleBin, DEFAULT_EDITION_FOR_TESTS, path, code)
             return this
         }
 
         fun test(name: String, path: String, @Language("Rust") code: String = simpleTest): TestProjectBuilder {
-            addTarget(name, TargetKind.Test, Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.Test, DEFAULT_EDITION_FOR_TESTS, path, code)
             return this
         }
 
         fun bench(name: String, path: String, @Language("Rust") code: String = simpleBench): TestProjectBuilder {
-            addTarget(name, TargetKind.Bench, Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.Bench, DEFAULT_EDITION_FOR_TESTS, path, code)
             return this
         }
 
         fun lib(name: String, path: String, @Language("Rust") code: String = hello): TestProjectBuilder {
-            addTarget(name, TargetKind.Lib(LibKind.LIB), Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.Lib(LibKind.LIB), DEFAULT_EDITION_FOR_TESTS, path, code)
             return this
         }
 
@@ -204,7 +205,7 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
                             },
                             source = null,
                             origin = PackageOrigin.WORKSPACE,
-                            edition = Edition.EDITION_2015,
+                            edition = DEFAULT_EDITION_FOR_TESTS,
                             features = emptyMap(),
                             enabledFeatures = emptySet(),
                             cfgOptions = CfgOptions.EMPTY,

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -10,6 +10,7 @@ import org.rust.RsTestBase
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.model.impl.DEFAULT_EDITION_FOR_TESTS
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.*
 import org.rust.cargo.project.workspace.CargoWorkspaceData
@@ -143,7 +144,7 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
         fun target(
             name: String,
             kind: TargetKind,
-            edition: Edition = Edition.EDITION_2015
+            edition: Edition = DEFAULT_EDITION_FOR_TESTS
         ): CargoWorkspaceData.Target = CargoWorkspaceData.Target(
             crateRootUrl = "/tmp/lib/rs",
             name = name,
@@ -157,7 +158,7 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             name: String,
             isWorkspaceMember: Boolean,
             targets: List<CargoWorkspaceData.Target>,
-            edition: Edition = Edition.EDITION_2015
+            edition: Edition = DEFAULT_EDITION_FOR_TESTS
         ): CargoWorkspaceData.Package = CargoWorkspaceData.Package(
             name = name,
             id = "$name 1.0.0",

--- a/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
@@ -6,8 +6,6 @@
 package org.rust.ide.annotator
 
 import org.rust.MockAdditionalCfgOptions
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.colors.RsColor
 
 class RsCfgDisabledCodeAnnotatorTest : RsAnnotatorTestBase(RsCfgDisabledCodeAnnotator::class) {
@@ -43,7 +41,6 @@ class RsCfgDisabledCodeAnnotatorTest : RsAnnotatorTestBase(RsCfgDisabledCodeAnno
     """)
 
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test disabled async function 2018 edition`() = checkHighlighting("""
         <CFG_DISABLED_CODE descr="Conditionally disabled code">#[cfg(not(intellij_rust))]
         async fn foo() {
@@ -52,7 +49,6 @@ class RsCfgDisabledCodeAnnotatorTest : RsAnnotatorTestBase(RsCfgDisabledCodeAnno
     """)
 
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test disabled try expr 2018 edition`() = checkHighlighting("""
         fn foo() {
         <CFG_DISABLED_CODE descr="Conditionally disabled code">#[cfg(not(intellij_rust))]try {

--- a/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.annotator
 
 import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.colors.RsColor
 
@@ -29,7 +28,6 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test edition 2018 keywords in edition 2018`() = checkErrors("""
         fn main() {
             let <error descr="`async` is reserved keyword in Edition 2018">async</error> = ();
@@ -42,7 +40,6 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
     """)
 
     // We should report an error here
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test reserved keywords in macro names in edition 2018`() = checkErrors("""
         fn main() {
             let x = async!();
@@ -62,7 +59,6 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test async in edition 2018`() = checkErrors("""
         <KEYWORD>async</KEYWORD> fn foo() {}
 
@@ -80,14 +76,12 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test try in edition 2018`() = checkErrors("""
         fn main() {
             <KEYWORD>try</KEYWORD> { () };
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test don't analyze macro def-call bodies, attributes and use items`() = checkErrors("""
         use dummy::async;
         use dummy::await;
@@ -117,7 +111,6 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test await postfix syntax`() = checkErrors("""
         fn main() {
             let x = f().await;
@@ -126,7 +119,6 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
     """)
 
     @BatchMode
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test no keyword highlighting in batch mode`() = checkHighlighting("""
         async fn foo() {}
         fn main() {

--- a/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.annotator
 
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.colors.RsColor
 
 class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018KeywordsAnnotator::class) {
@@ -16,6 +17,7 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
         annotationFixture.registerSeverities(listOf(RsColor.KEYWORD.testSeverity))
     }
 
+    @MockEdition(Edition.EDITION_2015)
     fun `test edition 2018 keywords in edition 2015`() = checkErrors("""
         fn main() {
             let async = ();
@@ -49,6 +51,7 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
         }
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     fun `test async in edition 2015`() = checkErrors("""
         <error descr="This feature is only available in Edition 2018">async</error> fn foo() {}
 
@@ -70,6 +73,7 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
         }
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     fun `test try in edition 2015`() = checkErrors("""
         fn main() {
             <error descr="This feature is only available in Edition 2018">try</error> { () };

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.annotator
 
 import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsDebuggerExpressionCodeFragment
@@ -1430,7 +1431,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
         mod bar {
             mod baz {
-                use foo::<error descr="Module `qwe` is private [E0603]">qwe</error>::Foo;
+                use crate::foo::<error descr="Module `qwe` is private [E0603]">qwe</error>::Foo;
             }
         }
     """)
@@ -1446,7 +1447,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         //- bar/mod.rs
             mod baz;
         //- bar/baz.rs
-            use foo::<error descr="Module `qwe` is private [E0603]">qwe</error>::Foo;
+            use crate::foo::<error descr="Module `qwe` is private [E0603]">qwe</error>::Foo;
     """, filePath = "bar/baz.rs")
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -1753,6 +1754,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         use crate::foo::{<error descr="`crate` in paths can only be used in start position [E0433]">crate</error>::Foo};
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     @MockRustcVersion("1.28.0")
     fun `test crate in path feature E0658`() = checkErrors("""
         mod foo {
@@ -1762,6 +1764,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         use <error descr="`crate` in paths is experimental [E0658]">crate</error>::foo::Foo;
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     @MockRustcVersion("1.29.0-nightly")
     fun `test crate in path feature E0658 2`() = checkErrors("""
         mod foo {
@@ -4479,6 +4482,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     fun `test use edition 2018 keyword as lifetime name in the edition 2015`() = checkErrors("""
         struct Me<'async>  {
             name: &'async str,

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.annotator
 
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.macros.MacroExpansionScope
@@ -962,7 +961,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test no duplicates with import E0252 textual-scoped macros`() = checkDontTouchAstInOtherFiles("""
     //- main.rs
         use test_package::foo;
@@ -972,7 +970,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         macro_rules! foo { () => {} }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test no duplicates with import E0252 private item`() = checkErrors("""
         mod mod1 {
             fn foo() {}
@@ -1744,12 +1741,10 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test crate keyword not at the beginning E0433`() = checkErrors("""
         use crate::foo::<error descr="`crate` in paths can only be used in start position [E0433]">crate</error>::Foo;
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test crate keyword not at the beginning in use group E0433`() = checkErrors("""
         use crate::foo::{<error descr="`crate` in paths can only be used in start position [E0433]">crate</error>::Foo};
     """)
@@ -1774,7 +1769,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         use <error descr="`crate` in paths is experimental [E0658]">crate</error>::foo::Foo;
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test crate in path feature E0658 3`() = checkErrors("""
         mod foo {
             pub struct Foo;
@@ -4251,7 +4245,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         fn foo() -> impl FooBar {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test E0116 inherent impls should be in same crate`() = checkByFileTree("""
     //- lib.rs
         pub struct ForeignStruct {}
@@ -4274,7 +4267,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl <error descr="Cannot define inherent `impl` for a type outside of the crate where the type is defined [E0116]">dyn ForeignTrait</error> {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test E0117 trait impls orphan rules`() = checkByFileTree("""
     //- lib.rs
@@ -4475,7 +4467,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test edition 2018 keyword as lifetime name`() = checkErrors("""
         struct Me<<error descr="Lifetimes cannot use keyword names">'async</error>> {
             name: &<error descr="Lifetimes cannot use keyword names">'async</error> str,

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -6,7 +6,7 @@
 package org.rust.ide.annotator
 
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.colors.RsColor
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
@@ -518,14 +518,14 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @MockEdition(Edition.EDITION_2018)
     fun `test panic with single literal`() = checkErrors("""
         fn main() {
             panic!("{}");
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2021)
+    @MockEdition(Edition.EDITION_2021)
     fun `test panic macro 2021`() = checkErrors("""
         use std::fmt;
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -206,7 +206,6 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test postfix await 2018`() = checkHighlightingWithMacro("""
         fn main() {
             dummy.<KEYWORD>await</KEYWORD>;
@@ -221,7 +220,6 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
         """)
     }
 
-    @MockEdition(Edition.EDITION_2018)
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test highlight macro in use item`() = checkByFileTree("""
     //- lib.rs

--- a/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
@@ -5,10 +5,6 @@
 
 package org.rust.ide.annotator
 
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
-
-@MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsInvalidReexportErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     fun `test reexport of public item from accessible module`() = checkErrors("""
         mod foo {

--- a/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
@@ -7,7 +7,6 @@ package org.rust.ide.annotator
 
 import org.intellij.lang.annotations.Language
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.colors.RsColor
 import org.rust.ide.experiments.RsExperiments
 
@@ -32,7 +31,6 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
     """)
 
     @MinRustcVersion("1.46.0")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test attributes under attribute proc macro`() = checkHighlighting("""
@@ -46,7 +44,6 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
     """)
 
     @MinRustcVersion("1.46.0")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test attributes under attribute proc macro 2`() = checkHighlighting("""

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddFeatureAttributeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddFeatureAttributeFixTest.kt
@@ -5,7 +5,9 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.MockEdition
 import org.rust.MockRustcVersion
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
@@ -39,11 +41,13 @@ class AddFeatureAttributeFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) 
             crate/*caret*/ type Foo = i128;
         """)
 
+    @MockEdition(Edition.EDITION_2015)
     @MockRustcVersion("1.28.0")
     fun `test add crate_in_paths feature is unavailable`() = checkFixIsUnavailable("Add `crate_in_paths` feature", """
         use <error>crate/*caret*/</error>::foo::Foo;
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     @MockRustcVersion("1.29.0-nightly")
     fun `test add crate_in_paths feature`() = checkFixByText("Add `crate_in_paths` feature", """
         use <error>crate/*caret*/</error>::foo::Foo;

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
@@ -343,7 +343,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         <error>impl <error>foo::B/*caret*/</error> for S</error> {}
     """, """
-        use foo::A;
+        use crate::foo::A;
 
         mod foo {
             pub trait A {}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
@@ -230,7 +230,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         }
     """, """
         mod foo {
-            use S;
+            use crate::S;
 
             pub fn bar(s: S) {}
         }
@@ -256,7 +256,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         }
     """, """
         mod foo {
-            use S;
+            use crate::S;
 
             pub fn bar(a: S) {}
         }

--- a/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTest.kt
+++ b/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTest.kt
@@ -5,9 +5,6 @@
 
 package org.rust.ide.console
 
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
-
 class RsConsoleCompletionTest : RsConsoleCompletionTestBase() {
 
     fun `test initial completion`() = checkContainsCompletion("""
@@ -133,7 +130,6 @@ class RsConsoleCompletionTest : RsConsoleCompletionTestBase() {
         mod1::frobnicate()/*caret*/
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test child module with import`() = checkSingleCompletion("""
         mod mod1 { pub fn frobnicate() {} }
         use mod1::frobnicate;
@@ -152,7 +148,6 @@ class RsConsoleCompletionTest : RsConsoleCompletionTestBase() {
         "BTreeSet"
     ))
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test imports 2`() = checkContainsCompletion("""
         use std::collections;
     """, """

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
@@ -6,10 +6,8 @@
 package org.rust.ide.docs
 
 import junit.framework.AssertionFailedError
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsExternalDocUrlStdTest : RsDocumentationProviderTest() {
@@ -120,7 +118,6 @@ class RsExternalDocUrlStdTest : RsDocumentationProviderTest() {
         }
     """, "https://doc.rust-lang.org/std/keyword.true.html")
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test await`() = doUrlTestByText("""
         fn main() {
             foo().await;

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -11,7 +11,6 @@ import org.rust.ExpandMacros
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsConstant
@@ -1199,7 +1198,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         keyword <b>enum</b></pre></div><div class='content'><p>.+</p></div>
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test async keyword doc`() = doTestRegex("""
         async fn foo() {}
@@ -1239,7 +1237,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         }
     """, null)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test await doc 2`() = doTestRegex("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -12,6 +12,7 @@ import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsConstant
 import org.rust.lang.core.psi.ext.RsElement
@@ -1229,7 +1230,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         keyword <b>false</b></pre></div><div class='content'><p>.+</p></div>
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @MockEdition(Edition.EDITION_2015)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test await doc 1`() = doTest("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
@@ -291,7 +291,7 @@ class RsResolveLinkTest : RsTestBase() {
                 pub struct Baz;
                           //X
             }
-            pub use foo::bar::Baz;
+            pub use crate::foo::bar::Baz;
         }
 
         struct Foo;
@@ -306,7 +306,7 @@ class RsResolveLinkTest : RsTestBase() {
                               //X
                 }
             }
-            pub use foo::bar::baz;
+            pub use crate::foo::bar::baz;
         }
 
         struct Foo;
@@ -321,7 +321,7 @@ class RsResolveLinkTest : RsTestBase() {
                               //X
                 }
             }
-            pub use foo::bar::*;
+            pub use crate::foo::bar::*;
         }
 
         struct Foo;

--- a/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
+++ b/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
@@ -7,11 +7,9 @@ package org.rust.ide.highlight
 
 import com.intellij.codeInsight.highlighting.HighlightUsagesHandler
 import org.intellij.lang.annotations.Language
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 
 class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
 
@@ -306,7 +304,6 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """, "return 1", "2", "3", "4", "5")
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test no highlight for ? in try `() = doTest("""
         fn main(){
             let a = try {

--- a/src/test/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspectionTest.kt
@@ -5,10 +5,6 @@
 
 package org.rust.ide.inspections
 
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
-
-@MockEdition(Edition.EDITION_2018)
 class RsConstantConditionIfInspectionTest : RsInspectionsTestBase(RsConstantConditionIfInspection::class) {
 
     fun `test always true, empty branches`() = checkFixByText("Simplify expression", """

--- a/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
@@ -7,8 +7,6 @@ package org.rust.ide.inspections
 
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.fixes.withMockModuleAttachSelector
 
 class RsDetachedFileInspectionTest : RsInspectionsTestBase(RsDetachedFileInspection::class) {
@@ -78,7 +76,6 @@ class RsDetachedFileInspectionTest : RsInspectionsTestBase(RsDetachedFileInspect
         //- a/foo.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test attach file to a parent mod file`() = checkFixByFileTree("Attach file to a.rs", """
         //- lib.rs
             mod a;

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -237,7 +237,6 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         struct S;
     """, false)
 
-    @MockEdition(Edition.EDITION_2018)
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test attribute macro`() = checkByFileTree("""

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -6,10 +6,8 @@
 package org.rust.ide.inspections.borrowck
 
 import org.rust.MockAdditionalCfgOptions
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
@@ -725,7 +723,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
         }
     """, checkWarn = false)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test move in async block`() = checkByText("""
         struct S;
 

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/QualifyPathFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/QualifyPathFixTest.kt
@@ -8,12 +8,12 @@ package org.rust.ide.inspections.fixes
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsUnresolvedReferenceInspection
 
 class QualifyPathFixTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
-    fun `test function call`() = checkFixByText("Qualify path to `foo::bar`", """
+    fun `test function call`() = checkFixByText("Qualify path to `crate::foo::bar`", """
         mod foo {
             pub fn bar() {}
         }
@@ -25,11 +25,11 @@ class QualifyPathFixTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection
             pub fn bar() {}
         }
         fn main() {
-            foo::bar();
+            crate::foo::bar();
         }
     """)
 
-    fun `test struct type`() = checkFixByText("Qualify path to `foo::S`", """
+    fun `test struct type`() = checkFixByText("Qualify path to `crate::foo::S`", """
         mod foo {
             pub struct S;
         }
@@ -41,11 +41,11 @@ class QualifyPathFixTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection
             pub struct S;
         }
         fn main() {
-            let x: foo::S;
+            let x: crate::foo::S;
         }
     """)
 
-    fun `test generic struct type`() = checkFixByText("Qualify path to `foo::S`", """
+    fun `test generic struct type`() = checkFixByText("Qualify path to `crate::foo::S`", """
         mod foo {
             pub struct S<T>(T);
         }
@@ -57,11 +57,11 @@ class QualifyPathFixTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection
             pub struct S<T>(T);
         }
         fn main() {
-            let x: foo::S<u32>;
+            let x: crate::foo::S<u32>;
         }
     """)
 
-    fun `test struct associated method call`() = checkFixByText("Qualify path to `foo::S`", """
+    fun `test struct associated method call`() = checkFixByText("Qualify path to `crate::foo::S`", """
         mod foo {
             pub struct S;
             impl S {
@@ -79,11 +79,11 @@ class QualifyPathFixTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection
             }
         }
         fn main() {
-            let x = foo::S::bar();
+            let x = crate::foo::S::bar();
         }
     """)
 
-    fun `test generic struct associated method call`() = checkFixByText("Qualify path to `foo::S`", """
+    fun `test generic struct associated method call`() = checkFixByText("Qualify path to `crate::foo::S`", """
         mod foo {
             pub struct S<T>(T);
             impl<T> S<T> {
@@ -101,7 +101,7 @@ class QualifyPathFixTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection
             }
         }
         fn main() {
-            let x = foo::S::<u32>::bar();
+            let x = crate::foo::S::<u32>::bar();
         }
     """)
 
@@ -148,7 +148,7 @@ class QualifyPathFixTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @MockEdition(Edition.EDITION_2015)
     fun `test add extern crate with 2015 edition`() = checkFixByFileTree("Qualify path", """
         //- dep-lib/lib.rs
         pub mod foo {

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -9,7 +9,6 @@ import org.rust.MinRustcVersion
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.utils.import.Testmarks
 
@@ -426,7 +425,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item from not std crate (edition 2018)`() = checkAutoImportFixByFileTree("""
         //- dep-lib/lib.rs
         pub mod foo {
@@ -611,7 +609,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test module re-export with module alias 1`() = checkAutoImportFixByFileTree("""
         //- trans-lib/lib.rs
         pub mod foo {
@@ -628,7 +625,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(x: bar/*caret*/::FooBar) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test module re-export with module alias 2`() = checkAutoImportFixByFileTree("""
         //- trans-lib/lib.rs
         pub mod foo {
@@ -645,7 +641,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(x: FooBar/*caret*/) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test crate re-export in use item`() = checkAutoImportFixByFileTree("""
         //- trans-lib/lib.rs
         pub struct FooBar;
@@ -661,7 +656,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(x: FooBar/*caret*/) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test crate re-export in use item with alias`() = checkAutoImportFixByFileTree("""
         //- trans-lib/lib.rs
         pub struct FooBar;
@@ -677,7 +671,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(x: FooBar/*caret*/) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item from workspace over std and extern crate`() = checkAutoImportFixByFileTreeWithMultipleChoice("""
         //- dep-lib/lib.rs
         pub mod foo {
@@ -708,7 +701,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(t: Rc/*caret*/<usize>) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item from std over extern crate`() = checkAutoImportFixByFileTreeWithMultipleChoice("""
         //- dep-lib/lib.rs
         pub mod foo {
@@ -727,7 +719,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(t: Rc/*caret*/<usize>) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item from proc_macro`() = checkAutoImportFixByFileTree("""
     //- dep-proc-macro/lib.rs
         fn foo(_: <error descr="Unresolved reference: `TokenStream`">TokenStream/*caret*/</error>) {}
@@ -738,7 +729,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(_: TokenStream) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test item in core reexported in std`() = checkAutoImportFixByTextWithoutHighlighting("""
         fn main() {
             UnsafeCell/*caret*/;
@@ -752,7 +742,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
     """)
 
     @MinRustcVersion("1.51.0")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test item in core not reexported in std (with no_std)`() = checkAutoImportVariantsByText("""
         #![no_std]
         fn main() {
@@ -760,14 +749,12 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         }
     """, listOf("core::slice::SplitInclusive", "core::str::SplitInclusive"))
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test item from 'test' crate (without extern crate)`() = checkAutoImportFixIsUnavailable("""
         fn main() {
             <error descr="Unresolved reference: `test_main`">/*caret*/test_main</error>();
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test item from 'test' crate (with extern crate)`() = checkAutoImportFixByTextWithoutHighlighting("""
         extern crate test;
         fn main() {
@@ -783,7 +770,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test add extern crate for alloc (with no_std)`() = checkAutoImportFixByTextWithoutHighlighting("""
         #![no_std]
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -10,6 +10,7 @@ import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.utils.import.Testmarks
 
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
@@ -31,8 +32,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(t: <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>) {}
     """, """
         //- main.rs
-        extern crate dep_lib_target;
-
         use dep_lib_target::foo::Bar;
 
         fn foo(t: Bar/*caret*/) {}
@@ -56,6 +55,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(t: Bar/*caret*/) {}
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     fun `test insert new extern crate item after existing extern crate items`() = checkAutoImportFixByFileTree("""
         //- dep-lib/lib.rs
         pub mod foo {
@@ -75,6 +75,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(t: Bar/*caret*/) {}
     """, checkOptimizeImports = false)
 
+    @MockEdition(Edition.EDITION_2015)
     fun `test insert extern crate item after inner attributes`() = checkAutoImportFixByFileTree("""
         //- main.rs
         #![allow(non_snake_case)]
@@ -126,8 +127,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         }
     """, """
         //- main.rs
-        extern crate dep_lib_target;
-
         use dep_lib_target::foo::baz::FooBar;
 
         fn main() {
@@ -202,6 +201,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         }
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     fun `test insert extern crate item in crate root`() = checkAutoImportFixByFileTree("""
         //- dep-lib/lib.rs
         pub struct Foo;
@@ -230,6 +230,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
     """)
 
     // existing `extern crate` is ignored for simplicity
+    @MockEdition(Edition.EDITION_2015)
     fun `test insert relative use item 1`() = checkAutoImportFixByFileTree("""
         //- dep-lib/lib.rs
         pub struct Foo;
@@ -265,6 +266,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
     """)
 
     // existing `extern crate` is ignored for simplicity
+    @MockEdition(Edition.EDITION_2015)
     fun `test insert relative use item 2`() = checkAutoImportFixByFileTree("""
         //- dep-lib/lib.rs
         pub struct Foo;
@@ -359,20 +361,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
             let x = 123.<error descr="Unresolved reference: `foo`">foo/*caret*/</error>();
         }
     """, """
-        //- dep-lib/lib.rs
-        pub trait Foo {
-            fn foo(&self);
-        }
-
-        impl<T> Foo for T {
-            fn foo(&self) {
-                unimplemented!()
-            }
-        }
-
         //- main.rs
-        extern crate dep_lib_target;
-
         use dep_lib_target::Foo;
 
         fn main() {
@@ -422,8 +411,6 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         pub struct Foo;
 
         //- dep-lib/lib.rs
-        extern crate dep_lib_target;
-
         pub use dep_lib_target::Foo;
 
         //- main.rs
@@ -431,17 +418,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
             let foo = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
     """, """
-        //- dep-lib-new/lib.rs
-        pub struct Foo;
-
-        //- dep-lib/lib.rs
-        extern crate dep_lib_target;
-
-        pub use dep_lib_target::Foo;
-
         //- main.rs
-        extern crate dep_lib_target;
-
         use dep_lib_target::Foo;
 
         fn main() {
@@ -622,7 +599,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::fmt();
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             #[derive(Debug)]

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.inspections.import
 
 import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.utils.import.Testmarks
 
 class AutoImportFixTest : AutoImportFixTestBase() {
@@ -20,7 +21,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -40,7 +41,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::A;
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub enum Foo { A }
@@ -60,7 +61,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let a = <error descr="Unresolved reference: `A`">A/*caret*/</error>;
         }
     """, """
-        use foo::Foo::A;
+        use crate::foo::Foo::A;
 
         mod foo {
             pub enum Foo { A }
@@ -78,7 +79,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let a = <error descr="Unresolved reference: `A`">A/*caret*/</error>;
         }
     """, """
-        use Foo::A;
+        use crate::Foo::A;
 
         enum Foo { A }
 
@@ -125,7 +126,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `bar`">bar/*caret*/</error>();
         }
     """, """
-        use foo::bar;
+        use crate::foo::bar;
 
         mod foo {
             pub fn bar() -> i32 { 0 }
@@ -148,7 +149,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::foo();
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -169,7 +170,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         fn f<T>(foo: <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error><T>) {}
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo<T>(T);
@@ -187,7 +188,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::<i32> {};
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo<T> { x: T }
@@ -210,7 +211,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::<i32>::bar();
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo<T>(T);
@@ -233,7 +234,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::<i32> { x } = ();
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo<T> { x: T }
@@ -256,7 +257,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::<i32>::bar(x) = ();
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo<T>(T);
@@ -281,7 +282,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `bar`">bar/*caret*/</error>::foo_bar();
         }
     """, """
-        use foo::bar;
+        use crate::foo::bar;
 
         mod foo {
             pub mod bar {
@@ -295,7 +296,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test insert use item after existing use items`() = checkAutoImportFixByText("""
-        use foo::Bar;
+        use crate::foo::Bar;
 
         mod foo {
             pub struct Bar;
@@ -309,8 +310,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
     """, """
-        use bar::Foo;
-        use foo::Bar;
+        use crate::bar::Foo;
+        use crate::foo::Bar;
 
         mod foo {
             pub struct Bar;
@@ -338,7 +339,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, """
         #![allow(non_snake_case)]
 
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -365,7 +366,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         mod tests {
-            use foo::Foo;
+            use crate::foo::Foo;
 
             fn foo() {
                 let f = Foo/*caret*/;
@@ -384,7 +385,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
     """, """
-        use foo::bar::Foo;
+        use crate::foo::bar::Foo;
 
         mod foo {
             pub mod bar {
@@ -537,7 +538,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, """
         mod aaa {
             mod bbb {
-                use ccc::ddd::Foo;
+                use crate::ccc::ddd::Foo;
 
                 fn foo() {
                     let x = Foo/*caret*/;
@@ -573,7 +574,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         mod ccc;
     """, """
         //- aaa/bbb/mod.rs
-        use ccc::ddd::Foo;
+        use crate::ccc::ddd::Foo;
 
         fn foo() {
             let x = Foo/*caret*/;
@@ -592,7 +593,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """, """
         //- main.rs
-        use foo::bar;
+        use crate::foo::bar;
 
         mod foo {
             pub mod bar;
@@ -617,7 +618,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `bar`">bar/*caret*/</error>();
         }
     """, """
-        use foo1::bar;
+        use crate::foo1::bar;
 
         mod foo1 {
             pub fn bar() {}
@@ -649,7 +650,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `bar`">bar/*caret*/</error>::foo_bar();
         }
     """, """
-        use foo2::bar;
+        use crate::foo2::bar;
 
         mod foo1 {
             pub fn bar() {}
@@ -721,7 +722,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>::bar();
         }
     """, """
-        use foo::Bar;
+        use crate::foo::Bar;
 
         mod foo {
             pub trait Bar {
@@ -743,7 +744,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>::bar();
         }
     """, """
-        use foo::Bar;
+        use crate::foo::Bar;
 
         mod foo {
             pub trait Bar {
@@ -776,7 +777,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>::C;
         }
     """, """
-        use foo::Bar;
+        use crate::foo::Bar;
 
         mod foo {
             pub trait Bar {
@@ -812,7 +813,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        use foo::Bar;
+        use crate::foo::Bar;
 
         mod foo {
             pub use self::bar::Bar;
@@ -840,7 +841,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub use self::bar::Bar as Foo;
@@ -869,7 +870,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let a = <error descr="Unresolved reference: `Baz`">Baz/*caret*/</error>;
         }
     """, """
-        use foo::Baz;
+        use crate::foo::Baz;
 
         mod foo {
             pub use self::bar::{Baz, Qwe};
@@ -898,7 +899,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let a = <error descr="Unresolved reference: `Baz`">Baz/*caret*/</error>;
         }
     """, """
-        use foo::Baz;
+        use crate::foo::Baz;
 
         mod foo {
             pub use self::bar::Baz::{self};
@@ -927,7 +928,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let a = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub use self::bar::{Baz as Foo, Qwe};
@@ -958,7 +959,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = <error descr="Unresolved reference: `FooBar`">FooBar/*caret*/</error>;
         }
     """, """
-        use foo::baz::FooBar;
+        use crate::foo::baz::FooBar;
 
         mod foo {
             pub use self::bar::baz;
@@ -1001,8 +1002,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         fn main() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
-    """, listOf("baz::Foo", "foo::Foo", "foo::bar::Foo"), "baz::Foo", """
-        use baz::Foo;
+    """, listOf("crate::baz::Foo", "crate::foo::Foo", "crate::foo::bar::Foo"), "crate::baz::Foo", """
+        use crate::baz::Foo;
 
         mod foo {
             pub struct Foo;
@@ -1047,8 +1048,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         fn main() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
-    """, listOf( "bar::Foo","foo::Foo", "qwe::Foo"),  "bar::Foo", """
-        use bar::Foo;
+    """, listOf("crate::bar::Foo", "crate::foo::Foo", "crate::qwe::Foo"), "crate::bar::Foo", """
+        use crate::bar::Foo;
 
         mod foo {
             pub struct Foo;
@@ -1084,19 +1085,19 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         mod baz {
             pub mod qqq {
-                pub use foo::bar;
+                pub use crate::foo::bar;
             }
         }
 
         mod xxx {
-            pub use baz::qqq;
+            pub use crate::baz::qqq;
         }
 
         fn main() {
             let a = <error descr="Unresolved reference: `FooBar`">FooBar/*caret*/</error>;
         }
     """, """
-        use foo::bar::FooBar;
+        use crate::foo::bar::FooBar;
 
         mod foo {
             pub mod bar {
@@ -1106,12 +1107,12 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         mod baz {
             pub mod qqq {
-                pub use foo::bar;
+                pub use crate::foo::bar;
             }
         }
 
         mod xxx {
-            pub use baz::qqq;
+            pub use crate::baz::qqq;
         }
 
         fn main() {
@@ -1121,29 +1122,29 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test cyclic module reexports`() = checkAutoImportFixByText("""
         pub mod x {
-            pub use y;
+            pub use crate::y;
 
             pub struct Z;
         }
 
         pub mod y {
-            pub use x;
+            pub use crate::x;
         }
 
         fn main() {
             let x = <error descr="Unresolved reference: `Z`">Z/*caret*/</error>;
         }
     """, """
-        use x::Z;
+        use crate::x::Z;
 
         pub mod x {
-            pub use y;
+            pub use crate::y;
 
             pub struct Z;
         }
 
         pub mod y {
-            pub use x;
+            pub use crate::x;
         }
 
         fn main() {
@@ -1153,44 +1154,44 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test crazy cyclic module reexports`() = checkAutoImportFixByTextWithMultipleChoice("""
         pub mod x {
-            pub use u;
+            pub use crate::u;
 
             pub mod y {
-                pub use u::v;
+                pub use crate::u::v;
 
                 pub struct Z;
             }
         }
 
         pub mod u {
-            pub use x::y;
+            pub use crate::x::y;
 
             pub mod v {
-                pub use x;
+                pub use crate::x;
             }
         }
 
         fn main() {
             let z = <error descr="Unresolved reference: `Z`">Z/*caret*/</error>;
         }
-    """, listOf("u::y::Z", "x::y::Z"), "u::y::Z", """
-        use u::y::Z;
+    """, listOf("crate::u::y::Z", "crate::x::y::Z"), "crate::u::y::Z", """
+        use crate::u::y::Z;
 
         pub mod x {
-            pub use u;
+            pub use crate::u;
 
             pub mod y {
-                pub use u::v;
+                pub use crate::u::v;
 
                 pub struct Z;
             }
         }
 
         pub mod u {
-            pub use x::y;
+            pub use crate::x::y;
 
             pub mod v {
-                pub use x;
+                pub use crate::x;
             }
         }
 
@@ -1209,18 +1210,18 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         mod baz {
-            pub use foo::bar::FooBar;
+            pub use crate::foo::bar::FooBar;
         }
 
         mod quuz {
-            pub use foo::bar;
+            pub use crate::foo::bar;
         }
 
         fn main() {
             let x = <error descr="Unresolved reference: `FooBar`">FooBar/*caret*/</error>;
         }
-    """, listOf("baz::FooBar", "foo::FooBar"), "baz::FooBar", """
-        use baz::FooBar;
+    """, listOf("crate::baz::FooBar", "crate::foo::FooBar"), "crate::baz::FooBar", """
+        use crate::baz::FooBar;
 
         mod foo {
             pub use self::bar::FooBar;
@@ -1231,11 +1232,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         mod baz {
-            pub use foo::bar::FooBar;
+            pub use crate::foo::bar::FooBar;
         }
 
         mod quuz {
-            pub use foo::bar;
+            pub use crate::foo::bar;
         }
 
         fn main() {
@@ -1256,7 +1257,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         fn foo(x: <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>) {}
     """, """
-        use struct_mod::Foo;
+        use crate::struct_mod::Foo;
 
         mod struct_mod {
             pub struct Foo { foo: i32 }
@@ -1295,8 +1296,9 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         fn main() {
             let x = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
-    """, listOf("enum_mod::Bar::Foo", "struct_mod::Foo", "type_alias_mod::Foo"), "enum_mod::Bar::Foo", """
-        use enum_mod::Bar::Foo;
+    """, listOf("crate::enum_mod::Bar::Foo", "crate::struct_mod::Foo", "crate::type_alias_mod::Foo"),
+        "crate::enum_mod::Bar::Foo", """
+        use crate::enum_mod::Bar::Foo;
 
         mod struct_mod {
             pub struct Foo { foo: i32 }
@@ -1339,7 +1341,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         fn foo<T: <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>>(x: T) {}
     """, """
-        use trait_mod::Foo;
+        use crate::trait_mod::Foo;
 
         mod struct_mod {
             pub struct Foo { foo: i32 }
@@ -1391,8 +1393,9 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         fn main() {
             let x = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error> { };
         }
-    """, listOf("block_struct_mod::Foo", "enum_struct_mod::Bar::Foo", "type_alias_mod::Foo"), "enum_struct_mod::Bar::Foo", """
-        use enum_struct_mod::Bar::Foo;
+    """, listOf("crate::block_struct_mod::Foo", "crate::enum_struct_mod::Bar::Foo", "crate::type_alias_mod::Foo"),
+        "crate::enum_struct_mod::Bar::Foo", """
+        use crate::enum_struct_mod::Bar::Foo;
 
         mod struct_mod {
             pub struct Foo;
@@ -1460,7 +1463,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = 123.<error descr="Unresolved reference: `foo`">foo/*caret*/</error>();
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo {
@@ -1490,7 +1493,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = 123.<error descr="Unresolved reference: `foo`">foo/*caret*/</error>();
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo {
@@ -1520,7 +1523,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = i32::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(123);
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo {
@@ -1553,7 +1556,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = S::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(123);
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo {
@@ -1586,7 +1589,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = <i32>::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(123);
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo {
@@ -1618,7 +1621,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = i32::<error descr="Unresolved reference: `C`">C/*caret*/</error>(123);
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo {
@@ -1648,7 +1651,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = i32::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(123);
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo {
@@ -1710,7 +1713,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = <error descr="Unresolved reference: `S`">S/*caret*/</error>::foo();
         }
     """, """
-        use foo::S;
+        use crate::foo::S;
 
         mod foo {
             pub struct S;
@@ -1747,7 +1750,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let x = 123.<error descr="Unresolved reference: `foo_bar`">foo_bar/*caret*/</error>();
         }
     """, """
-        use foo::baz::FooBar;
+        use crate::foo::baz::FooBar;
 
         mod foo {
             pub use self::bar::baz;
@@ -1814,8 +1817,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         fn main() {
             let x = 123.<error descr="Unresolved reference: `foo`">foo/*caret*/</error>();
         }
-    """, listOf("foo::Bar", "foo::Foo"), "foo::Bar", """
-        use foo::Bar;
+    """, listOf("crate::foo::Bar", "crate::foo::Foo"), "crate::foo::Bar", """
+        use crate::foo::Bar;
 
         mod foo {
             pub trait Foo {
@@ -1880,11 +1883,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
                 fn do_x(&self);
             }
 
-            impl X for ::Foo {
+            impl X for crate::Foo {
                 fn do_x(&self) {}
             }
 
-            impl X for ::Bar {
+            impl X for crate::Bar {
                 fn do_x(&self) {}
             }
         }
@@ -1893,7 +1896,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             Bar.<error>do_x/*caret*/</error>();
         }
     """, """
-        use a::X;
+        use crate::a::X;
 
         struct Foo;
         struct Bar;
@@ -1911,11 +1914,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
                 fn do_x(&self);
             }
 
-            impl X for ::Foo {
+            impl X for crate::Foo {
                 fn do_x(&self) {}
             }
 
-            impl X for ::Bar {
+            impl X for crate::Bar {
                 fn do_x(&self) {}
             }
         }
@@ -2051,7 +2054,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             pub struct S;
         }
         mod c {
-            use b::S;
+            use crate::b::S;
 
             fn x() -> S {
 
@@ -2071,7 +2074,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             pub struct S;
         }
         pub mod c {
-            use b::S;
+            use crate::b::S;
 
             fn x() -> S {}
         }
@@ -2089,7 +2092,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
             }
         }
-    """, listOf("a::S", "b::S"), "b::S", """
+    """, listOf("crate::a::S", "crate::b::S"), "crate::b::S", """
         mod a {
             pub struct S;
         }
@@ -2097,7 +2100,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             pub struct S;
         }
         mod c {
-            use b::S;
+            use crate::b::S;
 
             fn x() -> S {
 
@@ -2118,7 +2121,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let a = <error descr="Unresolved reference: `A`">A/*caret*/</error>;
         }
     """, """
-        use c::A;
+        use crate::c::A;
 
         mod c {
             pub use self::a::*;
@@ -2146,7 +2149,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let a = <error descr="Unresolved reference: `A`">A/*caret*/</error>;
         }
     """, """
-        use c::A;
+        use crate::c::A;
 
         mod c {
             pub use self::a::{{*}};
@@ -2163,7 +2166,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test group imports`() = checkAutoImportFixByText("""
         // comment
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -2175,7 +2178,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """, """
         // comment
-        use foo::{Bar, Foo};
+        use crate::foo::{Bar, Foo};
 
         mod foo {
             pub struct Foo;
@@ -2189,7 +2192,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test add import to existing group`() = checkAutoImportFixByText("""
         // comment
-        use foo::{Bar, Foo};
+        use crate::foo::{Bar, Foo};
 
         mod foo {
             pub struct Foo;
@@ -2202,7 +2205,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """, """
         // comment
-        use foo::{Bar, Baz, Foo};
+        use crate::foo::{Bar, Baz, Foo};
 
         mod foo {
             pub struct Foo;
@@ -2216,7 +2219,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test group imports only at the last level`() = checkAutoImportFixByText("""
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -2229,8 +2232,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        use foo::bar::Bar;
-        use foo::Foo;
+        use crate::foo::bar::Bar;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -2245,7 +2248,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test group imports only if the other import doesn't have a modifier`() = checkAutoImportFixByText("""
-        pub use foo::Foo;
+        pub use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -2256,8 +2259,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        use foo::Bar;
-        pub use foo::Foo;
+        use crate::foo::Bar;
+        pub use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -2271,7 +2274,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test group imports only if the other import doesn't have an attribute`() = checkAutoImportFixByText("""
         #[attribute = "value"]
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -2282,9 +2285,9 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        use foo::Bar;
+        use crate::foo::Bar;
         #[attribute = "value"]
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -2297,7 +2300,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test group imports with aliases 1`() = checkAutoImportFixByText("""
-        use foo::Foo as F;
+        use crate::foo::Foo as F;
 
         mod foo {
             pub struct Foo;
@@ -2308,7 +2311,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        use foo::{Bar, Foo as F};
+        use crate::foo::{Bar, Foo as F};
 
         mod foo {
             pub struct Foo;
@@ -2321,7 +2324,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test group imports with aliases 2`() = checkAutoImportFixByText("""
-        use foo::{Bar as B, Foo as F};
+        use crate::foo::{Bar as B, Foo as F};
 
         mod foo {
             pub struct Foo;
@@ -2332,7 +2335,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
         }
     """, """
-        use foo::{Bar as B, Bar, Foo as F};
+        use crate::foo::{Bar as B, Bar, Foo as F};
 
         mod foo {
             pub struct Foo;
@@ -2345,7 +2348,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test group imports with nested groups`() = checkAutoImportFixByText("""
-        use foo::{{Bar, Foo}};
+        use crate::foo::{{Bar, Foo}};
 
         mod foo {
             pub struct Foo;
@@ -2357,7 +2360,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Baz`">Baz/*caret*/</error>;
         }
     """, """
-        use foo::{{Bar, Foo}, Baz};
+        use crate::foo::{{Bar, Foo}, Baz};
 
         mod foo {
             pub struct Foo;
@@ -2591,7 +2594,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             macro_rules! foo {
@@ -2614,7 +2617,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             <S<T>>::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(&a);
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo { fn foo(&self) {} }
@@ -2634,7 +2637,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             a.<error descr="Unresolved reference: `foo`">foo/*caret*/</error>();
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo { fn foo(&self) {} }
@@ -2646,7 +2649,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @MockEdition(Edition.EDITION_2015)
     fun `test import item from a renamed crate (2015 edition)`() = checkAutoImportFixByFileTree("""
         //- dep-lib-to-be-renamed/lib.rs
         pub mod foo {
@@ -2688,7 +2691,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub(crate) struct Foo;

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.inspections.import
 
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.utils.import.Testmarks
 
@@ -88,7 +87,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import enum variant of reexported enum`() = checkAutoImportFixByText("""
         mod inner1 {
             pub use inner2::Foo;
@@ -420,7 +418,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import private item from parent mod`() = checkAutoImportFixByText("""
         mod a1 {
             struct Foo;
@@ -445,7 +442,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test don't try to import private reexport from parent mod 1`() = checkAutoImportFixByText("""
         mod a1 {
             use crate::b1::b2::Foo;
@@ -480,7 +476,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """, Testmarks.ignorePrivateImportInParentMod)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test don't try to import private reexport from parent mod 2`() = checkAutoImportFixByText("""
         mod a1 {
             use crate::b1::b2::b3;
@@ -680,7 +675,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item if it can't be resolved`() = checkAutoImportFixByText("""
         mod foo {
             pub mod bar {
@@ -1431,7 +1425,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item with correct namespace when multiple namespaces available`() = checkAutoImportFixByTextWithoutHighlighting("""
         mod inner {
             pub struct foo {}
@@ -1666,7 +1659,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import trait default method UFCS 2`() = checkAutoImportFixByFileTree("""
     //- lib.rs
         pub trait Trait {
@@ -1843,7 +1835,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test import trait method, use direct path`() = checkAutoImportFixByFileTree("""
     //- dep-lib/lib.rs
@@ -2002,7 +1993,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item in root module (edition 2018)`() = checkAutoImportFixByText("""
         mod foo {
             pub struct Foo;
@@ -2023,7 +2013,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item from root module (edition 2018)`() = checkAutoImportFixByText("""
         struct Foo;
 
@@ -2373,7 +2362,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test insert import at correct location`() = checkAutoImportFixByText("""
         use crate::aaa::A;
         use crate::bbb::B;
@@ -2403,7 +2391,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test insert import at correct location (unsorted imports)`() = checkAutoImportFixByText("""
         use crate::aaa::A;
         use crate::ddd::D;
@@ -2434,7 +2421,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, checkOptimizeImports = false)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test insert import from different crate at correct location`() = checkAutoImportFixByFileTree("""
     //- dep-lib/lib.rs
         pub mod aaa { pub struct A; }
@@ -2667,7 +2653,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item from a renamed crate (2018 edition)`() = checkAutoImportFixByFileTree("""
         //- dep-lib-to-be-renamed/lib.rs
         pub mod foo {
@@ -2703,7 +2688,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not try to import 'pub(crate)' item from dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
         //- dep-lib/lib.rs
         pub mod foo {
@@ -2714,7 +2698,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not try to import an item from 'pub(crate)' mod in dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
         //- dep-lib/lib.rs
         pub(crate) mod foo {
@@ -2725,7 +2708,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not try to import an item reexported from 'pub(crate)' mod in dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
         //- dep-lib/lib.rs
         mod foo {
@@ -2739,7 +2721,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not try to import 'pub(crate)' item reexported from dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
         //- dep-lib/lib.rs
         mod foo {
@@ -2753,7 +2734,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not try to import an item reexported by 'pub(crate) use' in dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
         //- dep-lib/lib.rs
         mod foo {
@@ -2767,7 +2747,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not try to import an item reexported by intermediate 'pub(crate) use' in dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
         //- dep-lib/lib.rs
         mod foo {
@@ -2784,7 +2763,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not try to import an item reexported by 'pub(crate) extern crate' in dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
         //- trans-lib/lib.rs
         pub struct FooBar;
@@ -2797,7 +2775,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not try to import item from transitive dependency`() = checkAutoImportFixIsUnavailableByFileTree("""
     //- trans-lib/lib.rs
         pub mod mod1 {
@@ -2811,7 +2788,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item from transitive dependency reexported by dependency`() = checkAutoImportFixByFileTree("""
     //- trans-lib/lib.rs
         pub mod mod1 {
@@ -2838,7 +2814,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import macro`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         #[macro_export]
@@ -2859,7 +2834,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import macro 2`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         pub macro foo() {}
@@ -2879,7 +2853,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     // e.g. `lazy_static`
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import macro with same name as dependency`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         #[macro_export]
@@ -2900,7 +2873,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not import function as macro path`() = checkAutoImportFixIsUnavailableByFileTree("""
     //- lib.rs
         pub fn func() {}
@@ -2911,7 +2883,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test do not import cfg-disabled item`() = checkAutoImportFixIsUnavailableByFileTree("""
     //- foo.rs
         pub fn func() {}
@@ -2923,7 +2894,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test use absolute path when extern crate has same name as child mod`() = checkAutoImportFixByFileTree("""
     //- lib.rs
         pub fn func() {}
@@ -2942,7 +2912,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test UFCS with unnamed trait import inside another trait impl`() = checkAutoImportFixIsUnavailable("""
         mod inner {
             pub struct Foo {}
@@ -2959,7 +2928,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import inside included file`() = checkAutoImportFixByFileTree("""
         //- foo.rs
         fn func() {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspectionTest.kt
@@ -6,11 +6,9 @@
 package org.rust.ide.inspections.lints
 
 import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-@MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsBareTraitObjectsInspectionTest : RsInspectionsTestBase(RsBareTraitObjectsInspection::class) {
 
     fun `test simple trait object`() = checkFixByText("Add 'dyn' keyword to trait object", """

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspectionTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.inspections.lints
 
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.inspections.RsInspectionsTestBase
 
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
@@ -68,7 +69,7 @@ class RsBareTraitObjectsInspectionTest : RsInspectionsTestBase(RsBareTraitObject
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @MockEdition(Edition.EDITION_2015)
     fun `test simple trait object in edition 2015`() = checkByText("""
         trait Trait {}
         fn main(){

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -7,7 +7,6 @@ package org.rust.ide.inspections.lints
 
 import org.junit.ComparisonFailure
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.lang.core.macros.MacroExpansionScope
@@ -180,7 +179,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg-disabled import and usage`() = checkByText("""
         mod foo {
@@ -355,7 +353,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test star import reexport`() = checkByText("""
         mod foo {
             mod bar {
@@ -371,7 +368,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test star import star reexport`() = checkByText("""
         mod foo {
             mod bar {
@@ -401,7 +397,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in same module`() = checkByText("""
        mod foo {
             mod bar {
@@ -459,7 +454,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
     """)
 
     @MinRustcVersion("1.46.0")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
@@ -474,7 +468,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
     """)
 
     @MinRustcVersion("1.46.0")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
@@ -560,8 +553,7 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
     """)
 
     // TODO: https://github.com/intellij-rust/intellij-rust/issues/7314 needs to be fixed
-    /*@MockEdition(CargoWorkspace.Edition.EDITION_2018)
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    /*@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test colon colon import`() = checkByText("""
         mod foo {
             use ::{std::collections};
@@ -571,7 +563,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)*/
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test use imported item in use speck with alias`() = checkByText("""
         mod bar {
             pub fn foo1() {}
@@ -650,7 +641,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test used qualified macro`() = checkByText("""
         mod foo {
             #[macro_export]
@@ -720,7 +710,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)*/
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import unused in child module`() = checkByText("""
         mod foo {
             pub struct S;
@@ -730,7 +719,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         mod bar {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module (direct reference)`() = checkByText("""
         mod foo {
             pub struct S;
@@ -742,7 +730,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module (named import)`() = checkByText("""
         mod foo {
             pub struct S;
@@ -755,7 +742,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module (glob import)`() = checkByText("""
         mod foo {
             pub struct S;
@@ -768,7 +754,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module (transitive glob import)`() = checkByText("""
         mod foo {
             pub struct S;
@@ -784,7 +769,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module (private transitive glob import)`() = checkByText("""
         mod foo {
             pub struct S;
@@ -801,7 +785,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test pub(crate) import used in super module`() = checkByText("""
         mod inner1 {
             pub fn func() {}
@@ -815,7 +798,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test pub(crate) import with alias used in super module`() = checkByText("""
         mod inner1 {
             pub fn func() {}
@@ -829,7 +811,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module (match pattern)`() = checkByText("""
         mod foo {
             pub const S: i32 = 0;
@@ -847,7 +828,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module in macro 1`() = checkByText("""
         macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
         mod foo {
@@ -862,7 +842,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module in macro 2`() = checkByText("""
         macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
         mod foo {
@@ -879,7 +858,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
     """)
 
     // TODO: Support text search inside macro expansions
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module in macro 3`() = expect<ComparisonFailure> {
     checkByText("""
         mod inner {
@@ -898,7 +876,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
     """)
     }
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module in nested macro 1`() = checkByText("""
         macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
         mod foo {
@@ -915,7 +892,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in child module in nested macro 2`() = checkByText("""
         macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
         mod foo {
@@ -933,7 +909,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test private import used in expanded child module`() = checkByText("""
         macro_rules! gen_foo {
             ($($ t:tt)*) => {
@@ -953,7 +928,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test writeln macro`() = checkByText("""
         use std::io::Write;
@@ -963,7 +937,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test println macro`() = checkByText("""
         use std::collections::HashSet;
@@ -972,7 +945,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test format macro`() = checkByText("""
         use std::collections::HashSet;
@@ -981,7 +953,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test format macro with trait method call`() = checkByText("""
         struct S;
@@ -998,7 +969,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg-disabled function`() = checkByText("""
         mod inner {
@@ -1014,7 +984,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg-disabled method`() = checkByText("""
         mod inner {
@@ -1033,7 +1002,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test disabled in doctests`() = checkByText("""
         /// ```
         /// use test_project::func;
@@ -1042,7 +1010,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
     """)
 
     // emulates situation when method is unresolved because of some bug
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test ignore trait import when there is unresolved related method 1`() = checkByText("""
         mod foo {
             pub trait T {
@@ -1057,7 +1024,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test ignore trait import when there is unresolved related method 2`() = checkByText("""
         mod foo {
             pub trait T {
@@ -1072,7 +1038,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test ignore import when there is unresolved related path`() = checkByText("""
         mod foo {
             pub mod inner {}

--- a/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
@@ -443,8 +443,8 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
     """)
 
     fun `test import unresolved type`() = checkFixByText("Add remaining patterns", """
-        use a::E::A;
-        use a::foo;
+        use crate::a::E::A;
+        use crate::a::foo;
 
         mod a {
             pub enum E { A, B }
@@ -457,8 +457,8 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
             };
         }
     """, """
-        use a::E::A;
-        use a::{E, foo};
+        use crate::a::E::A;
+        use crate::a::{E, foo};
 
         mod a {
             pub enum E { A, B }
@@ -908,7 +908,7 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
     """)
 
     fun `test empty match import unresolved type`() = checkFixByText("Add remaining patterns", """
-        use a::foo;
+        use crate::a::foo;
 
         mod a {
             pub enum FooBar { Foo, Bar }
@@ -919,7 +919,7 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
             <error descr="Match must be exhaustive [E0004]">match/*caret*/</error> foo() {};
         }
     """, """
-        use a::{foo, FooBar};
+        use crate::a::{foo, FooBar};
 
         mod a {
             pub enum FooBar { Foo, Bar }

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
@@ -128,7 +128,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
     """)
 
     fun `test import unresolved type (add)`() = checkFixByText("Change return type of function 'foo' to '(S, A)'", """
-        use a::bar;
+        use crate::a::bar;
 
         mod a {
             pub struct S;
@@ -140,7 +140,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
             <error>bar()<caret></error>
         }
     """, """
-        use a::{A, bar, S};
+        use crate::a::{A, bar, S};
 
         mod a {
             pub struct S;
@@ -154,7 +154,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
     """)
 
     fun `test import unresolved type (replace)`() = checkFixByText("Change return type of function 'foo' to '(S, A)'", """
-        use a::bar;
+        use crate::a::bar;
 
         mod a {
             pub struct S;
@@ -166,7 +166,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
             <error>bar()<caret></error>
         }
     """, """
-        use a::{A, bar, S};
+        use crate::a::{A, bar, S};
 
         mod a {
             pub struct S;
@@ -180,7 +180,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
     """)
 
     fun `test import skip default type argument`() = checkFixByText("Change return type of function 'foo' to 'S'", """
-        use a::bar;
+        use crate::a::bar;
 
         mod a {
             pub struct R;
@@ -192,7 +192,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
             <error>bar()<caret></error>
         }
     """, """
-        use a::{bar, S};
+        use crate::a::{bar, S};
 
         mod a {
             pub struct R;
@@ -206,7 +206,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
     """)
 
     fun `test import aliased type`() = checkFixByText("Change return type of function 'foo' to 'S'", """
-        use a::bar;
+        use crate::a::bar;
 
         mod a {
             pub struct R;
@@ -218,7 +218,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
             <error>bar()<caret></error>
         }
     """, """
-        use a::{bar, S};
+        use crate::a::{bar, S};
 
         mod a {
             pub struct R;
@@ -260,7 +260,8 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
         }
     """)
 
-    fun `test use qualified name for ambiguous type`() = checkFixByText("Change return type of function 'foo' to 'a::Foo'", """
+    fun `test use qualified name for ambiguous type`() = checkFixByText(
+        "Change return type of function 'foo' to 'crate::a::Foo'", """
         mod a {
             pub struct Foo;
         }
@@ -275,12 +276,13 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
         }
         struct Foo;
 
-        fn foo() -> a::Foo {
+        fn foo() -> crate::a::Foo {
             a::Foo
         }
     """)
 
-    fun `test use qualified name for ambiguous nested type`() = checkFixByText("Change return type of function 'foo' to '(a::S, b::S)'", """
+    fun `test use qualified name for ambiguous nested type`() = checkFixByText(
+        "Change return type of function 'foo' to '(crate::a::S, crate::b::S)'", """
         struct S;
         mod a {
             pub struct S;
@@ -301,12 +303,12 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
             pub struct S;
         }
 
-        fn foo() -> (a::S, b::S) {
+        fn foo() -> (crate::a::S, crate::b::S) {
             (a::S, b::S)
         }
     """)
 
-    fun `test do not qualify type parameter`() = checkFixByText("Change return type of function 'foo' to 'b::S<T>'", """
+    fun `test do not qualify type parameter`() = checkFixByText("Change return type of function 'foo' to 'crate::b::S<T>'", """
         struct T;
         struct S<T>(T);
         mod b {
@@ -323,7 +325,7 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
             pub struct S<T>(T);
         }
 
-        fn foo() -> b::S<T> {
+        fn foo() -> crate::b::S<T> {
             b::S::<T>(T)
         }
     """)

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.inspections.typecheck
 
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 
@@ -330,7 +328,6 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test qualify ambiguous type with reexported path`() = checkFixByText("Change return type of function 'foo' to 'crate::a::S'", """
         struct S;
         mod a {
@@ -359,7 +356,6 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test use correct path 1`() = checkFixByFileTree("Change return type of function 'func' to 'Foo'", """
     //- lib.rs
         pub struct Foo;
@@ -384,7 +380,6 @@ class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::cla
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test use correct path 2`() = checkFixByFileTree("Change return type of function 'func' to 'test_package::Foo'", """
     //- lib.rs
         pub struct Foo;

--- a/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
@@ -206,7 +206,7 @@ class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::cla
 
         struct S/*caret*/;
     """, "Foo\t\t", """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub trait Foo {

--- a/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
@@ -152,7 +152,7 @@ class AddRemainingArmsIntentionTest : RsIntentionTestBase(AddRemainingArmsIntent
             }
         }
     """, """
-        use foo::Alias;
+        use crate::foo::Alias;
 
         mod foo {
             pub enum Enum {

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntentionTest.kt
@@ -276,7 +276,7 @@ class ConvertMethodCallToUFCSIntentionTest : RsIntentionTestBase(ConvertMethodCa
             a./*caret*/bar();
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct Foo;
@@ -460,7 +460,7 @@ class ConvertMethodCallToUFCSIntentionTest : RsIntentionTestBase(ConvertMethodCa
             x./*caret*/foo();
         }
     """, """
-        use foo::Bar;
+        use crate::foo::Bar;
 
         mod foo {
             pub struct Foo;

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.intentions
 
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.intentions.createFromUsage.CreateFunctionIntention
 
 class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention::class) {
@@ -754,7 +752,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test function call type to create async function`() = doAvailableTest("""
         async fn foo() {
             /*caret*/bar().await;
@@ -769,7 +766,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test function call type create async function in blocks`() = doAvailableTest("""
         fn foo() {
             async {
@@ -788,7 +784,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test function call type create async function in nested blocks`() = doAvailableTest("""
         fn foo() {
             async {
@@ -811,7 +806,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test function call type create async function in nested function`() = doAvailableTest("""
         fn main() {
             async fn foo() {
@@ -829,7 +823,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test method call type to create async function`() = doAvailableTest("""
         struct S;
 
@@ -851,7 +844,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test method call type create async function in blocks`() = doAvailableTest("""
         struct S;
 
@@ -877,7 +869,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test method call type create async function in nested blocks`() = doAvailableTest("""
         struct S;
 
@@ -907,7 +898,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test method call type create async function in nested function`() = doAvailableTest("""
         struct S;
 
@@ -936,7 +926,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test function call type create in the async function call`() = doAvailableTest("""
         async fn foo() {
             baz(/*caret*/bar()).await;
@@ -954,7 +943,6 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         async fn baz(a: u32) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test method call type create in the async function call`() = doAvailableTest("""
         struct S;
 

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -1006,7 +1006,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
             baz/*caret*/(bar::get_s())
         }
     """, """
-        use bar::{S, T};
+        use crate::bar::{S, T};
 
         mod bar {
             pub struct S;

--- a/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
@@ -175,7 +175,7 @@ class CreateStructIntentionTest : RsIntentionTestBase(CreateStructIntention::cla
             Foo/*caret*/ { a: bar::S };
         }
     """, """
-        use bar::S;
+        use crate::bar::S;
 
         mod bar {
             pub struct S;

--- a/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
@@ -153,7 +153,7 @@ class CreateTupleStructIntentionTest : RsIntentionTestBase(CreateTupleStructInte
             Foo/*caret*/(bar::S);
         }
     """, """
-        use bar::S;
+        use crate::bar::S;
 
         mod bar {
             pub struct S;

--- a/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
@@ -322,7 +322,7 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention::class
     """)
 
     fun `test import unresolved type`() = doAvailableTest("""
-        use a::foo;
+        use crate::a::foo;
 
         mod a {
             pub struct S;
@@ -333,7 +333,7 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention::class
             let /*caret*/x = foo();
         }
     """, """
-        use a::{foo, S};
+        use crate::a::{foo, S};
 
         mod a {
             pub struct S;
@@ -346,7 +346,7 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention::class
     """)
 
     fun `test import unresolved type alias`() = doAvailableTest("""
-        use a::foo;
+        use crate::a::foo;
 
         mod a {
             pub struct S;
@@ -358,7 +358,7 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention::class
             let /*caret*/x = foo();
         }
     """, """
-        use a::{foo, R};
+        use crate::a::{foo, R};
 
         mod a {
             pub struct S;

--- a/src/test/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntentionTest.kt
@@ -7,7 +7,7 @@ package org.rust.ide.intentions
 
 import org.intellij.lang.annotations.Language
 import org.rust.MockServerFixture
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2015
+import org.rust.cargo.project.model.impl.DEFAULT_EDITION_FOR_TESTS
 import org.rust.ide.actions.ShareInPlaygroundActionTest
 
 class ShareInPlaygroundIntentionTest : RsIntentionTestBase(ShareInPlaygroundIntention::class) {
@@ -42,6 +42,6 @@ class ShareInPlaygroundIntentionTest : RsIntentionTestBase(ShareInPlaygroundInte
 
     private fun doTest(@Language("Rust") code: String, @Language("Rust") codeToShare: String) {
         InlineFile(code.trimIndent())
-        ShareInPlaygroundActionTest.doTest(project, mockServerFixture, codeToShare, EDITION_2015, "stable", ::launchAction)
+        ShareInPlaygroundActionTest.doTest(project, mockServerFixture, codeToShare, DEFAULT_EDITION_FOR_TESTS, "stable", ::launchAction)
     }
 }

--- a/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
@@ -101,14 +101,14 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
     """)
 
     fun `test import unresolved type`() = doAvailableTest("""
-            use a::foo;
+            use crate::a::foo;
             mod a {
                 pub struct S;
                 pub fn foo() -> S { S }
             }
             fn main() { let var/*caret*/ = foo(); }
     """, """
-            use a::{foo, S};
+            use crate::a::{foo, S};
             mod a {
                 pub struct S;
                 pub fn foo() -> S { S }
@@ -133,7 +133,7 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
     """)
 
     fun `test import type parameter`() = doAvailableTest("""
-            use a::foo;
+            use crate::a::foo;
             mod a {
                 pub struct S<T>(T);
                 pub struct P;
@@ -141,7 +141,7 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
             }
             fn main() { let var/*caret*/ = foo(); }
     """, """
-            use a::{foo, P, S};
+            use crate::a::{foo, P, S};
             mod a {
                 pub struct S<T>(T);
                 pub struct P;
@@ -151,7 +151,7 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
     """)
 
     fun `test import type alias`() = doAvailableTest("""
-            use a::{foo, A};
+            use crate::a::{foo, A};
             mod a {
                 pub struct S;
                 pub type A = S;
@@ -160,7 +160,7 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
             }
             fn main() { let var/*caret*/ = foo(); }
     """, """
-            use a::{foo, A, B};
+            use crate::a::{foo, A, B};
             mod a {
                 pub struct S;
                 pub type A = S;
@@ -171,7 +171,7 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
     """)
 
     fun `test import skip default type argument`() = doAvailableTest("""
-            use a::foo;
+            use crate::a::foo;
             mod a {
                 pub struct R;
                 pub struct S<T = R>(T);
@@ -179,7 +179,7 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
             }
             fn main() { let var/*caret*/ = foo(); }
     """, """
-            use a::{foo, S};
+            use crate::a::{foo, S};
             mod a {
                 pub struct R;
                 pub struct S<T = R>(T);

--- a/src/test/kotlin/org/rust/ide/intentions/SubstituteTypeAliasIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SubstituteTypeAliasIntentionTest.kt
@@ -208,7 +208,7 @@ class SubstituteTypeAliasIntentionTest : RsIntentionTestBase(SubstituteTypeAlias
             unimplemented!()
         }
     """, """
-        use foo::S;
+        use crate::foo::S;
 
         mod foo {
             pub struct S;

--- a/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
@@ -580,7 +580,7 @@ Cannot change signature of function with cfg-disabled parameters""")
             foo::bar(0);
         }
     """, """
-        use foo::S;
+        use crate::foo::S;
 
         mod foo {
             pub struct S(u32);
@@ -612,7 +612,7 @@ Cannot change signature of function with cfg-disabled parameters""")
             foo::bar(0);
         }
     """, """
-        use foo::{Option, S1, S2};
+        use crate::foo::{Option, S1, S2};
 
         mod foo {
             pub enum Option<T> {
@@ -1212,7 +1212,7 @@ Cannot change signature of function with cfg-disabled parameters""")
 
         fn bar/*caret*/() {}
     """, """
-        use foo::Vec;
+        use crate::foo::Vec;
 
         mod foo {
             pub struct S;
@@ -1240,7 +1240,7 @@ Cannot change signature of function with cfg-disabled parameters""")
 
         fn bar/*caret*/() {}
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo {
             pub struct S;

--- a/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
@@ -8,9 +8,7 @@ package org.rust.ide.refactoring
 import com.intellij.refactoring.BaseRefactoringProcessor
 import org.intellij.lang.annotations.Language
 import org.rust.MockAdditionalCfgOptions
-import org.rust.MockEdition
 import org.rust.RsTestBase
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.refactoring.changeSignature.Parameter
 import org.rust.ide.refactoring.changeSignature.ParameterProperty
 import org.rust.ide.refactoring.changeSignature.RsChangeFunctionSignatureConfig
@@ -922,7 +920,6 @@ Cannot change signature of function with cfg-disabled parameters""")
         visibility = createVisibility("pub")
     }
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import return type in different module`() = doTest("""
         mod foo {
             pub struct S;
@@ -945,7 +942,6 @@ Cannot change signature of function with cfg-disabled parameters""")
         returnTypeDisplay = referToType("S", findElementInEditor<RsStructItem>())
     }
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import new parameter type in different module`() = doTest("""
         mod foo {
             pub struct S;
@@ -968,7 +964,6 @@ Cannot change signature of function with cfg-disabled parameters""")
         parameters.add(parameter("s", referToType("S", findElementInEditor<RsStructItem>())))
     }
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import changed parameter type in different module`() = doTest("""
         mod foo {
             pub struct S;

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
@@ -452,7 +452,7 @@ class RsExtractEnumVariantTest : RsTestBase() {
     """)
 
     fun `test import generated struct if needed`() = doAvailableTest("""
-        use a::E;
+        use crate::a::E;
 
         mod a {
             pub enum E {
@@ -465,7 +465,7 @@ class RsExtractEnumVariantTest : RsTestBase() {
             let _ = E::V1 { x: 0, y: 1 };
         }
     """, """
-        use a::{E, V1};
+        use crate::a::{E, V1};
 
         mod a {
             pub struct /*caret*/V1 {
@@ -485,7 +485,7 @@ class RsExtractEnumVariantTest : RsTestBase() {
     """)
 
     fun `test import generated tuple if needed`() = doAvailableTest("""
-        use a::E;
+        use crate::a::E;
 
         mod a {
             pub enum E {
@@ -498,7 +498,7 @@ class RsExtractEnumVariantTest : RsTestBase() {
             let _ = E::V1(0, 1);
         }
     """, """
-        use a::{E, V1};
+        use crate::a::{E, V1};
 
         mod a {
             pub struct /*caret*/V1(pub i32, pub i32);
@@ -605,7 +605,7 @@ class RsExtractEnumVariantTest : RsTestBase() {
             let f = ctr2(0, 1);
         }
     """, """
-        use foo::Bar;
+        use crate::foo::Bar;
 
         mod foo {
             pub struct Bar(pub i32, pub u32);

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -7,11 +7,9 @@ package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
 import org.rust.MockAdditionalCfgOptions
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.refactoring.extractFunction.ExtractFunctionUi
 import org.rust.ide.refactoring.extractFunction.RsExtractFunctionConfig
 import org.rust.ide.refactoring.extractFunction.withMockExtractFunctionUi
@@ -531,7 +529,6 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """,  "bar")
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extract a function in a impl trait (choose existing impl)`() = doTest("""
         struct S;
 
@@ -568,7 +565,6 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """,  "bar")
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extract a function in a impl trait (choose existing impl with same generic parameters)`() = doTest("""
         struct S1;
         struct Foo<T> { t: T }
@@ -605,7 +601,6 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """,  "bar")
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extract a function in a impl trait (don't choose existing impl with different generic parameters)`() = doTest("""
         struct S1;
         struct S2;
@@ -647,7 +642,6 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extract a function in a impl trait (don't choose existing cfg-disabled impl)`() = doTest("""
         struct S1;
         struct Foo<T> { t: T }
@@ -1124,7 +1118,6 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """, "bar")
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extract async function with await`() = doTest("""
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }
@@ -1145,7 +1138,6 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """, "bar")
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extract async function with nested await`() = doTest("""
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }
@@ -1180,7 +1172,6 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """, "bar")
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extract sync function with await inside block`() = doTest("""
         async fn foo() {
             <selection>async { async { () }.await };</selection>
@@ -1195,7 +1186,6 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """, "bar")
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extract sync function with await inside closure`() = doTest("""
         #![feature(async_closure)]
         async fn foo() {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1339,7 +1339,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "foo")
 
     fun `test import parameter types`() = doTest("""
-        use a::foo;
+        use crate::a::foo;
 
         mod a {
             pub struct A;
@@ -1351,7 +1351,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>s;</selection>
         }
     """, """
-        use a::{A, foo};
+        use crate::a::{A, foo};
 
         mod a {
             pub struct A;
@@ -1369,7 +1369,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     fun `test import return type`() = doTest("""
-        use a::foo;
+        use crate::a::foo;
 
         mod a {
             pub struct A;
@@ -1380,7 +1380,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>foo()</selection>;
         }
     """, """
-        use a::{A, foo};
+        use crate::a::{A, foo};
 
         mod a {
             pub struct A;
@@ -1397,7 +1397,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     fun `test do not import default types`() = doTest("""
-        use a::foo;
+        use crate::a::foo;
 
         mod a {
             pub struct S;
@@ -1409,7 +1409,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>foo()</selection>;
         }
     """, """
-        use a::{A, foo};
+        use crate::a::{A, foo};
 
         mod a {
             pub struct S;
@@ -1427,7 +1427,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     fun `test import non default types`() = doTest("""
-        use a::foo;
+        use crate::a::foo;
 
         mod a {
             pub struct S1;
@@ -1440,7 +1440,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>foo()</selection>;
         }
     """, """
-        use a::{A, foo, S2};
+        use crate::a::{A, foo, S2};
 
         mod a {
             pub struct S1;
@@ -1459,7 +1459,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     fun `test import aliased type`() = doTest("""
-        use a::foo;
+        use crate::a::foo;
 
         mod a {
             pub struct A;
@@ -1472,7 +1472,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>s</selection>
         }
     """, """
-        use a::{foo, Foo};
+        use crate::a::{foo, Foo};
 
         mod a {
             pub struct A;

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractStructFieldsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractStructFieldsTest.kt
@@ -8,10 +8,10 @@ package org.rust.ide.refactoring
 import com.intellij.openapi.project.Project
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
-import org.rust.ide.refactoring.generate.RsStructMemberChooserObject
-import org.rust.ide.refactoring.generate.StructMemberChooserUi
 import org.rust.ide.refactoring.extractStructFields.ExtractFieldsUi
 import org.rust.ide.refactoring.extractStructFields.withMockExtractFieldsUi
+import org.rust.ide.refactoring.generate.RsStructMemberChooserObject
+import org.rust.ide.refactoring.generate.StructMemberChooserUi
 import org.rust.ide.refactoring.generate.withMockStructMemberChooserUi
 import org.rust.launchAction
 
@@ -319,7 +319,7 @@ class RsExtractStructFieldsTest : RsTestBase() {
             foo::A { a: 0 }
         }
     """, "S1", listOf("a"), """
-        use foo::S1;
+        use crate::foo::S1;
 
         mod foo {
             pub struct S1 {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
@@ -7,7 +7,6 @@ package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.inspections.lints.RsUnusedImportInspection
 
 @WithEnabledInspections(RsUnusedImportInspection::class)
@@ -644,7 +643,6 @@ class RsImportOptimizerTest: RsTestBase() {
         mod foo {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test do not remove cfg-disabled import`() = checkNotChanged("""
         mod foo {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceConstantTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceConstantTest.kt
@@ -76,7 +76,7 @@ class RsIntroduceConstantTest : RsTestBase() {
         const I: i32 = 5;
 
         mod a {
-            use I;
+            use crate::I;
 
             fn foo() {
                 let x = I;
@@ -109,7 +109,7 @@ class RsIntroduceConstantTest : RsTestBase() {
 
         fn foo() {
             mod bar {
-                use I;
+                use crate::I;
 
                 fn baz() {
                     let a = I;

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -7,8 +7,10 @@ package org.rust.ide.refactoring.implementMembers
 
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import org.intellij.lang.annotations.Language
-import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2018
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsTraitImplementationInspection
 
 class ImplementMembersHandlerTest : RsTestBase() {
@@ -118,7 +120,6 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
-    @MockEdition(EDITION_2018)
     fun `test import unresolved types 2`() = doTest("""
         use crate::a::T;
         mod a {
@@ -373,7 +374,6 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
-    @MockEdition(EDITION_2018)
     fun `test use absolute path in the case of name conflict`() = doTest("""
         use crate::a::T;
         struct R;
@@ -404,7 +404,6 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
-    @MockEdition(EDITION_2018)
     fun `test use relative path in the case of name conflict if intermediate mod is imported`() = doTest("""
         use crate::a::T;
         use crate::a::b;
@@ -443,7 +442,6 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
-    @MockEdition(EDITION_2018)
     fun `test use relative path in the case of name conflict if intermediate mod is imported (aliased)`() = doTest("""
         use crate::a::T;
         use crate::a::b as c;
@@ -482,7 +480,6 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
-    @MockEdition(EDITION_2018)
     fun `test use absolute path in the case of name conflict (name conflict is created during importing)`() = doTest("""
         use crate::a::T;
         use crate::a::foo::R;
@@ -515,7 +512,6 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
-    @MockEdition(EDITION_2018)
     fun `test use fully qualified path if cannot import an item`() = doTest("""
         use crate::a::T;
         mod a {

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -91,7 +91,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test import unresolved types`() = doTest("""
-        use a::T;
+        use crate::a::T;
         mod a {
             pub struct R;
             pub trait T {
@@ -103,7 +103,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (R, R)", byDefault = true, isSelected = true)
     ), """
-        use a::{R, T};
+        use crate::a::{R, T};
         mod a {
             pub struct R;
             pub trait T {
@@ -120,7 +120,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
     @MockEdition(EDITION_2018)
     fun `test import unresolved types 2`() = doTest("""
-        use a::T;
+        use crate::a::T;
         mod a {
             mod private {
                 pub struct R;
@@ -135,9 +135,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (private::R, private::R)", byDefault = true, isSelected = true)
     ), """
-        use a::T;
-        use crate::a::R;
-
+        use crate::a::{R, T};
         mod a {
             mod private {
                 pub struct R;
@@ -156,7 +154,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test import unresolved types inside type qualifier`() = doTest("""
-        use a::T;
+        use crate::a::T;
         mod a {
             pub struct R;
             pub trait WithAssoc { type Item; }
@@ -172,7 +170,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f(a: <R as WithAssoc>::Item)", byDefault = true, isSelected = true)
     ), """
-        use a::{R, T, WithAssoc};
+        use crate::a::{R, T, WithAssoc};
         mod a {
             pub struct R;
             pub trait WithAssoc { type Item; }
@@ -192,7 +190,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test import unresolved type aliases`() = doTest("""
-        use a::T;
+        use crate::a::T;
         mod a {
             pub struct R;
             pub type U = R;
@@ -206,7 +204,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (R, U, V)", byDefault = true, isSelected = true)
     ), """
-        use a::{R, T, U, V};
+        use crate::a::{R, T, U, V};
         mod a {
             pub struct R;
             pub type U = R;
@@ -224,7 +222,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test don't import type alias inner type`() = doTest("""
-        use a::T;
+        use crate::a::T;
         mod a {
             pub struct A;
             pub struct B;
@@ -239,7 +237,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> U<P>", byDefault = true, isSelected = true)
     ), """
-        use a::{T, U};
+        use crate::a::{T, U};
         mod a {
             pub struct A;
             pub struct B;
@@ -258,8 +256,8 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test don't import a type if it is already in the scope with a different name`() = doTest("""
-        use a::T;
-        use a::R as U;
+        use crate::a::T;
+        use crate::a::R as U;
         mod a {
             pub struct R;
             pub trait T {
@@ -271,8 +269,8 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (R, R)", byDefault = true, isSelected = true)
     ), """
-        use a::T;
-        use a::R as U;
+        use crate::a::T;
+        use crate::a::R as U;
         mod a {
             pub struct R;
             pub trait T {
@@ -288,7 +286,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test import unresolved trait bounds`() = doTest("""
-        use a::T;
+        use crate::a::T;
         mod a {
             pub trait Bound1 {}
             pub trait Bound2 {}
@@ -301,7 +299,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f<A: Bound1>() where A: Bound2", byDefault = true, isSelected = true)
     ), """
-        use a::{Bound1, Bound2, T};
+        use crate::a::{Bound1, Bound2, T};
         mod a {
             pub trait Bound1 {}
             pub trait Bound2 {}
@@ -318,7 +316,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test import unresolved constant`() = doTest("""
-        use a::T;
+        use crate::a::T;
         mod a {
             pub const C: usize = 1;
             pub trait T {
@@ -330,7 +328,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> [u8; C]", byDefault = true, isSelected = true)
     ), """
-        use a::{C, T};
+        use crate::a::{C, T};
         mod a {
             pub const C: usize = 1;
             pub trait T {
@@ -346,8 +344,8 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test don't import a constant if it is already in the scope with a different name`() = doTest("""
-        use a::T;
-        use a::C as D;
+        use crate::a::T;
+        use crate::a::C as D;
         mod a {
             pub const C: usize = 1;
             pub trait T {
@@ -359,8 +357,8 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> [u8; C]", byDefault = true, isSelected = true)
     ), """
-        use a::T;
-        use a::C as D;
+        use crate::a::T;
+        use crate::a::C as D;
         mod a {
             pub const C: usize = 1;
             pub trait T {
@@ -377,7 +375,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
     @MockEdition(EDITION_2018)
     fun `test use absolute path in the case of name conflict`() = doTest("""
-        use a::T;
+        use crate::a::T;
         struct R;
         mod a {
             pub struct R;
@@ -390,7 +388,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (R, R)", byDefault = true, isSelected = true)
     ), """
-        use a::T;
+        use crate::a::T;
         struct R;
         mod a {
             pub struct R;
@@ -408,8 +406,8 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
     @MockEdition(EDITION_2018)
     fun `test use relative path in the case of name conflict if intermediate mod is imported`() = doTest("""
-        use a::T;
-        use a::b;
+        use crate::a::T;
+        use crate::a::b;
         struct R;
         mod a {
             pub mod b {
@@ -425,8 +423,8 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (R, R)", byDefault = true, isSelected = true)
     ), """
-        use a::T;
-        use a::b;
+        use crate::a::T;
+        use crate::a::b;
         struct R;
         mod a {
             pub mod b {
@@ -447,8 +445,8 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
     @MockEdition(EDITION_2018)
     fun `test use relative path in the case of name conflict if intermediate mod is imported (aliased)`() = doTest("""
-        use a::T;
-        use a::b as c;
+        use crate::a::T;
+        use crate::a::b as c;
         struct R;
         mod a {
             pub mod b {
@@ -464,8 +462,8 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (R, R)", byDefault = true, isSelected = true)
     ), """
-        use a::T;
-        use a::b as c;
+        use crate::a::T;
+        use crate::a::b as c;
         struct R;
         mod a {
             pub mod b {
@@ -486,7 +484,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
     @MockEdition(EDITION_2018)
     fun `test use absolute path in the case of name conflict (name conflict is created during importing)`() = doTest("""
-        use a::T;
+        use crate::a::T;
         use crate::a::foo::R;
         mod a {
             pub mod foo { pub struct R; }
@@ -500,7 +498,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (foo::R, bar::R)", byDefault = true, isSelected = true)
     ), """
-        use a::T;
+        use crate::a::T;
         use crate::a::foo::R;
         mod a {
             pub mod foo { pub struct R; }
@@ -519,7 +517,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
     @MockEdition(EDITION_2018)
     fun `test use fully qualified path if cannot import an item`() = doTest("""
-        use a::T;
+        use crate::a::T;
         mod a {
             /*private*/ struct R;
             pub trait T {
@@ -531,7 +529,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """, listOf(
         ImplementMemberSelection("f() -> (R, R)", byDefault = true, isSelected = true)
     ), """
-        use a::T;
+        use crate::a::T;
         mod a {
             /*private*/ struct R;
             pub trait T {

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileReexportTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileReexportTest.kt
@@ -5,10 +5,6 @@
 
 package org.rust.ide.refactoring.move
 
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
-
-@MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsMoveFileReexportTest : RsMoveFileTestBase() {
     override val dataPath = "org/rust/ide/refactoring/move/fixtures/"
 

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileTest.kt
@@ -7,11 +7,8 @@ package org.rust.ide.refactoring.move
 
 import com.intellij.openapi.ui.TestDialog
 import com.intellij.util.IncorrectOperationException
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.withTestDialog
 
-@MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsMoveFileTest : RsMoveFileTestBase() {
     override val dataPath = "org/rust/ide/refactoring/move/fixtures/"
 

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileVisibilityTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileVisibilityTest.kt
@@ -6,10 +6,7 @@
 package org.rust.ide.refactoring.move
 
 import com.intellij.refactoring.BaseRefactoringProcessor
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
 
-@MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsMoveFileVisibilityTest : RsMoveFileTestBase() {
 
     private fun expectConflicts(action: () -> Unit) {
@@ -329,7 +326,6 @@ class RsMoveFileVisibilityTest : RsMoveFileTestBase() {
         """)
     }
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test inside reference, when new parent module is private`() = expectConflicts {
         doTestExpectError(
             arrayOf("mod1/foo.rs"),

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsSelectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsSelectionTest.kt
@@ -5,10 +5,6 @@
 
 package org.rust.ide.refactoring.move
 
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
-
-@MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsMoveTopLevelItemsSelectionTest : RsMoveTopLevelItemsTestBase() {
 
     fun `test cursor before item`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -5,12 +5,13 @@
 
 package org.rust.ide.refactoring.move
 
-import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithEnabledInspections
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.lints.RsUnusedImportInspection
 
 @WithEnabledInspections(RsUnusedImportInspection::class)
-@MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
 
     fun `test simple`() = doTest("""

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
@@ -7,10 +7,11 @@ package org.rust.lang.core.completion
 
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsAwaitCompletionTest : RsCompletionTestBase() {
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @MockEdition(Edition.EDITION_2015)
     fun `test postfix await 2015 (anon)`() = checkNotContainsCompletion("await", """
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }
@@ -20,7 +21,7 @@ class RsAwaitCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @MockEdition(Edition.EDITION_2015)
     fun `test postfix await 2015 (adt)`() = checkNotContainsCompletion("await", """
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.completion
 
 import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsAwaitCompletionTest : RsCompletionTestBase() {
@@ -33,7 +32,6 @@ class RsAwaitCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test postfix await 2018 (anon)`() = checkCompletion("await", """
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }
@@ -50,7 +48,6 @@ class RsAwaitCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test postfix await 2018 (adt)`() = checkCompletion("await", """
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.lang.core.completion
 
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsCompletionFilteringTest: RsCompletionTestBase() {
     fun `test unsatisfied bound filtered 1`() = doSingleCompletion("""
@@ -164,7 +162,6 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test public item reexported with restricted visibility 1`() = checkNoCompletion("""
         pub mod inner1 {
             pub mod inner2 {
@@ -177,7 +174,6 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test public item reexported with restricted visibility 2`() = checkContainsCompletion("bar2", """
         pub mod inner1 {
             pub mod inner2 {
@@ -190,7 +186,6 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test private reexport of public function`() = checkNoCompletion("""
         mod mod1 {
             pub fn foo() {}
@@ -205,14 +200,12 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
     """)
 
     // there was error in new resolve when legacy textual macros are always completed
-    @MockEdition(Edition.EDITION_2018)
     fun `test no completion on empty mod 1`() = checkNoCompletion("""
         macro_rules! empty { () => {}; }
         mod foo {}
         pub use foo::empt/*caret*/
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test no completion on empty mod 2`() = checkNoCompletion("""
         mod foo {}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.completion
 
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsCompletionTest : RsCompletionTestBase() {
     fun `test local variable`() = doSingleCompletion("""
@@ -574,7 +573,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test complete macro 3`() = checkContainsCompletion("foobar1", """
         mod inner {
             macro_rules! foobar1 { () => {} }
@@ -1090,7 +1088,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         fn foo(f: FnOnce(/*caret*/)) {}
     """, completionChar = '(', testmark = Testmarks.doNotAddOpenParenCompletionChar)
 
-    @MockEdition(Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test completion cfg-disabled item 1`() = checkNoCompletionByFileTree("""
     //- main.rs
@@ -1103,7 +1100,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         pub fn func() {}
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test completion cfg-disabled item 2`() = doSingleCompletionByFileTree("""
     //- main.rs
@@ -1192,7 +1188,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         fn main() { foo(MyOtherEnum::Variant(/*caret*/)) }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test do not complete non-mod items in vis restriction path`() = checkNoCompletion("""
         pub mod bar {
             pub mod foo {
@@ -1202,7 +1197,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         pub struct Item;
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test do not complete non-ancestor mods in vis restriction path`() = checkNoCompletion("""
         pub mod bar {
             pub mod foo {
@@ -1212,7 +1206,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         pub mod foo {}
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test complete ancestor module in vis restriction path`() = doFirstCompletion("""
         pub mod bar {
             pub mod foo {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -163,13 +163,13 @@ class RsCompletionTest : RsCompletionTestBase() {
         pub struct Foo;
 
         mod m {
-            use F/*caret*/;
+            use crate::F/*caret*/;
         }
     """, """
         pub struct Foo;
 
         mod m {
-            use Foo/*caret*/;
+            use crate::Foo/*caret*/;
         }
     """)
 
@@ -421,9 +421,9 @@ class RsCompletionTest : RsCompletionTestBase() {
         pub enum Spam { Quux, Eggs }
 
     //- foo/mod.rs
-        use Spam::Qu/*caret*/;
+        use crate::Spam::Qu/*caret*/;
     """, """
-        use Spam::Quux/*caret*/;
+        use crate::Spam::Quux/*caret*/;
     """)
 
     fun `test enum variant`() = doSingleCompletion("""
@@ -1181,14 +1181,14 @@ class RsCompletionTest : RsCompletionTestBase() {
             pub enum MyOtherEnum { Variant(i32) }
             pub fn foo(e: MyOtherEnum) {}
         }
-        use anothermod::foo;
+        use crate::anothermod::foo;
         fn main() { foo(MyOther/*caret*/) }
     """, """
         mod anothermod {
             pub enum MyOtherEnum { Variant(i32) }
             pub fn foo(e: MyOtherEnum) {}
         }
-        use anothermod::{foo, MyOtherEnum};
+        use crate::anothermod::{foo, MyOtherEnum};
         fn main() { foo(MyOtherEnum::Variant(/*caret*/)) }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
@@ -188,7 +188,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
             /*caret*/
         }
     """, """
-        use foo::S;
+        use crate::foo::S;
 
         mod foo {
             pub struct S;
@@ -216,7 +216,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
             /*caret*/
         }
     """, """
-        use foo::ALIAS;
+        use crate::foo::ALIAS;
 
         mod foo {
             pub type ALIAS = u32;
@@ -245,7 +245,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
             /*caret*/
         }
     """, """
-        use foo::{S, T};
+        use crate::foo::{S, T};
 
         mod foo {
             pub struct S;
@@ -277,7 +277,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
             /*caret*/
         }
     """, """
-        use foo::{ALIAS1, ALIAS2};
+        use crate::foo::{ALIAS1, ALIAS2};
 
         mod foo {
             pub type ALIAS1 = u32;

--- a/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
@@ -27,7 +27,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
             let _ = BTreeM/*caret*/
         }
     """, """
-        use collections::BTreeMap;
+        use crate::collections::BTreeMap;
 
         mod collections {
             pub struct BTreeMap;
@@ -172,7 +172,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
             let a = Enu/*caret*/
         }
     """, """
-        use a::Enum;
+        use crate::a::Enum;
 
         mod a {
             pub enum Enum {
@@ -192,7 +192,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
             let a = V/*caret*/
         }
     """, """
-        use Enum::V1;
+        use crate::Enum::V1;
 
         enum Enum { V1 }
 
@@ -213,7 +213,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
             pub struct Bar;
         }
         mod baz {
-            use foo::Bar;
+            use crate::foo::Bar;
 
             fn x(x: Bar/*caret*/) {}
         }
@@ -231,7 +231,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
             pub struct Bar;
         }
         pub mod baz {
-            use foo::Bar;
+            use crate::foo::Bar;
 
             fn x(x: Bar/*caret*/) {}
         }
@@ -246,7 +246,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
             ba/*caret*/
         }
     """, """
-        use foo::bar;
+        use crate::foo::bar;
 
         mod foo {
             pub fn bar(x: i32) {}
@@ -268,7 +268,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
             ba/*caret*/
         }
     """, """
-        use foo::bar;
+        use crate::foo::bar;
 
         mod foo {
             pub fn bar(x: i32) {}
@@ -310,7 +310,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
             }
         }
     """, """
-        use foo::Foo;
+        use crate::foo::Foo;
 
         mod foo { pub struct Foo; }
         macro_rules! foo {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
@@ -7,10 +7,8 @@ package org.rust.lang.core.completion
 
 import com.intellij.codeInsight.lookup.LookupElementPresentation
 import org.intellij.lang.annotations.Language
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.hasCaretMarker
 import org.rust.ide.settings.RsCodeInsightSettings
 import org.rust.lang.core.completion.RsCommonCompletionProvider.Testmarks
@@ -82,7 +80,6 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test suggest a symbol with same name as in scope but in different namespace`() = doTestByText("""
         fn foo() {}
         mod inner {
@@ -99,7 +96,6 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         fn test(x: foo/*caret*/) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test same item as in scope but with different name`() = doTestByText("""
         use crate::mod1::foo as bar;
         mod mod1 {
@@ -355,7 +351,6 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         fn foo(x: FooBar/*caret*/) {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test show all re-exports of single item`() {
         withOutOfScopeSettings {
@@ -380,7 +375,6 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         }
     }
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro`() = doTestByFileTree("""
     //- lib.rs
         #[macro_export]
@@ -397,7 +391,6 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2`() = doTestByFileTree("""
     //- lib.rs
         #[macro_export]
@@ -416,7 +409,6 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
 
     // TODO parse top-level identifier as RsPath
     // e.g. `lazy_static`
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro with same name as dependency`() = expect<IllegalStateException> {
         doTestByFileTree("""
     //- lib.rs
@@ -431,7 +423,6 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
     """)
     }
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro as type reference`() = doTestByFileTree("""
     //- lib.rs
         #[macro_export]

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
@@ -6,9 +6,11 @@
 package org.rust.lang.core.completion
 
 import com.intellij.openapi.util.SystemInfo
-import org.rust.*
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithActualStdlibRustProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.settings.toolchain
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.lang.core.macros.MacroExpansionScope
 
@@ -86,7 +88,6 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
         fn main() { std::stringify!(/*caret*/) }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
     fun `test complete all in std in 'use' in crate root`() = checkContainsCompletion("vec", """
         use std::/*caret*/;
     """)

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStubOnlyCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStubOnlyCompletionTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.lang.core.completion
 
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 
 class RsStubOnlyCompletionTest : RsCompletionTestBase() {
     fun `test function`() = doSingleCompletionByFileTree("""
@@ -57,16 +55,13 @@ class RsStubOnlyCompletionTest : RsCompletionTestBase() {
         fn bar(s: foo::S) { s.field/*caret*/ }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test complete all in extern crate in 'use' in crate root`() = doSingleCompletionByFileTree("""
     //- lib.rs
         pub fn foo() {}
     //- main.rs
-        extern crate test_package;
         use test_package::/*caret*/;
     """, """
-        extern crate test_package;
         use test_package::foo/*caret*/;
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsTraitMethodCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsTraitMethodCompletionTest.kt
@@ -23,7 +23,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::Bar;
+        use crate::baz::Bar;
 
         fn main() {
             Bar.fo/*caret*/
@@ -41,7 +41,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::{Bar, Foo};
+        use crate::baz::{Bar, Foo};
 
         fn main() {
             Bar.foo()/*caret*/
@@ -61,7 +61,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::Bar;
+        use crate::baz::Bar;
 
         fn main() {
             Bar.fo/*caret*/()
@@ -79,7 +79,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::{Bar, Foo};
+        use crate::baz::{Bar, Foo};
 
         fn main() {
             Bar.foo(/*caret*/)
@@ -99,7 +99,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::Bar;
+        use crate::baz::Bar;
 
         fn main() {
             Bar./*caret*/
@@ -117,7 +117,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::{Bar, Foo};
+        use crate::baz::{Bar, Foo};
 
         fn main() {
             Bar.foo()/*caret*/
@@ -137,7 +137,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::Bar;
+        use crate::baz::Bar;
 
         fn main() {
             Bar.fo/*caret*/
@@ -157,7 +157,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::{Bar, Foo};
+        use crate::baz::{Bar, Foo};
 
         fn main() {
             Bar.foo()/*caret*/
@@ -179,7 +179,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::{Bar, Foo};
+        use crate::baz::{Bar, Foo};
 
         fn main() {
             Bar.fo/*caret*/
@@ -197,7 +197,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::{Bar, Foo};
+        use crate::baz::{Bar, Foo};
 
         fn main() {
             Bar.foo()/*caret*/
@@ -217,7 +217,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::Bar;
+        use crate::baz::Bar;
 
         fn main() {
             Bar.fo/*caret*/()
@@ -235,7 +235,7 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
             }
         }
 
-        use baz::Bar;
+        use crate::baz::Bar;
 
         fn main() {
             Bar.foo(/*caret*/)

--- a/src/test/kotlin/org/rust/lang/core/completion/RsVisibilityCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsVisibilityCompletionTest.kt
@@ -5,9 +5,6 @@
 
 package org.rust.lang.core.completion
 
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
-
 class RsVisibilityCompletionTest : RsCompletionTestBase() {
     fun `test named field decl`() = checkCompletion("pub", """
         struct S {
@@ -116,7 +113,6 @@ class RsVisibilityCompletionTest : RsCompletionTestBase() {
         const /*caret*/fn foo() {}
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test no completion for function after async`() = checkNotContainsCompletion("pub", """
         async /*caret*/fn foo() {}
     """)

--- a/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
@@ -6,8 +6,10 @@
 package org.rust.lang.core.dfa
 
 import org.intellij.lang.annotations.Language
-import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.block
 import org.rust.lang.core.psi.ext.descendantsOfType
@@ -976,7 +978,6 @@ class RsControlFlowGraphTest : RsTestBase() {
         Termination
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test async block with infinite loop`() = testCFG("""
         fn foo() {
             1;

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
@@ -8,7 +8,6 @@ package org.rust.lang.core.macros.decl
 import com.intellij.psi.tree.TokenSet
 import org.rust.*
 import org.rust.cargo.project.model.cargoProjects
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2018
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2021
 import org.rust.cargo.util.parseSemVer
 import org.rust.lang.core.macros.RsMacroExpansionTestBase
@@ -139,7 +138,6 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() { let a; let b; let Some(1 | 2); }
     """)
 
-    @MockEdition(EDITION_2018)
     fun `test pat 2018 edition`() = doTest("""
         macro_rules! foo {
             ($ i1:pat | $ i2:pat) => { fn foo() { let $ i1; let $ i2; } }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.resolve
 
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.psi.RsTupleFieldDecl
 
 class RsCfgAttrResolveTest : RsResolveTestBase() {
@@ -103,7 +102,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test inline mod with cfg 2`() = checkByCode("""
         #[cfg(not(intellij_rust))]
         mod my {
@@ -117,7 +115,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
 
     // From https://github.com/rust-lang/hashbrown/blob/09e43a8cf97f37b17768b98f28291a24c5767847/src/lib.rs#L52-L68
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import inside inline mod with cfg`() = checkByCode("""
         #[cfg(not(intellij_rust))]
         mod my {
@@ -136,7 +133,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import overrides cfg-disabled item`() = checkByCode("""
         use foo::func;
         mod foo {
@@ -156,7 +152,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
 
     // https://github.com/clap-rs/clap/blob/5a1a209965bf28d3badafec8da6c5c975d3a686f/src/util/mod.rs#L13-L17
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test atom import of extern crate overrides cfg-disabled item`() = stubOnlyResolve("""
     //- lib.rs
         pub fn func() {}
@@ -175,7 +170,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         } //^ lib.rs
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test resolve inside inline mod with cfg 1`() = checkByCode("""
         #[cfg(not(intellij_rust))]
@@ -192,7 +186,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test resolve inside inline mod with cfg 2`() = checkByCode("""
         #[cfg(not(intellij_rust))]
@@ -206,7 +199,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
          //X
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test resolve inside non-inline mod with cfg`() = stubOnlyResolve("""
     //- main.rs
@@ -629,7 +621,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         //^ lib.rs
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg_attr with path on mod declaration`() = stubOnlyResolve("""
     //- bar.rs
@@ -643,7 +634,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }  //^ bar.rs
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test disabled cfg_attr with path on mod declaration`() = stubOnlyResolve("""
     //- foo.rs
@@ -658,7 +648,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     @ExpandMacros
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg-disabled macro call expanded to inline mod`() = stubOnlyResolve("""
     //- main.rs
@@ -683,7 +672,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     // Actual resolve result is not important, because proper multiresolve is not yet supported in new resolve.
     @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import inside expanded shadowed mod 1`() = stubOnlyResolve("""
     //- lib.rs
         macro_rules! as_is { ($($ t:tt)*) => { $($ t)* } }
@@ -709,7 +697,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     // From https://github.com/tokio-rs/tokio/blob/97c2c4203cd7c42960cac895987c43a17dff052e/tokio/src/process/mod.rs#L132-L134
     @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import inside expanded shadowed mod 2`() = stubOnlyResolve("""
     //- lib.rs
         macro_rules! as_is { ($($ t:tt)*) => { $($ t)* } }
@@ -735,7 +722,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     // From https://github.com/rust-lang/rust/blob/e0ef0fc392963438af5f0343bf7caa46fb9c3ec3/library/alloc/src/lib.rs#L164-L169
     @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import to shadowed mod`() = checkByCode("""
         #[cfg(intellij_rust)]
         pub mod boxed {
@@ -752,7 +738,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     // We check that there are no exceptions during building CrateDefMap (actual resolve result is not important)
     @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import to mod shadowed by expanded mod`() = checkByCode("""
         #[cfg(not(intellij_rust))]
         mod my {
@@ -865,7 +850,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve to 'cfg(not(test))' in external dependencies`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         #[cfg(test)]
@@ -884,7 +868,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }                      //^ dep-lib/not_test.rs
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test file level cfg attribute 1`() = stubOnlyResolve("""
     //- main.rs
@@ -903,7 +886,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         pub fn func() {}
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test file level cfg attribute 2`() = stubOnlyResolve("""
     //- main.rs
@@ -922,7 +904,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         pub fn func() {}
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg-enabled glob import overrides cfg-disabled named import`() = checkByCode("""
         #[cfg(not(intellij_rust))]
@@ -942,7 +923,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         } //^
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg-disabled item is unresolved 1`() = stubOnlyResolve("""
     //- main.rs
@@ -955,7 +935,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         pub fn func() {}
      """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg-disabled item is unresolved 2`() = stubOnlyResolve("""
     //- main.rs
@@ -969,7 +948,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test cfg-disabled item is resolved from cfg-disabled function 1`() = stubOnlyResolve("""
     //- main.rs
         #[cfg(not(intellij_rust))]
@@ -984,7 +962,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
 
     @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test cfg-disabled mod does not affect cfg-enabled mod`() = stubOnlyResolve("""
     //- main.rs
         #[cfg(intellij_rust)]
@@ -1002,7 +979,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     """)
 
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test cfg-disabled glob-import does not affect cfg-enabled one 1`() = checkByCode("""
         fn main() {
             let _ = Foo;
@@ -1025,7 +1001,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     """)
 
     @MockAdditionalCfgOptions("intellij_rust")
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test cfg-disabled glob-import does not affect cfg-enabled one 2`() = checkByCode("""
         fn main() {
             let _ = Foo;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
@@ -5,11 +5,9 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsDoctestInjectionResolveTest : RsResolveTestBase() {
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -80,7 +78,6 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
         pub fn foo() {}
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test qualified macro call inside function`() = stubOnlyResolve("""
     //- lib.rs
@@ -96,7 +93,6 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
                    //X
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve to inline mod`() = stubOnlyResolve("""
     //- lib.rs
         /// ```
@@ -111,7 +107,6 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
         fn foo() {}
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve in inline mod`() = stubOnlyResolve("""
     //- lib.rs
         /// ```
@@ -125,7 +120,6 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
         fn foo() {}
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve to super mod`() = stubOnlyResolve("""
     //- lib.rs
         /// ```

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
@@ -7,8 +7,6 @@ package org.rust.lang.core.resolve
 
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
 
 class RsIncludeMacroResolveTest : RsResolveTestBase() {
 
@@ -188,7 +186,6 @@ class RsIncludeMacroResolveTest : RsResolveTestBase() {
     """)
 
     @ExpandMacros
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro call in included file 1`() = checkResolve("""
     //- main.rs
         macro_rules! foo {
@@ -201,7 +198,6 @@ class RsIncludeMacroResolveTest : RsResolveTestBase() {
     """)
 
     @ExpandMacros
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro call in included file 2`() = checkResolve("""
     //- main.rs
         macro_rules! gen_use {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -5,8 +5,9 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.stdext.BothEditions
 
 @ExpandMacros
@@ -679,7 +680,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
                  //^ main.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test mod declared with macro inside inline expanded mod`() = stubOnlyResolve("""
     //- main.rs
         macro_rules! gen_mod_decl_item {
@@ -699,7 +699,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
                  //X
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test mod with path attribute declared with macro`() = stubOnlyResolve("""
     //- main.rs
         macro_rules! foo {
@@ -882,7 +881,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
     """)
 
     // we only test that there are no exception with new resolve
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test local_inner_macros expanded to extern crate`() = stubOnlyResolve("""
     //- main.rs
@@ -899,7 +897,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test expand macro with incomplete path`() = stubOnlyResolve("""
     //- main.rs
         macro_rules! gen_func {
@@ -931,7 +928,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         } //^
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro call expanded to macro def and macro call 1`() = checkByCode("""
         macro_rules! as_is { ($($ t:tt)*) => { $($ t)* }; }
         as_is! {
@@ -943,7 +939,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
 
     // when resolving macro call expanded from other macro call,
     // firstly left sibling expanded elements should be processed
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro call expanded to macro def and macro call 2`() = checkByCode("""
         macro_rules! foo {
             (1) => {
@@ -965,7 +960,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         } //^
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test propagate expanded macro def to grandparent mod`() = checkByCode("""
         mod inner {
             #[macro_use]

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ignoreInNewResolve
 
 class RsMacroResolveTest : RsResolveTestBase() {
@@ -162,7 +160,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         } //^
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve macro in lexical order 4`() = checkByCode("""
         mod a {
             macro_rules! foo { () => {} }
@@ -174,7 +171,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve macro in lexical order 5`() = checkByCode("""
         mod a {
             macro_rules! foo { () => {} }
@@ -186,7 +182,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test expand macro in lexical order 6`() = checkByCode("""
         mod a {
             struct Foo1;
@@ -200,7 +195,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve macro in lexical order 7`() = checkByCode("""
         mod a {
             struct Foo1;
@@ -280,7 +274,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
     """)
 
     // TODO
-    @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in nested mod (reexport)`() = expect<IllegalStateException> {
         checkByCode("""
             mod inner {
@@ -295,7 +288,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         """)
     }
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in nested mod (import)`() = checkByCode("""
         mod inner {
             #[macro_export]
@@ -311,7 +303,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in nested mod (macro call)`() = checkByCode("""
         mod inner {
             #[macro_export]
@@ -326,7 +317,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
              //^
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in crate root (reexport)`() = checkByCode("""
         #[macro_export]
         macro_rules! foo_ {
@@ -337,7 +327,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
               //^
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in crate root (import)`() = checkByCode("""
         #[macro_export]
         macro_rules! foo_ {
@@ -351,7 +340,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in crate root (macro call fqn)`() = checkByCode("""
         #[macro_export]
         macro_rules! foo_ {
@@ -364,7 +352,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
              //^
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test legacy textual macro reexported as macro 2 in crate root (macro call)`() = checkByCode("""
         #[macro_export]
         macro_rules! foo_ {
@@ -377,7 +364,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
         //^
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test propagate expanded macro def`() = checkByCode("""
         mod outer {
             #[macro_use]
@@ -399,7 +385,6 @@ class RsMacroResolveTest : RsResolveTestBase() {
     """)
 
     // From https://github.com/seed-rs/seed/blob/d9935ee25148c151931160d188d5f0e67c746cba/src/shortcuts.rs#L9-L45
-    @MockEdition(Edition.EDITION_2018)
     fun `test generate two macro defs with same name`() = checkByCode("""
         mod outer {
             macro_rules! with_dollar_sign {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
@@ -7,8 +7,6 @@ package org.rust.lang.core.resolve
 
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.lang.core.psi.ext.RsReferenceElement
 
 class RsMultiResolveTest : RsResolveTestBase() {
@@ -88,7 +86,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }         //^
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test use multi reference, item in duplicated inline mod`() = doTest("""
         mod m {
             pub fn foo() {}
@@ -102,7 +99,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
         } //^
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test duplicated inline mod`() = doTest("""
         mod m {}
         mod m {}
@@ -131,7 +127,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test import item vs local item`() = doTest("""
         mod m {
             pub fn foo() {}
@@ -145,7 +140,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
 
     // From https://github.com/Alexhuszagh/rust-lexical/blob/1ec9d7660e70ab731eecb3390bdf95e767548dcc/lexical-core/src/util/slice_index.rs#L82
     @ExpandMacros
-    @MockEdition(Edition.EDITION_2018)
     fun `test import item vs local item (inside expanded mod)`() = doTest("""
         mod m {
             pub fn foo() {}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsNamespaceResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsNamespaceResolveTest.kt
@@ -178,8 +178,8 @@ class RsNamespaceResolveTest : RsResolveTestBase() {
             pub use self::inner::inner;
         }
 
-        mod bar { pub use foo::inner; }
-        use bar::inner;
+        mod bar { pub use crate::foo::inner; }
+        use crate::bar::inner;
 
         fn f() { inner(); }
                  //^

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsNonPhysicalFileResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsNonPhysicalFileResolveTest.kt
@@ -9,8 +9,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.lang.RsLanguage
 
 class RsNonPhysicalFileResolveTest : RsResolveTestBase() {
@@ -43,7 +41,6 @@ class RsNonPhysicalFileResolveTest : RsResolveTestBase() {
         tryResolveEverything(memoryOnlyFile(code))
     }
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test macro 2`() {
         val code = """
             macro macro2() {}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.resolve
 
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -49,7 +48,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo_bar { () => {} }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro rules with underscore alias`() = stubOnlyResolve("""
     //- main.rs
         #[macro_use]
@@ -227,7 +225,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro inside import 1`() = stubOnlyResolve("""
     //- main.rs
         use test_package::foo;
@@ -237,7 +234,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo { () => {} }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro inside import 2`() = stubOnlyResolve("""
     //- main.rs
         use test_package::foo;
@@ -249,7 +245,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro inside import 3`() = stubOnlyResolve("""
     //- main.rs
         mod inner {
@@ -261,7 +256,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo { () => {} }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro inside import 4`() = stubOnlyResolve("""
     //- main.rs
         mod inner1 {
@@ -355,7 +349,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro with absolute path`() = stubOnlyResolve("""
     //- main.rs
         mod test_package {}
@@ -410,7 +403,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import wins extern crate import`() = stubOnlyResolve("""
     //- main.rs
         #[macro_use]
@@ -427,7 +419,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo { () => {}; }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test import wins macro from prelude`() = stubOnlyResolve("""
     //- main.rs
@@ -440,7 +431,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! assert_eq { () => {}; }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro from import inside function wins over macro from crate root`() = stubOnlyResolve("""
     //- lib.rs
         #[macro_export]
@@ -539,7 +529,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro reexported as macro 2`() = stubOnlyResolve("""
     //- lib.rs
         fn bar() {
@@ -551,7 +540,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         pub use foo_ as foo;
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (same mod)`() = stubOnlyResolve("""
     //- lib.rs
         mod inner {
@@ -561,7 +549,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }           //X
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (different mod same crate)`() = stubOnlyResolve("""
     //- lib.rs
         inner::foo!();
@@ -571,7 +558,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }           //X
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (different crate)`() = stubOnlyResolve("""
     //- main.rs
         test_package::foo!();
@@ -581,7 +567,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                 //X
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (inside function body)`() = expect<IllegalStateException> {
         stubOnlyResolve("""
         //- lib.rs
@@ -593,7 +578,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         """)
     }
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (import)`() = stubOnlyResolve("""
     //- main.rs
         use test_package::foo;
@@ -605,7 +589,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                 //X
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test macro 2 (unresolved in textual scope)`() = stubOnlyResolve("""
     //- lib.rs
         pub macro foo() {}
@@ -643,7 +626,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                             //^ dep-lib-new/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve reference without extern crate item 1 (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -652,7 +634,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                 //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve reference without extern crate item 2 (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -679,7 +660,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                                    //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve module instead of crate (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -703,7 +683,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                                    //^ lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve module instead of crate in nested mod (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -717,7 +696,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve module instead of crate in use item in nested mod (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -731,7 +709,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve crate instead of module in absolute use item (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -743,7 +720,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                             //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extern crate item (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -754,7 +730,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                                    //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extern crate item alias 1 (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -765,7 +740,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                             //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extern crate item alias 2 (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -776,7 +750,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                                    //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extern crate item alias with same name (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -787,7 +760,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                                    //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extern crate in super chain (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -799,7 +771,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extern crate alias`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -812,7 +783,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extern crate alias shadows implicit extern crate names`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -827,7 +797,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test local item shadows extern crate alias`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -844,7 +813,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
     """)
 
     @UseOldResolve
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test ambiguity of extern crate alias and other item with the same name`() {
         stubOnlyResolve("""
         //- dep-lib/lib.rs
@@ -860,7 +828,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         """)
     }
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
     fun `test ambiguity of extern crate alias and prelude item`() = expect<IllegalStateException> {
         stubOnlyResolve("""
@@ -877,7 +844,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
     }
 
     // Issue https://github.com/intellij-rust/intellij-rust/issues/3846
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extra use of crate name 1`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -887,7 +853,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                           //^ dep-lib/lib.rs
     """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve(project))
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test "extra use of crate name 1" with alias`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -897,7 +862,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                  //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extra use of crate name 2`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -907,7 +871,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                           //^ dep-lib/lib.rs
     """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve(project))
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import the same name as a crate name`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -918,7 +881,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                            //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import the same name as a crate name 2`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         mod dep_lib_target;
@@ -930,7 +892,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
     """)
 
     // Issue https://github.com/intellij-rust/intellij-rust/issues/3912
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test star import of item with the same name as extern crate`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         mod dep_lib_target {}
@@ -953,7 +914,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                                               //^ trans-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test complex circular dependent star imports`() = stubOnlyResolve("""
     //- foo.rs
         pub struct S1;
@@ -975,7 +935,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }      //^ foo.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test re-exported crate via use item without "extern crate" 2018 edition`() = stubOnlyResolve("""
     //- trans-lib/lib.rs
         pub struct Foo;
@@ -988,7 +947,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                //^ trans-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test extern crate double renaming`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub fn func() {}
@@ -1003,7 +961,6 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
     """)
 
     // https://github.com/intellij-rust/intellij-rust/issues/7215
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test usual import override glob-import`() = stubOnlyResolve("""
     //- lib.rs
         pub mod header {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.resolve
 
 import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
 class RsPackageLibraryResolveTest : RsResolveTestBase() {
@@ -624,8 +625,8 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
 
         mod baz;
     //- baz.rs
-        use bar::S;
-               //^ lib.rs
+        use crate::bar::S;
+                      //^ lib.rs
     """)
 
     fun `test transitive dependency on the same crate`() = stubOnlyResolve("""
@@ -660,7 +661,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                                    //^ dep-lib/lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @MockEdition(Edition.EDITION_2015)
     fun `test resolve reference without extern crate item 1 (edition 2015)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -669,7 +670,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                 //^ unresolved
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @MockEdition(Edition.EDITION_2015)
     fun `test resolve reference without extern crate item 2 (edition 2015)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
@@ -690,7 +691,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                                    //^ lib.rs
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @MockEdition(Edition.EDITION_2015)
     fun `test resolve module instead of crate (edition 2015)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 
 class RsPreciseTraitMatchingTest : RsResolveTestBase() {
@@ -548,7 +546,6 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         }   //^
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test cycle using glob-imports (and underscore trait re-export)`() = checkByCode("""
         mod a {
             pub use crate::b::*;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -365,11 +365,11 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
                 fn do_x(&self);
             }
 
-            impl X for ::Foo {
+            impl X for crate::Foo {
                 fn do_x(&self) {}
             }
 
-            impl X for ::Bar {
+            impl X for crate::Bar {
                 fn do_x(&self) {}
                    //X
             }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -6,13 +6,11 @@
 package org.rust.lang.core.resolve
 
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2018
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
 import org.rust.lang.core.macros.MacroExpansionScope
 
 @MinRustcVersion("1.46.0")
-@MockEdition(EDITION_2018)
 @ExpandMacros(MacroExpansionScope.WORKSPACE)
 @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
 @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -6,11 +6,9 @@
 package org.rust.lang.core.resolve
 
 import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
 
-@MockEdition(CargoWorkspace.Edition.EDITION_2018)
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
 class RsProcMacroResolveTest : RsResolveTestBase() {
     // FIXME

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
@@ -63,19 +63,17 @@ class RsResolveCacheTest : RsTestBase() {
     """, "\b2", Testmarks.removeChangedElement)
 
     fun `test resolve correctly without global cache invalidation 4`() = checkResolvedToXY("""
-        mod foo { pub struct S; }
+        mod really_long_name { pub struct S; }
            //Y
         mod bar {
-            mod foo { pub struct S; }
+            mod really_long_name { pub struct S; }
                //X
             fn baz() {
                 /*caret*/
-                foo
-                //^
-                ::S;
-            }
+                really_long_name::S;
+            }             //^
         }
-    """, "::")
+    """, "crate::")
 
     fun `test edit local pat binding`() = checkResolvedAndThenUnresolved("""
         fn main() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -5,9 +5,7 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.MockEdition
 import org.rust.MockRustcVersion
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ignoreInNewResolve
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.ext.RsFieldDecl
@@ -574,7 +572,6 @@ class RsResolveTest : RsResolveTestBase() {
          //X
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test nested super 2`() = checkByCode("""
         mod foo {
             mod bar {
@@ -590,7 +587,6 @@ class RsResolveTest : RsResolveTestBase() {
          //X
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test function and mod with same name`() = checkByCode("""
         mod foo {}
 
@@ -1416,7 +1412,6 @@ class RsResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test 'pub (in incomplete_path)'`() = checkByCode("""
         mod foo {
             mod bar {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -1002,9 +1002,8 @@ class RsResolveTest : RsResolveTestBase() {
           //X
         mod inner {
             fn main() {
-                ::inner::super::foo();
-                               //^
-            }
+                crate::inner::super::foo();
+            }                      //^
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2015.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2015.kt
@@ -8,9 +8,9 @@ package org.rust.lang.core.resolve
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
-@MockEdition(CargoWorkspace.Edition.EDITION_2015)
+@MockEdition(Edition.EDITION_2015)
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsStdlibResolveTestEdition2015 : RsResolveTestBase() {
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
@@ -5,10 +5,13 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
+import org.rust.ignoreInNewResolve
 
-@MockEdition(CargoWorkspace.Edition.EDITION_2018)
+@MockEdition(Edition.EDITION_2018)
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsStdlibResolveTestEdition2018 : RsResolveTestBase() {
     fun `test extern crate std is not injected on 2018 edition`() = stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2021.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2021.kt
@@ -9,10 +9,10 @@ import org.rust.MinRustcVersion
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 @MinRustcVersion("1.56.0-nightly")
-@MockEdition(CargoWorkspace.Edition.EDITION_2021)
+@MockEdition(Edition.EDITION_2021)
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsStdlibResolveTestEdition2021 : RsResolveTestBase() {
     fun `test 2021 edition prelude`() = stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -51,8 +51,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
 
     fun `test mod decl 2`() = stubOnlyResolve("""
     //- foo/mod.rs
-        use bar::Bar;
-                //^ bar.rs
+        use crate::bar::Bar;
+                      //^ bar.rs
 
     //- main.rs
         mod bar;
@@ -197,9 +197,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn quux() {}
     //- sub/mod.rs
         fn foo() {
-            ::quux();
-            //^ main.rs
-       }
+            crate::quux();
+       }         //^ main.rs
     """)
 
     fun `test resolve explicit mod path mod rs 2`() = stubOnlyResolve("""
@@ -210,9 +209,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn quux() {}
     //- sub/bar/mod.rs
         fn foo() {
-            ::quux();
-            //^ main.rs
-       }
+            crate::quux();
+       }         //^ main.rs
     """)
 
     fun `test resolve explicit mod path mod rs windows path separator`() = stubOnlyResolve("""
@@ -223,9 +221,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn quux() {}
     //- sub/bar/mod.rs
         fn foo() {
-            ::quux();
-            //^ main.rs
-       }
+            crate::quux();
+       }         //^ main.rs
     """)
 
     fun `test module path`() = stubOnlyResolve("""
@@ -238,9 +235,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn quux() {}
     //- aaa/bar.rs
         fn foo() {
-            ::quux();
-            //^ main.rs
-        }
+            crate::quux();
+        }        //^ main.rs
     """)
 
     fun `test module path 2`() = stubOnlyResolve("""
@@ -253,9 +249,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn quux() {}
     //- aaa/bbb/bar.rs
         fn foo() {
-            ::quux();
-            //^ main.rs
-        }
+            crate::quux();
+        }        //^ main.rs
     """)
 
     fun `test module path 3`() = stubOnlyResolve("""
@@ -269,9 +264,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn quux() {}
     //- aaa/bbb/ccc.rs
         fn foo() {
-            ::quux();
-            //^ main.rs
-        }
+            crate::quux();
+        }        //^ main.rs
     """)
 
     fun `test empty module path`() = stubOnlyResolve("""
@@ -285,9 +279,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn quux() {}
     //- bbb.rs
         fn foo() {
-            ::quux();
-            //^ main.rs
-        }
+            crate::quux();
+        }        //^ main.rs
     """)
 
     fun `test relative module path`() = stubOnlyResolve("""
@@ -301,9 +294,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
 
     //- aaa/bar.rs
         fn foo() {
-            ::quux();
-            //^ main.rs
-        }
+            crate::quux();
+        }        //^ main.rs
     """)
 
     fun `test path inside inline module in crate root`() = stubOnlyResolve("""
@@ -408,8 +400,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         stubOnlyResolve("""
         //- foo.rs
             fn main() {
-                ::bar::hello();
-            }         //^ bar.rs
+                crate::bar::hello();
+            }             //^ bar.rs
 
         //- lib.rs
             mod foo;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.MockEdition
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ignoreInNewResolve
 
 class RsStubOnlyResolveTest : RsResolveTestBase() {
@@ -769,7 +767,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test item reexported from 'pub(crate)' mod in dependency crate`() = stubOnlyResolve("""
     //- main.rs
         use test_package::*;
@@ -789,7 +786,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub use foo::*;
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve in detached file`() = stubOnlyResolve("""
     //- detached.rs
         macro foo() {}
@@ -799,7 +795,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         } //^ detached.rs
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve in detached file (to inline mod)`() = stubOnlyResolve("""
     //- detached.rs
         mod inner {
@@ -811,7 +806,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         } //^ detached.rs
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve in detached file (in inline mod)`() = stubOnlyResolve("""
     //- detached.rs
         mod inner {
@@ -823,7 +817,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve in detached file (from inline mod)`() = stubOnlyResolve("""
     //- detached.rs
         fn func() {}
@@ -835,7 +828,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve in detached file (in inner mod)`() = stubOnlyResolve("""
     //- detached.rs
         mod inner;
@@ -847,7 +839,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         } //^ detached/inner.rs
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve in detached file ($crate)`() = stubOnlyResolve("""
     //- detached.rs
         mod inner {
@@ -869,7 +860,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         } //^ detached.rs
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test resolve in detached file (in import)`() = stubOnlyResolve("""
     //- detached.rs
         pub use foo::func;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -694,7 +694,6 @@ class RsUseResolveTest : RsResolveTestBase() {
                   //^ unresolved
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test unified paths 2018 edition`() = checkByCode("""
         mod foo {
             pub fn bar() {}
@@ -735,7 +734,6 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test use incomplete path`() = checkByCode("""
         use foo::;
         mod foo {
@@ -750,7 +748,6 @@ class RsUseResolveTest : RsResolveTestBase() {
         } //^
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test complex cyclic chain with glob imports and aliases`() = checkByCode("""
         mod a {
             pub use crate::b::*;
@@ -770,7 +767,6 @@ class RsUseResolveTest : RsResolveTestBase() {
     """)
 
     @UseOldResolve
-    @MockEdition(Edition.EDITION_2018)
     fun `test usual import overrides glob import`() = checkByCode("""
         mod foo1 {
             pub mod bar {
@@ -799,7 +795,6 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test complex glob imports`() = checkByCode("""
         pub mod inner1 {
             pub mod foo {
@@ -822,7 +817,6 @@ class RsUseResolveTest : RsResolveTestBase() {
     """)
 
     // based on https://github.com/rust-lang/cargo/blob/875e0123259b0b6299903fe4aea0a12ecde9324f/src/cargo/util/mod.rs#L23
-    @MockEdition(Edition.EDITION_2018)
     fun `test import adds same name as existing 1`() = checkByCode("""
         use foo::foo;
         mod foo {
@@ -837,7 +831,6 @@ class RsUseResolveTest : RsResolveTestBase() {
     """)
 
     // based on https://github.com/rust-lang/cargo/blob/875e0123259b0b6299903fe4aea0a12ecde9324f/src/cargo/util/mod.rs#L23
-    @MockEdition(Edition.EDITION_2018)
     fun `test import adds same name as existing 2`() = checkByCode("""
         use foo::foo;
         mod foo {
@@ -854,7 +847,6 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockEdition(Edition.EDITION_2018)
     fun `test two usual imports with same name in different namespaces`() = checkByCode("""
         mod a {
             pub mod foo {}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -14,9 +14,8 @@ class RsUseResolveTest : RsResolveTestBase() {
 
     fun `test view path`() = checkByCode("""
         mod foo {
-            use ::bar::hello;
-                       //^
-        }
+            use crate::bar::hello;
+        }                 //^
 
         pub mod bar {
             pub fn hello() { }
@@ -29,7 +28,7 @@ class RsUseResolveTest : RsResolveTestBase() {
           //X
 
         mod inner {
-            use foo;
+            use crate::foo;
 
             fn inner() {
                 foo();
@@ -40,8 +39,7 @@ class RsUseResolveTest : RsResolveTestBase() {
 
     fun `test child from parent`() = checkByCode("""
         mod foo {
-            // This visits `mod foo` twice during resolve
-            use foo::bar::baz;
+            use crate::foo::bar::baz;
 
             pub mod bar {
                 pub fn baz() {}
@@ -60,7 +58,7 @@ class RsUseResolveTest : RsResolveTestBase() {
           //X
 
         mod inner {
-            use foo as bar;
+            use crate::foo as bar;
 
             fn main() {
                 bar();
@@ -73,13 +71,13 @@ class RsUseResolveTest : RsResolveTestBase() {
         mod foo {
             pub fn a() {}
                  //X
-            pub use bar::b as c;
-            pub use bar::d as e;
+            pub use crate::bar::b as c;
+            pub use crate::bar::d as e;
         }
 
         mod bar {
-            pub use foo::a as b;
-            pub use foo::c as d;
+            pub use crate::foo::a as b;
+            pub use crate::foo::c as d;
         }
 
         fn main() {
@@ -102,9 +100,8 @@ class RsUseResolveTest : RsResolveTestBase() {
 
     fun `test view path glob ident`() = checkByCode("""
         mod foo {
-            use bar::{hello as h};
-                      //^
-        }
+            use crate::bar::{hello as h};
+        }                  //^
 
         pub mod bar {
             pub fn hello() { }
@@ -114,9 +111,8 @@ class RsUseResolveTest : RsResolveTestBase() {
 
     fun `test view path glob self`() = checkByCode("""
         mod foo {
-            use bar::{self};
-                     //^ 62
-        }
+            use crate::bar::{self};
+        }                  //^
 
         pub mod bar { }
                //X
@@ -138,7 +134,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
 
         mod bar {
-            use foo::{hello};
+            use crate::foo::{hello};
 
             fn main() {
                 hello();
@@ -154,7 +150,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
 
         mod bar {
-            use foo::{self};
+            use crate::foo::{self};
 
             fn main() {
                 foo::hello();
@@ -170,7 +166,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
 
         mod bar {
-            use foo::{hello as spam};
+            use crate::foo::{hello as spam};
 
             fn main() {
                 spam();
@@ -183,14 +179,14 @@ class RsUseResolveTest : RsResolveTestBase() {
         mod foo {
             pub fn a() {}
                  //X
-            pub use bar::{b as c, d as e};
+            pub use crate::bar::{b as c, d as e};
         }
 
         mod bar {
-            pub use foo::{a as b, c as d};
+            pub use crate::foo::{a as b, c as d};
         }
 
-        use foo::e;
+        use crate::foo::e;
 
         fn main() {
             e();
@@ -200,9 +196,8 @@ class RsUseResolveTest : RsResolveTestBase() {
 
     fun `test enum variant`() = checkByCode("""
         mod foo {
-            use bar::E::{X};
-                       //^
-        }
+            use crate::bar::E::{X};
+        }                     //^
 
         mod bar {
             pub enum E {
@@ -232,7 +227,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
 
         mod b {
-            use a::*;
+            use crate::a::*;
 
             fn main() {
                 foo();
@@ -304,8 +299,8 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
 
         mod c {
-            use a::*;
-            use b::*;
+            use crate::a::*;
+            use crate::b::*;
 
             fn main() {
                 bar()
@@ -321,11 +316,11 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
 
         mod b {
-            pub use a::*;
+            pub use crate::a::*;
         }
 
         mod c {
-            use b::*;
+            use crate::b::*;
 
             fn main() {
                 foo()
@@ -334,6 +329,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     fun `test only braces`() = checkByCode("""
         struct Spam;
               //X
@@ -605,10 +601,10 @@ class RsUseResolveTest : RsResolveTestBase() {
             pub use crate::bar::*;
         }
         mod foo {
-            use quux1::Foo;
+            use crate::quux1::Foo;
         }
         mod bar {
-            pub use quux2::Foo;
+            pub use crate::quux2::Foo;
         }
         mod quux1 {
             pub struct Foo;
@@ -674,7 +670,7 @@ class RsUseResolveTest : RsResolveTestBase() {
 
     fun `test cyclic dependent imports`() = checkByCode("""
         mod a {
-            pub use b::*;
+            pub use crate::b::*;
 
             pub mod c {
                 pub struct Foo;
@@ -684,7 +680,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }                //^
 
         mod b {
-            pub use a::*;
+            pub use crate::a::*;
             pub use self::c::*;
         }
     """)

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -8,7 +8,6 @@ package org.rust.lang.core.type
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
@@ -702,7 +701,6 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ !
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test await postfix 2018 (anon)`() = testExpr("""
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }
@@ -713,7 +711,6 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test await postfix 2018 (adt)`() = testExpr("""
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -9,6 +9,7 @@ import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
     fun `test function call`() = testExpr("""
@@ -726,6 +727,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    @MockEdition(Edition.EDITION_2015)
     fun `test await postfix 2015`() = testExpr("""
         struct S { await: i32 }
         fn main() {

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.lang.core.type
 
-import org.rust.*
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibAndStdlibLikeDependencyRustProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyFloat
@@ -858,7 +860,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ &S<X>
     """)
 
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test await pin future`() = stubOnlyTypeInfer("""
     //- main.rs
         use std::future::Future;

--- a/src/test/kotlin/org/rustPerformanceTests/RsCompletionPerformanceTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsCompletionPerformanceTest.kt
@@ -6,15 +6,12 @@
 package org.rustPerformanceTests
 
 import com.intellij.openapi.util.registry.Registry
-import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.lang.core.completion.RsCompletionTestBase
 import org.rust.stdext.Timings
 import org.rust.stdext.repeatBenchmark
 
-@MockEdition(Edition.EDITION_2018)
 class RsCompletionPerformanceTest : RsCompletionTestBase() {
     override fun isPerformanceTest(): Boolean = false
 


### PR DESCRIPTION
Currently, we have the 2015 edition as default in tests. This PR changes the default edition to 2021.
Most tests aren't affected by this change (i.e. work in all three 2015/2018/2021 editions).
Tests related to the 2015 edition now use explicit `@MockEdition(EDITION_2015)`, other tests were converted to the 2018/2021 edition.

changelog: Make 2021 default edition in tests