### PR TITLE
Suppress `Unresolved reference` inspection if the path qualifier is multiresolved

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -47,6 +47,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
                         // There is not sense to highlight path as unresolved
                         // if qualifier cannot be resolved as well
                         if (qualifier.resolveStatus != PathResolveStatus.RESOLVED) return
+                        if (qualifier.reference?.multiResolve()?.let { it.size > 1 } == true) return
                         null
                     }
                     // Despite the fact that path is (multi)resolved by our resolve engine, it can be unresolved from

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -289,6 +289,18 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         fn foo(a: <error descr="Unresolved reference: `MyStruct`">MyStruct</error>) {}/*caret*/
     """, false)
 
+    fun `test no unresolved reference if path qualifier is multiresolved`() = checkByText("""
+        mod foo {
+            fn foo() {}
+        }
+        mod foo {
+            fn bar() {}
+        }
+        fn main () {
+            foo::bar();
+        }
+    """, false)
+
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         withIgnoreWithoutQuickFix(ignoreWithoutQuickFix) { checkByText(text) }
     }


### PR DESCRIPTION
```rust
mod foo {
    fn foo() {}
}
mod foo {
    fn bar() {}
}
fn main () {
    foo::bar();
}
```

Previsouly: 
![image](https://user-images.githubusercontent.com/3221931/149319923-36cd29c4-c3ce-417c-9166-040f2a769ae6.png)

Now:
![image](https://user-images.githubusercontent.com/3221931/149320084-fd77da3f-eee8-4834-b1a5-6df6ca6ba419.png)

The error about multiresolved `foo` should be reported by another inspection (it's not implemented yet)