### PR TITLE
TY: fix #8236

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -6,9 +6,13 @@
 package org.rust.lang.core.resolve
 
 import com.intellij.util.SmartList
+import com.intellij.util.recursionSafeLazy
 import gnu.trove.THashMap
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.RsTraitRef
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.isValidProjectMember
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.infer.constGenerics
@@ -29,7 +33,7 @@ class RsCachedImplItem(
     val isValid: Boolean = impl.isValidProjectMember && !impl.isReservationImpl && !impl.isNegativeImpl
     val isInherent: Boolean get() = traitRef == null
 
-    val implementedTrait: BoundElement<RsTraitItem>? by lazy(PUBLICATION) { traitRef?.resolveToBoundTrait() }
+    val implementedTrait: BoundElement<RsTraitItem>? by recursionSafeLazy { traitRef?.resolveToBoundTrait() }
     val typeAndGenerics: Triple<Ty, List<TyTypeParameter>, List<CtConstParameter>>? by lazy(PUBLICATION) {
         impl.typeReference?.type?.let { Triple(it, impl.generics, impl.constGenerics) }
     }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
@@ -226,4 +226,24 @@ class RsTypeAwareCompletionTest : RsCompletionTestBase() {
             (*a)./*caret*/
         }
     """)
+
+    // Issue https://github.com/intellij-rust/intellij-rust/issues/8236
+    fun `test select impl with associated type projection in trait ref`() = checkContainsCompletion("foo", """
+        struct S;
+        struct X;
+        trait Trait { type Item; }
+        impl Trait for S { type Item = X; }
+
+        trait Bound<A> {}
+        impl Bound<<S as Trait>::Item> for S {}
+
+        struct Wrap<B>(B);
+        impl<C, D> Wrap<C> where C: Bound<D> {
+            fn foo(&self) -> D { todo!() }
+        }
+        fn main() {
+            let a = Wrap(S);
+            a./*caret*/;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1970,4 +1970,21 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ u8
     """)
+
+    // Issue https://github.com/intellij-rust/intellij-rust/issues/8236
+    fun `test select impl with associated type projection in trait ref`() = testExpr("""
+        struct S;
+        struct X;
+        trait Trait { type Item; }
+        impl Trait for S { type Item = X; }
+
+        trait Bound<A> {}
+        impl Bound<<S as Trait>::Item> for S {}
+
+        fn foo<B, C>(_: B) -> C where B: Bound<C> { todo!() }
+        fn main() {
+            let a = foo(S);
+            a;
+        } //^ X
+    """)
 }


### PR DESCRIPTION
Fixes #8236

The issue occurs when there is an impl for some type and that type also used in an associated type projection in the trait ref:

```rust
impl Trait1<<S as Trait2>::Item> for S {}
           //^                     //^
```

In particular, the PR fixes completion of `foo` in this case:

```rust
struct S;
struct X;
trait Trait { type Item; }
impl Trait for S { type Item = X; }
trait Bound<A> {}
impl Bound<<S as Trait>::Item> for S {}
struct Wrap<B>(B);
impl<C, D> Wrap<C> where C: Bound<D> {
    fn foo(&self) -> D { todo!() }
}
fn main() {
    let a = Wrap(S);
    a./*caret*/;
}
```