### PR TITLE
MACRO: prepare for attribute/derive macro expansion in doctests

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -128,7 +128,7 @@ fun getExpansionFromExpandedFile(context: MacroExpansionContext, expandedFile: R
 
 fun <T : RsMacroData, E : MacroExpansionError> MacroExpander<T, E>.expandMacro(
     def: T,
-    call: RsMacroCall,
+    call: RsPossibleMacroCall,
     factory: RsPsiFactory,
     storeRangeMap: Boolean
 ): RsResult<MacroExpansion, MacroExpansionAndParsingError<E>> {

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
@@ -46,7 +46,7 @@ sealed class GetMacroExpansionError {
         OldEngineStd -> "the old macro expansion engine can't expand macros in Rust stdlib"
         MemExpDuringMacroExpansion -> "internal error: in-memory macro expansion is requested during other " +
             "macro expansion"
-        MemExpAttrMacro -> "internal error: can't do in-memory expansion of an attribute or derive macro"
+        MemExpAttrMacro -> "the old macro expansion engine can't expand an attribute or derive macro"
         is MemExpParsingError -> "can't parse `$expansionText` as `$context`"
         NextStepMacroAccess -> "internal error: the expansion from a next expansion step is accessed during " +
             "a previous expansion step"

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -284,6 +284,26 @@ class RsProcMacroExpansionResolveTest : RsResolveTestBase() {
         }           //^
     """)
 
+    fun `test custom derive in a doctest`() = expect<IllegalStateException> {
+    checkByCode("""
+        /// ```
+        /// use test_proc_macros::DeriveImplForFoo;
+        ///
+        /// #[derive(DeriveImplForFoo)] // impl Foo { fn foo(&self) -> Bar {} }
+        /// struct Foo;
+        /// struct Bar;
+        /// impl Bar {
+        ///     fn bar(&self) {}
+        /// }    //X
+        ///
+        /// fn main() {
+        ///     Foo.foo().bar()
+        /// }           //^
+        /// ```
+        pub fn foo() {}
+    """, "lib.rs")
+    }
+
     fun `test attr legacy macro`() = checkByCode("""
         use test_proc_macros::attr_as_is;
 


### PR DESCRIPTION
This PR does not enable proc macro expansion in doctests, but it does some preparations for it