### PR TITLE
COMP: Take into account expected expression type coercability in completion sorting

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsTupleFieldCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsTupleFieldCompletionProvider.kt
@@ -20,7 +20,7 @@ import org.rust.lang.core.psi.RsFieldLookup
 import org.rust.lang.core.psi.ext.parentDotExpr
 import org.rust.lang.core.psi.ext.receiver
 import org.rust.lang.core.psiElement
-import org.rust.lang.core.types.expectedType
+import org.rust.lang.core.types.expectedTypeCoercable
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTuple
 import org.rust.lang.core.types.type
@@ -48,7 +48,7 @@ object RsTupleFieldCompletionProvider : RsCompletionProvider() {
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         val (fieldLookup, type) = context[TUPLE_FIELD_INFO] ?: return
 
-        val completionContext = RsCompletionContext(fieldLookup, expectedTy = fieldLookup.parentDotExpr.expectedType)
+        val completionContext = RsCompletionContext(fieldLookup, expectedTy = fieldLookup.parentDotExpr.expectedTypeCoercable)
 
         val elements = type.types.withIndex().map { (index, ty) ->
             createLookupElement(object : CompletionEntity {

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -10,7 +10,10 @@ import com.intellij.util.SmartList
 import org.rust.lang.core.completion.RsCompletionContext
 import org.rust.lang.core.completion.collectVariantsForEnumCompletion
 import org.rust.lang.core.completion.createLookupElement
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsDebuggerExpressionCodeFragment
+import org.rust.lang.core.psi.RsEnumItem
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.MethodResolveVariant
 import org.rust.lang.core.types.BoundElement
@@ -185,7 +188,7 @@ fun collectCompletionVariants(
         if (element !is RsDocAndAttributeOwner || element.existsAfterExpansionSelf) {
 
             if (element is RsEnumItem
-                && (context.expectedTy?.stripReferences() as? TyAdt)?.item == (element.declaredType as? TyAdt)?.item) {
+                && (context.expectedTy?.ty?.stripReferences() as? TyAdt)?.item == (element.declaredType as? TyAdt)?.item) {
                     val variants = collectVariantsForEnumCompletion(element, context, e.subst)
                     result.addAllElements(variants)
             }

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -24,6 +24,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.KnownItems
 import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.types.infer.ExpectedType
 import org.rust.lang.core.types.infer.RsInferenceResult
 import org.rust.lang.core.types.infer.inferTypeReferenceType
 import org.rust.lang.core.types.infer.inferTypesIn
@@ -93,6 +94,9 @@ val RsExpr.type: Ty
     get() = inference?.getExprType(this) ?: TyUnknown
 
 val RsExpr.expectedType: Ty?
+    get() = expectedTypeCoercable?.ty
+
+val RsExpr.expectedTypeCoercable: ExpectedType?
     get() = inference?.getExpectedExprType(this)
 
 val RsExpr.declaration: RsElement?

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
@@ -461,6 +461,22 @@ class RsCompletionSortingTest : RsTestBase() {
         RsFunction::class to "foo8"
     ))
 
+    fun `test expected types priority (coercable reference)`() = doTest("""
+        struct X;
+        fn foo1() -> &X {}
+        fn foo2() -> &i32 {}
+        fn foo3() -> &mut X {}
+        fn foo4() -> &&X {}
+        fn bar() -> &X {
+            foo/*caret*/
+        }
+    """, listOf(
+        RsFunction::class to "foo1", // &X
+        RsFunction::class to "foo3", // &mut X
+        RsFunction::class to "foo4", // &&X
+        RsFunction::class to "foo2", // &i32
+    ))
+
     fun `test tuple field order`() = doTest("""
         fn main() {
             let tuple = (0, "", 0.0);


### PR DESCRIPTION
An improvement to #3664

Take into account the fact that some types can be implicitly coerced to a different type.

```rust
struct X;
fn foo1() -> &X {}
fn foo2() -> &i32 {}
fn foo3() -> &mut X {}
fn foo4() -> &&X {}
fn bar() {
    accept(foo/*caret*/) // Completion variant should be sorted as `foo1`, `foo3`, `foo4`, `foo2` 
}                        // because `&mut X` and `&&X` are coercable to `&X`
fn accept(_: &X) {}
```

changelog: Take into account expected expression type coercability in completion sorting