### PR TITLE
Use jackson (instead of Gson) for Cargo metadata deserialization

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -5,7 +5,7 @@
 
 package org.rust.cargo.toolchain.impl
 
-import com.google.gson.annotations.SerializedName
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -202,7 +202,7 @@ object CargoMetadata {
          * See [docs](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-required-features-field)
          */
         @Suppress("KDocUnresolvedReference")
-        @SerializedName("required-features")
+        @JsonProperty("required-features")
         val required_features: List<String>?
     ) {
         val cleanKind: TargetKind

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroServerPool.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroServerPool.kt
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.core.io.JsonEOFException
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.google.common.annotations.VisibleForTesting
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.process.ProcessIOExecutorService
@@ -269,13 +269,13 @@ private class ProcMacroServerProcess private constructor(
 
     @Throws(IOException::class)
     private fun writeAndRead(request: Request): Response {
-        ProcMacroJsonParser.jackson.writeValue(stdin, request)
+        ProcMacroJsonParser.JSON_MAPPER.writeValue(stdin, request)
         stdin.write("\n")
         stdin.flush()
 
         stdout.skipUntilJsonObject()
 
-        return ProcMacroJsonParser.jackson.readValue(stdout, Response::class.java)
+        return ProcMacroJsonParser.JSON_MAPPER.readValue(stdout, Response::class.java)
     }
 
     /**
@@ -356,13 +356,13 @@ private class ProcMacroServerProcess private constructor(
 
 @VisibleForTesting
 object ProcMacroJsonParser {
-    val jackson: ObjectMapper = ObjectMapper()
+    val JSON_MAPPER: ObjectMapper = ObjectMapper()
         .configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false)
         .configure(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM, false)
         .configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false)
         .configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false)
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        .registerModule(KotlinModule())
+        .registerKotlinModule()
         .registerModule(
             SimpleModule()
                 .addSerializer(Request::class.java, RequestJsonSerializer())

--- a/src/main/kotlin/org/rust/openapiext/RsProcessResult.kt
+++ b/src/main/kotlin/org/rust/openapiext/RsProcessResult.kt
@@ -5,7 +5,7 @@
 
 package org.rust.openapiext
 
-import com.google.gson.JsonSyntaxException
+import com.fasterxml.jackson.core.JacksonException
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessOutput
 import org.rust.stdext.RsResult
@@ -17,7 +17,7 @@ sealed class RsProcessExecutionOrDeserializationException : RuntimeException {
     constructor(message: String) : super(message)
 }
 
-class JsonDeserializationException(cause: JsonSyntaxException) : RsProcessExecutionOrDeserializationException(cause)
+class RsDeserializationException(cause: JacksonException) : RsProcessExecutionOrDeserializationException(cause)
 
 sealed class RsProcessExecutionException : RsProcessExecutionOrDeserializationException {
     constructor(message: String) : super(message)

--- a/src/test/kotlin/org/rust/lang/core/macros/tt/TokenTreeJsonTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/tt/TokenTreeJsonTest.kt
@@ -126,7 +126,7 @@ class TokenTreeJsonTest : RsTestBase() {
     fun doTest(code: String, @Language("Json") expectedJson: String) {
         val subtree = project.createRustPsiBuilder(code).parseSubtree().subtree
 
-        val jackson = ProcMacroJsonParser.jackson
+        val jackson = ProcMacroJsonParser.JSON_MAPPER
         val actualJson = jackson
             .writer()
             .with(DefaultPrettyPrinter(TestPrettyPrinter()))


### PR DESCRIPTION
The main reason is to make errors uniform with #8494. Also, we moving towards ridding of Gson. Also, Jackson should have a better performance, but this is not measured and this is not the goal in this case.
