### PR TITLE
CARGO: add --filter-platform to invocations of cargo metadata

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -157,6 +157,14 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
         listener: ProcessListener? = null
     ): CargoMetadata.Project {
         val additionalArgs = mutableListOf("--verbose", "--format-version", "1", "--all-features")
+        // in environments where access to packages is restricted, packages for target other than the host's
+        // may not be available at all, which breaks IntelliJ's Rust integration completely; so, if we can
+        // retrieve the target triple from the toolchain, just use it (requires calling rustc)
+        toolchain.rustc().queryVersion()?.host?.let {
+            additionalArgs.add("--filter-platform")
+            additionalArgs.add(it)
+        }
+
         val json = CargoCommandLine("metadata", projectDirectory, additionalArgs)
             .execute(owner, listener = listener)
             .stdout


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/issues/7185

See issue above for more commentary. Without this change, packages with crate dependencies that are required for some platforms, but not the current one, and which are for whatever reason not available (e.g. disallowed for use due to license concerns), cause the Rust plugin to fail the "Updating workspace info" step during project sync.

changelog: Add `--filter-platform` with value pulled from `rustc -vV` to the arguments of `cargo metadata`