### PR TITLE
RES: fix primitive vs mod

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -36,7 +36,7 @@ sealed class TyPrimitive : Ty() {
     }
 
     companion object {
-        fun fromPath(path: RsPath): TyPrimitive? {
+        fun fromPath(path: RsPath, checkResolve: Boolean = true): TyPrimitive? {
             val name = path.referenceName ?: return null
 
             val result = fromName(name) ?: return null
@@ -47,10 +47,12 @@ sealed class TyPrimitive : Ty() {
 
             // struct u8;
             // let a: u8; // this is a struct "u8", not a primitive type "u8"
-            val pathReference = path.reference ?: return null
-            val resolvedTo = pathReference.multiResolve()
-            if (parent is RsBaseType && resolvedTo.any { it !is RsMod }) return null
-            if (parent is RsPath && resolvedTo.isNotEmpty()) return null
+            if (checkResolve) {
+                val pathReference = path.reference ?: return null
+                val resolvedTo = pathReference.multiResolve()
+                if (parent is RsBaseType && resolvedTo.any { it !is RsMod }) return null
+                if (parent is RsPath && resolvedTo.isNotEmpty()) return null
+            }
 
             return result
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -832,4 +832,32 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             X.foo();
         }   //^
     """)
+
+    fun `test primitive vs mod`() = checkByCode("""
+        mod impls {
+            #[lang = "str"]
+            impl str {
+                pub fn trim() {}
+            }
+        }
+        mod str {
+            pub fn trim() {}
+        }        //X
+        fn main() {
+            str::trim();
+        }      //^
+    """)
+
+    fun `test primitive vs mod 2`() = checkByCode("""
+        mod impls {
+            #[lang = "str"]
+            impl str {
+                pub fn trim() {}
+            }        //X
+        }
+        mod str {}
+        fn main() {
+            str::trim();
+        }      //^
+    """)
 }


### PR DESCRIPTION
Previously, `str::trim` was unresolved in this example:
```rust
mod str {
    pub fn foo() {}
}

fn main () {
    str::foo();
    str::trim("123");
}
```

![image](https://user-images.githubusercontent.com/3221931/149309113-ac22d774-96ea-4905-94bb-55ef7def772c.png)

Now it is resolved to a method in impl for `str`. `str` segment in `str::trim` path is still resolved to `mod str`, unfortunately :(