### PR TITLE
REF: support fields with qualified type paths in Generate getter/setter

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/generate/setter/GenerateSetterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/setter/GenerateSetterHandler.kt
@@ -37,8 +37,7 @@ class GenerateSetterHandler : GenerateAccessorHandler() {
 
         return chosenFields.mapNotNull {
             val fieldName = it.argumentIdentifier
-            val typeRef = it.field.typeReference ?: return@mapNotNull null
-            val typeStr = typeRef.substAndGetText(substitution)
+            val typeStr = it.typeReferenceText
 
             val fnSignature = "pub fn ${methodName(it)}(&mut self, $fieldName: $typeStr)"
             val fnBody = "self.$fieldName = $fieldName;"

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -454,4 +454,28 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
             }
         }
     """)
+
+    fun `test field with qualified path`() = doTest("""
+        mod foo {
+            pub struct S;
+        }
+
+        struct System {
+            s: foo::S/*caret*/
+        }
+    """, listOf(MemberSelection("s: foo::S", true)), """
+        mod foo {
+            pub struct S;
+        }
+
+        struct System {
+            s: foo::S
+        }
+
+        impl System {
+            pub fn s(&self) -> &foo::S {
+                &self.s
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateSetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateSetterActionTest.kt
@@ -244,4 +244,28 @@ class GenerateSetterActionTest : RsGenerateBaseTest() {
             }
         }
     """)
+
+    fun `test field with qualified path`() = doTest("""
+        mod foo {
+            pub struct S;
+        }
+
+        struct System {
+            s: foo::S/*caret*/
+        }
+    """, listOf(MemberSelection("s: foo::S", true)), """
+        mod foo {
+            pub struct S;
+        }
+
+        struct System {
+            s: foo::S
+        }
+
+        impl System {
+            pub fn set_s(&mut self, s: foo::S) {
+                self.s = s;
+            }
+        }
+    """)
 }


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/8354

changelog: Handle qualified field paths correctly in `Generate getter/setter` (`Code | Generate | Getter/Setter`) refactoring.