### PR TITLE
TY: infer type of `&raw const` and `&raw mut` operators

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -529,6 +529,8 @@ open class RsPsiRenderer(
             UnaryOperator.MINUS -> "-"
             UnaryOperator.NOT -> "!"
             UnaryOperator.BOX -> "box "
+            UnaryOperator.RAW_REF_CONST -> "&raw const "
+            UnaryOperator.RAW_REF_MUT -> "&raw mut "
         }
         sb.append(sign)
         val innerExpr = expr.expr

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -20,7 +20,9 @@ enum class UnaryOperator {
     DEREF, // `*a`
     MINUS, // `-a`
     NOT, // `!a`
-    BOX, // `box a`
+    BOX, // `box a`,
+    RAW_REF_CONST, // &raw const
+    RAW_REF_MUT // &raw mut
 }
 
 val RsUnaryExpr.operatorType: UnaryOperator
@@ -28,6 +30,11 @@ val RsUnaryExpr.operatorType: UnaryOperator
         val stub = greenStub as? RsUnaryExprStub
         if (stub != null) return stub.operatorType
         return when {
+            raw != null -> when {
+                const != null -> UnaryOperator.RAW_REF_CONST
+                mut != null -> UnaryOperator.RAW_REF_MUT
+                else -> error("Unknown unary operator type: `$text`")
+            }
             mut != null -> UnaryOperator.REF_MUT
             and != null -> UnaryOperator.REF
             mul != null -> UnaryOperator.DEREF

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -70,7 +70,7 @@ class RsFileStub(
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 222
+        private const val STUB_VERSION = 223
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -873,6 +873,8 @@ class RsTypeInferenceWalker(
         return when (expr.operatorType) {
             UnaryOperator.REF -> inferRefType(innerExpr, expected, Mutability.IMMUTABLE)
             UnaryOperator.REF_MUT -> inferRefType(innerExpr, expected, Mutability.MUTABLE)
+            UnaryOperator.RAW_REF_CONST -> inferRawRefType(innerExpr, expected, Mutability.IMMUTABLE)
+            UnaryOperator.RAW_REF_MUT -> inferRawRefType(innerExpr, expected, Mutability.MUTABLE)
             UnaryOperator.DEREF -> {
                 // expectation must NOT be used for deref
                 val base = resolveTypeVarsWithObligations(innerExpr.inferType())
@@ -893,6 +895,9 @@ class RsTypeInferenceWalker(
 
     private fun inferRefType(expr: RsExpr, expected: Ty?, mutable: Mutability): Ty =
         TyReference(expr.inferType((expected as? TyReference)?.referenced), mutable) // TODO infer the actual lifetime
+
+    private fun inferRawRefType(expr: RsExpr, expected: Ty?, mutable: Mutability): Ty =
+        TyPointer(expr.inferType((expected as? TyPointer)?.referenced), mutable)
 
     private fun inferIfExprType(expr: RsIfExpr, expected: Ty?): Ty {
         expr.condition?.inferTypes()

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -1658,4 +1658,22 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ <unknown>
     """)
+
+    fun `test &raw const expr`() = testExpr("""
+        fn main() {
+            let a = 123;
+            let b = &raw const a;
+            b;
+          //^ *const i32
+        }
+    """)
+
+    fun `test &raw mut expr`() = testExpr("""
+        fn main() {
+            let mut a = 123;
+            let b = &raw mut a;
+            b;
+          //^ *mut i32
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -5,10 +5,7 @@
 
 package org.rust.lang.core.type
 
-import org.rust.ExpandMacros
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibAndStdlibLikeDependencyRustProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.*
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyFloat
@@ -896,5 +893,18 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             foo(num2);
             num2;
         } //^ i32
+    """)
+
+    // https://github.com/intellij-rust/intellij-rust/issues/8405
+    @MinRustcVersion("1.51.0")
+    fun `test addr_of_mut!`() = stubOnlyTypeInfer("""
+    //- main.rs
+        use std::ptr::addr_of_mut;
+        fn main() {
+            let mut a = 123;
+            let b = addr_of_mut!(a);
+            b;
+          //^ *mut i32
+        }
     """)
 }


### PR DESCRIPTION
As a result, the plugin now knows the proper type of `addr_of!` and `addr_of_mut!` macro calls from stdlib

Fixes #8405


changelog: Infer type of `&raw const` and `&raw mut` [operators](https://rust-lang.github.io/rfcs/2582-raw-reference-mir-operator.html). As a result, the plugin now knows the proper type of `addr_of!` and `addr_of_mut!` macro calls from stdlib
