### PR TITLE
Refactor process running code: use RsResult instead of exceptions

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/RsCapturingProcessHandler.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsCapturingProcessHandler.kt
@@ -5,10 +5,24 @@
 
 package org.rust.cargo.runconfig
 
+import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.util.io.BaseOutputReader
+import org.rust.stdext.RsResult
+import org.rust.stdext.RsResult.Err
+import org.rust.stdext.RsResult.Ok
 
-class RsCapturingProcessHandler(commandLine: GeneralCommandLine) : CapturingProcessHandler(commandLine) {
+class RsCapturingProcessHandler private constructor(commandLine: GeneralCommandLine) : CapturingProcessHandler(commandLine) {
     override fun readerOptions(): BaseOutputReader.Options = BaseOutputReader.Options.BLOCKING
+
+    companion object {
+        fun startProcess(commandLine: GeneralCommandLine): RsResult<RsCapturingProcessHandler, ExecutionException> {
+            return try {
+                Ok(RsCapturingProcessHandler(commandLine))
+            } catch (e: ExecutionException) {
+                Err(e)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -41,6 +41,7 @@ import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.cargo.util.CargoArgsParser.Companion.parseArgs
 import org.rust.openapiext.JsonUtils.tryParseJsonObject
 import org.rust.openapiext.saveAllDocuments
+import org.rust.stdext.unwrapOrThrow
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -165,9 +166,9 @@ abstract class RsAsyncRunner(
                             result = checkToolchainSupported(project, host)
                             if (result != null) return
 
-                            val processForJson = RsCapturingProcessHandler(
+                            val processForJson = RsCapturingProcessHandler.startProcess(
                                 cargo.toGeneralCommandLine(project, command.prependArgument("--message-format=json"))
-                            )
+                            ).unwrapOrThrow()
                             processForJson.setHasPty(toolchain is RsWslToolchain)
                             val output = processForJson.runProcessWithProgressIndicator(indicator)
                             if (output.isCancelled || output.exitCode != 0) {

--- a/src/main/kotlin/org/rust/ide/actions/RsCreateCrateAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsCreateCrateAction.kt
@@ -19,6 +19,7 @@ import org.rust.cargo.toolchain.RsToolchainBase
 import org.rust.cargo.toolchain.tools.cargoOrWrapper
 import org.rust.ide.actions.ui.showCargoNewCrateUI
 import org.rust.openapiext.pathAsPath
+import org.rust.stdext.unwrapOrThrow
 
 
 class RsCreateCrateAction : RunCargoCommandActionBase() {
@@ -54,7 +55,7 @@ class RsCreateCrateAction : RunCargoCommandActionBase() {
         val targetDir = runWriteAction {
             root.createChildDirectory(this, name)
         }
-        cargo.init(project, project, targetDir, name, binary, "none")
+        cargo.init(project, project, targetDir, name, binary, "none").unwrapOrThrow()
 
         val manifest = targetDir.findChild(CargoConstants.MANIFEST_FILE)
         manifest?.let {

--- a/src/main/kotlin/org/rust/ide/actions/RustfmtCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RustfmtCargoProjectAction.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.actions
 
-import com.intellij.execution.ExecutionException
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.vfs.VfsUtil
@@ -18,6 +17,7 @@ import org.rust.cargo.toolchain.tools.Rustup.Companion.checkNeedInstallRustfmt
 import org.rust.cargo.toolchain.tools.rustfmt
 import org.rust.openapiext.isUnitTestMode
 import org.rust.openapiext.saveAllDocumentsAsTheyAre
+import org.rust.stdext.unwrapOrElse
 
 class RustfmtCargoProjectAction : DumbAwareAction() {
 
@@ -29,16 +29,15 @@ class RustfmtCargoProjectAction : DumbAwareAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val (cargoProject, rustfmt) = getContext(e) ?: return
         saveAllDocumentsAsTheyAre(reformatLater = false)
-        try {
-            if (checkNeedInstallRustfmt(cargoProject.project, cargoProject.workingDirectory)) return
-            rustfmt.reformatCargoProject(cargoProject)
-            val rootDir = cargoProject.rootDir ?: return
-            // We want to refresh file synchronously only in unit test to get new text right after `reformat` call
-            VfsUtil.markDirtyAndRefresh(!isUnitTestMode, true, true, rootDir)
-        } catch (e: ExecutionException) {
+        if (checkNeedInstallRustfmt(cargoProject.project, cargoProject.workingDirectory)) return
+        rustfmt.reformatCargoProject(cargoProject).unwrapOrElse {
             // Just easy way to know that something wrong happened
-            if (isUnitTestMode) throw e
+            if (isUnitTestMode) throw it
+            return
         }
+        val rootDir = cargoProject.rootDir ?: return
+        // We want to refresh file synchronously only in unit test to get new text right after `reformat` call
+        VfsUtil.markDirtyAndRefresh(!isUnitTestMode, true, true, rootDir)
     }
 
     private fun getContext(e: AnActionEvent): Pair<CargoProject, Rustfmt>? {

--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
@@ -46,6 +46,7 @@ import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.openapiext.*
 import org.rust.openapiext.JsonUtils.tryParseJsonObject
+import org.rust.stdext.unwrapOrElse
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
@@ -133,14 +134,13 @@ object RsExternalLinterUtils {
     ): RsExternalLinterResult? {
         ProgressManager.checkCanceled()
         val started = Instant.now()
-        val output = try {
-            toolchain
-                .cargoOrWrapper(workingDirectory)
-                .checkProject(project, owner, args)
-        } catch (e: ExecutionException) {
-            LOG.error(e)
-            return null
-        }
+        val output = toolchain
+            .cargoOrWrapper(workingDirectory)
+            .checkProject(project, owner, args)
+            .unwrapOrElse { e ->
+                LOG.error(e)
+                return null
+            }
         val finish = Instant.now()
         ProgressManager.checkCanceled()
         if (output.isCancelled) return null

--- a/src/main/kotlin/org/rust/ide/formatter/RustfmtFormattingService.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/RustfmtFormattingService.kt
@@ -24,8 +24,10 @@ import org.rust.cargo.toolchain.tools.rustfmt
 import org.rust.lang.core.psi.RsFile
 import org.rust.openapiext.document
 import org.rust.openapiext.execute
+import org.rust.openapiext.ignoreExitCode
 import org.rust.openapiext.runProcess
 import org.rust.stdext.enumSetOf
+import org.rust.stdext.unwrapOrThrow
 
 @Suppress("UnstableApiUsage")
 class RustfmtFormattingService : AsyncDocumentFormattingService() {
@@ -56,7 +58,6 @@ class RustfmtFormattingService : AsyncDocumentFormattingService() {
 
                 rustfmt.createCommandLine(cargoProject, document)?.execute(
                     cargoProject.project,
-                    ignoreExitCode = true,
                     stdIn = request.documentText.toByteArray(),
                     runner = {
                         addProcessListener(object : CapturingProcessAdapter() {
@@ -71,7 +72,7 @@ class RustfmtFormattingService : AsyncDocumentFormattingService() {
                         })
                         runProcess(indicator)
                     }
-                )
+                )?.ignoreExitCode()?.unwrapOrThrow()
             }
 
             override fun cancel(): Boolean {

--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -19,6 +19,7 @@ import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.toolchain.tools.cargo
 import org.rust.ide.icons.RsIcons
 import org.rust.openapiext.computeWithCancelableProgress
+import org.rust.stdext.unwrapOrThrow
 import java.io.File
 import javax.swing.Icon
 
@@ -45,7 +46,7 @@ class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationD
 
         val name = project.name.replace(' ', '_')
         val generatedFiles = project.computeWithCancelableProgress("Generating Cargo project...") {
-            cargo.makeProject(project, module, baseDir, name, template)
+            cargo.makeProject(project, module, baseDir, name, template).unwrapOrThrow() // TODO throw? really??
         }
 
         project.rustSettings.modify {

--- a/src/main/kotlin/org/rust/ide/newProject/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/Utils.kt
@@ -18,6 +18,7 @@ import org.rust.cargo.runconfig.wasmpack.WasmPackCommandConfiguration
 import org.rust.cargo.runconfig.wasmpack.WasmPackCommandConfigurationType
 import org.rust.cargo.toolchain.tools.Cargo
 import org.rust.cargo.toolchain.tools.Cargo.Companion.GeneratedFilesHolder
+import org.rust.openapiext.RsProcessResult
 import org.rust.openapiext.isHeadlessEnvironment
 import org.rust.stdext.toPath
 
@@ -27,7 +28,7 @@ fun Cargo.makeProject(
     baseDir: VirtualFile,
     name: String,
     template: RsProjectTemplate
-): GeneratedFilesHolder = when (template) {
+): RsProcessResult<GeneratedFilesHolder> = when (template) {
     is RsGenericTemplate -> init(project, module, baseDir, name, template.isBinary)
     is RsCustomTemplate -> generate(project, module, baseDir, name, template.url)
 }

--- a/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
@@ -32,6 +32,7 @@ import org.rust.ide.newProject.RsProjectTemplate
 import org.rust.ide.newProject.state.RsUserTemplatesState
 import org.rust.ide.notifications.showBalloon
 import org.rust.openapiext.UiDebouncer
+import org.rust.stdext.unwrapOrThrow
 import javax.swing.DefaultListModel
 import javax.swing.JList
 import javax.swing.ListSelectionModel
@@ -111,9 +112,9 @@ class RsNewProjectPanel(
         val cargo = cargo ?: return@Link
 
         object : Task.Modal(null, "Installing cargo-generate", true) {
-            var exitCode = 0
+            var exitCode: Int = Int.MIN_VALUE
 
-            override fun onSuccess() {
+            override fun onFinished() {
                 if (exitCode != 0) {
                     templateList.showBalloon("Failed to install cargo-generate", MessageType.ERROR, this@RsNewProjectPanel)
                 }
@@ -132,7 +133,7 @@ class RsNewProjectPanel(
                     override fun processTerminated(event: ProcessEvent) {
                         exitCode = event.exitCode
                     }
-                })
+                }).unwrapOrThrow()
             }
         }.queue()
     }.apply { isVisible = false }

--- a/src/main/kotlin/org/rust/openapiext/RsProcessResult.kt
+++ b/src/main/kotlin/org/rust/openapiext/RsProcessResult.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.openapiext
+
+import com.google.gson.JsonSyntaxException
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.process.ProcessOutput
+import org.rust.stdext.RsResult
+
+typealias RsProcessResult<T> = RsResult<T, RsProcessExecutionException>
+
+sealed class RsProcessExecutionOrDeserializationException : RuntimeException {
+    constructor(cause: Throwable) : super(cause)
+    constructor(message: String) : super(message)
+}
+
+class JsonDeserializationException(cause: JsonSyntaxException) : RsProcessExecutionOrDeserializationException(cause)
+
+sealed class RsProcessExecutionException : RsProcessExecutionOrDeserializationException {
+    constructor(message: String) : super(message)
+    constructor(cause: Throwable) : super(cause)
+
+    abstract val commandLineString: String
+
+    class Start(
+        override val commandLineString: String,
+        cause: ExecutionException,
+    ) : RsProcessExecutionException(cause)
+
+    class Canceled(
+        override val commandLineString: String,
+        val output: ProcessOutput,
+        message: String = errorMessage(commandLineString, output),
+    ) : RsProcessExecutionException(message)
+
+    class Timeout(
+        override val commandLineString: String,
+        val output: ProcessOutput,
+    ) : RsProcessExecutionException(errorMessage(commandLineString, output))
+
+    /** The process exited with non-zero exit code */
+    class ProcessAborted(
+        override val commandLineString: String,
+        val output: ProcessOutput,
+    ) : RsProcessExecutionException(errorMessage(commandLineString, output))
+
+    companion object {
+        fun errorMessage(commandLineString: String, output: ProcessOutput): String = """
+            |Execution failed (exit code ${output.exitCode}).
+            |$commandLineString
+            |stdout : ${output.stdout}
+            |stderr : ${output.stderr}
+        """.trimMargin()
+    }
+}
+
+fun RsProcessResult<ProcessOutput>.ignoreExitCode(): RsResult<ProcessOutput, RsProcessExecutionException.Start> = when (this) {
+    is RsResult.Ok -> RsResult.Ok(ok)
+    is RsResult.Err -> when (err) {
+        is RsProcessExecutionException.Start -> RsResult.Err(err)
+        is RsProcessExecutionException.Canceled -> RsResult.Ok(err.output)
+        is RsProcessExecutionException.Timeout -> RsResult.Ok(err.output)
+        is RsProcessExecutionException.ProcessAborted -> RsResult.Ok(err.output)
+    }
+}

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -38,6 +38,7 @@ import org.rust.cargo.util.DownloadResult
 import org.rust.ide.experiments.RsExperiments
 import org.rust.openapiext.RsPathManager
 import org.rust.stdext.HashCode
+import org.rust.stdext.unwrapOrThrow
 import org.rustPerformanceTests.fullyRefreshDirectoryInUnitTests
 import java.io.File
 import java.nio.file.Path
@@ -278,6 +279,7 @@ open class WithProcMacros(
             val testProcMacroProjectPath = Path.of("testData/$TEST_PROC_MACROS")
             fullyRefreshDirectoryInUnitTests(LocalFileSystem.getInstance().findFileByNioFile(testProcMacroProjectPath)!!)
             val (testProcMacroProject, _) = toolchain!!.cargo().fullProjectDescription(project, testProcMacroProjectPath)
+                .unwrapOrThrow()
             procMacroPackage = testProcMacroProject.packages.find { it.name == TEST_PROC_MACROS }!!
                 .copy(origin = PackageOrigin.DEPENDENCY)
             procMacroPackage

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectGenerationTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectGenerationTest.kt
@@ -92,7 +92,7 @@ class CargoProjectGenerationTest : RsWithToolchainTestBase() {
             myFixture.baseDir,
             "foo",
             template
-        )
+        ).unwrap()
 
         fileTree.assertContains(myFixture.baseDir)
     }


### PR DESCRIPTION
Use `RsResult<ProcessOutput, RsProcessExecutionException>` instead of `@Throws(ExecutionException::class)`

