### PR TITLE
T: fix test names that cause compilation warnings

### DIFF
--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.RecursionManager
-import com.intellij.openapi.util.io.StreamUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileFilter
@@ -473,7 +472,7 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
             val stream = RsTestBase::class.java.classLoader.getResourceAsStream(path)
                 ?: return null
 
-            return StreamUtil.readText(stream, Charsets.UTF_8)
+            return stream.bufferedReader().use { it.readText() }
         }
     }
 

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt
@@ -108,7 +108,7 @@ stack backtrace:
     }
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test crate with "-" in name`() =
+    fun `test crate with a hyphen in name`() =
         checkHighlights(filter,
             """
                 //- dep-lib/lib.rs

--- a/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
@@ -45,42 +45,42 @@ class RsDoctestAnnotatorTest : RsAnnotatorTestBase(RsDoctestAnnotator::class) {
         |fn foo() {}
         |""")
 
-    fun `test acceptable "lang" string`() = doTest("""
+    fun `test acceptable 'lang' string`() = doTest("""
         |/// ```rust, allow_fail, should_panic, no_run, test_harness, edition2018, edition2015
         |///<info> <inject>let a = 0;
         |</inject></info>/// ```
         |fn foo() {}
         |""")
 
-    fun `test no injection with unacceptable "lang" string`() = doTest("""
+    fun `test no injection with unacceptable 'lang' string`() = doTest("""
         |/// ```foobar
         |///let a = 0;
         |/// ```
         |fn foo() {}
         |""")
 
-    fun `test no injection with unacceptable "lang" string contain acceptable parts`() = doTest("""
+    fun `test no injection with unacceptable 'lang' string contain acceptable parts`() = doTest("""
         |/// ```rust, foobar
         |///let a = 0;
         |/// ```
         |fn foo() {}
         |""")
 
-    fun `test "# " escape`() = doTest("""
+    fun `test '# ' escape`() = doTest("""
         |/// ```
         |///<info> # <inject>extern crate foobar;
         |</inject></info>/// ```
         |fn foo() {}
         |""")
 
-    fun `test "##" escape`() = doTest("""
+    fun `test '##' escape`() = doTest("""
         |/// ```
         |///<info> #<inject>#![allow(deprecated)]
         |</inject></info>/// ```
         |fn foo() {}
         |""")
 
-    fun `test "#" escape`() = doTest("""
+    fun `test '#' escape`() = doTest("""
         |/// ```
         |///<info> #<inject>
         |</inject></info>/// ```

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1537,7 +1537,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
-    fun `test trait method without body can have arg with '?Sized' type E0277`() = checkErrors("""
+    fun `test trait method without body can have arg with 'qSized' type E0277`() = checkErrors("""
         #[lang = "sized"] trait Sized {}
         trait Foo {
             fn foo(x: Self);
@@ -2099,7 +2099,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     """)
 
     @MockRustcVersion("1.38.0-nightly")
-    fun `test leading | in or patterns 1`() = checkErrors("""
+    fun `test leading vertical bar in or patterns 1`() = checkErrors("""
         #![feature(or_patterns)]
         enum V { V1(i32), V2(i32) }
         fn foo(y: V, z: V) {
@@ -2111,7 +2111,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     """)
 
     @MockRustcVersion("1.38.0-nightly")
-    fun `test leading | in or patterns 2`() = checkFixByText("Remove `|`", """
+    fun `test leading vertical bar in or patterns 2`() = checkFixByText("Remove `|`", """
         #![feature(or_patterns)]
         enum Option<T> { None, Some(T) }
         enum V { V1(i32), V2(i32) }

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -124,7 +124,7 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
         }
     """)
 
-    fun `test ? operator`() = checkHighlightingWithMacro("""
+    fun `test question mark operator`() = checkHighlightingWithMacro("""
         fn <FUNCTION>foo</FUNCTION>() -> Result<<PRIMITIVE_TYPE>i32</PRIMITIVE_TYPE>, ()>{
             Ok(Ok(1)<Q_OPERATOR>?</Q_OPERATOR> * 2)
         }

--- a/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
+++ b/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
@@ -120,7 +120,7 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """, "return", "s.diverge()")
 
-    fun `test highlight ? operator as return`() = doTest("""
+    fun `test highlight question mark operator as return`() = doTest("""
         fn main() {
             if true {
                 Err(())?
@@ -129,7 +129,7 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """, "?", "return 0")
 
-    fun `test highlight ? operator as return with caret at ?`() = doTest("""
+    fun `test highlight question mark operator as return with caret at question mark`() = doTest("""
         fn main() {
             if true {
                 Err(())?/*caret*/
@@ -304,7 +304,7 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """, "return 1", "2", "3", "4", "5")
 
-    fun `test no highlight for ? in try `() = doTest("""
+    fun `test no highlight for question mark in try`() = doTest("""
         fn main(){
             let a = try {
                 Err(())?;
@@ -314,7 +314,7 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """, "return 0", "return 1")
 
-    fun `test highlight nothing on ? in try `() = doTest("""
+    fun `test highlight nothing on question mark in try`() = doTest("""
         fn main(){
             let a = try {
                 Err(())?/*caret*/;
@@ -355,7 +355,7 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
     """, "?", "return 0")
 
 
-    fun `test ? in macro`() = doTest("""
+    fun `test question mark in macro`() = doTest("""
         fn main(){
             macrocall![ ?/*caret*/ ];
             return 0;

--- a/src/test/kotlin/org/rust/ide/hints/parameter/RsGenericParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/parameter/RsGenericParameterInfoHandlerTest.kt
@@ -73,7 +73,7 @@ class RsGenericParameterInfoHandlerTest
         fn main() { foo::</*caret*/>(); }
     """, "T: OtherTrait", "", 0)
 
-    fun `test fn bounds with ?Sized`() = checkByText("""
+    fun `test fn bounds with qSized`() = checkByText("""
         pub trait Trait {}
         fn foo<T: Trait + ?Sized>(x: T) {}
         fn main() { foo::</*caret*/>(); }
@@ -86,7 +86,7 @@ class RsGenericParameterInfoHandlerTest
     """, "T: Trait", "", 0)
 
     // TODO: hint = "T", after intellij-rust#2783 fix
-    fun `test fn bounds with ?Sized and Sized`() = checkByText("""
+    fun `test fn bounds with qSized and Sized`() = checkByText("""
         #[lang = "sized"]
         pub trait Sized {}
         fn foo<T: Sized + ?Sized>(x: T) {}
@@ -94,7 +94,7 @@ class RsGenericParameterInfoHandlerTest
     """, "T: ?Sized", "", 0)
 
     // TODO: hint = "T: Trait", after intellij-rust#2783 fix
-    fun `test fn bounds with ?Sized and derived Sized`() = checkByText("""
+    fun `test fn bounds with qSized and derived Sized`() = checkByText("""
         #[lang = "sized"]
         pub trait Sized {}
         pub trait Trait : Sized {}

--- a/src/test/kotlin/org/rust/ide/inspections/RsExperimentalChecksInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsExperimentalChecksInspectionTest.kt
@@ -12,7 +12,7 @@ class RsExperimentalChecksInspectionTest : RsInspectionsTestBase(RsExperimentalC
         }
     """)
 
-    fun `test no "E0614 type cannot be dereferenced" when trying to dereference unknown type`() = checkByText("""
+    fun `test no 'E0614 type cannot be dereferenced' when trying to dereference unknown type`() = checkByText("""
         fn main() {
             let a = SomeUnknownType;
             let _ = *a;

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -291,7 +291,7 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    fun `test ? expression in closure with different error types`() = checkByText("""
+    fun `test question mark expression in closure with different error types`() = checkByText("""
         struct ErrorTo;
         struct ErrorFrom;
         impl From<ErrorFrom> for ErrorTo {

--- a/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
@@ -627,7 +627,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
         }
     """)
 
-    fun `test multiple if let pattern with leading |`() = doAvailableTest("""
+    fun `test multiple if let pattern with a leading vertical bar`() = doAvailableTest("""
         enum V { V1(i32), V2(i32), V3 }
         fn foo(v: V) {
             /*caret*/if let | V1(x) | V2(x) = v {

--- a/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt
@@ -573,7 +573,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
         }
     """)
 
-    fun `test multiple if let pattern with leading |`() = doAvailableTest("""
+    fun `test multiple if let pattern with a leading vertical bar`() = doAvailableTest("""
         enum V { V1(i32), V2(i32), V3 }
         fn foo(v: V) {
             /*caret*/match v {

--- a/src/test/kotlin/org/rust/ide/intentions/SplitIfIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SplitIfIntentionTest.kt
@@ -48,7 +48,7 @@ class SplitIfIntentionTest : RsIntentionTestBase(SplitIfIntention::class) {
         }
     """)
 
-    fun `test simple ||`() = doAvailableTest("""
+    fun `test simple OR`() = doAvailableTest("""
         fn main() {
             if true |/*caret*/| false {
                 42
@@ -84,7 +84,7 @@ class SplitIfIntentionTest : RsIntentionTestBase(SplitIfIntention::class) {
         }
     """)
 
-    fun `test simple || without else`() = doAvailableTest("""
+    fun `test simple OR without else`() = doAvailableTest("""
         fn main() {
             if true |/*caret*/| false {
                 42
@@ -144,7 +144,7 @@ class SplitIfIntentionTest : RsIntentionTestBase(SplitIfIntention::class) {
         }
     """)
 
-    fun `test multy || 1`() = doAvailableTest("""
+    fun `test multiple OR 1`() = doAvailableTest("""
         fn main() {
             if true |/*caret*/| false || 1 == 1 {
                 42
@@ -164,7 +164,7 @@ class SplitIfIntentionTest : RsIntentionTestBase(SplitIfIntention::class) {
         }
     """)
 
-    fun `test multy || 2`() = doAvailableTest("""
+    fun `test multiple OR 2`() = doAvailableTest("""
         fn main() {
             if true || false |/*caret*/| 1 == 1 {
                 42

--- a/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
@@ -683,7 +683,7 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         impl<T> Foo<T> for Bar where /*caret*/
     """)
 
-    fun `test if|match in start of statement`() = checkCompletion(CONDITION_KEYWORDS, """
+    fun `test if or match in start of statement`() = checkCompletion(CONDITION_KEYWORDS, """
         fn foo() {
             /*caret*/
         }
@@ -693,7 +693,7 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test if|match in let statement`() = checkCompletion(CONDITION_KEYWORDS, """
+    fun `test if or match in let statement`() = checkCompletion(CONDITION_KEYWORDS, """
         fn foo() {
             let x = /*caret*/
         }
@@ -703,7 +703,7 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test if|match in let statement with semicolon`() = checkCompletion(CONDITION_KEYWORDS, """
+    fun `test if or match in let statement with semicolon`() = checkCompletion(CONDITION_KEYWORDS, """
         fn foo() {
             let x = /*caret*/;
         }
@@ -713,7 +713,7 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test if|match in expression`() = checkCompletion(CONDITION_KEYWORDS, """
+    fun `test if or match in expression`() = checkCompletion(CONDITION_KEYWORDS, """
         fn foo() {
             let x = 1 + /*caret*/
         }
@@ -723,7 +723,7 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test no if|match after path segment`() = checkNotContainsCompletion(CONDITION_KEYWORDS, """
+    fun `test no if or match after path segment`() = checkNotContainsCompletion(CONDITION_KEYWORDS, """
         struct Foo;
 
         fn foo() {
@@ -731,7 +731,7 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test no if|match out of function`() = checkNotContainsCompletion(CONDITION_KEYWORDS, """
+    fun `test no if or match out of function`() = checkNotContainsCompletion(CONDITION_KEYWORDS, """
         const FOO: &str = /*caret*/
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
@@ -552,7 +552,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         struct Bar;
     """ to MacroExpansionMarks.failMatchPatternByExtraInput)
 
-    fun `test match * vs + group pattern`() = doTest("""
+    fun `test match 'asterisk' vs 'plus' group pattern`() = doTest("""
         macro_rules! foo {
             ($ ($ i:ident)+) => (
                 mod plus_matched {}
@@ -570,7 +570,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """ to null)
 
     // TODO should work only on 2018 edition
-    fun `test match * vs ? group pattern`() = doTest(MacroExpansionMarks.questionMarkGroupEnd, """
+    fun `test match 'asterisk' vs 'q' group pattern`() = doTest(MacroExpansionMarks.questionMarkGroupEnd, """
         macro_rules! foo {
             ($ ($ i:ident)?) => (
                 mod question_matched {}
@@ -720,7 +720,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
          fn foo() {}
     """)
 
-    fun `test distinguish between ',)+' and '),*' groups`() = doTest("""
+    fun `test distinguish between comma-ending groups`() = doTest("""
         macro_rules! foo {
             ($($ e:expr,)+) => { fn foo() { $( $ e; )+ } };
             ($($ e:expr),*) => { fn bar() { $( $ e; )* } };
@@ -817,7 +817,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
 
     // There was a problem with "debug" macro related to the fact that we parse macro call
     // with such name as a specific syntax construction
-    fun `test macro with name "debug"`() = doTest("""
+    fun `test macro with name 'debug'`() = doTest("""
         macro_rules! debug {
             ($ t:ty) => { fn foo() -> $ t {} }
         }
@@ -826,7 +826,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() -> i32 {}
     """)
 
-    fun `test macro with name "vec"`() = doTest("""
+    fun `test macro with name 'vec'`() = doTest("""
        macro_rules! vec {
            ($ t:ty) => { fn foo() -> $ t {} }
        }
@@ -836,7 +836,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    fun `test standard "vec!"`() {
+    fun `test standard 'vec!'`() {
         val rustcVersion = project.cargoProjects.singleProject().rustcInfo?.version?.semver
         // BACKCOMPAT: Rust 1.50
         val expansion = if (rustcVersion != null && rustcVersion < "1.51.0".parseSemVer()) {
@@ -914,7 +914,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() {}
     """ to NameResolutionTestmarks.dollarCrateMagicIdentifier)
 
-    fun `test incorrect "vis" group does not cause OOM`() = doErrorTest("""
+    fun `test incorrect 'vis' group does not cause OOM`() = doErrorTest("""
         // error: repetition matches empty token tree
         macro_rules! foo {
             ($($ p:vis)*) => {}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -562,7 +562,7 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     @ExpandMacros
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @MockAdditionalCfgOptions("intellij_rust")
-    fun `test exported macro with cfg on "extern crate" 1`() = stubOnlyResolve("""
+    fun `test exported macro with cfg on 'extern crate' 1`() = stubOnlyResolve("""
     //- lib.rs
         #[macro_export]
         macro_rules! foo { () -> {} }
@@ -583,7 +583,7 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     @ExpandMacros
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @MockAdditionalCfgOptions("intellij_rust")
-    fun `test exported macro with cfg on "extern crate" 2`() = stubOnlyResolve("""
+    fun `test exported macro with cfg on 'extern crate' 2`() = stubOnlyResolve("""
     //- lib.rs
         #[macro_export]
         macro_rules! foo { () -> {} }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -842,7 +842,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                           //^ dep-lib/lib.rs
     """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve(project))
 
-    fun `test "extra use of crate name 1" with alias`() = stubOnlyResolve("""
+    fun `test 'extra use of crate name 1' with alias`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;
     //- lib.rs
@@ -924,7 +924,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }      //^ foo.rs
     """)
 
-    fun `test re-exported crate via use item without "extern crate" 2018 edition`() = stubOnlyResolve("""
+    fun `test re-exported crate via use item without 'extern crate' 2018 edition`() = stubOnlyResolve("""
     //- trans-lib/lib.rs
         pub struct Foo;
     //- dep-lib/lib.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -520,7 +520,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test ? operator with result`() = checkByCode("""
+    fun `test question mark operator with result`() = checkByCode("""
         struct S { field: u32 }
                     //X
         fn foo() -> Result<S, ()> { unimplemented!() }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1016,7 +1016,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }             //^ unresolved
     """)
 
-    fun `test method in "impl for generic type" at type parameter with bound`() = checkByCode("""
+    fun `test method in 'impl for generic type' at type parameter with bound`() = checkByCode("""
         trait Bound {}
         trait Tr {
             fn foo(&self) {}
@@ -1027,7 +1027,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
-    fun `test "impl for generic type" is NOT used for associated type resolve`() = checkByCode("""
+    fun `test 'impl for generic type' is NOT used for associated type resolve`() = checkByCode("""
         trait Bound {}
         trait Tr { type Item; }
         impl<A: Bound> Tr for A { type Item = (); }
@@ -1036,7 +1036,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }           //^ unresolved
     """, NameResolutionTestmarks.skipAssocTypeFromImpl)
 
-    fun `test "impl for generic type" is USED for associated type resolve UFCS 1`() = checkByCode("""
+    fun `test 'impl for generic type' is USED for associated type resolve UFCS 1`() = checkByCode("""
         trait Bound {}
         trait Tr { type Item; }
         impl<A: Bound> Tr for A { type Item = (); }
@@ -1045,7 +1045,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }                   //^
     """)
 
-    fun `test "impl for generic type" is USED for associated type resolve UFCS 2`() = checkByCode("""
+    fun `test 'impl for generic type' is USED for associated type resolve UFCS 2`() = checkByCode("""
         trait Bound { type Item; }
         impl<A: Bound> Bound for &A { type Item = (); }
                                           //X

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -102,12 +102,12 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
                             //^ Sized
     """)
 
-    fun `test type parameter with ?Sized bound is not Sized`() = doTest("""
+    fun `test type parameter with qSized bound is not Sized`() = doTest("""
         fn foo<T: ?Sized>() -> Box<T> { unimplemented!() }
                                  //^ !Sized
     """)
 
-    fun `test type parameter with ?Sized bound is not Sized 2`() = doTest("""
+    fun `test type parameter with qSized bound is not Sized 2`() = doTest("""
         fn foo<T>() -> Box<T> where T: ?Sized { unimplemented!() }
                          //^ !Sized
     """)
@@ -124,7 +124,7 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
         }             //^ Sized
     """)
 
-    fun `test Self is ?Sized by default`() = doTest("""
+    fun `test Self is qSized by default`() = doTest("""
         trait Foo {
             fn foo(self: Self);
                         //^ !Sized

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -788,7 +788,7 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
     """)
 
     @ExpandMacros(MacroExpansionScope.ALL, "std")
-    fun `test iterate "for" complex pattern in complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
+    fun `test iterate 'for' complex pattern in complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
             for (a, _) in [(Some(42), false)].iter().map(|(n, f)| (n, f)) {
@@ -798,7 +798,7 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
     """)
 
     @ExpandMacros(MacroExpansionScope.ALL, "std")
-    fun `test iterate "while let" complex pattern = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
+    fun `test iterate 'while let' complex pattern = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
             while let Some((a, _)) = [(Some(42), false)].iter().map(|(n, f)| (n, f)).next() {
@@ -808,7 +808,7 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
     """)
 
     @ExpandMacros(MacroExpansionScope.ALL, "std")
-    fun `test "if let" complex pattern = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
+    fun `test 'if let' complex pattern = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
             if let Some((a, _)) = [(Some(42), false)].iter().map(|(n, f)| (n, f)).next() {
@@ -818,7 +818,7 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
     """)
 
     @ExpandMacros(MacroExpansionScope.ALL, "std")
-    fun `test "try expr" on a complex type = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
+    fun `test 'try expr' on a complex type = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
             let a = vec![Some(42)].into_iter().next()??;

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -369,12 +369,12 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
                             //^ &Struct<'_, Struct<'_, &'a str>>
     """, WITH_LIFETIMES)
 
-    fun `test no infinite recursion on "impl Self 1"`() = testType("""
+    fun `test no infinite recursion on 'impl Self' 1`() = testType("""
         impl Self {}
            //^ <unknown>
     """)
 
-    fun `test no infinite recursion on "impl Self 2"`() = testType("""
+    fun `test no infinite recursion on 'impl Self' 2`() = testType("""
         struct S<T>(T);
         impl S<Self> {}
            //^ S<<unknown>>


### PR DESCRIPTION
An example of warning: `Name contains characters which can cause problems on Windows`
