### PR TITLE
T: fix test names that cause compilation warnings

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphBuilderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphBuilderTest.kt
@@ -45,7 +45,7 @@ class RsMacroGraphBuilderTest : RsTestBase() {
         END
     """)
 
-    fun `test one rule ?`() = check("""
+    fun `test one rule option repetition`() = check("""
         macro_rules! my_macro {
             ($ ($ id:ident $ e:expr)? ) => (1);
         }
@@ -60,7 +60,7 @@ class RsMacroGraphBuilderTest : RsTestBase() {
         END
     """)
 
-    fun `test one rule repetition *`() = check("""
+    fun `test one rule zero-or-more repetition`() = check("""
         macro_rules! my_macro {
             ($ ($ id:ident),* ) => (1);
         }

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphWalkerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroGraphWalkerTest.kt
@@ -59,7 +59,7 @@ class RsMacroGraphWalkerTest : RsTestBase() {
         }
     """, hashSetOf(FragmentKind.Expr))
 
-    fun `test ident repetition *`() = check("""
+    fun `test ident zero-or-more repetition`() = check("""
         macro_rules! my_macro {
             ($ ($ id:ident)* $ t:ty) => (1);
         }
@@ -79,7 +79,7 @@ class RsMacroGraphWalkerTest : RsTestBase() {
         }
     """, hashSetOf(FragmentKind.Ident))
 
-    fun `test ident repetition ?`() = check("""
+    fun `test ident option repetition`() = check("""
         macro_rules! my_macro {
             ($ ($ id:ident)? $ t:ty) => (1);
         }


### PR DESCRIPTION
An example of warning: `Name contains characters which can cause problems on Windows`

Missed some tests in #8476
