### PR TITLE
ANN: Don't suggest multi-part quick fixes from External Linter

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
@@ -32,6 +32,7 @@ import com.intellij.util.ui.update.Update
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.cargo.toolchain.impl.Applicability
 import org.rust.cargo.toolchain.tools.CargoCheckArgs
 import org.rust.ide.notifications.RsExternalLinterSlowRunNotifier
 import org.rust.lang.core.psi.RsFile
@@ -116,7 +117,7 @@ class RsExternalLinterPass(
         try {
             @Suppress("UnstableApiUsage")
             annotationHolder.runAnnotatorWithContext(file) { _, holder ->
-                holder.createAnnotationsForFile(file, annotationResult)
+                holder.createAnnotationsForFile(file, annotationResult, Applicability.UNSPECIFIED)
             }
         } catch (t: Throwable) {
             if (t is ProcessCanceledException) throw t

--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
@@ -31,10 +31,7 @@ import com.intellij.util.messages.MessageBus
 import org.apache.commons.lang.StringEscapeUtils
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.toolchain.RsToolchainBase
-import org.rust.cargo.toolchain.impl.CargoTopMessage
-import org.rust.cargo.toolchain.impl.ErrorCode
-import org.rust.cargo.toolchain.impl.RustcMessage
-import org.rust.cargo.toolchain.impl.RustcSpan
+import org.rust.cargo.toolchain.impl.*
 import org.rust.cargo.toolchain.tools.CargoCheckArgs
 import org.rust.cargo.toolchain.tools.cargoOrWrapper
 import org.rust.ide.annotator.RsExternalLinterFilteredMessage.Companion.filterMessage
@@ -174,7 +171,11 @@ fun MessageBus.createDisposableOnAnyPsiChange(): Disposable {
     return disposable
 }
 
-fun AnnotationHolder.createAnnotationsForFile(file: RsFile, annotationResult: RsExternalLinterResult) {
+fun AnnotationHolder.createAnnotationsForFile(
+    file: RsFile,
+    annotationResult: RsExternalLinterResult,
+    minApplicability: Applicability
+) {
     val cargoPackageOrigin = file.containingCargoPackage?.origin
     if (cargoPackageOrigin != PackageOrigin.WORKSPACE) return
 
@@ -195,7 +196,9 @@ fun AnnotationHolder.createAnnotationsForFile(file: RsFile, annotationResult: Rs
             .problemGroup { annotationMessage }
             .needsUpdateOnTyping(true)
 
-        message.quickFixes.forEach { f -> annotationBuilder.withFix(f) }
+        message.quickFixes
+            .filter { it.applicability <= minApplicability }
+            .forEach { f -> annotationBuilder.withFix(f) }
 
         annotationBuilder.create()
     }
@@ -303,7 +306,13 @@ private fun createQuickFix(file: PsiFile, document: Document, span: RustcSpan?, 
     val textRange = span.toTextRange(document) ?: return null
     val endElement = file.findElementAt(textRange.endOffset - 1) ?: return null
     val startElement = file.findElementAt(textRange.startOffset) ?: endElement
-    return ApplySuggestionFix(message, span.suggested_replacement, startElement, endElement)
+    return ApplySuggestionFix(
+        message,
+        span.suggested_replacement,
+        span.suggestion_applicability,
+        startElement,
+        endElement
+    )
 }
 
 private fun formatMessage(message: String): String {

--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
@@ -197,8 +197,8 @@ fun AnnotationHolder.createAnnotationsForFile(
             .needsUpdateOnTyping(true)
 
         message.quickFixes
-            .filter { it.applicability <= minApplicability }
-            .forEach { f -> annotationBuilder.withFix(f) }
+            .singleOrNull { it.applicability <= minApplicability }
+            ?.let { f -> annotationBuilder.withFix(f) }
 
         annotationBuilder.create()
     }

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFix.kt
@@ -10,12 +10,14 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import org.rust.cargo.toolchain.impl.Applicability
 import org.rust.lang.core.psi.ext.endOffset
 import org.rust.lang.core.psi.ext.startOffset
 
 class ApplySuggestionFix(
     private val message: String,
     private val replacement: String,
+    val applicability: Applicability,
     startElement: PsiElement,
     endElement: PsiElement
 ) : LocalQuickFixAndIntentionActionOnPsiElement(startElement, endElement) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
@@ -31,6 +31,7 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.runconfig.command.workingDirectory
+import org.rust.cargo.toolchain.impl.Applicability
 import org.rust.cargo.toolchain.tools.CargoCheckArgs
 import org.rust.ide.annotator.RsExternalLinterResult
 import org.rust.ide.annotator.RsExternalLinterUtils
@@ -203,7 +204,7 @@ class RsExternalLinterInspection : GlobalSimpleInspectionTool() {
                 val annotationHolder = AnnotationHolderImpl(AnnotationSession(file))
                 @Suppress("UnstableApiUsage")
                 annotationHolder.runAnnotatorWithContext(file) { _, holder ->
-                    holder.createAnnotationsForFile(file, annotationResult)
+                    holder.createAnnotationsForFile(file, annotationResult, Applicability.MACHINE_APPLICABLE)
                 }
                 addAll(convertToProblemDescriptors(annotationHolder, file))
             }


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6529.

Also, now the plugin suggests only [machine-applicable](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_errors/enum.Applicability.html) quick fixes when External Linter inspection runs in batch mode.

changelog: Don't suggest multi-part quick fixes from External Linter
