### PR TITLE
HINT: improve inlay hints settings

### DIFF
--- a/src/212/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
+++ b/src/212/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
@@ -1,0 +1,8 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.type
+
+class RsChainMethodTypeHintsProvider : RsChainMethodTypeHintsProviderBase()

--- a/src/212/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
+++ b/src/212/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
@@ -1,0 +1,8 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.type
+
+class RsInlayTypeHintsProvider : RsInlayTypeHintsProviderBase()

--- a/src/213/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
+++ b/src/213/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.type
+
+import com.intellij.codeInsight.hints.InlayGroup
+
+// BACKCOMPAT: 2021.2. Merge it with `RsChainMethodTypeHintsProviderBase`
+@Suppress("UnstableApiUsage")
+class RsChainMethodTypeHintsProvider : RsChainMethodTypeHintsProviderBase() {
+    override val group: InlayGroup
+        get() = InlayGroup.METHOD_CHAINS_GROUP
+}

--- a/src/213/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
+++ b/src/213/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.type
+
+import com.intellij.codeInsight.hints.InlayGroup
+
+// BACKCOMPAT: 2021.2. Merge it with `RsInlayTypeHintsProviderBase`
+@Suppress("UnstableApiUsage")
+class RsInlayTypeHintsProvider : RsInlayTypeHintsProviderBase() {
+    override val group: InlayGroup
+        get() = InlayGroup.TYPES_GROUP
+}

--- a/src/main/kotlin/org/rust/RsBundle.kt
+++ b/src/main/kotlin/org/rust/RsBundle.kt
@@ -8,10 +8,14 @@ package org.rust
 import com.intellij.DynamicBundle
 import org.jetbrains.annotations.Nls
 import org.jetbrains.annotations.PropertyKey
+import java.util.function.Supplier
 
 private const val BUNDLE = "messages.RsBundle"
 
 object RsBundle : DynamicBundle(BUNDLE) {
     @Nls
     fun message(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any): String = getMessage(key, *params)
+
+    fun messagePointer(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any): Supplier<@Nls String> =
+        getLazyMessage(key, *params)
 }

--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHints.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHints.kt
@@ -17,9 +17,6 @@ import org.rust.stdext.buildList
 
 @Suppress("UnstableApiUsage")
 object RsInlayParameterHints {
-    val enabledOption: Option = Option("SHOW_PARAMETER_HINT", { "Show argument name hints" }, true)
-    val enabled: Boolean get() = enabledOption.get()
-
     val smartOption: Option = Option("SMART_HINTS", { "Show only smart hints" }, true)
     val smart: Boolean get() = smartOption.get()
 

--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHints.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHints.kt
@@ -8,6 +8,7 @@ package org.rust.ide.hints.parameter
 import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.Option
 import com.intellij.psi.PsiElement
+import org.rust.RsBundle
 import org.rust.ide.utils.CallInfo
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.existsAfterExpansion
@@ -17,7 +18,7 @@ import org.rust.stdext.buildList
 
 @Suppress("UnstableApiUsage")
 object RsInlayParameterHints {
-    val smartOption: Option = Option("SMART_HINTS", { "Show only smart hints" }, true)
+    val smartOption: Option = Option("SMART_HINTS", RsBundle.messagePointer("settings.rust.inlay.parameter.hints.only.smart"), true)
     val smart: Boolean get() = smartOption.get()
 
     fun provideHints(elem: PsiElement): List<InlayInfo> {

--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHintsProvider.kt
@@ -22,8 +22,7 @@ import org.rust.lang.core.psi.ext.valueParameters
 
 @Suppress("UnstableApiUsage")
 class RsInlayParameterHintsProvider : InlayParameterHintsProvider {
-    override fun getSupportedOptions(): List<Option> =
-        listOf(RsInlayParameterHints.enabledOption, RsInlayParameterHints.smartOption)
+    override fun getSupportedOptions(): List<Option> = listOf(RsInlayParameterHints.smartOption)
 
     override fun getDefaultBlackList(): Set<String> = emptySet()
 
@@ -35,12 +34,7 @@ class RsInlayParameterHintsProvider : InlayParameterHintsProvider {
         }
     }
 
-    override fun getParameterHints(element: PsiElement): List<InlayInfo> {
-        if (RsInlayParameterHints.enabled) {
-            return RsInlayParameterHints.provideHints(element)
-        }
-        return emptyList()
-    }
+    override fun getParameterHints(element: PsiElement): List<InlayInfo> = RsInlayParameterHints.provideHints(element)
 
     override fun getInlayPresentation(inlayText: String): String = inlayText
 

--- a/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
@@ -14,6 +14,7 @@ import com.intellij.codeInsight.hints.presentation.MenuOnClickPresentation
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -36,6 +37,7 @@ import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyAnon
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
+import org.rust.openapiext.escaped
 import javax.swing.JComponent
 import javax.swing.JPanel
 
@@ -52,7 +54,9 @@ abstract class RsChainMethodTypeHintsProviderBase : InlayHintsProvider<RsChainMe
         override val cases: List<Case>
             get() = listOf(
                 Case(RsBundle.message("settings.rust.inlay.hints.for.same.consecutive.types"), "consecutive_types", settings::showSameConsecutiveTypes),
-                Case(RsBundle.message("settings.rust.inlay.hints.for.iterators"), "iterators", settings::iteratorSpecialCase)
+                // New inlay hint settings consider case name as html, as a result `<...>` isn't rendered properly.
+                // So let's escape it if needed
+                Case(RsBundle.message("settings.rust.inlay.hints.for.iterators").escapeIfNeeded(), "iterators", settings::iteratorSpecialCase)
             )
 
         override fun createComponent(listener: ChangeListener): JComponent = JPanel()
@@ -130,6 +134,13 @@ abstract class RsChainMethodTypeHintsProviderBase : InlayHintsProvider<RsChainMe
 
     companion object {
         val KEY: SettingsKey<Settings> = SettingsKey("chain-method.hints")
+
+        private fun String.escapeIfNeeded(): String = if (isNewSettingsEnabled) escaped else this
+
+        private val isNewSettingsEnabled: Boolean
+            get() {
+                return Registry.`is`("new.inlay.settings", false)
+            }
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
@@ -18,6 +18,7 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
+import org.rust.RsBundle
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsDotExpr
 import org.rust.lang.core.psi.RsFile
@@ -41,16 +42,17 @@ import javax.swing.JPanel
 abstract class RsChainMethodTypeHintsProviderBase : InlayHintsProvider<RsChainMethodTypeHintsProviderBase.Settings> {
     override val key: SettingsKey<Settings> get() = KEY
 
-    override val name: String get() = "Chain method hints"
+    override val name: String get() = RsBundle.message("settings.rust.inlay.hints.title.method.chains")
 
     override val previewText: String? = null
 
     override fun createConfigurable(settings: Settings): ImmediateConfigurable = object : ImmediateConfigurable {
-
+        override val mainCheckboxText: String
+            get() = RsBundle.message("settings.rust.inlay.hints.for")
         override val cases: List<Case>
             get() = listOf(
-                Case("Show same consecutive types", "consecutive_types", settings::showSameConsecutiveTypes),
-                Case("Show iterators as `impl Iterator<...>`", "iterators", settings::iteratorSpecialCase)
+                Case(RsBundle.message("settings.rust.inlay.hints.for.same.consecutive.types"), "consecutive_types", settings::showSameConsecutiveTypes),
+                Case(RsBundle.message("settings.rust.inlay.hints.for.iterators"), "iterators", settings::iteratorSpecialCase)
             )
 
         override fun createComponent(listener: ChangeListener): JComponent = JPanel()

--- a/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
@@ -38,7 +38,7 @@ import org.rust.lang.core.types.type
 import javax.swing.JComponent
 import javax.swing.JPanel
 
-class RsChainMethodTypeHintsProvider : InlayHintsProvider<RsChainMethodTypeHintsProvider.Settings> {
+abstract class RsChainMethodTypeHintsProviderBase : InlayHintsProvider<RsChainMethodTypeHintsProviderBase.Settings> {
     override val key: SettingsKey<Settings> get() = KEY
 
     override val name: String get() = "Chain method hints"

--- a/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import org.rust.RsBundle
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -32,7 +33,7 @@ import javax.swing.JPanel
 abstract class RsInlayTypeHintsProviderBase : InlayHintsProvider<RsInlayTypeHintsProviderBase.Settings> {
     override val key: SettingsKey<Settings> get() = KEY
 
-    override val name: String get() = "Type hints"
+    override val name: String get() = RsBundle.message("settings.rust.inlay.hints.title.types")
 
     override val previewText: String
         get() = """
@@ -45,13 +46,16 @@ abstract class RsInlayTypeHintsProviderBase : InlayHintsProvider<RsInlayTypeHint
 
     override fun createConfigurable(settings: Settings): ImmediateConfigurable = object : ImmediateConfigurable {
 
+        override val mainCheckboxText: String
+            get() = RsBundle.message("settings.rust.inlay.hints.for")
+
         override val cases: List<Case>
             get() = listOf(
-                Case("Show for variables", "variables", settings::showForVariables),
-                Case("Show for closures", "closures", settings::showForLambdas),
-                Case("Show for loop variables", "loop_variables", settings::showForIterators),
-                Case("Show for type placeholders", "type_placeholders", settings::showForPlaceholders),
-                Case("Show obvious types", "obvious_types", settings::showObviousTypes)
+                Case(RsBundle.message("settings.rust.inlay.hints.for.variables"), "variables", settings::showForVariables),
+                Case(RsBundle.message("settings.rust.inlay.hints.for.closures"), "closures", settings::showForLambdas),
+                Case(RsBundle.message("settings.rust.inlay.hints.for.loop.variables"), "loop_variables", settings::showForIterators),
+                Case(RsBundle.message("settings.rust.inlay.hints.for.type.placeholders"), "type_placeholders", settings::showForPlaceholders),
+                Case(RsBundle.message("settings.rust.inlay.hints.for.obvious.types"), "obvious_types", settings::showObviousTypes)
             )
 
         override fun createComponent(listener: ChangeListener): JComponent = JPanel()

--- a/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
@@ -29,7 +29,7 @@ import javax.swing.JComponent
 import javax.swing.JPanel
 
 @Suppress("UnstableApiUsage")
-class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Settings> {
+abstract class RsInlayTypeHintsProviderBase : InlayHintsProvider<RsInlayTypeHintsProviderBase.Settings> {
     override val key: SettingsKey<Settings> get() = KEY
 
     override val name: String get() = "Type hints"

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -93,6 +93,18 @@ settings.rust.auto.import.title=Rust
 settings.rust.completion.suggest.out.of.scope.items=Suggest out-of-scope items
 settings.rust.completion.title=Rust
 
+settings.rust.inlay.hints.for.closures=Closures
+settings.rust.inlay.hints.for.iterators=Iterators as `impl Iterator<...>`
+settings.rust.inlay.hints.for.loop.variables=Loop variables
+settings.rust.inlay.hints.for.obvious.types=Obvious types
+settings.rust.inlay.hints.for.same.consecutive.types=Same consecutive types
+settings.rust.inlay.hints.for.type.placeholders=Type placeholders
+settings.rust.inlay.hints.for.variables=Variables
+settings.rust.inlay.hints.for=Show hints for:
+settings.rust.inlay.hints.title.method.chains=Method chains
+settings.rust.inlay.hints.title.types=Types
+settings.rust.inlay.parameter.hints.only.smart=Only smart hints
+
 structure.view.show.macro.expanded=Show Items from Macro Expansions
 structure.view.sort.visibility=Sort by Visibility
 

--- a/src/test/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHintsProviderTest.kt
@@ -234,7 +234,6 @@ class RsInlayParameterHintsProviderTest : RsTestBase() {
     private fun checkByText(@Language("Rust") code: String, smart: Boolean = true) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))
 
-        RsInlayParameterHints.enabledOption.set(true)
         RsInlayParameterHints.smartOption.set(smart)
 
         myFixture.testInlays({ (it.renderer as HintRenderer).text }) { it.renderer is HintRenderer }

--- a/src/test/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProviderTest.kt
@@ -152,8 +152,8 @@ class RsChainMethodTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsChainMetho
     @Suppress("UnstableApiUsage")
     private fun doTest(@Language("Rust") code: String, showSameConsecutiveTypes: Boolean = true) {
         val service = InlayHintsSettings.instance()
-        val key = RsChainMethodTypeHintsProvider.KEY
-        val settings = RsChainMethodTypeHintsProvider.Settings(showSameConsecutiveTypes = showSameConsecutiveTypes)
+        val key = RsChainMethodTypeHintsProviderBase.KEY
+        val settings = RsChainMethodTypeHintsProviderBase.Settings(showSameConsecutiveTypes = showSameConsecutiveTypes)
         val originalSettings = service.findSettings(key, RsLanguage) { settings }
         try {
             service.storeSettings(key, RsLanguage, settings)


### PR DESCRIPTION
These changes:
- support proper groups for type and method chain hints for new inlay settings. New inlay settings can be enabled via `new.inlay.settings` registry key. New settings are supposed to be enabled by default in 2022.1
- fix rendering of `` `impl Iterator<...>` `` in method chain settings in new settings
- drop redundant `Show argument name hints` option. We had it because of historical reasons but currently, it has the same effect as enabling/disabling whole `Parameters` hints
- Reword option names not to duplicate `show` and `hints` worlds
- Extract user-visible texts to message bundle for the future localization


Current inlay hint settings:
| | Before | After |
| - | - | - |
| **Parameters** | <img width="488" alt="Screen Shot 2021-12-15 at 19 23 25" src="https://user-images.githubusercontent.com/2539310/146225066-83642591-e545-4f13-85bd-c82de0e62176.png"> | <img width="447" alt="Screen Shot 2021-12-15 at 19 20 31" src="https://user-images.githubusercontent.com/2539310/146225469-a50bac02-c742-4b7e-a8cc-fa14c42a6640.png"> |
| **Types** | <img width="493" alt="Screen Shot 2021-12-15 at 19 23 34" src="https://user-images.githubusercontent.com/2539310/146225137-4045eb57-5e57-49a3-a065-232a6e8d317b.png"> | <img width="438" alt="Screen Shot 2021-12-15 at 19 20 22" src="https://user-images.githubusercontent.com/2539310/146225426-f39c2010-9094-4508-87b8-90ab50bdf5fe.png"> |
| **Method chains** | <img width="547" alt="Screen Shot 2021-12-15 at 19 23 40" src="https://user-images.githubusercontent.com/2539310/146225257-c1cda7e5-c63a-4341-b2c1-a5e1d7cb16d7.png"> | <img width="513" alt="Screen Shot 2021-12-15 at 19 20 10" src="https://user-images.githubusercontent.com/2539310/146225364-93e7558f-2744-4133-819f-2f171d82115e.png"> |


New inlay hint settings:
| | Before | After |
| - | - | - |
| **Parameters** | <img width="363" alt="Screen Shot 2021-12-15 at 19 29 54" src="https://user-images.githubusercontent.com/2539310/146225887-ec0a74f9-9b03-4104-b58d-113282573120.png"> | <img width="373" alt="Screen Shot 2021-12-15 at 19 22 41" src="https://user-images.githubusercontent.com/2539310/146226145-b7010cf4-04c8-4d57-abbd-d34c793d3ed3.png"> |
| **Types** | <img width="365" alt="Screen Shot 2021-12-15 at 19 30 09" src="https://user-images.githubusercontent.com/2539310/146225954-bf2fdcbb-bb22-4b5a-93f7-ffe9e5a73d1a.png"> | <img width="366" alt="Screen Shot 2021-12-15 at 19 22 57" src="https://user-images.githubusercontent.com/2539310/146226087-85bc9007-a398-44e7-890c-a84cb795650a.png"> |
| **Method chains** | <img width="367" alt="Screen Shot 2021-12-15 at 19 30 16" src="https://user-images.githubusercontent.com/2539310/146226001-16bc52e5-30ca-4788-8fd6-7e4f0cfbe1a3.png"> | <img width="366" alt="Screen Shot 2021-12-15 at 19 23 06" src="https://user-images.githubusercontent.com/2539310/146226056-473dbb45-eb7b-4560-9766-369965b311e4.png"> |


changelog: Improve `Preferences | Editor | Inlay Hints` rendering: drop redundant options and fix wording
