### PR TITLE
ANN: escape module name if needed in `Attach to module` quick-fix

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -225,7 +225,7 @@ class RsPsiFactory(
         tryCreateModDeclItem(modName) ?: error("Failed to create mod decl with name: `$modName`")
 
     fun tryCreateModDeclItem(modName: String): RsModDeclItem? =
-        createFromText("mod $modName;")
+        createFromText("mod ${modName.escapeIdentifierIfNeeded()};")
 
     fun createUseItem(text: String, visibility: String = "", alias: String? = null): RsUseItem {
         val aliasText = if (!alias.isNullOrEmpty()) " as $alias" else ""

--- a/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
@@ -284,6 +284,19 @@ class RsDetachedFileInspectionTest : RsInspectionsTestBase(RsDetachedFileInspect
         //- foo.rs
     """)
 
+    fun `test attach file with keywork-like name`() = checkFixByFileTree("Attach file to main.rs", """
+        //- main.rs
+            fn main() {}
+        //- macro.rs
+        <warning descr="File is not included in module tree, analysis is not available"></warning>/*caret*/
+    """, """
+        //- main.rs
+            mod r#macro;
+
+            fn main() {}
+        //- macro.rs
+    """)
+
     private fun checkFixWithMultipleModules(
         @Language("Rust") before: String,
         @Language("Rust") after: String,


### PR DESCRIPTION
Fixes #8445

changelog: Properly add new module declaration by `Attach file to module` quick-fix if a new module has a keyword-like name
