### PR TITLE
Update External Linter widget properly

### DIFF
--- a/src/main/kotlin/org/rust/ide/status/RsExternalLinterWidget.kt
+++ b/src/main/kotlin/org/rust/ide/status/RsExternalLinterWidget.kt
@@ -13,9 +13,12 @@ import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.StatusBarWidgetFactory
 import com.intellij.openapi.wm.impl.status.TextPanel
+import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
 import com.intellij.ui.ClickListener
 import com.intellij.util.ui.UIUtil
 import org.rust.cargo.project.configurable.RsExternalLinterConfigurable
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.RustProjectSettingsService.*
 import org.rust.cargo.project.settings.rustSettings
@@ -34,6 +37,13 @@ class RsExternalLinterWidgetFactory : StatusBarWidgetFactory {
     override fun createWidget(project: Project): StatusBarWidget = RsExternalLinterWidget(project)
     override fun disposeWidget(widget: StatusBarWidget) = Disposer.dispose(widget)
     override fun canBeEnabledOn(statusBar: StatusBar): Boolean = true
+}
+
+class RsExternalLinterWidgetUpdater(private val project: Project) : CargoProjectsService.CargoProjectsListener {
+    override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
+        val manager = project.service<StatusBarWidgetsManager>()
+        manager.updateWidget(RsExternalLinterWidgetFactory::class.java)
+    }
 }
 
 class RsExternalLinterWidget(private val project: Project) : TextPanel.WithIconAndArrows(), CustomStatusBarWidget {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1247,6 +1247,8 @@
     <projectListeners>
         <listener class="org.rust.lang.core.macros.MacroExpansionManagerWaker"
                   topic="org.rust.cargo.project.model.CargoProjectsService$CargoProjectsListener" />
+        <listener class="org.rust.ide.status.RsExternalLinterWidgetUpdater"
+                  topic="org.rust.cargo.project.model.CargoProjectsService$CargoProjectsListener"/>
     </projectListeners>
 
     <actions>


### PR DESCRIPTION
Fixes some minor issues introduced in #8018

Previously, there were two issues:
- when a project didn't have attached cargo projects at the project opening (including new project creation case), the widget wasn't shown
- after detaching all cargo projects the widget was still shown, although it didn't make sense

Now the plugin updates widget on changes in cargo project set
