### PR TITLE
DBG: second attempt to support debugging in Rider for Unreal Engine

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerDriverConfigurationProviderImpl.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerDriverConfigurationProviderImpl.kt
@@ -17,19 +17,25 @@ class RsDebuggerDriverConfigurationProviderImpl : RsDebuggerDriverConfigurationP
         @Suppress("MoveVariableDeclarationIntoWhen")
         val lldbStatus = RsDebuggerToolchainService.getInstance().getLLDBStatus()
         return when (lldbStatus) {
-            is LLDBStatus.Binaries -> RsLLDBDriverConfiguration(lldbStatus, isElevated)
+            LLDBStatus.Bundled -> RsLLDBDriverConfiguration(isElevated)
+            is LLDBStatus.Binaries -> RsCustomBinariesLLDBDriverConfiguration(lldbStatus, isElevated)
             else -> null
         }
     }
 }
 
-private class RsLLDBDriverConfiguration(
-    private val binaries: LLDBStatus.Binaries,
+private open class RsLLDBDriverConfiguration(
     private val isElevated: Boolean
 ) : LLDBDriverConfiguration() {
+    override fun isElevated(): Boolean = isElevated
+}
+
+private class RsCustomBinariesLLDBDriverConfiguration(
+    private val binaries: LLDBStatus.Binaries,
+    isElevated: Boolean
+) : RsLLDBDriverConfiguration(isElevated) {
     override fun getDriverName(): String = "Rust LLDB"
     override fun useSTLRenderers(): Boolean = false
     override fun getLLDBFrameworkFile(architectureType: ArchitectureType): File = binaries.frameworkFile
     override fun getLLDBFrontendFile(architectureType: ArchitectureType): File = binaries.frontendFile
-    override fun isElevated(): Boolean = isElevated
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
@@ -76,6 +76,7 @@ object RsDebugRunnerUtils {
             RsDebuggerToolchainService.LLDBStatus.Unavailable -> return false
             RsDebuggerToolchainService.LLDBStatus.NeedToDownload -> "Debugger is not loaded yet" to "Download"
             RsDebuggerToolchainService.LLDBStatus.NeedToUpdate -> "Debugger is outdated" to "Update"
+            RsDebuggerToolchainService.LLDBStatus.Bundled,
             is RsDebuggerToolchainService.LLDBStatus.Binaries -> return true
         }
 

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerGeneralSettingsConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerGeneralSettingsConfigurableUi.kt
@@ -8,7 +8,6 @@ package org.rust.debugger.settings
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.options.ConfigurableUi
 import com.intellij.ui.layout.panel
-import com.intellij.util.PlatformUtils
 import org.rust.debugger.RsDebuggerToolchainService
 import org.rust.debugger.RsDebuggerToolchainService.LLDBStatus
 import javax.swing.JComponent
@@ -16,11 +15,9 @@ import javax.swing.JComponent
 class RsDebuggerGeneralSettingsConfigurableUi : ConfigurableUi<RsDebuggerSettings>, Disposable {
     private val needsToolchainSettings: Boolean
         get() {
-            // CLion has own Toolchain settings
-            if (PlatformUtils.isCLion()) return false
-            val status = RsDebuggerToolchainService.getInstance().getBundledLLDBStatus()
+            val status = RsDebuggerToolchainService.getInstance().getLLDBStatus()
             // If there is bundled LLDB, no need to show this toolchain settings
-            return status !is LLDBStatus.Binaries
+            return status !is LLDBStatus.Bundled
         }
 
     private val components: List<RsDebuggerUiComponent> = run {

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerToolchainConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerToolchainConfigurableUi.kt
@@ -64,7 +64,8 @@ class RsDebuggerToolchainConfigurableUi : RsDebuggerUiComponent() {
         @Suppress("MoveVariableDeclarationIntoWhen")
         val status = RsDebuggerToolchainService.getInstance().getLLDBStatus(lldbPathField.text)
         val (text, isVisible) = when (status) {
-            LLDBStatus.Unavailable -> error("Unreachable")
+            LLDBStatus.Unavailable,
+            LLDBStatus.Bundled -> error("Unreachable")
             LLDBStatus.NeedToDownload -> "Download" to true
             LLDBStatus.NeedToUpdate -> "Update" to true
             is LLDBStatus.Binaries -> "" to false

--- a/debugger/src/main/resources/META-INF/debugger-only.xml
+++ b/debugger/src/main/resources/META-INF/debugger-only.xml
@@ -1,4 +1,6 @@
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <depends>com.intellij.cidr.debugger</depends>
+
     <xi:include href="/META-INF/core-debugger-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,7 @@
     <depends optional="true" config-file="idea-only.xml">com.intellij.modules.java</depends>
     <depends optional="true" config-file="clion-only.xml">com.intellij.modules.clion</depends>
     <depends optional="true" config-file="debugger-only.xml">com.intellij.modules.appcode</depends>
+    <depends optional="true" config-file="debugger-only.xml">com.intellij.modules.rider</depends>
     <depends optional="true" config-file="native-debug-only.xml">com.intellij.nativeDebug</depends>
     <depends optional="true" config-file="copyright-only.xml">com.intellij.copyright</depends>
     <depends optional="true" config-file="duplicates-only.xml">com.intellij.modules.duplicatesDetector</depends>


### PR DESCRIPTION
Part of #5422
Previous attempt: #6907

Fixes #7201

After #6907, Rider for Unreal Engine has changed the inner structure of plugins related to native debugging. Previously, it contained bundled [Native Debugging Support](https://plugins.jetbrains.com/plugin/12775-native-debugging-support) plugin with bundled debugger binaries. Now, it contains the same plugin `com.intellij.cidr.debugger` as CLion (that's why it didn't work with initial implementation), so we don't need to invent a way how to determine if IDE contains bundled debugger binaries and we can just use `LLDBDriverConfiguration.hasBundledLLDB()`

Current restrictions:
- only [Rider for Unreal Engine](https://www.jetbrains.com/lp/rider-unreal/) is supported for now
- only LLDB

changelog: Provide debugging in [Rider for Unreal Engine](https://www.jetbrains.com/lp/rider-unreal/). Note, previously there was an attempt to support the debugging in Rider for Unreal Engine but it didn't work because of some technical reasons
