### PR TITLE
INSP: Sort resolved paths first in auto-import

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
@@ -82,16 +82,21 @@ class ImportContext2 private constructor(
     }
 
     class PathInfo(
-        val parentPathText: String?,
-        val pathParsingMode: RustParserUtil.PathParsingMode,
+        val rootPathText: String?,
+        val rootPathParsingMode: RustParserUtil.PathParsingMode?,
+        val rootPathAllowedNamespaces: Set<Namespace>?,
         val namespaceFilter: (RsQualifiedNamedElement) -> Boolean,
     ) {
         companion object {
-            fun from(path: RsPath, isCompletion: Boolean): PathInfo = PathInfo(
-                parentPathText = (path.parent as? RsPath)?.text,
-                pathParsingMode = path.pathParsingMode,
-                namespaceFilter = path.namespaceFilter(isCompletion),
-            )
+            fun from(path: RsPath, isCompletion: Boolean): PathInfo {
+                val rootPath = path.rootPath().takeIf { it != path }
+                return PathInfo(
+                    rootPathText = rootPath?.text,
+                    rootPathParsingMode = rootPath?.pathParsingMode,
+                    rootPathAllowedNamespaces = rootPath?.allowedNamespaces(isCompletion),
+                    namespaceFilter = path.namespaceFilter(isCompletion),
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -87,6 +87,7 @@ fun RsPath.allowedNamespaces(isCompletion: Boolean = false): Set<Namespace> = wh
     }
     is RsPathExpr -> if (isCompletion) TYPES_N_VALUES else VALUES
     is RsPatTupleStruct -> VALUES
+    is RsMacroCall -> MACROS
     is RsPathCodeFragment -> parent.ns
     else -> TYPES_N_VALUES
 }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -695,6 +695,38 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    fun `test sort resolved paths before unresolved paths`() = checkAutoImportVariantsByText("""
+        mod mod1 {
+            pub mod inner {}
+        }
+
+        mod mod2 {
+            pub mod inner {
+                pub fn foo() {}
+            }
+        }
+
+        fn main() {
+            inner/*caret*/::foo();
+        }
+    """, listOf("crate::mod2::inner", "crate::mod1::inner"))
+
+    fun `test sort resolved paths before unresolved paths (macros)`() = checkAutoImportVariantsByText("""
+        mod mod1 {
+            pub mod inner {}
+        }
+
+        mod mod2 {
+            pub mod inner {
+                pub macro foo() {}
+            }
+        }
+
+        fn main() {
+            inner/*caret*/::foo!();
+        }
+    """, listOf("crate::mod2::inner", "crate::mod1::inner"))
+
     fun `test don't import trait assoc function if its import is useless`() = checkAutoImportFixIsUnavailable("""
         mod foo {
             pub trait Bar {


### PR DESCRIPTION
```rust
fn main() {
    foo::func();
}
```
When there is multiply auto-import variants for `foo`, we will sort first variants for which `foo::func` become resolved.

changelog: Improve sorting of auto-import variants
