### PR TITLE
REF: Fix adding trait imports for usages in "Extract Trait" refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractEnumVariant/RsExtractEnumVariantProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractEnumVariant/RsExtractEnumVariantProcessor.kt
@@ -64,7 +64,7 @@ class RsExtractEnumVariantProcessor(
 
         for (occurrence in occurrences) {
             if (occurrence.reference?.resolve() == null) {
-                RsImportHelper.importElements(occurrence, setOf(inserted))
+                RsImportHelper.importElement(occurrence, inserted)
             }
         }
         val tupleField = RsPsiFactory.TupleField(

--- a/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/RsExtractStructFieldsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/RsExtractStructFieldsProcessor.kt
@@ -86,7 +86,7 @@ class RsExtractStructFieldsProcessor(
 
         for (occurrence in occurrences) {
             if (occurrence.reference?.resolve() == null) {
-                RsImportHelper.importElements(occurrence, setOf(inserted))
+                RsImportHelper.importElement(occurrence, inserted)
             }
         }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceConstant/RsIntroduceConstantHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceConstant/RsIntroduceConstantHandler.kt
@@ -110,7 +110,7 @@ private fun replaceWithConstant(
             val created = factory.createExpression(name)
             val element = it.replace(created) as RsPathExpr
             if (element.path.reference?.resolve() == null) {
-                RsImportHelper.importElements(element, setOf(insertedConstant))
+                RsImportHelper.importElement(element, insertedConstant)
             }
             element
         }

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -57,6 +57,9 @@ object RsImportHelper {
         importTypeReferencesFromTys(context, listOf(ty), useAliases, skipUnchangedDefaultTypeArguments)
     }
 
+    fun importElement(context: RsElement, element: RsQualifiedNamedElement) =
+        importElements(context, setOf(element))
+
     fun importElements(context: RsElement, elements: Set<RsQualifiedNamedElement>) {
         if (!RsCodeInsightSettings.getInstance().importOutOfScopeItems) return
         val importContext = ImportContext.from(context.project, context)

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractTraitTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractTraitTest.kt
@@ -316,6 +316,69 @@ class RsExtractTraitTest : RsTestBase() {
         }
     """)
 
+    fun `test add trait imports`() = doTest("""
+        struct Foo {}
+        impl Foo {
+            /*caret*/const ASSOC_CONST: i32 = 7;
+            /*caret*/fn foo() {}
+            /*caret*/fn bar(&self) {}
+        }
+
+        mod mod1 {
+            fn func(foo: crate::Foo) {
+                foo.bar();
+                foo.bar();
+            }
+        }
+        mod mod2 {
+            fn func() {
+                crate::Foo::foo();
+            }
+        }
+        mod mod3 {
+            fn func() {
+                crate::Foo::ASSOC_CONST;
+            }
+        }
+    """, """
+        struct Foo {}
+
+        impl Trait for Foo {
+            const ASSOC_CONST: i32 = 7;
+            fn foo() {}
+            fn bar(&self) {}
+        }
+
+        trait Trait {
+            const ASSOC_CONST: i32;
+            fn foo();
+            fn bar(&self);
+        }
+
+        mod mod1 {
+            use crate::Trait;
+
+            fn func(foo: crate::Foo) {
+                foo.bar();
+                foo.bar();
+            }
+        }
+        mod mod2 {
+            use crate::Trait;
+
+            fn func() {
+                crate::Foo::foo();
+            }
+        }
+        mod mod3 {
+            use crate::Trait;
+
+            fn func() {
+                crate::Foo::ASSOC_CONST;
+            }
+        }
+    """)
+
     private fun doTest(
         @Language("Rust") before: String,
         @Language("Rust") after: String


### PR DESCRIPTION
Consider there was method in `impl Struct` which after refactoring was extracted to `trait Trait`. Then we need to add an import for `Trait` to modules that use the method.

Meta issue: #8326

changelog: Fix adding trait imports for usages in "Extract Trait" refactoring
