### PR TITLE
GRD: update gradle and gradle plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ val compileNativeCodeTaskName = "compileNativeCode"
 plugins {
     idea
     kotlin("jvm") version "1.5.31"
-    id("org.jetbrains.intellij") version "1.2.1"
+    id("org.jetbrains.intellij") version "1.3.0"
     id("org.jetbrains.grammarkit") version "2021.1.3"
     id("net.saliman.properties") version "1.5.1"
     id("org.gradle.test-retry") version "1.3.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ val compileNativeCodeTaskName = "compileNativeCode"
 
 plugins {
     idea
-    kotlin("jvm") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
     id("org.jetbrains.intellij") version "1.3.0"
     id("org.jetbrains.grammarkit") version "2021.1.3"
     id("net.saliman.properties") version "1.5.1"
@@ -107,8 +107,9 @@ allprojects {
         withType<KotlinCompile> {
             kotlinOptions {
                 jvmTarget = "1.8"
-                languageVersion = "1.5"
-                apiVersion = "1.4"
+                languageVersion = "1.6"
+                // see https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
+                apiVersion = "1.5"
                 freeCompilerArgs = listOf("-Xjvm-default=enable")
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
These changes update:
- gradle to 7.3.2
- `org.jetbrains.intellij` to 1.3.0
- kotlin plugin to `1.6.10`. In addition to this change, kotlin language version was updated to 1.6 and API version to 1.5. So now we can use new language features from [Kotlin 1.6](https://kotlinlang.org/docs/whatsnew16.html) and all API added in Kotlin 1.5

changelog: Update Kotlin language version to 1.6 and API version to 1.5. So now we can use new language features from [Kotlin 1.6](https://kotlinlang.org/docs/whatsnew16.html) and all API added in Kotlin 1.5
