### PR TITLE
T: Check that build scripts are evaluated correctly

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -218,7 +218,14 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
             return null
         }
 
-        if (processOutput.exitCode != 0) return null
+        if (processOutput.exitCode != 0) {
+            if (isUnitTestMode) {
+                // If `cargo check` output contains error like "The system cannot find the path specified",
+                // maybe It's because some file path on Windows is too long (more than 256 symbols).
+                LOG.error("Can't compile build scripts. Cargo check output: '${processOutput.stdoutLines}'")
+            }
+            return null
+        }
 
         val messages = mutableMapOf<PackageId, MutableList<CompilerMessage>>()
 


### PR DESCRIPTION
We run `cargo check` to evaluate build scripts and compile proc macros. With this PR If `cargo check` was finished unsuccessfully, the test will fail with `cargo check` output attached. This may help investigate test failures.

---

E.g. in #8216 `cargo check` in tests on Windows failed with message like
```
error: failed to write `...\target\debug\.fingerprint\serde_derive-516b7eb56c091c46\run-build-script-build-script-build.json`

Caused by:
  The system cannot find the path specified. (os error 3)
```
which actually means that the path to a file is longer than 256 chars.