### PR TITLE
ACT: Fix an exception in `Un-elide lifetimes` intention while processing nested ADTs

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
@@ -163,7 +163,7 @@ private fun addLifetimeParameter(ref: PotentialLifetimeRef, names: List<String>)
             }
 
             val baseTypeName = elem.name
-            val types = factory.createTypeParameterList(typeList)
+            val types = factory.createTypeArgumentList(typeList)
             val replacement = factory.createType("$baseTypeName${types.text}")
             elem.replace(replacement)
         }

--- a/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
@@ -103,6 +103,15 @@ class UnElideLifetimesIntentionTest : RsIntentionTestBase(UnElideLifetimesIntent
         fn foo<'a, 'b>(p1: &'a i32, p2: &'b i32) -> &'<selection>_</selection> i32 { p2 }
     """)
 
+    // TODO: support nested types
+    fun `test nested adt`() = doAvailableTest("""
+        struct S<'a, T>(&'a T);
+        fn /*caret*/foo(s: S<S<i32>>) -> S<S<i32>> { s }
+    """, """
+        struct S<'a, T>(&'a T);
+        fn /*caret*/foo<'a>(s: S<'a, S<i32>>) -> S<'a, S<i32>> { s }
+    """)
+
     fun `test method decl`() = doAvailableTest("""
         trait Foo {
             fn /*caret*/bar(&self, x: &i32, y: &i32, z: i32) -> &i32;


### PR DESCRIPTION
changelog: Fix an exception in `Un-elide lifetimes` intention while processing nested ADTs
