### PR TITLE
INSP: Fix default parameters handling in `Wrong number of type arguments` inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
@@ -90,7 +90,7 @@ private fun checkFunctionCall(actualArgs: Int, expectedRequiredParams: Int, expe
     return when {
         actualArgs > expectedTotalParams ->
             if (expectedRequiredParams != expectedTotalParams) "at most $expectedTotalParams" else "$expectedTotalParams"
-        actualArgs in 1 until expectedTotalParams ->
+        actualArgs in 1 until expectedRequiredParams ->
             if (expectedRequiredParams != expectedTotalParams) "at least $expectedRequiredParams" else "$expectedTotalParams"
         else -> null
     }

--- a/src/test/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspectionTest.kt
@@ -327,6 +327,29 @@ class RsWrongGenericArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWron
         }
     """)
 
+    fun `test call expr with default type argument`() = checkByText("""
+        struct S<A, B = i32>(A, B);
+        fn main() {
+            S(1, 2);
+            S::<>(1, 2);
+            S::<i32>(1, 2);
+            S::<i32, i32>(1, 2);
+            <error descr="Wrong number of type arguments: expected at most 2, found 3 [E0107]">S::<i32, i32, i32>(1, 2)</error>;
+        }
+    """)
+
+    fun `test method call with default type argument`() = checkByText("""
+        struct S;
+        impl S { fn foo<A, B = i32>(&self, a: A, b: B) {} }
+        fn main() {
+            S.foo(1, 2);
+            S.foo::<>(1, 2);
+            S.foo::<i32>(1, 2);
+            S.foo::<i32, i32>(1, 2);
+            S.<error descr="Wrong number of type arguments: expected at most 2, found 3 [E0107]">foo::<i32, i32, i32>(1, 2)</error>;
+        }
+    """)
+
     fun `test dyn trait`() = checkByText("""
         trait Trait<A> {}
         fn foo() {


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/8296.

Relates to https://github.com/intellij-rust/intellij-rust/pull/5354.

changelog: Fix default parameters handling in `Wrong number of type arguments` inspection
