### PR TITLE
RES: resolve `self` in `use proc_macro_crate::{self}`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -443,6 +443,12 @@ private fun processQualifiedPathResolveVariants1(
     processor: RsResolveProcessor
 ): Boolean {
     val (base, subst) = resolvedQualifier
+
+    if (parent is RsUseSpeck && path.path == null) {
+        selfInGroup.hit()
+        if (processor("self", base)) return true
+    }
+
     if (base is RsMod) {
         val result = processor.lazy("super") {
             // `super` is allowed only after `self` and `super`
@@ -473,11 +479,6 @@ private fun processQualifiedPathResolveVariants1(
         if (resolveBetweenDifferentTargets && baseModContainingCrate?.kind?.isProcMacro == true) {
             return false
         }
-    }
-
-    if (parent is RsUseSpeck && path.path == null) {
-        selfInGroup.hit()
-        if (processor("self", base)) return true
     }
 
     val prevScope = hashMapOf<String, Set<Namespace>>()

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -969,4 +969,12 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
             pub use crate::header::HeaderMap;
         }
     """)
+
+    fun `test resolve custom derive proc macro from macro call through macro_use with rename`() = stubOnlyResolve("""
+        //- dep-proc-macro/lib.rs
+
+        //- lib.rs
+            use dep_proc_macro::{self};
+                               //^ dep-proc-macro/lib.rs
+    """)
 }


### PR DESCRIPTION
For example,

```toml
[dependencies]
serde_derive = "*"
```

```rust
use serde_derive::{self};
```

previously, this `self` was considered unresolved:

![image](https://user-images.githubusercontent.com/3221931/149343858-d9c4bafe-d451-422f-9225-b56ec7453aa1.png)
