### PR TITLE
GRD: use `-Xjvm-default=all` and get rid of `@JvmDefault`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,7 +110,7 @@ allprojects {
                 languageVersion = "1.6"
                 // see https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
                 apiVersion = "1.5"
-                freeCompilerArgs = listOf("-Xjvm-default=enable")
+                freeCompilerArgs = listOf("-Xjvm-default=all")
             }
         }
         withType<PatchPluginXmlTask> {

--- a/src/main/kotlin/org/rust/RsProjectTaskQueueService.kt
+++ b/src/main/kotlin/org/rust/RsProjectTaskQueueService.kt
@@ -40,20 +40,16 @@ class RsProjectTaskQueueService : Disposable {
 val Project.taskQueue: RsProjectTaskQueueService get() = service()
 
 interface RsTask {
-    @JvmDefault
     val taskType: TaskType
         get() = INDEPENDENT
 
-    @JvmDefault
     val progressBarShowDelay: Int
         get() = 0
 
     /** If true, the task will not be run (and progress bar will not be shown) until the smart mode */
-    @JvmDefault
     val waitForSmartMode: Boolean
         get() = false
 
-    @JvmDefault
     val runSyncInUnitTests: Boolean
         get() = false
 

--- a/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
@@ -65,7 +65,6 @@ interface Crate : UserDataHolderEx {
      * A cargo package can have cyclic dependencies through `[dev-dependencies]` (see [CrateGraphService] docs).
      * Cyclic dependencies are not contained in [dependencies], [flatDependencies] or [reverseDependencies].
      */
-    @JvmDefault
     val dependenciesWithCyclic: Collection<Dependency>
         get() = dependencies
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAttrProcMacroOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAttrProcMacroOwner.kt
@@ -16,12 +16,10 @@ import org.rust.lang.core.stubs.common.RsAttrProcMacroOwnerPsiOrStub
  */
 interface RsAttrProcMacroOwner : RsOuterAttributeOwner, RsAttrProcMacroOwnerPsiOrStub<RsMetaItem> {
     /** @see ProcMacroAttribute */
-    @JvmDefault
     val procMacroAttribute: ProcMacroAttribute<RsMetaItem>
         get() = ProcMacroAttribute.getProcMacroAttribute(this)
 
     /** @see ProcMacroAttribute */
-    @JvmDefault
     val procMacroAttributeWithDerives: ProcMacroAttribute<RsMetaItem>
         get() = ProcMacroAttribute.getProcMacroAttribute(this, withDerives = true)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -28,7 +28,6 @@ import org.rust.openapiext.testAssert
 import org.rust.stdext.nextOrNull
 
 interface RsDocAndAttributeOwner : RsElement, NavigatablePsiElement, RsAttributeOwnerPsiOrStub<RsMetaItem> {
-    @JvmDefault
     override val rawMetaItems: Sequence<RsMetaItem>
         get() = RsInnerAttributeOwnerRegistry.rawMetaItems(this)
 }
@@ -39,7 +38,6 @@ interface RsInnerAttributeOwner : RsDocAndAttributeOwner {
      * In contrast, inner attributes can be either direct
      * children or grandchildren.
      */
-    @JvmDefault
     val innerAttrList: List<RsInnerAttr>
         get() = RsInnerAttributeOwnerRegistry.innerAttrs(this)
 }
@@ -63,11 +61,9 @@ interface RsInnerAttributeOwner : RsDocAndAttributeOwner {
  * ```
  */
 interface RsOuterAttributeOwner : RsDocAndAttributeOwner {
-    @JvmDefault
     val outerAttrList: List<RsOuterAttr>
         get() = stubChildrenOfType()
 
-    @JvmDefault
     override val rawOuterMetaItems: Sequence<RsMetaItem>
         get() = outerAttrList.asSequence().map { it.metaItem }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
@@ -15,11 +15,9 @@ val RsFieldDecl.escapedName: String? get() = (this as? RsNamedElement)?.escapedN
 interface RsFieldDecl : RsOuterAttributeOwner, RsVisibilityOwner {
     val typeReference: RsTypeReference?
 
-    @JvmDefault
     override val visibility: RsVisibility
         get() = (owner as? RsEnumVariant)?.visibility ?: super.visibility
 
-    @JvmDefault
     override val isPublic: Boolean
         get() = (owner as? RsEnumVariant)?.isPublic ?: super.isPublic
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
@@ -48,7 +48,6 @@ interface RsMod : RsQualifiedNamedElement, RsItemsOwner, RsVisible, PsiElement {
     /**
      *  Returns directory where direct submodules should be located
      */
-    @JvmDefault
     fun getOwnedDirectory(createIfNotExists: Boolean = false): PsiDirectory? {
         if (this is RsFile && name == RsConstants.MOD_RS_FILE || isCrateRoot) return contextualFile.originalFile.parent
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt
@@ -15,6 +15,5 @@ interface RsPathReferenceElement : RsReferenceElement, RsPathPsiOrStub {
 
     override val referenceNameElement: PsiElement?
 
-    @JvmDefault
     override val referenceName: String? get() = referenceNameElement?.unescapedText
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsReferenceElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsReferenceElement.kt
@@ -16,7 +16,6 @@ import org.rust.lang.core.resolve.ref.RsReference
 interface RsReferenceElementBase : RsElement {
     val referenceNameElement: PsiElement?
 
-    @JvmDefault
     val referenceName: String? get() = referenceNameElement?.unescapedText
 }
 
@@ -34,7 +33,6 @@ interface RsMandatoryReferenceElement : RsReferenceElement {
 
     override val referenceNameElement: PsiElement
 
-    @JvmDefault
     override val referenceName: String get() = referenceNameElement.unescapedText
 
     override fun getReference(): RsReference

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
@@ -17,15 +17,12 @@ interface RsVisible : RsElement {
 }
 
 interface RsVisibilityOwner : RsVisible {
-    @JvmDefault
     val vis: RsVis?
         get() = PsiTreeUtil.getStubChildOfType(this, RsVis::class.java)
 
-    @JvmDefault
     override val visibility: RsVisibility
         get() = vis?.visibility ?: RsVisibility.Private
 
-    @JvmDefault
     override val isPublic: Boolean
         get() = vis != null
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/common/PsiOrStubInterfaces.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/common/PsiOrStubInterfaces.kt
@@ -23,7 +23,6 @@ interface RsMetaItemPsiOrStub {
     val path: RsPathPsiOrStub?
     val metaItemArgs: RsMetaItemArgsPsiOrStub?
 
-    @JvmDefault
     val metaItemArgsList: List<RsMetaItemPsiOrStub>
         get() = metaItemArgs?.metaItemList.orEmpty()
 
@@ -39,11 +38,9 @@ interface RsMetaItemArgsPsiOrStub {
 interface RsAttributeOwnerPsiOrStub<T : RsMetaItemPsiOrStub> {
     val rawMetaItems: Sequence<T>
 
-    @JvmDefault
     val rawOuterMetaItems: Sequence<T>
         get() = emptySequence()
 
-    @JvmDefault
     val containingCrate: Crate?
         get() = when (this) {
             is PsiElement -> (this as RsElement).containingCrate


### PR DESCRIPTION
Since [kotlin 1.4-M3](https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/) it's possible to apply `@JvmDefault` behavior to all default methods using `-Xjvm-default=all` compiler option.

Now all default methods are "JVM default" methods

changelog: Always generate Java-compatible byte code for interface methods with default implementation without `@JvmDefault` annotation