### PR TITLE
COMP: complete 2nd path segment if the first segment is unresolved but can be imported

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
@@ -144,7 +144,7 @@ private fun RsPath.namespaceFilter(isCompletion: Boolean): (RsQualifiedNamedElem
     else -> { _ -> true }
 }
 
-private val RsPath.pathParsingMode: RustParserUtil.PathParsingMode
+val RsPath.pathParsingMode: RustParserUtil.PathParsingMode
     get() = when (parent) {
         is RsPathExpr,
         is RsStructLiteral,


### PR DESCRIPTION
Consider a case when we want a completion for `Rc::`, but `Rc` is not imported:

```rust
fn main() {
    let a = Rc::/*caret*/
}
```

With this PR, the plugin will show
completion for all possible `Rc` that can be imported.
After selecting a variant, the import will be inserted:

```rust
use std::rc::Rc;

fn main() {
    let a = Rc::new()
}
```


https://user-images.githubusercontent.com/3221931/146943940-82765d30-7855-4987-bbd2-17d3f8d9b3a7.mp4


