### PR TITLE
Fix `sqlx` macro expansion: set working directory for proc macro expander process

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -21,6 +21,7 @@ import org.rust.openapiext.RsPathManager
 import org.rust.openapiext.findFileByMaybeRelativePath
 import org.rust.stdext.HashCode
 import org.rust.stdext.mapToSet
+import java.io.File
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
@@ -402,6 +403,9 @@ object CargoMetadata {
             "CARGO_PKG_LICENSE" to license.orEmpty(),
             "CARGO_PKG_LICENSE_FILE" to license_file.orEmpty(),
             "CARGO_CRATE_NAME" to name.replace('-', '_'),
+            // A hack to make `sqlx` use correct `target` directory. Really, we should just set
+            // PWD for proc macro expander process to `rootPath`
+            "CARGO_TARGET_DIR" to rootPath + File.separator + "target"
         )
 
         val outDir = buildScriptMessage?.out_dir


### PR DESCRIPTION
Fixes #8238

`sqlx` macros write files to `target/sqlx` directory by a relative path. It expects that PWD is set to the directory with `target` (and `Cargo.toml`) file. In this PR I hotfixed it by setting `CARGO_TARGET_DIR` env var. I also set PWD to a temporary directory (it's not currently possible to set PWD to different directories for different proc macros, this required changes in rust-analyzer).

changelog: Fix expansion of `sqlx` procedural macros with `offline` feature