### PR TITLE
TY: fix type inference if dependencies have names as stdlib crates

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -22,6 +22,7 @@ import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.ThreeState
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.util.AutoInjectedCrates.CORE
@@ -759,9 +760,14 @@ fun processLocalVariables(place: RsElement, originalProcessor: (RsPatBinding) ->
 /**
  * Resolves an absolute path.
  */
-fun resolveStringPath(path: String, workspace: CargoWorkspace, project: Project): Pair<RsNamedElement, CargoWorkspace.Package>? {
+fun resolveStringPath(
+    path: String,
+    workspace: CargoWorkspace,
+    project: Project,
+    isStd: ThreeState = ThreeState.UNSURE
+): Pair<RsNamedElement, CargoWorkspace.Package>? {
     val (pkgName, crateRelativePath) = splitAbsolutePath(path) ?: return null
-    val pkg = workspace.findPackageByName(pkgName) ?: run {
+    val pkg = workspace.findPackageByName(pkgName, isStd) ?: run {
         return if (isUnitTestMode) {
             // Allows to set a fake path for some item in tests via
             // lang attribute, e.g. `#[lang = "std::iter::Iterator"]`

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -410,7 +410,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test resolve derive traits`() {
+    fun `test resolve derive traits`() = resolveDeriveTraits()
+
+    @ProjectDescriptor(WithStdlibAndStdlibLikeDependencyRustProjectDescriptor::class)
+    fun `test resolve derive traits with stdlib-like dependencies`() = resolveDeriveTraits()
+
+    private fun resolveDeriveTraits() {
         val traitToPath = mapOf(
             "std::marker::Clone" to "clone.rs",
             "std::marker::Copy" to "marker.rs",

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -5,10 +5,7 @@
 
 package org.rust.lang.core.type
 
-import org.rust.ExpandMacros
-import org.rust.MockEdition
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.ext.*
@@ -118,6 +115,16 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
     """)
 
     fun `test vec!`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            let x = vec!(1, 2u16, 4, 8);
+            x;
+          //^ Vec<u16> | Vec<u16, Global>
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibAndStdlibLikeDependencyRustProjectDescriptor::class)
+    fun `test vec! with stdlib-like dependencies`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
             let x = vec!(1, 2u16, 4, 8);


### PR DESCRIPTION
Fixes #8224

changelog: Fix type inference if dependencies have names as stdlib crates
