### PR TITLE
INT: correctly parenthesize block-like expressions in Inline Value refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
@@ -71,7 +71,7 @@ private fun replaceExpr(factory: RsPsiFactory, element: RsElement, expr: RsExpr)
     val parent = element.parent
     val needsParentheses = when {
         expr is RsBinaryExpr && (parent is RsBinaryExpr || parent.requiresSingleExpr) -> true
-        (expr is RsRangeExpr || expr is RsLambdaExpr) && parent.requiresSingleExpr -> true
+        expr.isBlockLikeExpr && parent.requiresSingleExpr -> true
         expr is RsStructLiteral && (parent is RsMatchExpr || parent is RsForExpr || parent is RsCondition) -> true
         else -> false
     }
@@ -82,6 +82,12 @@ private fun replaceExpr(factory: RsPsiFactory, element: RsElement, expr: RsExpr)
     }
     element.replace(newExpr)
 }
+
+private val PsiElement.isBlockLikeExpr: Boolean
+    get() =
+        this is RsRangeExpr || this is RsLambdaExpr ||
+        this is RsMatchExpr || this is RsBlockExpr ||
+        this is RsLoopExpr || this is RsWhileExpr
 
 private val PsiElement.requiresSingleExpr: Boolean
     get() = this is RsDotExpr || this is RsTryExpr || this is RsUnaryExpr || this is RsCastExpr || this is RsCallExpr

--- a/src/test/kotlin/org/rust/ide/refactoring/RsInlineValueTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsInlineValueTest.kt
@@ -263,6 +263,68 @@ class RsInlineValueTest : RsTestBase() {
         }
     """)
 
+    fun `test parenthesize match expression inline into cast`() = doTest("""
+        fn foo() -> u64 {
+            let x/*caret*/ = match true {
+                true => 0,
+                false => 1
+            };
+            x as u64
+        }
+    """, """
+        fn foo() -> u64 {
+            (match true {
+                true => 0,
+                false => 1
+            }) as u64
+        }
+    """)
+
+    fun `test parenthesize block expression inline into cast`() = doTest("""
+        fn foo() -> u64 {
+            let x/*caret*/ = {
+                0
+            };
+            x as u64
+        }
+    """, """
+        fn foo() -> u64 {
+            ({
+                0
+            }) as u64
+        }
+    """)
+
+    fun `test parenthesize loop expression inline into cast`() = doTest("""
+        fn foo() -> u64 {
+            let x/*caret*/ = loop {
+                break 0
+            };
+            x as u64
+        }
+    """, """
+        fn foo() -> u64 {
+            (loop {
+                break 0
+            }) as u64
+        }
+    """)
+
+    fun `test parenthesize while expression inline into cast`() = doTest("""
+        fn foo() {
+            let x/*caret*/ = while true {
+                break;
+            };
+            x as ();
+        }
+    """, """
+        fn foo() {
+            (while true {
+                break;
+            }) as ();
+        }
+    """)
+
     fun `test struct literal inlined into match`() = doTest("""
         struct S {
             a: u32


### PR DESCRIPTION
Turns out that I have missed a few cases that require parentheses in `RsInlineValueProcessor`.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/8267

changelog: Correctly parenthesize block-like expressions (e.g. `match`) in Inline Value refactoring.