### PR TITLE
INSP: Don't show auto-import from auxiliary stdlib crates such as unwind

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -782,4 +782,27 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
             SplitInclusive/*caret*/;
         }
     """, listOf("core::slice::SplitInclusive", "core::str::SplitInclusive"))
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test item from 'test' crate (without extern crate)`() = checkAutoImportFixIsUnavailable("""
+        fn main() {
+            <error descr="Unresolved reference: `test_main`">/*caret*/test_main</error>();
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test item from 'test' crate (with extern crate)`() = checkAutoImportFixByTextWithoutHighlighting("""
+        extern crate test;
+        fn main() {
+            /*caret*/test_main();
+        }
+    """, """
+        extern crate test;
+
+        use test::test_main;
+
+        fn main() {
+            test_main();
+        }
+    """)
 }


### PR DESCRIPTION
Related: #8284

Now only `std`, `core` and `alloc` crates are always included in auto-import. Other stdlib crates such as `proc_macro`, `test`, `unwind` are included in auto-import only if there is explicit `extern crate` for them. Note that proc-macro crates has explicit dependency on `proc_macro`, so it is also always included in auto-import.

changelog: Don't show auto-import from auxiliary stdlib crates such as `unwind`
