### PR TITLE
Don't perform cargo refresh when another IDE project become trusted

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -112,7 +112,9 @@ open class CargoProjectsServiceImpl(
         if (isNewTrustedProjectApiAvailable) {
             @Suppress("LeakingThis")
             whenProjectTrusted(this) {
-                refreshAllProjects()
+                if (it == project) {
+                    refreshAllProjects()
+                }
             }
         }
     }


### PR DESCRIPTION
The bug was introduced in #8167. When some IDEA project is marked as trusted, `cargo refresh` action is performed in all other opened projects. This also lead to flaky tests

https://user-images.githubusercontent.com/3221931/147363985-9ea94a7a-6449-4f96-bdeb-4a17d1f84124.mp4


