### PR TITLE
Mark usages in doctests as "Test usages"

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/RsTestSourcesFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/RsTestSourcesFilter.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.TestSourcesFilter
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.ide.injected.isDoctestInjection
+
+class RsTestSourcesFilter : TestSourcesFilter() {
+    override fun isTestSource(file: VirtualFile, project: Project): Boolean {
+        return file.isDoctestInjection(project)
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -37,6 +37,7 @@
         <!-- Sources -->
 
         <generatedSourcesFilter implementation="org.rust.cargo.project.model.RsGeneratedSourcesFilter"/>
+        <testSourcesFilter implementation="org.rust.cargo.project.model.RsTestSourcesFilter"/>
         <writingAccessProvider implementation="org.rust.cargo.project.model.RsGeneratedSourcesWritingAccessProvider"/>
 
         <!-- PSI managing -->


### PR DESCRIPTION

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/3221931/150124870-8eedd9a3-6bcc-4e72-82e1-80f63b78b7e7.png) | ![image](https://user-images.githubusercontent.com/3221931/150124642-ccffe895-cb38-40e8-9637-3965bfc5b554.png) |
| ![image](https://user-images.githubusercontent.com/3221931/150124970-ca218d33-05ec-4eb9-a91a-d0d824ea36cb.png) | ![image](https://user-images.githubusercontent.com/3221931/150124659-028e4fb6-7cc8-4cba-94b2-14510494389f.png) |


changelog: Mark usages in [doctests](https://doc.rust-lang.org/rustdoc/documentation-tests.html) as "Test usages"
