### PR TITLE
TOML: Fix doc urls for quoted dependencies names

### DIFF
--- a/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
@@ -81,6 +81,16 @@ class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase(
         base64 = "=0.8.0"  # - Open documentation for `base64@=0.8.0`
     """, "https://docs.rs/base64/%3D0.8.0")
 
+    fun `test quoted crate name`() = doTest("""
+        [dependencies]
+        "foo" = "1" # - Open documentation for `foo@^1`
+    """, "https://docs.rs/foo/%5E1")
+
+    fun `test invalid crate name`() = doTest("""
+        [dependencies]
+        a.b = "1"
+    """)
+
     private fun doTest(@Language("Toml") source: String, vararg expectedUrls: String) {
         doTestByText(source)
 


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/issues/6856#issuecomment-826134752
I guess we can close that issue with this fix.

changelog: Provide correct URLs for `Cargo.toml` dependencies with quoted names
