### PR TITLE
CI: create release branch one day earlier

### DIFF
--- a/scripts/check_release_branch_date.py
+++ b/scripts/check_release_branch_date.py
@@ -15,4 +15,4 @@ if __name__ == '__main__':
     week = timedelta(7)
 
     # Should be synchronized with .github/workflows/release-branch.yml
-    print(json.dumps({"create_release_branch": delta < week}))
+    print(json.dumps({"create_release_branch": delta <= week}))


### PR DESCRIPTION
i.e. usually on Monday morning.
It should help QA to make test planning more precise

changelog: Create a release branch one day earlier, i.e. usually on Monday morning one week before release
