### PR TITLE
INSP: handle arbitrary and explicit self parameter in RsSelfConventionInspection

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1380,14 +1380,18 @@ class RsTypeInferenceWalker(
     }
 }
 
-private val RsSelfParameter.typeOfValue: Ty
+val RsFunction.selfType: Ty?
     get() {
-        val selfType = when (val owner = parentFunction.owner) {
+        return when (val owner = owner) {
             is RsAbstractableOwner.Impl -> owner.impl.selfType
             is RsAbstractableOwner.Trait -> owner.trait.selfType
-            else -> return TyUnknown
+            else -> null
         }
+    }
 
+val RsSelfParameter.typeOfValue: Ty
+    get() {
+        val selfType = parentFunction.selfType ?: TyUnknown
         return typeOfValue(selfType)
     }
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
@@ -88,4 +88,37 @@ class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionIns
             fn to_something(self) -> u32 { 0 }
         }
     """)
+
+    fun `test arbitrary self type`() = checkByText("""
+        #[lang="deref"]
+        trait Deref {
+            type Target;
+        }
+
+        struct Wrapper<T>(T);
+
+        impl<T> Deref for Wrapper<T> {
+            type Target = T;
+        }
+
+        struct Foo;
+        impl Foo {
+            fn as_foo(self: Wrapper<Self>) -> u32 { 0 }
+            fn is_awesome(self: Wrapper<Self>) {}
+            fn from_nothing(<warning descr="methods called `from_*` usually take no self; consider choosing a less ambiguous name">self: Wrapper<Self></warning>) -> u32 { 0 }
+        }
+    """)
+
+    fun `test explicit self type`() = checkByText("""
+        struct Foo;
+        impl Foo {
+            fn as_foo(<warning descr="methods called `as_*` usually take self by reference or self by mutable reference; consider choosing a less ambiguous name">self: Self</warning>) -> u32 { 0 }
+            fn as_foo_2(self: &Self) -> u32 { 0 }
+            fn as_foo_mut(self: &mut Self) -> u32 { 0 }
+            fn is_awesome(self: &Self) {}
+            fn into_foo(<warning descr="methods called `into_*` usually take self by value; consider choosing a less ambiguous name">self: &Self</warning>) -> u32 { 0 }
+            fn into_foo_mut(<warning descr="methods called `into_*` usually take self by value; consider choosing a less ambiguous name">self: &mut Self</warning>) -> u32 { 0 }
+            fn from_nothing(<warning descr="methods called `from_*` usually take no self; consider choosing a less ambiguous name">self: Self</warning>) -> u32 { 0 }
+        }
+    """)
 }


### PR DESCRIPTION
I fixed the corresponding issue, but it seems to me that explicit `Self` types should be better supported by type inference. For example here:

```rust
struct Foo;
impl Foo {
    fn is_awesome(self: &mut Self) {}
}

fn main() {
    let foo = Foo;
    foo.is_awesome();
}
```
`foo.is_awesome()` is not underline as not being mutable, so probably `self: &mut Self` is not treated in the same way as `&mut self`.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/8352

changelog: Support artbitrary and explicit self types in `Self convention inspection`.