### PR TITLE
Fix "Find usages" for modules with relative path attribute

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -7,10 +7,8 @@ package org.rust.lang.core.resolve2
 
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileWithId
-import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiFile
 import com.intellij.util.containers.map2Array
@@ -383,18 +381,6 @@ class ModData(
         visitor(this)
         for (childMod in childModules.values) {
             childMod.visitDescendants(visitor)
-        }
-    }
-
-    fun recordChildFileInUnusualLocation(childFileId: FileId) {
-        val persistentFS = PersistentFS.getInstance()
-        val childFile = persistentFS.findFileById(childFileId) ?: return
-        val childDirectory = childFile.parent ?: return
-        val containedDirectory = persistentFS.findFileById(directoryContainedAllChildFiles ?: return) ?: return
-        if (!VfsUtil.isAncestor(containedDirectory, childDirectory, false)) {
-            VfsUtil.getCommonAncestor(containedDirectory, childDirectory)?.let {
-                directoryContainedAllChildFiles = it.fileId
-            }
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -390,7 +390,7 @@ class DefCollector(
             defMap.missedFiles.add(filePath)
         }
         if (includingFile != null) {
-            modData.recordChildFileInUnusualLocation(includingFile.fileId)
+            recordChildFileInUnusualLocation(modData, includingFile.fileId)
         }
     }
 

--- a/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
+++ b/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
@@ -282,6 +282,22 @@ class RsFindUsagesTest : RsTestBase() {
         fn func(_: Foo) {} // - type reference
     """)
 
+    fun `test usage in child mod in unusual location 1`() = doTestByFileTree("""
+    //- main.rs
+        mod mod1;
+    //- mod1/mod.rs
+        mod mod2;
+        fn func() {}
+         //^
+    //- mod1/mod2/mod.rs
+        #[path = "../../foo.rs"]
+        mod mod3;
+    //- foo.rs
+        fn main() {
+            crate::mod1::func(); // - function call
+        }
+    """)
+
     private fun doTestByText(@Language("Rust") code: String) = doTestByFileTree("//- main.rs\n$code")
 
     private fun doTestByFileTree(@Language("Rust") code: String) {


### PR DESCRIPTION
Fixes #8107

changelog: Fix "Find usages" when usage is in module with relative path attribute
