### PR TITLE
INSP: show unresolved reference errors for macros if proc macros enabled

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -262,7 +262,7 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
 
         #[<error descr="Unresolved reference: `unresolved`">unresolved</error>]
         fn qux() { }
-    """, false)
+    """, true)
 
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         withIgnoreWithoutQuickFix(ignoreWithoutQuickFix) { checkByText(text) }


### PR DESCRIPTION
The `unresolved reference` inspection was enabled for attribute and derive macros in #7928, but such errors were shown if either there is a quick-fix (an auto-import candidate)
or the option `Ignore unresolved references without quick fix` in the inspection settings is disabled (it is enabled by default):

![image](https://user-images.githubusercontent.com/3221931/146970336-355dbe0d-a93b-46dd-af0a-311be7dbcc2a.png)

Now, we always show `unresolved reference` for all kinds of macros if proc macro expansion is enabled. This should help to discover macro expansion issues.
I'm planning to extend this to all kinds of paths in the future because our new name resolution and (proc) macro expansion seem to work well enough. 

changelog: Always show `unresolved reference` errors for macro calls if proc macro expansion is enabled. Previously such errors were shown if either there is a quick-fix (an auto-import candidate)
or the option `Ignore unresolved references without quick fix` in the inspection settings is disabled. Note, procedural macro expansion is still under development, and it's disabled by default for now. To turn it on, enable `org.rust.cargo.evaluate.build.scripts` and `org.rust.macros.proc` [experimental features](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features)
