### PR TITLE
CI: set up dependabot for gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,14 @@ updates:
       labels: [ ]
       assignees:
           - "vlad20012"
+
+    - package-ecosystem: "gradle"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "04:00" # UTC
+      open-pull-requests-limit: 10
+      labels: [ ]
+      assignees:
+          - "Undin"


### PR DESCRIPTION
changelog: Set up [dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically) to update gradle dependencies automatically
