### PR TITLE
RES: Add `extern crate alloc;` in auto-import if needed

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -70,7 +70,7 @@ fun ImportInfo.insertExternCrateIfNeeded(context: RsElement): Int? {
             // we don't add corresponding extern crate item manually for the same reason
             attributes == RsFile.Attributes.NO_STD && crate.isCore -> Testmarks.autoInjectedCoreCrate.hit()
             else -> {
-                if (needInsertExternCrateItem && !context.isAtLeastEdition2018) {
+                if (needInsertExternCrateItem) {
                     crateRoot?.insertExternCrateItem(RsPsiFactory(context.project), externCrateName)
                 } else {
                     if (depth != null) {

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -805,4 +805,21 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
             test_main();
         }
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test add extern crate for alloc (with no_std)`() = checkAutoImportFixByTextWithoutHighlighting("""
+        #![no_std]
+        fn main() {
+            Vec/*caret*/::new();
+        }
+    """, """
+        #![no_std]
+        extern crate alloc;
+
+        use alloc::vec::Vec;
+
+        fn main() {
+            Vec::new();
+        }
+    """)
 }


### PR DESCRIPTION
changelog: Fix auto-import from `alloc` crate when using [`#![no_std]`](https://docs.rust-embedded.org/book/intro/no-std.html)