### PR TITLE
MACRO: expand proc macros from [dev-dependencies]

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -202,7 +202,7 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
         projectDirectory: Path,
         listener: ProcessListener?
     ): BuildMessages? {
-        val additionalArgs = listOf("--message-format", "json", "--workspace")
+        val additionalArgs = listOf("--message-format", "json", "--workspace", "--tests")
         val nativeHelper = RsPathManager.nativeHelper(toolchain is RsWslToolchain)
         val envs = if (nativeHelper != null && Registry.`is`("org.rust.cargo.evaluate.build.scripts.wrapper")) {
             EnvironmentVariablesData.create(mapOf(RUSTC_WRAPPER to nativeHelper.toString()), true)


### PR DESCRIPTION
changelog: Expand proc macros from `dev-dependencies`. Note, procedural macro expansion is still under development, and it's disabled by default for now. To turn it on, enable `org.rust.cargo.evaluate.build.scripts` and `org.rust.macros.proc` [experimental features](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features)