### PR TITLE
COMP: Allow completing out of scope items at empty path

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -128,7 +128,7 @@ abstract class RsCompletionTestFixtureBase<IN>(
         prepare(code)
         val lookups = myFixture.completeBasic()
         checkNotNull(lookups) {
-            "Expected completions that don't contain $variants, but no completions found"
+            "Expected completions that don't contain $variants, but got single variant"
         }
         if (lookups.any { it.render() in variants }) {
             error("Expected completions that don't contain $variants, but got ${lookups.map { it.render() }}")

--- a/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
@@ -11,7 +11,6 @@ import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.hasCaretMarker
 import org.rust.ide.settings.RsCodeInsightSettings
-import org.rust.lang.core.completion.RsCommonCompletionProvider.Testmarks
 import org.rust.openapiext.Testmark
 
 class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
@@ -138,15 +137,19 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         }
     """, suggestOutOfScopeItems = false)
 
-    fun `test doesn't suggest non-imported symbols for empty path`() = doTest("""
-        pub mod foo {}
+    fun `test suggest non-imported symbols for empty path`() = doTestContainsCompletion("BTreeMap", """
+        mod collections {
+            pub struct BTreeMap;
+        }
         fn main() {
             let _ = /*caret*/;
         }
-    """, Testmarks.outOfScopeItemsCompletion)
+    """)
 
-    fun `test doesn't suggest non-imported symbols for empty path in macro bodies`() = doTest("""
-        pub mod foo {}
+    fun `test suggest non-imported symbols for empty path in macro bodies`() = doTestContainsCompletion("BTreeMap", """
+        mod collections {
+            pub struct BTreeMap;
+        }
         macro_rules! foo {
             ($($ i:item)*) => { $($ i)* };
         }
@@ -155,7 +158,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
                 let _ = /*caret*/
             }
         }
-    """, Testmarks.outOfScopeItemsCompletion)
+    """)
 
     fun `test enum completion`() = doTestByText("""
         mod a {
@@ -456,6 +459,13 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         importOutOfScopeItems: Boolean = true,
         check: (String, String) -> Unit
     ) = withOutOfScopeSettings(suggestOutOfScopeItems, importOutOfScopeItems) { check(before, after) }
+
+    private fun doTestContainsCompletion(
+        variant: String,
+        @Language("Rust") code: String,
+        suggestOutOfScopeItems: Boolean = true,
+        importOutOfScopeItems: Boolean = true
+    ) = withOutOfScopeSettings(suggestOutOfScopeItems, importOutOfScopeItems) { checkContainsCompletion(variant, code) }
 
     private fun withOutOfScopeSettings(
         suggestOutOfScopeItems: Boolean = true,

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
@@ -93,7 +93,7 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
         }
     """, setOf("iii", "i32"))
 
-    fun `test no completion from index`() = doTest("""
+    fun `test no completion for out-of-scope items 1`() = doTest("""
         macro_rules! my_macro {
             ($ e:expr, foo) => (1);
             ($ e:expr, bar) => (1);
@@ -101,6 +101,21 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
 
         fn main() {
             my_macro!(Hash/*caret*/);
+        }
+
+        pub mod collections {
+            pub struct HashMap;
+        }
+    """, setOf(), setOf("HashMap"))
+
+    fun `test no completion for out-of-scope items 2`() = doTest("""
+        macro_rules! my_macro {
+            ($ e:expr, foo) => (1);
+            ($ e:expr, bar) => (1);
+        }
+
+        fn main() {
+            my_macro!(/*caret*/);
         }
 
         pub mod collections {


### PR DESCRIPTION
Since auto-import is "blazing fast", we can allow completing out-of-scope items at an empty position.
This is effectively a list of all importable names in the project

https://user-images.githubusercontent.com/3221931/147351567-90b82234-ada5-4ff4-8cad-a78cded4e76d.mp4


