### PR TITLE
RUN: Fetch actual rustc version before loading pretty printers

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurator.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurator.kt
@@ -8,6 +8,7 @@ package org.rust.debugger.runconfig
 import com.jetbrains.cidr.execution.debugger.CidrDebugProcess
 import com.jetbrains.cidr.execution.debugger.CidrDebugProcessConfigurator
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.runconfig.command.workingDirectory
 
 class RsDebugProcessConfigurator : CidrDebugProcessConfigurator {
     override fun configure(process: CidrDebugProcess) {
@@ -27,6 +28,6 @@ class RsDebugProcessConfigurator : CidrDebugProcessConfigurator {
                 return
             }
         }
-        RsDebugProcessConfigurationHelper(process, cargoProject, isCrossLanguage = true).configure()
+        RsDebugProcessConfigurationHelper(process, cargoProject?.workingDirectory, isCrossLanguage = true).configure()
     }
 }


### PR DESCRIPTION
Previously, if you changed the toolchain from local to WSL or vice versa, and did not refresh Cargo Projects, the plugin could not load the pretty printers correctly.

changelog: Fetch actual rustc version before loading pretty printers