### PR TITLE
RES: Use 2018 edition for detached files

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -206,7 +206,11 @@ interface CargoWorkspace {
     enum class Edition(val presentation: String) {
         EDITION_2015("2015"),
         EDITION_2018("2018"),
-        EDITION_2021("2021")
+        EDITION_2021("2021");
+
+        companion object {
+            val DEFAULT: Edition = EDITION_2018
+        }
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
@@ -13,7 +13,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.settings.toolchain
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.RsToolchainBase
@@ -54,7 +54,7 @@ class Rustfmt(toolchain: RsToolchainBase) : RustupComponent(NAME, toolchain) {
             if (currentRustcVersion != null) {
                 val edition = runReadAction {
                     val psiFile = file.toPsiFile(cargoProject.project)
-                    psiFile?.edition ?: CargoWorkspace.Edition.EDITION_2018
+                    psiFile?.edition ?: Edition.DEFAULT
                 }
                 add("--edition=${edition.presentation}")
             }

--- a/src/main/kotlin/org/rust/ide/actions/ShareInPlaygroundAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/ShareInPlaygroundAction.kt
@@ -24,7 +24,7 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.util.io.HttpRequests
 import org.jetbrains.annotations.TestOnly
 import org.rust.RsBundle
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.notifications.showBalloon
 import org.rust.ide.utils.USER_AGENT
 import org.rust.lang.core.psi.RsFile
@@ -65,7 +65,7 @@ class ShareInPlaygroundAction : DumbAwareAction() {
             if (!confirmShare(file, hasSelection)) return
 
             val channel = file.cargoProject?.rustcInfo?.version?.channel?.channel ?: "stable"
-            val edition = (file.crate?.edition ?: CargoWorkspace.Edition.EDITION_2018).presentation
+            val edition = (file.crate?.edition ?: Edition.DEFAULT).presentation
 
             object : Task.Backgroundable(project, RsBundle.message("action.Rust.ShareInPlayground.progress.title")) {
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -522,7 +522,7 @@ private fun getFormatMacroCtx(formatMacro: RsMacroCall): Pair<Int, List<RsFormat
         // panic macro handles any literal (even with `{}`) if it's single argument in 2015 and 2018 editions,
         // but starting with edition 2021 the first string literal is always format string
         "panic" -> {
-            val edition = formatMacro.containingCrate?.edition ?: Edition.EDITION_2018
+            val edition = formatMacro.containingCrate?.edition ?: Edition.DEFAULT
             if (formatMacroArgs.size < 2 && edition < Edition.EDITION_2021) null else 0
         }
         "write",

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -17,6 +17,7 @@ import com.intellij.util.Query
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.lang.core.completion.getOriginalOrSelf
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.findDependency
@@ -59,13 +60,13 @@ val RsElement.containingCrate: Crate?
 
 val RsElement.containingCargoPackage: CargoWorkspace.Package? get() = containingCargoTarget?.pkg
 
-val PsiElement.edition: CargoWorkspace.Edition?
+val PsiElement.edition: Edition?
     get() = contextOrSelf<RsElement>()?.containingCrate?.edition
 
 val PsiElement.isAtLeastEdition2018: Boolean
     get() {
-        val edition = edition ?: return false
-        return edition >= CargoWorkspace.Edition.EDITION_2018
+        val edition = edition ?: Edition.DEFAULT
+        return edition >= Edition.EDITION_2018
     }
 
 /**

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -876,4 +876,14 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
             func();
         } //^ detached.rs
     """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test resolve in detached file (in import)`() = stubOnlyResolve("""
+    //- detached.rs
+        pub use foo::func;
+                   //^ detached.rs
+        pub mod foo {
+            pub fn func() {}
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #8212

changelog: Fix resolve of imports inside detached files
