### PR TITLE
ANN: don't highlight documentation elements in cfg-disabled code

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotator.kt
@@ -13,6 +13,7 @@ import org.rust.ide.injected.doctestInfo
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.descendantOfTypeStrict
 import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.isEnabledByCfg
 import org.rust.lang.doc.psi.*
 import org.rust.openapiext.isUnitTestMode
 
@@ -42,6 +43,8 @@ class RsDocHighlightingAnnotator : AnnotatorBase() {
             element is RsDocLink && element.descendantOfTypeStrict<RsDocGap>() == null -> RsColor.DOC_LINK
             else -> null
         } ?: return
+
+        if (!element.isEnabledByCfg) return
 
         val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotatorTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.annotator
 
 import org.intellij.lang.annotations.Language
+import org.rust.MockAdditionalCfgOptions
 import org.rust.ide.colors.RsColor
 
 class RsDocHighlightingAnnotatorTest : RsAnnotatorTestBase(RsDocHighlightingAnnotator::class) {
@@ -216,6 +217,17 @@ class RsDocHighlightingAnnotatorTest : RsAnnotatorTestBase(RsDocHighlightingAnno
     fun `test emphasis and strong emphasis`() = checkHighlightingStrict("""
         /// <DOC_EMPHASIS>*emphasis*</DOC_EMPHASIS>, and <DOC_EMPHASIS>_also emphasis_</DOC_EMPHASIS>
         /// <DOC_STRONG>**strong emphasis**</DOC_STRONG>, and <DOC_STRONG>__also strong emphasis__</DOC_STRONG>
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test no highlighting in cfg-disabled code`() = checkHighlightingStrict("""
+        /// # Heading
+        /// *emphasis*, and _also emphasis_
+        /// **strong emphasis**, and __also strong emphasis__
+        /// [link](/uri "title")
+        /// `code`
+        #[cfg(not(intellij_rust))]
+        fn foo() {}
     """)
 
     private fun checkHighlightingStrict(@Language("Rust") text: String) =


### PR DESCRIPTION
The bug:

![image](https://user-images.githubusercontent.com/3221931/151833455-41210d07-a599-40bb-8599-814442fe247f.png)


changelog: don't highlight documentation elements in cfg-disabled code