### PR TITLE
REF: try to find existing impl in Generate refactoring in simple cases

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
@@ -18,10 +18,8 @@ import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructItem
-import org.rust.lang.core.psi.ext.RsItemElement
-import org.rust.lang.core.psi.ext.ancestorOrSelf
-import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.skipParens
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.RsCachedImplItem
 import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.emptySubstitution
 import org.rust.lang.core.types.type
@@ -96,6 +94,9 @@ abstract class BaseGenerateHandler : LanguageCodeInsightActionHandler {
         struct: RsStructItem
     ): RsImplItem {
         return if (implBlock == null) {
+            val sibling = findSiblingImplItem(struct)
+            if (sibling != null) return sibling
+
             val impl = psiFactory.createInherentImplItem(structName, struct.typeParameterList, struct.whereClause)
             struct.parent.addAfter(impl, struct) as RsImplItem
         } else {
@@ -117,4 +118,20 @@ abstract class BaseGenerateHandler : LanguageCodeInsightActionHandler {
     )
 
     protected abstract val dialogTitle: @Suppress("UnstableApiUsage") @DialogTitle String
+}
+
+/**
+ * Try to find an impl item that is a sibling of the given `struct`.
+ * Works on a best effort basis, if the impl block has any generics, it will not be considered.
+ */
+private fun findSiblingImplItem(struct: RsStructItem): RsImplItem? {
+    return (struct.contextStrict<RsItemsOwner>())
+        ?.childrenOfType<RsImplItem>()
+        ?.firstOrNull { impl ->
+            val cachedImpl = RsCachedImplItem.forImpl(impl)
+            val (type, generics, constGenerics) = cachedImpl.typeAndGenerics ?: return@firstOrNull false
+            cachedImpl.isInherent && cachedImpl.isValid
+                && generics.isEmpty() && constGenerics.isEmpty()  // TODO: Support generics
+                && type.isEquivalentTo(struct.declaredType)
+        }
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateConstructorActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateConstructorActionTest.kt
@@ -286,4 +286,25 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
             }
         }
     """)
+
+    fun `test reuse impl block`() = doTest("""
+        struct System {
+            s: u32/*caret*/
+        }
+
+        impl System {
+            fn foo(&self) {}
+        }
+    """, listOf(MemberSelection("s: u32", true)), """
+        struct System {
+            s: u32
+        }
+
+        impl System {
+            fn foo(&self) {}
+            pub fn new(s: u32) -> Self {
+                System { s }
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -478,4 +478,25 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
             }
         }
     """)
+
+    fun `test reuse impl block`() = doTest("""
+        struct System {
+            s: u32/*caret*/
+        }
+
+        impl System {
+            fn foo(&self) {}
+        }
+    """, listOf(MemberSelection("s: u32", true)), """
+        struct System {
+            s: u32
+        }
+
+        impl System {
+            fn foo(&self) {}
+            pub fn s(&self) -> u32 {
+                self.s
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateSetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateSetterActionTest.kt
@@ -268,4 +268,25 @@ class GenerateSetterActionTest : RsGenerateBaseTest() {
             }
         }
     """)
+
+    fun `test reuse impl block`() = doTest("""
+        struct System {
+            s: u32/*caret*/
+        }
+
+        impl System {
+            fn foo(&self) {}
+        }
+    """, listOf(MemberSelection("s: u32", true)), """
+        struct System {
+            s: u32
+        }
+
+        impl System {
+            fn foo(&self) {}
+            pub fn set_s(&mut self, s: u32) {
+                self.s = s;
+            }
+        }
+    """)
 }


### PR DESCRIPTION
The generate getter, setter and constructor refactorings can be invoked on two places: ADT or an impl block. If invoked on an impl block, the generated item(s) will be created in that impl item, but if they are invoked on an ADT, a new impl block is always created.

Even though it might be difficult to always exactly find all impl blocks (e.g. blocks in another file/module, block containing complex generics), I think that in the most simple case this should be a bit smarter and try to find a "near" impl block.

Maybe also the generate constructor refactoring shouldn't be available if it finds a "near" impl block that already contains a `new` function?

changelog: The Generate getter/setter/constructor refactoring actions will now try to use existing impl blocks instead of creating a new one. An impl block will be reused only if it's inside the same module as the struct/enum on which the refactoring is invoked and if the struct/enum contains no generics.