### PR TITLE
Temporarily return 212 builds to release workflow

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -172,7 +172,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                platform-version: [ 213 ]
+                platform-version: [ 212, 213 ]
         env:
             ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}


### PR DESCRIPTION
It's needed to build all necessary builds (212 and 213) for 164 release