### PR TITLE
RES: Consider functions in type argument lists as const arguments

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeArgumentList.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeArgumentList.kt
@@ -13,7 +13,7 @@ val RsTypeArgumentList.typeArguments: List<RsTypeReference>
     get() = typeReferenceList.filter { ref ->
         val type = ref as? RsBaseType
         val element = type?.path?.reference?.resolve()
-        element !is RsConstant && element !is RsConstParameter
+        element !is RsConstant && element !is RsFunction && element !is RsConstParameter
     }
 
 val RsTypeArgumentList.constArguments: List<RsElement>

--- a/src/test/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsOrderInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsOrderInspectionTest.kt
@@ -50,4 +50,10 @@ class RsWrongGenericArgumentsOrderInspectionTest : RsInspectionsTestBase(RsWrong
             foo::<<error descr="Constant provided when a type was expected [E0747]">C1</error>, <error descr="Type provided when a constant was expected [E0747]">S</error>>;
         }
     """)
+
+    fun `test func as const argrument`() = checkByText("""
+        struct S<T, const C: usize>;
+        fn foo() {}
+        fn main() { S::<<error descr="Constant provided when a type was expected [E0747]">foo</error>, foo>; }
+    """)
 }


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/8308.

changelog: Consider functions in type argument lists as const arguments
