### PR TITLE
Remove use of old auto-import code in AddImportIntention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/AddImportIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImportIntention.kt
@@ -11,7 +11,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.parentOfType
-import org.rust.ide.utils.import.ImportCandidate
 import org.rust.ide.utils.import.ImportInfo
 import org.rust.ide.utils.import.import
 import org.rust.lang.core.psi.*
@@ -55,17 +54,13 @@ class AddImportIntention : RsElementBaseIntentionAction<AddImportIntention.Conte
     override fun invoke(project: Project, editor: Editor, ctx: Context) {
         val path = ctx.path
 
+        val target = path.reference?.resolve() as? RsQualifiedNamedElement ?: return
         if (ctx.needsImport) {
-            val targetItem = path.reference?.resolve() as? RsQualifiedNamedElement ?: return
             val usePath = path.generateUsePath()
-            val candidate = ImportCandidate(
-                QualifiedNamedItem.ExplicitItem(targetItem),
-                ImportInfo.LocalImportInfo(usePath)
-            )
-            candidate.import(ctx.path)
+            val importInfo = ImportInfo.LocalImportInfo(usePath)
+            importInfo.import(path)
         }
 
-        val target = ctx.path.reference?.resolve() as? RsQualifiedNamedElement ?: return
         ReferencesSearch.search(target, LocalSearchScope(path.containingMod)).forEach {
             if (it.element.parentOfType<RsUseItem>() != null) return@forEach
             val pathReference = it.element as? RsPath ?: return@forEach

--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -22,14 +22,15 @@ import org.rust.stdext.isSortedWith
  * Inserts a use declaration to the mod where [context] located for importing the selected candidate ([this]).
  * This action requires write access.
  */
-fun ImportCandidateBase.import(context: RsElement) {
+fun ImportCandidateBase.import(context: RsElement) = info.import(context)
+
+fun ImportInfo.import(context: RsElement) {
     checkWriteAccessAllowed()
     val psiFactory = RsPsiFactory(context.project)
 
     // depth of `mod` relative to module with `extern crate` item
     // we use this info to create correct relative use item path if needed
-    val relativeDepth = info.insertExternCrateIfNeeded(context)
-    val prefix = when (relativeDepth) {
+    val prefix = when (val relativeDepth = insertExternCrateIfNeeded(context)) {
         null -> ""
         0 -> "self::"
         else -> "super::".repeat(relativeDepth)
@@ -50,7 +51,7 @@ fun ImportCandidateBase.import(context: RsElement) {
         containingFile is RsFile && RsIncludeMacroIndex.getIncludedFrom(containingFile) != null -> containingFile
         else -> null
     } ?: context.containingMod
-    insertionScope.insertUseItem(psiFactory, "$prefix${info.usePath}")
+    insertionScope.insertUseItem(psiFactory, "$prefix$usePath")
 }
 
 /**


### PR DESCRIPTION
Removes use of `ImportCandidate` class in `AddImportIntention`. This is needed for removing the old auto-import code which we will do soon
