### PR TITLE
ANN: don't highlight format templates in cfg-disabled code

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -21,6 +21,7 @@ import org.rust.lang.core.FeatureAvailability
 import org.rust.lang.core.macros.MacroExpansionMode
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.existsAfterExpansion
 import org.rust.lang.core.psi.ext.startOffset
 import org.rust.lang.core.psi.ext.withSubst
 import org.rust.lang.core.resolve.KnownItems
@@ -39,6 +40,7 @@ import org.rust.openapiext.isUnitTestMode
 class RsFormatMacroAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         val formatMacro = element as? RsMacroCall ?: return
+        if (!formatMacro.existsAfterExpansion) return
 
         val (macroPos, macroArgs) = getFormatMacroCtx(formatMacro) ?: return
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -580,4 +580,22 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
             }
         }
     """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test no highlighting in cfg-disabled code`() = checkErrors("""
+        $implDisplayI32
+
+        #[cfg(not(intellij_rust))]
+        fn foo() {
+            println!("{}");
+            println!("{0}{1}", 1);
+            println!("{0}{1}{3}", 1, 1);
+            println!("Hello {:1${'$'}}", 1);
+        }
+
+        fn bar() {
+            #[cfg(not(intellij_rust))]
+            println!("{}");
+        }
+    """)
 }


### PR DESCRIPTION
The bug:
![image](https://user-images.githubusercontent.com/3221931/151784380-e2df70d2-d927-4221-958a-7f6eb63bbb12.png)


changelog: don't highlight format templates in cfg-disabled code
