### PR TITLE
CARGO: parse available compiler messages even if build script evaluation fails

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/BuildMessages.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/BuildMessages.kt
@@ -8,7 +8,8 @@ package org.rust.cargo.toolchain.impl
 import org.rust.cargo.project.workspace.PackageId
 
 class BuildMessages(
-    private val messages: Map<PackageId, List<CompilerMessage>>
+    private val messages: Map<PackageId, List<CompilerMessage>>,
+    val isSuccessful: Boolean
 ) {
 
     fun get(packageId: PackageId): List<CompilerMessage> = messages[packageId].orEmpty()
@@ -20,6 +21,12 @@ class BuildMessages(
                     val outDir = (message as? BuildScriptMessage)?.out_dir ?: return@map message
                     message.copy(out_dir = replacer(outDir))
                 }
-            }
+            },
+            isSuccessful
         )
+
+    companion object {
+        val DEFAULT = BuildMessages(emptyMap(), true)
+        val FAILED = BuildMessages(emptyMap(), false)
+    }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -202,6 +202,9 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
         projectDirectory: Path,
         listener: ProcessListener?
     ): BuildMessages {
+        // `--tests` is needed here to compile dev dependencies during build script evaluation.
+        // `--all-targets` also can help to build dev dependencies,
+        // but it may force unnecessary compilation of examples, benches and other targets
         val additionalArgs = listOf("--message-format", "json", "--workspace", "--tests")
         val nativeHelper = RsPathManager.nativeHelper(toolchain is RsWslToolchain)
         val envs = if (nativeHelper != null && Registry.`is`("org.rust.cargo.evaluate.build.scripts.wrapper")) {

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/RsProcMacroExpansionResolveIntegrationTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/RsProcMacroExpansionResolveIntegrationTest.kt
@@ -8,6 +8,7 @@ package org.rustSlowTests.lang.resolve
 import com.intellij.util.ThrowableRunnable
 import org.rust.ExpandMacros
 import org.rust.MinRustcVersion
+import org.rust.WithExperimentalFeatures
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.impl.testCargoProjects
 import org.rust.cargo.toolchain.wsl.RsWslToolchain
@@ -17,12 +18,12 @@ import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsMethodCall
 import org.rust.openapiext.RsPathManager
 import org.rust.openapiext.pathAsPath
-import org.rust.openapiext.runWithEnabledFeatures
 
 @MinRustcVersion("1.46.0")
 @ExpandMacros(MacroExpansionScope.WORKSPACE)
+@WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
 class RsProcMacroExpansionResolveIntegrationTest : RsWithToolchainTestBase() {
-    fun `test 2 cargo projects (proc macro is a separate cargo project)`() = runWithProcMacrosEnabled {
+    fun `test 2 cargo projects (proc macro is a separate cargo project)`() {
         fileTree {
             dir("my_proc_macro") {
                 toml("Cargo.toml", """
@@ -87,7 +88,7 @@ class RsProcMacroExpansionResolveIntegrationTest : RsWithToolchainTestBase() {
         }
     }
 
-    fun `test from crates_io`() = runWithProcMacrosEnabled {
+    fun `test from crates_io`() {
         buildProject {
             toml("Cargo.toml", """
                 [package]
@@ -119,7 +120,7 @@ class RsProcMacroExpansionResolveIntegrationTest : RsWithToolchainTestBase() {
         }.checkReferenceIsResolved<RsMethodCall>("src/lib.rs")
     }
 
-    fun `test dev-dependency from crates_io`() = runWithProcMacrosEnabled {
+    fun `test dev-dependency from crates_io`() {
         buildProject {
             toml("Cargo.toml", """
                 [package]
@@ -161,9 +162,5 @@ class RsProcMacroExpansionResolveIntegrationTest : RsWithToolchainTestBase() {
             return
         }
         super.runTestRunnable(testRunnable)
-    }
-
-    private fun <T> runWithProcMacrosEnabled(action: () -> T): T {
-        return runWithEnabledFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS) { action() }
     }
 }


### PR DESCRIPTION
Previously, the plugin didn't parse compiler messages if a build script evaluation process returned a non-zero error code.
As a result, if the workspace host code couldn't be compiled (for example, because of a broken build script) or executed (for example, because of panic in build script), the plugin stopped processing any generated by build scripts item and expanding any proc macro call.

Now, if a proc macro lib is successfully compiled or a library's build script is successfully executed during build script evaluation (even if build script evaluation fails eventually), the plugin will process generated items and expand proc macros call from such libraries

changelog: Process available items generated by build script and expand available procedural macro calls even if the whole project host code (build scripts and procedural macro libraries) cannot be successfully compiled and executed
