### PR TITLE
T: refactor `Testmark`s: use `@CheckTestmarkHit` instead of a parameter

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMover.kt
@@ -56,7 +56,7 @@ class RsCommaListElementUpDownMover : RsLineMover() {
             isMovingOutOfBraceBlock(sibling, down) ||
             isMovingOutOfBracketBlock(sibling, down)
         ) {
-            UpDownMoverTestMarks.moveOutOfBlock.hit()
+            UpDownMoverTestMarks.MoveOutOfBlock.hit()
             return null
         }
         return sibling

--- a/src/main/kotlin/org/rust/ide/actions/mover/RsItemUpDownMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsItemUpDownMover.kt
@@ -33,7 +33,7 @@ class RsItemUpDownMover : RsLineMover() {
 
     override fun findTargetElement(sibling: PsiElement, down: Boolean): PsiElement? {
         if (isMovingOutOfBraceBlock(sibling, down) && sibling.parent is RsMembers) {
-            UpDownMoverTestMarks.moveOutOfImpl.hit()
+            UpDownMoverTestMarks.MoveOutOfImpl.hit()
             return null
         }
         return sibling

--- a/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt
@@ -104,8 +104,8 @@ abstract class RsLineMover : LineMover() {
 }
 
 object UpDownMoverTestMarks {
-    val moveOutOfImpl = Testmark("moveOutOfImpl")
-    val moveOutOfMatch = Testmark("moveOutOfMatch")
-    val moveOutOfBody = Testmark("moveOutOfBody")
-    val moveOutOfBlock = Testmark("moveOutOfBlock")
+    object MoveOutOfImpl : Testmark()
+    object MoveOutOfMatch : Testmark()
+    object MoveOutOfBody : Testmark()
+    object MoveOutOfBlock : Testmark()
 }

--- a/src/main/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMover.kt
@@ -9,8 +9,11 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import org.rust.ide.actions.mover.RsLineMover.Companion.RangeEndpoint
-import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.lang.core.psi.RsElementTypes.BLOCK
+import org.rust.lang.core.psi.RsElementTypes.COMMA
+import org.rust.lang.core.psi.RsMatchArm
+import org.rust.lang.core.psi.RsMatchBody
+import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.elementType
@@ -31,7 +34,7 @@ class RsMatchArmUpDownMover : RsLineMover() {
 
     override fun findTargetElement(sibling: PsiElement, down: Boolean): PsiElement? {
         if (isMovingOutOfBraceBlock(sibling, down)) {
-            UpDownMoverTestMarks.moveOutOfMatch.hit()
+            UpDownMoverTestMarks.MoveOutOfMatch.hit()
             return null
         }
         return sibling

--- a/src/main/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMover.kt
@@ -41,7 +41,7 @@ class RsStatementUpDownMover : RsLineMover() {
             isMovingOutOfMatchArmBlock(sibling, down) ||
             isMovingOutOfBlockExprInsideArgList(sibling, down)
         ) {
-            UpDownMoverTestMarks.moveOutOfBody.hit()
+            UpDownMoverTestMarks.MoveOutOfBody.hit()
             return null
         }
         val block = getClosestBlock(sibling, down) ?: return sibling

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -173,13 +173,13 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
                 val pkg = (element as? RsElement)?.containingCargoPackage ?: return emptyList()
                 // Packages without source don't have documentation at docs.rs
                 if (pkg.source == null) {
-                    Testmarks.pkgWithoutSource.hit()
+                    Testmarks.PkgWithoutSource.hit()
                     return emptyList()
                 }
                 "$DOCS_RS_HOST/${pkg.name}/${pkg.version}"
             }
             else -> {
-                Testmarks.nonDependency.hit()
+                Testmarks.NonDependency.hit()
                 return emptyList()
             }
         }
@@ -209,7 +209,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
         get() {
             // items with #[doc(hidden)] attribute don't have external documentation
             if (queryAttributes.isDocHidden) {
-                Testmarks.docHidden.hit()
+                Testmarks.DocHidden.hit()
                 return false
             }
 
@@ -234,7 +234,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
 
             // macros without #[macro_export] are not public and don't have external documentation
             if (this is RsMacro) {
-                return Testmarks.notExportedMacro.hitOnFalse(hasMacroExport)
+                return Testmarks.NotExportedMacro.hitOnFalse(hasMacroExport)
             }
             // TODO: we should take into account real path of item for user, i.e. take into account reexports
             // instead of already resolved item path
@@ -256,10 +256,10 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
     }
 
     object Testmarks {
-        val docHidden = Testmark("docHidden")
-        val notExportedMacro = Testmark("notExportedMacro")
-        val pkgWithoutSource = Testmark("pkgWithoutSource")
-        val nonDependency = Testmark("nonDependency")
+        object DocHidden : Testmark()
+        object NotExportedMacro : Testmark()
+        object PkgWithoutSource : Testmark()
+        object NonDependency : Testmark()
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/formatter/RustfmtFormattingService.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/RustfmtFormattingService.kt
@@ -49,7 +49,7 @@ class RustfmtFormattingService : AsyncDocumentFormattingService() {
             private val indicator: ProgressIndicatorBase = ProgressIndicatorBase()
 
             override fun run() {
-                RustfmtTestmarks.rustfmtUsed.hit()
+                RustfmtTestmarks.RustfmtUsed.hit()
 
                 if (checkNeedInstallRustfmt(project, cargoProject.workingDirectory)) {
                     request.onTextReady(request.documentText)

--- a/src/main/kotlin/org/rust/ide/formatter/Util.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/Util.kt
@@ -13,5 +13,5 @@ val CodeStyleSettings.rust: RsCodeStyleSettings
     get() = getCustomSettings(RsCodeStyleSettings::class.java)
 
 object RustfmtTestmarks {
-    val rustfmtUsed: Testmark = Testmark("rustfmtUsed")
+    object RustfmtUsed : Testmark()
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
@@ -49,13 +49,13 @@ class RsAssertEqualInspection : RsLocalInspectionTool() {
             val lookup = ImplLookup.relativeTo(expr)
             // The `assert_eq!` macro, as opposed to `assert!`, requires both arguments to implement `core::fmt::Debug`.
             if (!lookup.isDebug(leftType) || !lookup.isDebug(rightType)) {
-                Testmarks.debugTraitIsNotImplemented.hit()
+                Testmarks.DebugTraitIsNotImplemented.hit()
                 return false
             }
             // Don't try to convert `assert!` macro into `assert_eq!/assert_ne!`
             // if expressions can't be compared at all
             if (!lookup.isPartialEq(leftType, rightType)) {
-                Testmarks.partialEqTraitIsNotImplemented.hit()
+                Testmarks.PartialEqTraitIsNotImplemented.hit()
                 return false
             }
             return true
@@ -95,7 +95,7 @@ class RsAssertEqualInspection : RsLocalInspectionTool() {
     }
 
     object Testmarks {
-        val partialEqTraitIsNotImplemented = Testmark("partialEqTraitIsNotImplemented")
-        val debugTraitIsNotImplemented = Testmark("debugTraitIsNotImplemented")
+        object PartialEqTraitIsNotImplemented : Testmark()
+        object DebugTraitIsNotImplemented : Testmark()
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsLiftInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLiftInspection.kt
@@ -65,7 +65,7 @@ class RsLiftInspection : RsLocalInspectionTool() {
                 (parent as? RsMatchArm)?.addCommaIfNeeded(factory)
                 expr.replace(factory.createRetExpr(expr.text))
             } else {
-                Testmarks.insideRetExpr.hit()
+                Testmarks.InsideRetExpr.hit()
             }
         }
 
@@ -79,7 +79,7 @@ class RsLiftInspection : RsLocalInspectionTool() {
     }
 
     object Testmarks {
-        val insideRetExpr = Testmark("insideRetExpr")
+        object InsideRetExpr : Testmark()
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -37,7 +37,7 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
         private fun sortedImplItems(implItems: List<RsAbstractable>, traitItems: List<RsAbstractable>): List<RsAbstractable>? {
             val traitItemMap = traitItems.withIndex().associate { it.value.key() to it.index }
             if (implItems.any { it.key() !in traitItemMap }) {
-                Testmarks.implMemberNotInTrait.hit()
+                Testmarks.ImplMemberNotInTrait.hit()
                 return null
             }
             val sortedImplItems = implItems.sortedBy { traitItemMap[it.key()] }
@@ -65,7 +65,7 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
     }
 
     object Testmarks {
-        val implMemberNotInTrait = Testmark("implMemberNotInTrait")
+        object ImplMemberNotInTrait : Testmark()
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -114,7 +114,7 @@ class AutoImportFix(element: RsElement, private val context: Context) :
 
             if (path.ancestorStrict<RsUseSpeck>() != null) {
                 // Don't try to import path in use item
-                Testmarks.pathInUseItem.hit()
+                Testmarks.PathInUseItem.hit()
                 return null
             }
 
@@ -125,7 +125,7 @@ class AutoImportFix(element: RsElement, private val context: Context) :
                 // Don't import names that are already in scope but cannot be resolved
                 // because namespace of psi element prevents correct name resolution.
                 // It's possible for incorrect or incomplete code like "let map = HashMap"
-                Testmarks.nameInScope.hit()
+                Testmarks.NameInScope.hit()
                 return null
             }
 
@@ -190,7 +190,7 @@ class AutoImportFix(element: RsElement, private val context: Context) :
     }
 
     object Testmarks {
-        val pathInUseItem = Testmark("pathInUseItem")
-        val nameInScope = Testmark("nameInScope")
+        object PathInUseItem : Testmark()
+        object NameInScope : Testmark()
     }
 }

--- a/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
@@ -33,7 +33,7 @@ class ExtractInlineModuleIntention : RsElementBaseIntentionAction<RsModItem>() {
         decl = ctx.parent?.addBefore(decl, ctx) as? RsModDeclItem ?: return
 
         if (ctx.firstChild != ctx.mod) {
-            Testmarks.copyAttrs.hit()
+            Testmarks.CopyAttrs.hit()
             decl.addRangeBefore(ctx.firstChild, ctx.mod.prevSibling, decl.mod)
         }
 
@@ -48,6 +48,6 @@ class ExtractInlineModuleIntention : RsElementBaseIntentionAction<RsModItem>() {
     }
 
     object Testmarks {
-        val copyAttrs = Testmark("copyAttrs")
+        object CopyAttrs : Testmark()
     }
 }

--- a/src/main/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntention.kt
@@ -38,7 +38,7 @@ class ImplTraitToTypeParamIntention : RsElementBaseIntentionAction<ImplTraitToTy
         // can't convert outer `impl Trait` because inner one
         // will appear in type parameter constrains which is invalid
         if (argType.descendantsOfType<RsTraitType>().any { it.impl != null }) {
-            outerImplTestMark.hit()
+            OuterImplTestMark.hit()
             HintManager.getInstance().showErrorHint(
                 editor,
                 "Please convert innermost `impl Trait` first",
@@ -92,6 +92,6 @@ class ImplTraitToTypeParamIntention : RsElementBaseIntentionAction<ImplTraitToTy
     )
 
     companion object {
-        val outerImplTestMark = Testmark("called on outer impl Trait")
+        object OuterImplTestMark : Testmark()
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsDirectoryRenameProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsDirectoryRenameProcessor.kt
@@ -32,7 +32,7 @@ class RsDirectoryRenameProcessor : RenamePsiFileProcessor() {
     }
 
     override fun prepareRenaming(element: PsiElement, newName: String, allRenames: MutableMap<PsiElement, String>) {
-        Testmarks.rustDirRenameHandler.hit()
+        Testmarks.RustDirRenameHandler.hit()
         super.prepareRenaming(element, newName, allRenames)
         if (!RefactoringSettings.getInstance().RENAME_SEARCH_FOR_REFERENCES_FOR_DIRECTORY) return
 
@@ -48,6 +48,6 @@ class RsDirectoryRenameProcessor : RenamePsiFileProcessor() {
         ?: (this as PsiDirectory)
 
     object Testmarks {
-        val rustDirRenameHandler = Testmark("rustDirRename")
+        object RustDirRenameHandler : Testmark()
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsNameSuggestions.kt
@@ -104,7 +104,7 @@ private val uselessNames = listOf("new", "default")
 private fun LinkedHashSet<String>.addName(name: String?) {
     if (name == null || name in uselessNames || !isValidRustVariableIdentifier(name)) return
     NameUtil.getSuggestionsByName(name, "", "", false, false, false)
-        .filter { it !in uselessNames && IntroduceVariableTestmarks.invalidNamePart.hitOnFalse(isValidRustVariableIdentifier(it)) }
+        .filter { it !in uselessNames && IntroduceVariableTestmarks.InvalidNamePart.hitOnFalse(isValidRustVariableIdentifier(it)) }
         .mapTo(this) { it.toSnakeCase(false) }
 }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandler.kt
@@ -21,7 +21,7 @@ class ImplementMembersHandler : LanguageCodeInsightActionHandler {
         val elementAtCaret = file.findElementAt(editor.caretModel.offset)
         val classOrObject = elementAtCaret?.ancestorOrSelf<RsImplItem>()
         return if (classOrObject == null) {
-            ImplementMembersMarks.noImplInHandler.hit()
+            ImplementMembersMarks.NoImplInHandler.hit()
             false
         } else {
             true
@@ -40,6 +40,6 @@ class ImplementMembersHandler : LanguageCodeInsightActionHandler {
 }
 
 object ImplementMembersMarks {
-    val noImplInHandler = Testmark("noImplInHandler")
+    object NoImplInHandler : Testmark()
 }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/RsIntroduceVariableHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/RsIntroduceVariableHandler.kt
@@ -47,5 +47,5 @@ class RsIntroduceVariableHandler : RefactoringActionHandler {
 }
 
 object IntroduceVariableTestmarks {
-    val invalidNamePart = Testmark("invalidNamePart")
+    object InvalidNamePart : Testmark()
 }

--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
@@ -279,7 +279,7 @@ private fun ImportContext2.checkVisibility(visItem: VisItem, modData: ModData): 
         val isPrivate = visibility.inMod == modData && !visibility.inMod.isCrateRoot
         val isExplicitlyDeclared = !visItem.isCrateRoot && visItem.containingMod == modData.path
         if (isPrivate && !isExplicitlyDeclared) {
-            Testmarks.ignorePrivateImportInParentMod.hit()
+            Testmarks.IgnorePrivateImportInParentMod.hit()
             return false
         }
     }

--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -42,7 +42,7 @@ fun ImportInfo.import(context: RsElement) {
             // In doctest injections all our code is located inside one invisible (main) function.
             // If we try to change PSI outside of that function, we'll take a crash.
             // So here we limit the module search with the last function (and never inert to an RsFile)
-            Testmarks.doctestInjectionImport.hit()
+            Testmarks.DoctestInjectionImport.hit()
             val scope = context.ancestors.find { it is RsMod && it !is RsFile }
                 ?: context.ancestors.findLast { it is RsFunction }
             ((scope as? RsFunction)?.block ?: scope) as RsItemsOwner
@@ -66,16 +66,16 @@ fun ImportInfo.insertExternCrateIfNeeded(context: RsElement): Int? {
             // but if crate of imported element is `std` and there aren't `#![no_std]` and `#![no_core]`
             // we don't add corresponding extern crate item manually
             // because it will be done by compiler implicitly
-            attributes == RsFile.Attributes.NONE && crate.isStd -> Testmarks.autoInjectedStdCrate.hit()
+            attributes == RsFile.Attributes.NONE && crate.isStd -> Testmarks.AutoInjectedStdCrate.hit()
             // if crate of imported element is `core` and there is `#![no_std]`
             // we don't add corresponding extern crate item manually for the same reason
-            attributes == RsFile.Attributes.NO_STD && crate.isCore -> Testmarks.autoInjectedCoreCrate.hit()
+            attributes == RsFile.Attributes.NO_STD && crate.isCore -> Testmarks.AutoInjectedCoreCrate.hit()
             else -> {
                 if (needInsertExternCrateItem) {
                     crateRoot?.insertExternCrateItem(RsPsiFactory(context.project), externCrateName)
                 } else {
                     if (depth != null) {
-                        Testmarks.externCrateItemInNotCrateRoot.hit()
+                        Testmarks.ExternCrateItemInNotCrateRoot.hit()
                         return depth
                     }
                 }
@@ -206,11 +206,11 @@ val Crate.isCore: Boolean
     get() = origin == PackageOrigin.STDLIB && normName == AutoInjectedCrates.CORE
 
 object Testmarks {
-    val autoInjectedStdCrate = Testmark("autoInjectedStdCrate")
-    val autoInjectedCoreCrate = Testmark("autoInjectedCoreCrate")
-    val externCrateItemInNotCrateRoot = Testmark("externCrateItemInNotCrateRoot")
-    val doctestInjectionImport = Testmark("doctestInjectionImport")
-    val ignorePrivateImportInParentMod = Testmark("ignorePrivateImportInParentMod")
+    object AutoInjectedStdCrate : Testmark()
+    object AutoInjectedCoreCrate : Testmark()
+    object ExternCrateItemInNotCrateRoot : Testmark()
+    object DoctestInjectionImport : Testmark()
+    object IgnorePrivateImportInParentMod : Testmark()
 }
 
 /**

--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -372,7 +372,7 @@ private fun addGenericTypeCompletion(element: RsGenericDeclaration, document: Do
 private fun InsertionContext.doNotAddOpenParenCompletionChar() {
     if (completionChar == '(') {
         setAddCompletionChar(false)
-        Testmarks.doNotAddOpenParenCompletionChar.hit()
+        Testmarks.DoNotAddOpenParenCompletionChar.hit()
     }
 }
 
@@ -451,5 +451,5 @@ private fun isCompatibleTypes(lookup: ImplLookup, actualTy: Ty?, expectedType: E
 }
 
 object Testmarks {
-    val doNotAddOpenParenCompletionChar = Testmark("doNotAddOpenParenCompletionChar")
+    object DoNotAddOpenParenCompletionChar : Testmark()
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -189,7 +189,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         if (TyPrimitive.fromPath(path) != null) return
         // TODO: implement special rules paths in meta items
         if (path.parent is RsMetaItem) return
-        Testmarks.outOfScopeItemsCompletion.hit()
+        Testmarks.OutOfScopeItemsCompletion.hit()
 
         val context = RsCompletionContext(path, expectedTy, isSimplePath = true)
         val candidates = if (path.useAutoImportWithNewResolve) run {
@@ -307,7 +307,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         get() = PlatformPatterns.psiElement().withParent(psiElement<RsReferenceElement>())
 
     object Testmarks {
-        val outOfScopeItemsCompletion = Testmark("outOfScopeItemsCompletion")
+        object OutOfScopeItemsCompletion : Testmark()
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsFullMacroArgumentCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsFullMacroArgumentCompletionProvider.kt
@@ -32,7 +32,7 @@ object RsFullMacroArgumentCompletionProvider : RsCompletionProvider() {
         val position = parameters.position
         val dstElement = position.findExpansionElements()?.firstOrNull() ?: return
         val dstOffset = dstElement.startOffset + (parameters.offset - position.startOffset)
-        Testmarks.touched.hit()
+        Testmarks.Touched.hit()
         rerunCompletion(parameters.withPosition(dstElement, dstOffset), result)
     }
 
@@ -42,6 +42,6 @@ object RsFullMacroArgumentCompletionProvider : RsCompletionProvider() {
             .inside(psiElement(MACRO_ARGUMENT))
 
     object Testmarks {
-        val touched = Testmark("RsFullMacroArgumentCompletionProvider.touched")
+        object Touched : Testmark()
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionProvider.kt
@@ -52,7 +52,7 @@ object RsPartialMacroArgumentCompletionProvider : RsCompletionProvider() {
         val graph = macro.graph ?: return
         val offsetInArgument = parameters.offset - bodyTextRange.startOffset
 
-        Testmarks.touched.hit()
+        Testmarks.Touched.hit()
 
         val walker = MacroGraphWalker(project, graph, macroCallBody, offsetInArgument)
         val fragmentDescriptors = walker.run().takeIf { it.isNotEmpty() } ?: return
@@ -79,6 +79,6 @@ object RsPartialMacroArgumentCompletionProvider : RsCompletionProvider() {
             .inside(psiElement<RsMacroArgument>())
 
     object Testmarks {
-        val touched = Testmark("RsPartialMacroArgumentCompletionProvider.touched")
+        object Touched : Testmark()
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/CrateGraphServiceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/CrateGraphServiceImpl.kt
@@ -288,7 +288,7 @@ private class CrateGraphBuilder {
                 lowerPackage(ProjectPackage(pkg.project, dep.pkg))?.let { Crate.Dependency(dep.name, it) }
             } catch (ignored: CyclicGraphException) {
                 // This can occur because `dev-dependencies` can cyclic depends on this package
-                CrateGraphTestmarks.cyclicDevDependency.hit()
+                CrateGraphTestmarks.CyclicDevDependency.hit()
                 cyclic += dep
                 null
             }

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/Util.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/Util.kt
@@ -22,5 +22,5 @@ fun Iterable<Crate.Dependency>.flattenTopSortedDeps(): LinkedHashSet<Crate> {
 }
 
 object CrateGraphTestmarks {
-    val cyclicDevDependency = Testmark("cyclicDevDependency")
+    object CyclicDevDependency : Testmark()
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/DocsLowering.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/DocsLowering.kt
@@ -40,7 +40,7 @@ fun PsiBuilder.lowerDocComments(): Pair<CharSequence, RangeMap>? {
         return null
     }
 
-    MacroExpansionMarks.docsLowering.hit()
+    MacroExpansionMarks.DocsLowering.hit()
 
     val sb = StringBuilder((originalText.length * 1.1).toInt())
     val ranges = SmartList<MappedTextRange>()

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -459,7 +459,7 @@ class SourceFile(
             }
             RefKind.STRONG -> error("unreachable") // handled above
             RefKind.STUB -> {
-                Testmarks.stubBasedRefMatch.hit()
+                Testmarks.StubBasedRefMatch.hit()
                 // Transition to any state from `STUB` is forbidden in the read action
                 matcher.stub(psi, _infos)
             }
@@ -571,7 +571,7 @@ class SourceFile(
      */
     private fun recoverRefs(prefetchedCalls: List<RsPossibleMacroCall>?) {
         checkReadAccessAllowed()
-        Testmarks.refsRecover.hit()
+        Testmarks.RefsRecover.hit()
 
         val psi = loadPsi() ?: return
         val calls = prefetchedCalls ?: psi.stubDescendantsOfTypeStrict<RsPossibleMacroCall>()
@@ -582,7 +582,7 @@ class SourceFile(
         for (call in calls) {
             val info = unboundInfos.find { it.isUpToDate(call, call.resolveToMacroWithoutPsi()) }
             if (info != null) {
-                Testmarks.refsRecoverExactHit.hit()
+                Testmarks.RefsRecoverExactHit.hit()
                 unboundInfos.remove(info)
                 bindList += Pair(info, call.calcStubIndex())
             } else {
@@ -595,11 +595,11 @@ class SourceFile(
         for (call in orphans) {
             val info = unboundInfos.find { it.callHash == call.bodyHash }
             if (info != null) {
-                Testmarks.refsRecoverCallHit.hit()
+                Testmarks.RefsRecoverCallHit.hit()
                 unboundInfos.remove(info)
                 bindList += Pair(info, call.calcStubIndex())
             } else {
-                Testmarks.refsRecoverNotHit.hit()
+                Testmarks.RefsRecoverNotHit.hit()
                 infosToAdd += ExpandedMacroInfoImpl.newStubLinked(this, call)
             }
         }
@@ -637,7 +637,7 @@ class SourceFile(
                 infos.find { it.macroCallStrongRef == seekingCall }
 
             override fun stub(psi: RsFile, infos: List<ExpandedMacroInfoImpl>): ExpandedMacroInfoImpl? {
-                Testmarks.stubBasedLookup.hit()
+                Testmarks.StubBasedLookup.hit()
                 val seekingStubIndex = seekingCall.calcStubIndex()
                 return infos.find { it.macroCallStubIndex == seekingStubIndex }
             }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -308,12 +308,12 @@ class MacroExpansionManagerImpl(
     }
 
     object Testmarks {
-        val stubBasedRefMatch = Testmark("stubBasedRefMatch")
-        val stubBasedLookup = Testmark("stubBasedLookup")
-        val refsRecover = Testmark("refsRecover")
-        val refsRecoverExactHit = Testmark("refsRecoverExactHit")
-        val refsRecoverCallHit = Testmark("refsRecoverCallHit")
-        val refsRecoverNotHit = Testmark("refsRecoverNotHit")
+        object StubBasedRefMatch : Testmark()
+        object StubBasedLookup : Testmark()
+        object RefsRecover : Testmark()
+        object RefsRecoverExactHit : Testmark()
+        object RefsRecoverCallHit : Testmark()
+        object RefsRecoverNotHit : Testmark()
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
@@ -216,7 +216,7 @@ class DeclMacroExpander(val project: Project): MacroExpander<RsDeclMacroData, De
                             }
                         }
                         VarLookupResult.None -> {
-                            MacroExpansionMarks.substMetaVarNotFound.hit()
+                            MacroExpansionMarks.SubstMetaVarNotFound.hit()
                             sb.safeAppend(child.text)
                             return@forEachChild
                         }
@@ -345,7 +345,7 @@ class MacroPattern private constructor(
     fun match(macroCallBody: PsiBuilder): MacroMatchingResult {
         return matchPartial(macroCallBody).andThen { result ->
             if (!macroCallBody.eof()) {
-                MacroExpansionMarks.failMatchPatternByExtraInput.hit()
+                MacroExpansionMarks.FailMatchPatternByExtraInput.hit()
                 err(::ExtraInput, macroCallBody)
             } else {
                 Ok(result)
@@ -370,7 +370,7 @@ class MacroPattern private constructor(
                     val lastOffset = macroCallBody.currentOffset
                     val parsed = kind.parse(macroCallBody)
                     if (!parsed || (lastOffset == macroCallBody.currentOffset && kind != FragmentKind.Vis)) {
-                        MacroExpansionMarks.failMatchPatternByBindingType.hit()
+                        MacroExpansionMarks.FailMatchPatternByBindingType.hit()
                         return err(::FragmentIsNotParsed, macroCallBody, name, kind)
                     }
                     val text = macroCallBody.originalText.substring(lastOffset, macroCallBody.currentOffset)
@@ -399,7 +399,7 @@ class MacroPattern private constructor(
                 }
                 else -> {
                     if (!macroCallBody.isSameToken(node)) {
-                        MacroExpansionMarks.failMatchPatternByToken.hit()
+                        MacroExpansionMarks.FailMatchPatternByToken.hit()
                         val actualToken = macroCallBody.tokenType?.toString()
                         val actualTokenText = macroCallBody.tokenText
                         return if (actualToken != null && actualTokenText != null) {
@@ -432,7 +432,7 @@ class MacroPattern private constructor(
 
         while (true) {
             if (macroCallBody.eof()) {
-                MacroExpansionMarks.groupInputEnd1.hit()
+                MacroExpansionMarks.GroupInputEnd1.hit()
                 mark?.rollbackTo()
                 break
             }
@@ -441,25 +441,25 @@ class MacroPattern private constructor(
             val result = pattern.matchPartial(macroCallBody)
             if (result is Ok) {
                 if (macroCallBody.currentOffset == lastOffset) {
-                    MacroExpansionMarks.groupMatchedEmptyTT.hit()
+                    MacroExpansionMarks.GroupMatchedEmptyTT.hit()
                     return err(::EmptyGroup, macroCallBody)
                 }
                 groups += result.ok
             } else {
-                MacroExpansionMarks.groupInputEnd2.hit()
+                MacroExpansionMarks.GroupInputEnd2.hit()
                 mark?.rollbackTo()
                 break
             }
 
             if (macroCallBody.eof()) {
-                MacroExpansionMarks.groupInputEnd3.hit()
+                MacroExpansionMarks.GroupInputEnd3.hit()
                 // Don't need to roll the marker back: we just successfully parsed a group
                 break
             }
 
             if (group.q != null) {
                 // `$(...)?` means "0 or 1 occurrences"
-                MacroExpansionMarks.questionMarkGroupEnd.hit()
+                MacroExpansionMarks.QuestionMarkGroupEnd.hit()
                 break
             }
 
@@ -468,7 +468,7 @@ class MacroPattern private constructor(
 
             if (separator != null) {
                 if (!macroCallBody.isSameToken(separator)) {
-                    MacroExpansionMarks.failMatchGroupBySeparator.hit()
+                    MacroExpansionMarks.FailMatchGroupBySeparator.hit()
                     break
                 }
             }
@@ -476,7 +476,7 @@ class MacroPattern private constructor(
 
         val isExpectedAtLeastOne = group.plus != null
         if (isExpectedAtLeastOne && groups.isEmpty()) {
-            MacroExpansionMarks.failMatchGroupTooFewElements.hit()
+            MacroExpansionMarks.FailMatchGroupTooFewElements.hit()
             return err(::TooFewGroupElements, macroCallBody)
         }
 
@@ -541,16 +541,16 @@ fun PsiBuilder.isSameToken(node: ASTNode): Boolean {
 }
 
 object MacroExpansionMarks {
-    val failMatchPatternByToken = Testmark("failMatchPatternByToken")
-    val failMatchPatternByExtraInput = Testmark("failMatchPatternByExtraInput")
-    val failMatchPatternByBindingType = Testmark("failMatchPatternByBindingType")
-    val failMatchGroupBySeparator = Testmark("failMatchGroupBySeparator")
-    val failMatchGroupTooFewElements = Testmark("failMatchGroupTooFewElements")
-    val questionMarkGroupEnd = Testmark("questionMarkGroupEnd")
-    val groupInputEnd1 = Testmark("groupInputEnd1")
-    val groupInputEnd2 = Testmark("groupInputEnd2")
-    val groupInputEnd3 = Testmark("groupInputEnd3")
-    val groupMatchedEmptyTT = Testmark("groupMatchedEmptyTT")
-    val substMetaVarNotFound = Testmark("substMetaVarNotFound")
-    val docsLowering = Testmark("docsLowering")
+    object FailMatchPatternByToken : Testmark()
+    object FailMatchPatternByExtraInput : Testmark()
+    object FailMatchPatternByBindingType : Testmark()
+    object FailMatchGroupBySeparator : Testmark()
+    object FailMatchGroupTooFewElements : Testmark()
+    object QuestionMarkGroupEnd : Testmark()
+    object GroupInputEnd1 : Testmark()
+    object GroupInputEnd2 : Testmark()
+    object GroupInputEnd3 : Testmark()
+    object GroupMatchedEmptyTT : Testmark()
+    object SubstMetaVarNotFound : Testmark()
+    object DocsLowering : Testmark()
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -603,7 +603,7 @@ class ImplLookup(
                         filtered.singleOrNull {
                             it !is SelectionCandidate.Impl || it.formalSelfTy !is TyTypeParameter
                         }?.let {
-                            TypeInferenceMarks.traitSelectionSpecialization.hit()
+                            TypeInferenceMarks.TraitSelectionSpecialization.hit()
                             SelectionResult.Ok(it)
                         } ?: SelectionResult.Ambiguous
                     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -14,7 +14,6 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.lang.core.resolve.ref.advancedDeepResolve
 import org.rust.lang.core.resolve2.processItemDeclarations2
-import org.rust.openapiext.Testmark
 import org.rust.openapiext.recursionGuard
 import org.rust.stdext.intersects
 import java.util.*
@@ -116,7 +115,6 @@ fun processItemDeclarations(
             // Use items like `use foo;` or `use foo::{self}` are meaningful since 2018 edition
             // only if `foo` is a crate, and it is `pub use` item. Otherwise,
             // we should ignore it or it breaks resolve of such `foo` in other places.
-            ItemResolutionTestmarks.extraAtomUse.hit()
             if (!withPrivateImports) {
                 val crate = findDependencyCrateByName(path, name)
                 if (crate != null && processor(name, crate)) return true
@@ -236,8 +234,6 @@ fun processExternCrateItem(item: RsExternCrateItem, processor: RsResolveProcesso
         val nameWithAlias = item.nameWithAlias
         if (nameWithAlias != "self") {
             if (processor(nameWithAlias, mod)) return true
-        } else {
-            ItemResolutionTestmarks.externCrateSelfWithoutAlias.hit()
         }
     }
     return false
@@ -287,9 +283,4 @@ enum class ItemProcessingMode(val withExternCrates: Boolean) {
     WITH_PRIVATE_IMPORTS(false),
     WITH_PRIVATE_IMPORTS_N_EXTERN_CRATES(true),
     WITH_PRIVATE_IMPORTS_N_EXTERN_CRATES_COMPLETION(true);
-}
-
-object ItemResolutionTestmarks {
-    val externCrateSelfWithoutAlias = Testmark("externCrateSelfWithoutAlias")
-    val extraAtomUse = Testmark("extraAtomUse")
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroBodyReferenceDelegateImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroBodyReferenceDelegateImpl.kt
@@ -18,7 +18,7 @@ class RsMacroBodyReferenceDelegateImpl(
 
     private val delegates: List<RsReference>
         get() {
-            Testmarks.touched.hit()
+            Testmarks.Touched.hit()
             return element.findExpansionElements()?.mapNotNull { delegated ->
                 delegated.ancestors
                     .mapNotNull { it.reference }
@@ -34,6 +34,6 @@ class RsMacroBodyReferenceDelegateImpl(
         delegates.flatMap { it.multiResolve() }.distinct()
 
     object Testmarks {
-        val touched = Testmark("touched")
+        object Touched : Testmark()
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
@@ -168,7 +168,7 @@ class RsResolveCache(project: Project) : Disposable {
     }
 
     private fun onRustStructureChanged(file: PsiFile?) {
-        Testmarks.rustStructureDependentCacheCleared.hit()
+        Testmarks.RustStructureDependentCacheCleared.hit()
         _rustStructureDependentCache.set(null)
         if (file != null && _macroCache.get() != null) {
             val viFile = file.virtualFile
@@ -195,7 +195,7 @@ class RsResolveCache(project: Project) : Disposable {
         val referenceElement = element.parent as? RsReferenceElement ?: return
         val referenceNameElement = referenceElement.referenceNameElement ?: return
         if (referenceNameElement == element) {
-            Testmarks.removeChangedElement.hit()
+            Testmarks.RemoveChangedElement.hit()
             referenceElement.ancestors.filter { it is RsReferenceElement }.forEach {
                 rustStructureDependentCache.remove(it)
             }
@@ -212,8 +212,8 @@ class RsResolveCache(project: Project) : Disposable {
     }
 
     object Testmarks {
-        val rustStructureDependentCacheCleared = Testmark("cacheCleared")
-        val removeChangedElement = Testmark("removeChangedElement")
+        object RustStructureDependentCacheCleared : Testmark()
+        object RemoveChangedElement : Testmark()
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -146,13 +146,13 @@ private fun inferSlicePatsTypes(
 
         val patRestCount = patList.count { it.isRest }
         if (patRestCount != 1) {
-            PatternMatchingTestMarks.multipleRestPats.hit()
+            PatternMatchingTestMarks.MultipleRestPats.hit()
             return CtUnknown
         }
 
         val restSize = arraySize - patList.size.toLong() + 1
         if (restSize < 0) {
-            PatternMatchingTestMarks.negativeRestSize.hit()
+            PatternMatchingTestMarks.NegativeRestSize.hit()
             return CtUnknown
         }
 
@@ -228,6 +228,6 @@ private fun Ty.stripReferences(defBm: RsBindingModeKind): Pair<Ty, RsBindingMode
 }
 
 object PatternMatchingTestMarks {
-    val multipleRestPats = Testmark("multipleRestPats")
-    val negativeRestSize = Testmark("negativeRestSize")
+    object MultipleRestPats : Testmark()
+    object NegativeRestSize : Testmark()
 }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -446,7 +446,7 @@ class RsInferenceContext(
                 })
                 if (isTy2ContainsTy1) {
                     // "E0308 cyclic type of infinite size"
-                    TypeInferenceMarks.cyclicType.hit()
+                    TypeInferenceMarks.CyclicType.hit()
                     varUnificationTable.unifyVarValue(ty1r, TyUnknown)
                 } else {
                     varUnificationTable.unifyVarValue(ty1r, ty2)
@@ -1128,13 +1128,13 @@ data class ExpectedType(val ty: Ty, val coercable: Boolean = false) : TypeFoldab
 }
 
 object TypeInferenceMarks {
-    val cyclicType = Testmark("cyclicType")
-    val questionOperator = Testmark("questionOperator")
-    val methodPickTraitScope = Testmark("methodPickTraitScope")
-    val methodPickTraitsOutOfScope = Testmark("methodPickTraitsOutOfScope")
-    val methodPickCheckBounds = Testmark("methodPickCheckBounds")
-    val methodPickDerefOrder = Testmark("methodPickDerefOrder")
-    val methodPickCollapseTraits = Testmark("methodPickCollapseTraits")
-    val traitSelectionSpecialization = Testmark("traitSelectionSpecialization")
-    val macroExprDepthLimitReached = Testmark("reachMacroExprDepthLimit")
+    object CyclicType : Testmark()
+    object QuestionOperator : Testmark()
+    object MethodPickTraitScope : Testmark()
+    object MethodPickTraitsOutOfScope : Testmark()
+    object MethodPickCheckBounds : Testmark()
+    object MethodPickDerefOrder : Testmark()
+    object MethodPickCollapseTraits : Testmark()
+    object TraitSelectionSpecialization : Testmark()
+    object MacroExprDepthLimitReached : Testmark()
 }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -630,7 +630,7 @@ class RsTypeInferenceWalker(
         val containingMod = context.containingMod
         return variants.singleOrLet { list ->
             // 1. filter traits that are not imported
-            TypeInferenceMarks.methodPickTraitScope.hit()
+            TypeInferenceMarks.MethodPickTraitScope.hit()
             val traitToCallee = hashMapOf<RsTraitItem, MutableList<T>>()
             val filtered = mutableListOf<T>()
             for (callee in list) {
@@ -645,7 +645,7 @@ class RsTypeInferenceWalker(
                 filtered += traitToCallee.getValue(it)
             }
             filtered.ifEmpty {
-                TypeInferenceMarks.methodPickTraitsOutOfScope.hit()
+                TypeInferenceMarks.MethodPickTraitsOutOfScope.hit()
                 list
             }
         }.singleOrFilter { callee ->
@@ -655,7 +655,7 @@ class RsTypeInferenceWalker(
                 || callee.element.isVisibleFrom(containingMod)
         }.singleOrFilter { callee ->
             // 3. Filter methods by trait bounds (try to select all obligations for each impl)
-            TypeInferenceMarks.methodPickCheckBounds.hit()
+            TypeInferenceMarks.MethodPickCheckBounds.hit()
             ctx.canEvaluateBounds(callee.source, callee.selfTy)
         }
     }
@@ -667,7 +667,7 @@ class RsTypeInferenceWalker(
     ): MethodResolveVariant? {
         val filtered = filterAssocItems(variants, methodCall).singleOrLet { list ->
             // 4. Pick results matching receiver type
-            TypeInferenceMarks.methodPickDerefOrder.hit()
+            TypeInferenceMarks.MethodPickDerefOrder.hit()
 
             fun pick(ty: Ty): List<MethodResolveVariant> =
                 list.filter { it.element.selfParameter?.typeOfValue(it.selfTy) == ty }
@@ -697,7 +697,7 @@ class RsTypeInferenceWalker(
                 // Specific impl will be selected later according to the method parameter type.
                 val first = filtered.first()
                 collapseToTrait(filtered.map { it.element })?.let { fn ->
-                    TypeInferenceMarks.methodPickCollapseTraits.hit()
+                    TypeInferenceMarks.MethodPickCollapseTraits.hit()
                     MethodResolveVariant(
                         first.name,
                         fn,
@@ -1012,7 +1012,7 @@ class RsTypeInferenceWalker(
             val okType = tryItem.findAssociatedType("Ok") ?: return TyUnknown
             return ctx.normalizeAssociatedTypesIn(TyProjection.valueOf(base, BoundElement(tryItem), okType)).value
         }
-        TypeInferenceMarks.questionOperator.hit()
+        TypeInferenceMarks.QuestionOperator.hit()
         return base.typeArguments.getOrElse(0) { TyUnknown }
     }
 
@@ -1086,7 +1086,7 @@ class RsTypeInferenceWalker(
 
     private fun inferMacroExprType(macroExpr: RsMacroExpr, expected: Ty?): Ty {
         if (macroExprDepth > DEFAULT_RECURSION_LIMIT) {
-            TypeInferenceMarks.macroExprDepthLimitReached.hit()
+            TypeInferenceMarks.MacroExprDepthLimitReached.hit()
             return TyUnknown
         }
         macroExprDepth++

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
@@ -81,8 +81,8 @@ class CfgEvaluator(
         val result = evaluatePredicate(cfgPredicate)
 
         when (result) {
-            True -> CfgTestmarks.evaluatesTrue.hit()
-            False -> CfgTestmarks.evaluatesFalse.hit()
+            True -> CfgTestmarks.EvaluatesTrue.hit()
+            False -> CfgTestmarks.EvaluatesFalse.hit()
             Unknown -> Unit
         }
 
@@ -243,6 +243,6 @@ private sealed class CfgPredicate {
 }
 
 object CfgTestmarks {
-    val evaluatesTrue = Testmark("evaluatesTrue")
-    val evaluatesFalse = Testmark("evaluatesFalse")
+    object EvaluatesTrue : Testmark()
+    object EvaluatesFalse : Testmark()
 }

--- a/src/test/kotlin/org/rust/CheckTestmarkHit.kt
+++ b/src/test/kotlin/org/rust/CheckTestmarkHit.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import org.rust.openapiext.Testmark
+import kotlin.reflect.KClass
+
+/**
+ * The [testmarkClasses] must be a kotlin object (`object Foo : Testmark`).
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CheckTestmarkHit(vararg val testmarkClasses: KClass<out Testmark>)
+
+/**
+ * The [testmarkClasses] must be a kotlin object (`object Foo : Testmark`).
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CheckTestmarkNotHit(vararg val testmarkClasses: KClass<out Testmark>)

--- a/src/test/kotlin/org/rust/NewResolve.kt
+++ b/src/test/kotlin/org/rust/NewResolve.kt
@@ -9,21 +9,10 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import junit.framework.TestCase
 import org.rust.lang.core.resolve2.defMapService
-import org.rust.lang.core.resolve2.isNewResolveEnabled
-import org.rust.openapiext.TestmarkPred
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class UseOldResolve
-
-fun TestmarkPred.ignoreInNewResolve(project: Project): TestmarkPred {
-    if (!project.isNewResolveEnabled) return this
-    return object : TestmarkPred {
-        override fun <T> checkHit(f: () -> T): T = f()
-
-        override fun <T> checkNotHit(f: () -> T): T = f()
-    }
-}
 
 fun TestCase.setupResolveEngine(project: Project, testRootDisposable: Disposable) {
     val defMap = project.defMapService

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -74,7 +74,9 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
             return
         }
 
-        super.runTestRunnable(testRunnable)
+        val testmark = collectTestmarksFromAnnotations()
+
+        testmark.checkHit { super.runTestRunnable(testRunnable) }
     }
 
     override fun setUp() {

--- a/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
@@ -330,7 +330,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
 
     private fun reformatRange(file: PsiFile, textRange: TextRange = file.textRange, shouldHitTestmark: Boolean = true) {
         project.rustSettings.modifyTemporary(testRootDisposable) { it.useRustfmt = true }
-        val testmark = RustfmtTestmarks.rustfmtUsed
+        val testmark = RustfmtTestmarks.RustfmtUsed
         val checkMark: (() -> Unit) -> Unit = if (shouldHitTestmark) testmark::checkHit else testmark::checkNotHit
         checkMark {
             WriteCommandAction.runWriteCommandAction(project, ReformatCodeProcessor.getCommandName(), null, {

--- a/src/test/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMoverTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMoverTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.actions.mover
 
+import org.rust.CheckTestmarkHit
+
 class RsCommaListElementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
     fun `test function parameter`() = moveDownAndBackUp("""
         fn foo(
@@ -269,6 +271,7 @@ class RsCommaListElementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfBlock::class)
     fun `test move up first vec argument`() = moveUp("""
         fn foo() {
             bar(
@@ -281,8 +284,9 @@ class RsCommaListElementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
                 ],
             );
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfBlock)
+    """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfBlock::class)
     fun `test move down last vec argument`() = moveDown("""
         fn foo() {
             bar(
@@ -295,7 +299,7 @@ class RsCommaListElementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
                 ],
             );
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfBlock)
+    """)
 
     fun `test move vec adds comma 1`() = moveDown("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/actions/mover/RsItemUpDownMoverTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsItemUpDownMoverTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.actions.mover
 
 import org.intellij.lang.annotations.Language
+import org.rust.CheckTestmarkHit
 
 class RsItemUpDownMoverTest : RsStatementUpDownMoverTestBase() {
     fun `test step nowhere`() = doTest("""
@@ -48,6 +49,7 @@ class RsItemUpDownMoverTest : RsStatementUpDownMoverTestBase() {
         fn /*caret*/foo() {}
     """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfImpl::class)
     fun `test impl prevent step out`() = moveDownAndBackUp("""
         struct S;
         impl S {
@@ -55,13 +57,14 @@ class RsItemUpDownMoverTest : RsStatementUpDownMoverTestBase() {
                 test!();
             }
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfImpl)
+    """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfImpl::class)
     fun `test trait prevent step out`() = moveDownAndBackUp("""
         trait T {
             type /*caret*/Foo;
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfImpl)
+    """)
 
     fun `test can move items inside impl`() {
         moveDownAndBackUp("""

--- a/src/test/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMoverTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMoverTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.actions.mover
 
+import org.rust.CheckTestmarkHit
+
 class RsMatchArmUpDownMoverTest : RsStatementUpDownMoverTestBase() {
     fun `test step over match arm single line expr`() = moveDownAndBackUp("""
         fn main() {
@@ -46,6 +48,7 @@ class RsMatchArmUpDownMoverTest : RsStatementUpDownMoverTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfMatch::class)
     fun `test prevent step out match body`() = moveDownAndBackUp("""
         fn main() {
             match test {
@@ -54,7 +57,7 @@ class RsMatchArmUpDownMoverTest : RsStatementUpDownMoverTestBase() {
                 }
             }
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfMatch)
+    """)
 
     fun `test can move several arms`() = moveDownAndBackUp("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.actions.mover
 
+import org.rust.CheckTestmarkHit
+
 class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
     fun `test straightline down`() = moveDown("""
         fn main() {
@@ -34,21 +36,23 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfBody::class)
     fun `test straightline down out of body`() = moveDown("""
         fn main() {
             1;
             2;
             3/*caret*/;
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+    """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfBody::class)
     fun `test straightline up out of body`() = moveUp("""
         fn main() {
             1/*caret*/;
             2;
             3;
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+    """)
 
     fun `test up into if block`() = moveUp("""
         fn main() {
@@ -585,6 +589,7 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfBody::class)
     fun `test move up first statement in match arm body`() = moveUp("""
         fn main() {
              match x {
@@ -601,8 +606,9 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
                  }
              };
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+    """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfBody::class)
     fun `test move down last statement in match arm body`() = moveDown("""
         fn main() {
              match x {
@@ -619,7 +625,7 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
                  }
              };
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+    """)
 
     // https://github.com/intellij-rust/intellij-rust/issues/7376
     fun `test move down in block inside argument list`() = moveDown("""
@@ -644,6 +650,7 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfBody::class)
     fun `test move up first statement of block expr inside argument list`() = moveUp("""
         fn foo(a: u32) {}
 
@@ -654,8 +661,9 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
                 1
             });
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+    """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfBody::class)
     fun `test move up first statement of lambda inside argument list`() = moveUp("""
         fn foo<F: Fn() -> ()>(f: F) -> u32 { 0 }
 
@@ -674,8 +682,9 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
                 })
             };
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+    """)
 
+    @CheckTestmarkHit(UpDownMoverTestMarks.MoveOutOfBody::class)
     fun `test move up first statement of lambda ref inside argument list`() = moveUp("""
         fn foo<F: Fn() -> ()>(f: &mut F) -> u32 { 0 }
 
@@ -694,5 +703,5 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
                 })
             };
         }
-    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTestBase.kt
@@ -8,36 +8,31 @@ package org.rust.ide.actions.mover
 import com.intellij.openapi.actionSystem.IdeActions
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
-import org.rust.openapiext.Testmark
 
 abstract class RsStatementUpDownMoverTestBase : RsTestBase() {
     fun moveDown(
         @Language("Rust") before: String,
         @Language("Rust") after: String = before,
-        testmark: Testmark? = null
-    ) = doTest(before, after, IdeActions.ACTION_MOVE_STATEMENT_DOWN_ACTION, testmark)
+    ) = doTest(before, after, IdeActions.ACTION_MOVE_STATEMENT_DOWN_ACTION)
 
     fun moveUp(
         @Language("Rust") before: String,
         @Language("Rust") after: String = before,
-        testmark: Testmark? = null
-    ) = doTest(before, after, IdeActions.ACTION_MOVE_STATEMENT_UP_ACTION, testmark)
+    ) = doTest(before, after, IdeActions.ACTION_MOVE_STATEMENT_UP_ACTION)
 
     fun moveDownAndBackUp(
         @Language("Rust") down: String,
         @Language("Rust") up: String = down,
-        testmark: Testmark? = null
     ) {
-        moveDown(down, up, testmark)
-        moveUp(up, down, testmark)
+        moveDown(down, up)
+        moveUp(up, down)
     }
 
     private fun doTest(
         @Language("Rust") before: String,
         @Language("Rust") after: String = before,
         actionId: String,
-        testmark: Testmark? = null
     ) {
-        checkEditorAction(before.trimIndent() + "\n", after.trimIndent() + "\n", actionId, false, testmark)
+        checkEditorAction(before.trimIndent() + "\n", after.trimIndent() + "\n", actionId, false)
     }
 }

--- a/src/test/kotlin/org/rust/ide/annotator/AnnotationTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/AnnotationTestFixtureBase.kt
@@ -16,7 +16,6 @@ import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.impl.BaseFixture
 import junit.framework.TestCase
 import org.rust.findAnnotationInstance
-import org.rust.openapiext.Testmark
 import kotlin.reflect.KClass
 
 abstract class AnnotationTestFixtureBase(
@@ -85,14 +84,14 @@ abstract class AnnotationTestFixtureBase(
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
-        testmark: Testmark? = null
-    ) = check(text,
+    ) = check(
+        text,
         checkWarn = checkWarn,
         checkInfo = checkInfo,
         checkWeakWarn = checkWeakWarn,
         ignoreExtraHighlighting = ignoreExtraHighlighting,
         configure = this::configureByText,
-        testmark = testmark)
+    )
 
     fun checkFixByText(
         fixName: String,
@@ -101,12 +100,14 @@ abstract class AnnotationTestFixtureBase(
         checkWarn: Boolean = true,
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
-        testmark: Testmark? = null
-    ) = checkFix(fixName, before, after,
+    ) = checkFix(
+        fixName,
+        before,
+        after,
         configure = this::configureByText,
         checkBefore = { codeInsightFixture.checkHighlighting(checkWarn, checkInfo, checkWeakWarn) },
         checkAfter = this::checkByText,
-        testmark = testmark)
+    )
 
     fun checkFixIsUnavailable(
         fixName: String,
@@ -115,14 +116,15 @@ abstract class AnnotationTestFixtureBase(
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
-        testmark: Testmark? = null
-    ) = checkFixIsUnavailable(fixName, text,
+    ) = checkFixIsUnavailable(
+        fixName,
+        text,
         checkWarn = checkWarn,
         checkInfo = checkInfo,
         checkWeakWarn = checkWeakWarn,
         ignoreExtraHighlighting = ignoreExtraHighlighting,
         configure = this::configureByText,
-        testmark = testmark)
+    )
 
     protected fun checkFixIsUnavailable(
         fixName: String,
@@ -132,9 +134,8 @@ abstract class AnnotationTestFixtureBase(
         checkWeakWarn: Boolean,
         ignoreExtraHighlighting: Boolean,
         configure: (String) -> Unit,
-        testmark: Testmark? = null
     ) {
-        check(text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, configure, testmark)
+        check(text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, configure)
         check(codeInsightFixture.filterAvailableIntentions(fixName).isEmpty()) {
             "Fix $fixName should not be possible to apply."
         }
@@ -144,12 +145,14 @@ abstract class AnnotationTestFixtureBase(
         fixName: String,
         before: String,
         after: String,
-        testmark: Testmark? = null
-    ) = checkFix(fixName, before, after,
+    ) = checkFix(
+        fixName,
+        before,
+        after,
         configure = this::configureByText,
         checkBefore = {},
         checkAfter = this::checkByText,
-        testmark = testmark)
+    )
 
     protected open fun <T> check(
         content: T,
@@ -158,13 +161,9 @@ abstract class AnnotationTestFixtureBase(
         checkWeakWarn: Boolean,
         ignoreExtraHighlighting: Boolean,
         configure: (T) -> Unit,
-        testmark: Testmark? = null
     ) {
-        val action: () -> Unit = {
-            configure(content)
-            codeInsightFixture.checkHighlighting(checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting)
-        }
-        testmark?.checkHit(action) ?: action()
+        configure(content)
+        codeInsightFixture.checkHighlighting(checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting)
     }
 
     protected open fun checkFix(
@@ -174,15 +173,11 @@ abstract class AnnotationTestFixtureBase(
         configure: (String) -> Unit,
         checkBefore: () -> Unit,
         checkAfter: (String) -> Unit,
-        testmark: Testmark? = null
     ) {
-        val action: () -> Unit = {
-            configure(before)
-            checkBefore()
-            applyQuickFix(fixName)
-            checkAfter(after)
-        }
-        testmark?.checkHit(action) ?: action()
+        configure(before)
+        checkBefore()
+        applyQuickFix(fixName)
+        checkAfter(after)
     }
 
     fun checkByText(text: String) {

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
@@ -13,7 +13,6 @@ import org.rust.RsTestBase
 import org.rust.fileTreeFromText
 import org.rust.lang.core.psi.RsCodeFragment
 import org.rust.lang.core.psi.ext.RsElement
-import org.rust.openapiext.Testmark
 
 abstract class RsAnnotationTestBase : RsTestBase() {
 
@@ -45,8 +44,7 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
-        testmark: Testmark? = null
-    ) = annotationFixture.checkByText(text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, testmark)
+    ) = annotationFixture.checkByText(text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting)
 
     protected fun checkFixByText(
         fixName: String,
@@ -55,15 +53,13 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkWarn: Boolean = true,
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
-        testmark: Testmark? = null
-    ) = annotationFixture.checkFixByText(fixName, before, after, checkWarn, checkInfo, checkWeakWarn, testmark)
+    ) = annotationFixture.checkFixByText(fixName, before, after, checkWarn, checkInfo, checkWeakWarn)
 
     protected fun checkFixByTextWithoutHighlighting(
         fixName: String,
         @Language("Rust") before: String,
         @Language("Rust") after: String,
-        testmark: Testmark? = null
-    ) = annotationFixture.checkFixByTextWithoutHighlighting(fixName, before, after, testmark)
+    ) = annotationFixture.checkFixByTextWithoutHighlighting(fixName, before, after)
 
     protected fun checkByFileTree(
         @Language("Rust") text: String,
@@ -72,8 +68,7 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
         stubOnly: Boolean = true,
-        testmark: Testmark? = null
-    ) = annotationFixture.checkByFileTree(text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, stubOnly, testmark)
+    ) = annotationFixture.checkByFileTree(text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, stubOnly)
 
     protected fun checkFixByFileTree(
         fixName: String,
@@ -83,16 +78,14 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         stubOnly: Boolean = true,
-        testmark: Testmark? = null
-    ) = annotationFixture.checkFixByFileTree(fixName, before, after, checkWarn, checkInfo, checkWeakWarn, stubOnly, testmark)
+    ) = annotationFixture.checkFixByFileTree(fixName, before, after, checkWarn, checkInfo, checkWeakWarn, stubOnly)
 
     protected fun checkFixByFileTreeWithoutHighlighting(
         fixName: String,
         @Language("Rust") before: String,
         @Language("Rust") after: String,
         stubOnly: Boolean = true,
-        testmark: Testmark? = null
-    ) = annotationFixture.checkFixByFileTreeWithoutHighlighting(fixName, before, after, stubOnly, testmark)
+    ) = annotationFixture.checkFixByFileTreeWithoutHighlighting(fixName, before, after, stubOnly)
 
     protected fun checkFixIsUnavailable(
         fixName: String,
@@ -101,8 +94,7 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
-        testmark: Testmark? = null
-    ) = annotationFixture.checkFixIsUnavailable(fixName, text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, testmark)
+    ) = annotationFixture.checkFixIsUnavailable(fixName, text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting)
 
     protected fun checkFixIsUnavailableByFileTree(
         fixName: String,
@@ -112,8 +104,7 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
         stubOnly: Boolean = true,
-        testmark: Testmark? = null
-    ) = annotationFixture.checkFixIsUnavailableByFileTree(fixName, text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, stubOnly, testmark)
+    ) = annotationFixture.checkFixIsUnavailableByFileTree(fixName, text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, stubOnly)
 
     protected fun checkDontTouchAstInOtherFiles(@Language("Rust") text: String, checkInfo: Boolean = false, filePath: String? = null) {
         fileTreeFromText(text).create()

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
@@ -15,7 +15,6 @@ import org.intellij.lang.annotations.Language
 import org.rust.TestProject
 import org.rust.createAndOpenFileWithCaretMarker
 import org.rust.fileTreeFromText
-import org.rust.openapiext.Testmark
 import kotlin.reflect.KClass
 
 open class RsAnnotationTestFixture<C>(
@@ -33,14 +32,14 @@ open class RsAnnotationTestFixture<C>(
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
         stubOnly: Boolean = true,
-        testmark: Testmark? = null
-    ) = check(text,
+    ) = check(
+        text,
         checkWarn = checkWarn,
         checkInfo = checkInfo,
         checkWeakWarn = checkWeakWarn,
         ignoreExtraHighlighting = ignoreExtraHighlighting,
         configure = { configureByFileTree(it, stubOnly) },
-        testmark = testmark)
+    )
 
     fun checkFixByFileTree(
         fixName: String,
@@ -50,24 +49,28 @@ open class RsAnnotationTestFixture<C>(
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         stubOnly: Boolean = true,
-        testmark: Testmark? = null
-    ) = checkFix(fixName, before, after,
+    ) = checkFix(
+        fixName,
+        before,
+        after,
         configure = { configureByFileTree(it, stubOnly) },
         checkBefore = { codeInsightFixture.checkHighlighting(checkWarn, checkInfo, checkWeakWarn) },
         checkAfter = this::checkByFileTree,
-        testmark = testmark)
+    )
 
     fun checkFixByFileTreeWithoutHighlighting(
         fixName: String,
         @Language("Rust") before: String,
         @Language("Rust") after: String,
         stubOnly: Boolean = true,
-        testmark: Testmark? = null
-    ) = checkFix(fixName, before, after,
+    ) = checkFix(
+        fixName,
+        before,
+        after,
         configure = { configureByFileTree(it, stubOnly) },
         checkBefore = {},
         checkAfter = this::checkByFileTree,
-        testmark = testmark)
+    )
 
     fun checkFixIsUnavailableByFileTree(
         fixName: String,
@@ -77,14 +80,15 @@ open class RsAnnotationTestFixture<C>(
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
         stubOnly: Boolean = true,
-        testmark: Testmark? = null
-    ) = checkFixIsUnavailable(fixName, text,
+    ) = checkFixIsUnavailable(
+        fixName,
+        text,
         checkWarn = checkWarn,
         checkInfo = checkInfo,
         checkWeakWarn = checkWeakWarn,
         ignoreExtraHighlighting = ignoreExtraHighlighting,
         configure = { configureByFileTree(it, stubOnly) },
-        testmark = testmark)
+    )
 
     fun checkByFile(
         file: VirtualFile,
@@ -93,14 +97,14 @@ open class RsAnnotationTestFixture<C>(
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
-        testmark: Testmark? = null,
-    ) = check(file,
+    ) = check(
+        file,
         checkWarn = checkWarn,
         checkInfo = checkInfo,
         checkWeakWarn = checkWeakWarn,
         ignoreExtraHighlighting = ignoreExtraHighlighting,
         configure = { configureByFile(file, context) },
-        testmark = testmark)
+    )
 
     private fun checkByFileTree(text: String) {
         fileTreeFromText(replaceCaretMarker(text)).check(codeInsightFixture)

--- a/src/test/kotlin/org/rust/ide/annotator/RsWithToolchainAnnotationTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsWithToolchainAnnotationTestBase.kt
@@ -10,7 +10,6 @@ import org.rust.FileTree
 import org.rust.FileTreeBuilder
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.fileTree
-import org.rust.openapiext.Testmark
 
 abstract class RsWithToolchainAnnotationTestBase<C> : RsWithToolchainTestBase() {
 
@@ -35,11 +34,10 @@ abstract class RsWithToolchainAnnotationTestBase<C> : RsWithToolchainTestBase() 
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
-        testmark: Testmark? = null,
         builder: FileTreeBuilder.() -> Unit
     ) {
         val file = configureProject(fileTree(builder), context)
-        annotationFixture.checkByFile(file, context, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, testmark)
+        annotationFixture.checkByFile(file, context, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting)
     }
 
     /**

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt
@@ -51,7 +51,6 @@ class ConvertToSizedTypeFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             checkWarn = true,
             checkInfo = false,
             checkWeakWarn = false,
-            testmark = null
         )
     }
 }

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -13,7 +13,6 @@ import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.lang.RsLanguage
-import org.rust.openapiext.Testmark
 import kotlin.reflect.KMutableProperty0
 
 class RsCommenterTest : RsTestBase() {
@@ -280,9 +279,8 @@ class RsCommenterTest : RsTestBase() {
         after: String,
         actionId: String,
         trimIndent: Boolean,
-        testmark: Testmark?
     ) {
-        super.checkEditorAction(before, after, actionId, trimIndent, testmark)
+        super.checkEditorAction(before, after, actionId, trimIndent)
         resetActionManagerState()
     }
 

--- a/src/test/kotlin/org/rust/ide/docs/RsDocumentationProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsDocumentationProviderTest.kt
@@ -9,7 +9,6 @@ import com.intellij.codeInsight.documentation.DocumentationManager
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
-import org.rust.openapiext.Testmark
 
 abstract class RsDocumentationProviderTest : RsTestBase() {
 
@@ -59,16 +58,15 @@ abstract class RsDocumentationProviderTest : RsTestBase() {
         }
     }
 
-    protected fun doUrlTestByText(@Language("Rust") text: String, expectedUrl: String?, testmark: Testmark? = null) =
-        doUrlTest(text, expectedUrl, testmark, this::configureByText)
+    protected fun doUrlTestByText(@Language("Rust") text: String, expectedUrl: String?) =
+        doUrlTest(text, expectedUrl, this::configureByText)
 
-    protected fun doUrlTestByFileTree(@Language("Rust") text: String, expectedUrl: String?, testmark: Testmark? = null) =
-        doUrlTest(text, expectedUrl, testmark) { configureByFileTree(it) }
+    protected fun doUrlTestByFileTree(@Language("Rust") text: String, expectedUrl: String?) =
+        doUrlTest(text, expectedUrl) { configureByFileTree(it) }
 
     private fun doUrlTest(
         @Language("Rust") text: String,
         expectedUrl: String?,
-        testmark: Testmark?,
         configure: (String) -> Unit
     ) {
         configure(text)
@@ -77,11 +75,8 @@ abstract class RsDocumentationProviderTest : RsTestBase() {
         val element = DocumentationManager.getInstance(project)
             .findTargetElement(myFixture.editor, offset, myFixture.file, originalElement)!!
 
-        val action: () -> Unit = {
-            val actualUrls = RsDocumentationProvider().getUrlFor(element, originalElement)
-            assertEquals(listOfNotNull(expectedUrl), actualUrls)
-        }
-        testmark?.checkHit(action) ?: action()
+        val actualUrls = RsDocumentationProvider().getUrlFor(element, originalElement)
+        assertEquals(listOfNotNull(expectedUrl), actualUrls)
     }
 
     protected fun String.hideSpecificStyles(): String = replace(STYLE_REGEX, """style="..."""")

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.docs
 
+import org.rust.CheckTestmarkHit
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.ide.docs.RsDocumentationProvider.Testmarks
@@ -98,12 +99,13 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
         }
     """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/struct.Foo.html#method.foo")
 
+    @CheckTestmarkHit(Testmarks.DocHidden::class)
     fun `test doc hidden`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
         #[doc(hidden)]
         pub fn foo() {}
                //^
-    """, null, Testmarks.docHidden)
+    """, null)
 
     fun `test macro`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
@@ -125,13 +127,14 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
         }
     """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/macro.foo.html")
 
+    @CheckTestmarkHit(Testmarks.NotExportedMacro::class)
     fun `test not exported macro`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
         macro_rules! foo {
                     //^
             () => { unimplemented!() };
         }
-    """, null, Testmarks.notExportedMacro)
+    """, null)
 
     fun `test macro 2`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
@@ -147,15 +150,17 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
 
     """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/foo/macro.bar.html")
 
+    @CheckTestmarkHit(Testmarks.NonDependency::class)
     fun `test not external url for workspace package`() = doUrlTestByFileTree("""
         //- lib.rs
         pub enum Foo { FOO, BAR }
                 //^
-    """, null, Testmarks.nonDependency)
+    """, null)
 
+    @CheckTestmarkHit(Testmarks.PkgWithoutSource::class)
     fun `test not external url for dependency package without source`() = doUrlTestByFileTree("""
         //- no-source-lib/lib.rs
         pub enum Foo { FOO, BAR }
                 //^
-    """, null, Testmarks.pkgWithoutSource)
+    """, null)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections
 
+import org.rust.CheckTestmarkHit
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
@@ -102,6 +103,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
+    @CheckTestmarkHit(RsAssertEqualInspection.Testmarks.DebugTraitIsNotImplemented::class)
     fun `test fix unavailable when arguments do not implement Debug`() = checkFixIsUnavailable("Convert to assert_eq!", """
         #[derive(PartialEq)]
         struct Number(u32);
@@ -111,8 +113,9 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
             let y = Number(10);
             assert!(x == y/*caret*/);
         }
-    """, checkWeakWarn = true, testmark = RsAssertEqualInspection.Testmarks.debugTraitIsNotImplemented)
+    """, checkWeakWarn = true)
 
+    @CheckTestmarkHit(RsAssertEqualInspection.Testmarks.PartialEqTraitIsNotImplemented::class)
     fun `test fix unavailable when arguments do not implement PartialEq`() = checkFixIsUnavailable("Convert to assert_eq!", """
         #[derive(Debug)]
         struct Number(u32);
@@ -122,7 +125,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
             let y = Number(10);
             assert!(x == y/*caret*/);
         }
-    """, checkWeakWarn = true, testmark = RsAssertEqualInspection.Testmarks.partialEqTraitIsNotImplemented)
+    """, checkWeakWarn = true)
 
     fun `test fix available when arguments derive PartialEq & Debug`() = checkFixByText("Convert to assert_ne!", """
         #[derive(Debug, PartialEq)]

--- a/src/test/kotlin/org/rust/ide/inspections/RsLiftInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsLiftInspectionTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.inspections
 
+import org.rust.CheckTestmarkHit
+
 class RsLiftInspectionTest : RsInspectionsTestBase(RsLiftInspection::class) {
 
     fun `test lift return in if 1`() = checkFixByText("Lift return out of 'if'", """
@@ -56,6 +58,7 @@ class RsLiftInspectionTest : RsInspectionsTestBase(RsLiftInspection::class) {
         }
     """, checkWeakWarn = true)
 
+    @CheckTestmarkHit(RsLiftInspection.Testmarks.InsideRetExpr::class)
     fun `test lift return in if with return`() = checkFixByText("Lift return out of 'if'", """
         fn foo(x: bool) -> i32 {
             return /*weak_warning descr="Return can be lifted out of 'if'"*/if/*caret*//*weak_warning**/ x {
@@ -72,7 +75,7 @@ class RsLiftInspectionTest : RsInspectionsTestBase(RsLiftInspection::class) {
                 0
             };
         }
-    """, checkWeakWarn = true, testmark = RsLiftInspection.Testmarks.insideRetExpr)
+    """, checkWeakWarn = true)
 
     fun `test lift return in else if`() = checkFixIsUnavailable("Lift return out of 'if'", """
         fn get_char(n: u32) -> char {

--- a/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.inspections
 
+import org.rust.CheckTestmarkHit
+
 class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTraitMembersInspection::class) {
 
     fun `test same order`() = checkFixIsUnavailable("Apply same member order", """
@@ -76,6 +78,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
         }
     """)
 
+    @CheckTestmarkHit(RsSortImplTraitMembersInspection.Testmarks.ImplMemberNotInTrait::class)
     fun `test impl with unknown members`() = checkFixIsUnavailable("Apply same member order", """
         trait Foo {
             fn f();
@@ -86,7 +89,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             fn f() {}
             fn h() {}
         }
-    """, testmark = RsSortImplTraitMembersInspection.Testmarks.implMemberNotInTrait)
+    """)
 
     fun `test different order`() = checkFixByText("Apply same member order", """
         struct Struct {

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -107,6 +107,7 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         }
     """)
 
+    @CheckTestmarkHit(AutoImportFix.Testmarks.NameInScope::class)
     fun `test do not highlight unresolved path references if name is in scope`() = checkByText("""
         use foo::Foo;
 
@@ -117,7 +118,7 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         fn main() {
             Foo
         }
-    """, testmark = AutoImportFix.Testmarks.nameInScope)
+    """)
 
     fun `test do not highlight unresolved method of trait bound if multiple defs (invalid code)`() = checkByText("""
         mod foo {

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -5,22 +5,20 @@
 
 package org.rust.ide.inspections.import
 
-import org.rust.MinRustcVersion
-import org.rust.MockEdition
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.utils.import.Testmarks
 
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
 class AutoImportFixStdTest : AutoImportFixTestBase() {
+    @CheckTestmarkHit(Testmarks.AutoInjectedStdCrate::class)
     fun `test import item from std crate`() = checkAutoImportFixByText("""
         fn foo<T: <error descr="Unresolved reference: `error`">error/*caret*/</error>::Error>(_: T) {}
     """, """
         use std::error;
 
         fn foo<T: error/*caret*/::Error>(_: T) {}
-    """, Testmarks.autoInjectedStdCrate)
+    """)
 
     fun `test import item from not std crate`() = checkAutoImportFixByFileTree("""
         //- dep-lib/lib.rs
@@ -96,6 +94,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(t: Bar/*caret*/) {}
     """)
 
+    @CheckTestmarkHit(Testmarks.AutoInjectedStdCrate::class)
     fun `test import reexported item from stdlib`() = checkAutoImportFixByText("""
         fn main() {
             let mutex = <error descr="Unresolved reference: `Mutex`">Mutex/*caret*/</error>::new(Vec::new());
@@ -106,7 +105,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn main() {
             let mutex = Mutex/*caret*/::new(Vec::new());
         }
-    """, Testmarks.autoInjectedStdCrate)
+    """)
 
     fun `test module reexport`() = checkAutoImportFixByFileTree("""
         //- dep-lib/lib.rs
@@ -133,14 +132,16 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(Testmarks.AutoInjectedStdCrate::class)
     fun `test module reexport in stdlib`() = checkAutoImportFixByText("""
         fn foo<T: <error descr="Unresolved reference: `Hash`">Hash/*caret*/</error>>(t: T) {}
     """, """
         use std::hash::Hash;
 
         fn foo<T: Hash/*caret*/>(t: T) {}
-    """, Testmarks.autoInjectedStdCrate)
+    """)
 
+    @CheckTestmarkHit(Testmarks.AutoInjectedCoreCrate::class)
     fun `test import without std crate 1`() = checkAutoImportFixByText("""
         #![no_std]
 
@@ -151,7 +152,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         use core::hash::Hash;
 
         fn foo<T: Hash/*caret*/>(t: T) {}
-    """, Testmarks.autoInjectedCoreCrate)
+    """)
 
     fun `test import without std crate 2`() = checkAutoImportFixByText("""
         #![no_std]

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -442,6 +442,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(Testmarks.IgnorePrivateImportInParentMod::class)
     fun `test don't try to import private reexport from parent mod 1`() = checkAutoImportFixByText("""
         mod a1 {
             use crate::b1::b2::Foo;
@@ -474,8 +475,9 @@ class AutoImportFixTest : AutoImportFixTestBase() {
                 pub struct Foo;
             }
         }
-    """, Testmarks.ignorePrivateImportInParentMod)
+    """)
 
+    @CheckTestmarkHit(Testmarks.IgnorePrivateImportInParentMod::class)
     fun `test don't try to import private reexport from parent mod 2`() = checkAutoImportFixByText("""
         mod a1 {
             use crate::b1::b2::b3;
@@ -512,7 +514,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
                 }
             }
         }
-    """, Testmarks.ignorePrivateImportInParentMod)
+    """)
 
     fun `test complex module structure`() = checkAutoImportFixByText("""
         mod aaa {
@@ -1002,13 +1004,14 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(AutoImportFix.Testmarks.PathInUseItem::class)
     fun `test do not import path in use item`() = checkAutoImportFixIsUnavailable("""
         mod bar {
             pub struct Bar;
         }
 
         use <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
-    """, AutoImportFix.Testmarks.pathInUseItem)
+    """)
 
     fun `test multiple import`() = checkAutoImportFixByTextWithMultipleChoice("""
         mod foo {
@@ -2481,6 +2484,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @CheckTestmarkHit(Testmarks.DoctestInjectionImport::class)
     fun `test import outer item in doctest injection`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /// ```
@@ -2494,9 +2498,10 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         /// foo();
         /// ```
         pub fn foo() {}
-    """, Testmarks.doctestInjectionImport)
+    """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @CheckTestmarkHit(Testmarks.DoctestInjectionImport::class)
     fun `test import outer item in doctest injection with tildes`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /// ~~~
@@ -2510,9 +2515,10 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         /// foo();
         /// ~~~
         pub fn foo() {}
-    """, Testmarks.doctestInjectionImport)
+    """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @CheckTestmarkHit(Testmarks.DoctestInjectionImport::class)
     fun `test import outer item in doctest injection in star comment`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /**
@@ -2530,9 +2536,10 @@ class AutoImportFixTest : AutoImportFixTestBase() {
          * ```
          */
         pub fn foo() {}
-    """,  Testmarks.doctestInjectionImport)
+    """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @CheckTestmarkHit(Testmarks.DoctestInjectionImport::class)
     fun `test import second outer item in doctest injection`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /// ```
@@ -2551,7 +2558,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         /// ```
         pub fn foo() {}
         pub fn bar() {}
-    """, Testmarks.doctestInjectionImport)
+    """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test import second outer item without grouping in doctest injection`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
@@ -2576,6 +2583,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @CheckTestmarkHit(Testmarks.DoctestInjectionImport::class)
     fun `test import outer item in doctest injection with inner module`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
     //- lib.rs
         /// ```
@@ -2597,7 +2605,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         /// }
         /// ```
         pub fn foo() {}
-    """, Testmarks.doctestInjectionImport)
+    """)
 
     @ExpandMacros
     fun `test import struct from macro`() = checkAutoImportFixByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
@@ -11,22 +11,20 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsUnresolvedReferenceInspection
 import org.rust.ide.utils.import.ImportCandidateBase
 import org.rust.lang.core.psi.RsFile
-import org.rust.openapiext.Testmark
 
 abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
 
-    protected fun checkAutoImportFixIsUnavailable(@Language("Rust") text: String, testmark: Testmark? = null) =
-        doTest(checkOptimizeImports = false) { checkFixIsUnavailable(AutoImportFix.NAME, text, testmark = testmark) }
+    protected fun checkAutoImportFixIsUnavailable(@Language("Rust") text: String) =
+        doTest(checkOptimizeImports = false) { checkFixIsUnavailable(AutoImportFix.NAME, text) }
 
-    protected fun checkAutoImportFixIsUnavailableByFileTree(@Language("Rust") text: String, testmark: Testmark? = null) =
-        doTest(checkOptimizeImports = false) { checkFixIsUnavailableByFileTree(AutoImportFix.NAME, text, testmark = testmark) }
+    protected fun checkAutoImportFixIsUnavailableByFileTree(@Language("Rust") text: String) =
+        doTest(checkOptimizeImports = false) { checkFixIsUnavailableByFileTree(AutoImportFix.NAME, text) }
 
     protected fun checkAutoImportFixByText(
         @Language("Rust") before: String,
         @Language("Rust") after: String,
-        testmark: Testmark? = null,
         checkOptimizeImports: Boolean = true,
-    ) = doTest(checkOptimizeImports) { checkFixByText(AutoImportFix.NAME, before, after, testmark = testmark) }
+    ) = doTest(checkOptimizeImports) { checkFixByText(AutoImportFix.NAME, before, after) }
 
     protected fun checkAutoImportFixByTextWithoutHighlighting(
         @Language("Rust") before: String,
@@ -36,24 +34,21 @@ abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferen
     protected fun checkAutoImportFixByFileTree(
         @Language("Rust") before: String,
         @Language("Rust") after: String,
-        testmark: Testmark? = null,
         checkOptimizeImports: Boolean = true,
-    ) = doTest(checkOptimizeImports) { checkFixByFileTree(AutoImportFix.NAME, before, after, testmark = testmark) }
+    ) = doTest(checkOptimizeImports) { checkFixByFileTree(AutoImportFix.NAME, before, after) }
 
     protected fun checkAutoImportFixByFileTreeWithoutHighlighting(
         @Language("Rust") before: String,
         @Language("Rust") after: String,
-        testmark: Testmark? = null
-    ) = doTest { checkFixByFileTreeWithoutHighlighting(AutoImportFix.NAME, before, after, testmark = testmark) }
+    ) = doTest { checkFixByFileTreeWithoutHighlighting(AutoImportFix.NAME, before, after) }
 
     protected fun checkAutoImportFixByTextWithMultipleChoice(
         @Language("Rust") before: String,
         expectedElements: List<String>,
         choice: String,
         @Language("Rust") after: String,
-        testmark: Testmark? = null
     ) = checkAutoImportFixWithMultipleChoice(expectedElements, choice) {
-        checkFixByText(AutoImportFix.NAME, before, after, testmark = testmark)
+        checkFixByText(AutoImportFix.NAME, before, after)
     }
 
     protected fun checkAutoImportFixByFileTreeWithMultipleChoice(

--- a/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.intentions
 
+import org.rust.CheckTestmarkHit
 import org.rust.FileTree
 import org.rust.fileTree
 
@@ -99,7 +100,8 @@ class ExtractInlineModuleIntentionTest : RsIntentionTestBase(ExtractInlineModule
         }
     )
 
-    fun `test extracting module preserves attributes and visibility`() = ExtractInlineModuleIntention.Testmarks.copyAttrs.checkHit {
+    @CheckTestmarkHit(ExtractInlineModuleIntention.Testmarks.CopyAttrs::class)
+    fun `test extracting module preserves attributes and visibility`() {
         doTest(
             fileTree {
                 rust("main.rs", """

--- a/src/test/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntentionTest.kt
@@ -5,7 +5,8 @@
 
 package org.rust.ide.intentions
 
-import org.rust.ide.intentions.ImplTraitToTypeParamIntention.Companion.outerImplTestMark
+import org.rust.CheckTestmarkHit
+import org.rust.ide.intentions.ImplTraitToTypeParamIntention.Companion.OuterImplTestMark
 
 class ImplTraitToTypeParamIntentionTest : RsIntentionTestBase(ImplTraitToTypeParamIntention::class) {
     fun `test simple`() = doAvailableTest("""
@@ -64,13 +65,14 @@ class ImplTraitToTypeParamIntentionTest : RsIntentionTestBase(ImplTraitToTypePar
         fn test<X: Trait<u32>, T: Trait<X>, const N: usize>(arg: T) {}
     """)
 
+    @CheckTestmarkHit(OuterImplTestMark::class)
     fun `test nested outer`() = doAvailableTest("""
         trait Trait<T>{}
         fn test(arg: impl/*caret*/ Trait<impl Trait>) {}
     """, """
         trait Trait<T>{}
         fn test(arg: impl Trait<impl Trait>) {}
-    """, outerImplTestMark)
+    """)
 
     fun `test with lifetime`() = doAvailableTest("""
         trait Trait{}

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -14,7 +14,6 @@ import com.intellij.util.ui.UIUtil
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
-import org.rust.openapiext.Testmark
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.reflect.KClass
@@ -95,12 +94,6 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
         UIUtil.dispatchAllInvocationEvents()
         myFixture.launchAction(intention)
     }
-
-    protected fun doAvailableTest(
-        @Language("Rust") before: String,
-        @Language("Rust") after: String,
-        testmark: Testmark
-    ) = testmark.checkHit { doAvailableTest(before, after) }
 
     protected fun doUnavailableTest(@Language("Rust") before: String, fileName: String = "main.rs") {
         InlineFile(before, fileName).withCaret()

--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -269,7 +269,7 @@ class RenameTest : RsTestBase() {
     @ProjectDescriptor(EmptyDescriptor::class)
     fun `test do not invoke rename refactoring for directory outside of cargo project`() {
         val dir = myFixture.tempDirFixture.findOrCreateDir("dir").toPsiDirectory(project)!!
-        RsDirectoryRenameProcessor.Testmarks.rustDirRenameHandler.checkNotHit {
+        RsDirectoryRenameProcessor.Testmarks.RustDirRenameHandler.checkNotHit {
             myFixture.renameElement(dir, "dir2")
         }
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
@@ -6,12 +6,12 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
+import org.rust.CheckTestmarkHit
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.refactoring.introduceVariable.IntroduceVariableTestmarks
 import org.rust.lang.core.psi.RsExpr
-import org.rust.openapiext.Testmark
 
 
 class RsIntroduceVariableHandlerTest : RsTestBase() {
@@ -222,6 +222,7 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(IntroduceVariableTestmarks.InvalidNamePart::class)
     fun `test tuple struct`() = doTest("""
         pub struct NodeType(pub u32);
 
@@ -243,7 +244,7 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
             let node_type = t.ty;
             foo(node_type)
         }
-    """, mark = IntroduceVariableTestmarks.invalidNamePart)
+    """)
 
     // https://github.com/intellij-rust/intellij-rust/issues/2919
     fun `test issue2919`() = doTest("""
@@ -477,7 +478,6 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
         target: Int,
         @Language("Rust") after: String,
         replaceAll: Boolean = false,
-        mark: Testmark? = null
     ) {
         var shownTargetChooser = false
         withMockTargetExpressionChooser(object : ExtractExpressionUi {
@@ -490,7 +490,7 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
             override fun chooseOccurrences(expr: RsExpr, occurrences: List<RsExpr>): List<RsExpr> =
                 if (replaceAll) occurrences else listOf(expr)
         }) {
-            checkEditorAction(before, after, "IntroduceVariable", testmark = mark)
+            checkEditorAction(before, after, "IntroduceVariable")
             check(expressions.isEmpty() || shownTargetChooser) {
                 "Chooser isn't shown"
             }

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -52,7 +52,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
             struct /*caret*/S;
             impl T for S {}
         """)
-        ImplementMembersMarks.noImplInHandler.checkHit {
+        ImplementMembersMarks.NoImplInHandler.checkHit {
             val presentation = myFixture.testAction(ActionManagerEx.getInstanceEx().getAction("ImplementMethods"))
             check(!presentation.isEnabled)
         }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -1047,6 +1047,7 @@ class RsCompletionTest : RsCompletionTestBase() {
         fn foo(f: &FnOnce(/*caret*/)) {}
     """)
 
+    @CheckTestmarkHit(Testmarks.DoNotAddOpenParenCompletionChar::class)
     fun `test do not insert second parenthesis 1`() = checkCompletion("foo", """
         fn foo() {}
         fn foo2() {}
@@ -1059,8 +1060,9 @@ class RsCompletionTest : RsCompletionTestBase() {
         fn main() {
             foo()/*caret*/
         }
-    """, completionChar = '(', testmark = Testmarks.doNotAddOpenParenCompletionChar)
+    """, completionChar = '(')
 
+    @CheckTestmarkHit(Testmarks.DoNotAddOpenParenCompletionChar::class)
     fun `test do not insert second parenthesis 2`() = checkCompletion("V1", """
         enum E {
             V1(i32),
@@ -1077,16 +1079,17 @@ class RsCompletionTest : RsCompletionTestBase() {
         fn main() {
             E::V1(/*caret*/)
         }
-    """, completionChar = '(', testmark = Testmarks.doNotAddOpenParenCompletionChar)
+    """, completionChar = '(')
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @CheckTestmarkHit(Testmarks.DoNotAddOpenParenCompletionChar::class)
     fun `test do not insert second parenthesis 3`() = checkCompletion("FnOnce", """
         struct FnOnceStruct;
         fn foo(f: FnOnce/*caret*/) {}
     """, """
         struct FnOnceStruct;
         fn foo(f: FnOnce(/*caret*/)) {}
-    """, completionChar = '(', testmark = Testmarks.doNotAddOpenParenCompletionChar)
+    """, completionChar = '(')
 
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test completion cfg-disabled item 1`() = checkNoCompletionByFileTree("""

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -10,7 +10,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
-import org.rust.openapiext.Testmark
 
 abstract class RsCompletionTestBase(private val defaultFileName: String = "main.rs") : RsTestBase() {
 
@@ -96,9 +95,8 @@ abstract class RsCompletionTestBase(private val defaultFileName: String = "main.
         lookupString: String,
         @Language("Rust") before: String,
         @Language("Rust") after: String,
-        completionChar: Char = '\n',
-        testmark: Testmark? = null
-    ) = completionFixture.checkCompletion(lookupString, before, after, completionChar, testmark)
+        completionChar: Char = '\n'
+    ) = completionFixture.checkCompletion(lookupString, before, after, completionChar)
 
     protected fun checkNotContainsCompletion(
         variant: String,

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -12,7 +12,6 @@ import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.impl.BaseFixture
 import org.intellij.lang.annotations.Language
 import org.rust.hasCaretMarker
-import org.rust.openapiext.Testmark
 import org.rust.replaceCaretMarker
 
 abstract class RsCompletionTestFixtureBase<IN>(
@@ -57,21 +56,13 @@ abstract class RsCompletionTestFixtureBase<IN>(
         before: IN,
         @Language("Rust") after: String,
         completionChar: Char,
-        testmark: Testmark?
     ) {
-        val action = {
-            checkByText(before, after.trimIndent()) {
-                val items = myFixture.completeBasic()
-                    ?: return@checkByText // single completion was inserted
-                val lookupItem = items.find { it.lookupString == lookupString } ?: error("Lookup string $lookupString not found")
-                myFixture.lookup.currentItem = lookupItem
-                myFixture.type(completionChar)
-            }
-        }
-        if (testmark != null) {
-            testmark.checkHit(action)
-        } else {
-            action()
+        checkByText(before, after.trimIndent()) {
+            val items = myFixture.completeBasic()
+                ?: return@checkByText // single completion was inserted
+            val lookupItem = items.find { it.lookupString == lookupString } ?: error("Lookup string $lookupString not found")
+            myFixture.lookup.currentItem = lookupItem
+            myFixture.type(completionChar)
         }
     }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
@@ -136,8 +136,8 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
     """, setOf("iii", "i32"))
 
     private fun doTest(@Language("Rust") code: String, contains: Set<String>, notContains: Set<String> = emptySet()) {
-        RsPartialMacroArgumentCompletionProvider.Testmarks.touched.checkHit {
-            RsFullMacroArgumentCompletionProvider.Testmarks.touched.checkNotHit {
+        RsPartialMacroArgumentCompletionProvider.Testmarks.Touched.checkHit {
+            RsFullMacroArgumentCompletionProvider.Testmarks.Touched.checkNotHit {
                 if (contains.isNotEmpty()) {
                     checkContainsCompletion(contains.toList(), code)
                 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
@@ -5,12 +5,14 @@
 
 package org.rust.lang.core.macros
 
+import org.rust.CheckTestmarkHit
 import org.rust.ExpandMacros
 import org.rust.lang.core.resolve.RsResolveTestBase
 import org.rust.lang.core.resolve.ref.RsMacroBodyReferenceDelegateImpl.Testmarks
 
 @ExpandMacros
 class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
+    @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test item context`() = checkByCode("""
         struct X;
              //X
@@ -18,8 +20,9 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
         foo! {
             type T = X;
         }          //^
-    """, Testmarks.touched)
+    """)
 
+    @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test statement context`() = checkByCode("""
         struct X;
              //X
@@ -29,8 +32,9 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
                 type T = X;
             };         //^
         }
-    """, Testmarks.touched)
+    """)
 
+    @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test expression context`() = checkByCode("""
         struct X;
              //X
@@ -38,17 +42,19 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
         fn main () {
             let a = foo!(X);
         }              //^
-    """, Testmarks.touched)
+    """)
 
+    @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test type context`() = checkByCode("""
         struct X;
              //X
         macro_rules! foo { ($($ i:tt)*) => { $( $ i )* }; }
         type T = foo!(X);
                     //^
-    """, Testmarks.touched)
+    """)
 
     // TODO implement `getContext()` in all RsPat PSI elements
+    @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test pattern context`() = expect<IllegalStateException> {
         checkByCode("""
         const X: i32 = 0;
@@ -61,9 +67,10 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
                 _ => {}
             }
         }
-    """, Testmarks.touched)
+    """)
     }
 
+    @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test lifetime`() = checkByCode("""
         macro_rules! foo {
             ($ i:item) => { $ i };
@@ -75,8 +82,9 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
                 fn foo(&self) -> &'a u8 {}
             }                    //^
         }
-    """, Testmarks.touched)
+    """)
 
+    @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test 2-segment path 1`() = checkByCode("""
         mod foo {
           //X
@@ -86,8 +94,9 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
         foo! {
             type T = foo::X;
         }          //^
-    """, Testmarks.touched)
+    """)
 
+    @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test 2-segment path 2`() = checkByCode("""
         mod foo {
             pub struct X;
@@ -96,5 +105,5 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
         foo! {
             type T = foo::X;
         }               //^
-    """, Testmarks.touched)
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -25,20 +25,12 @@ import org.rust.stdext.unwrapOrElse
 import kotlin.math.min
 
 abstract class RsMacroExpansionTestBase : RsTestBase() {
-    fun doTest(@Language("Rust") code: String, @Language("Rust") vararg expectedExpansions: Pair<String, Testmark?>) {
+    protected fun doTest(@Language("Rust") code: String, @Language("Rust") vararg expectedExpansions: Pair<String, Testmark?>) {
         InlineFile(code)
         checkAllMacroExpansionsInFile(myFixture.file, expectedExpansions)
     }
 
-    fun doTest(
-        mark: Testmark,
-        @Language("Rust") code: String,
-        @Language("Rust") vararg expectedExpansions: String
-    ) {
-        mark.checkHit { doTest(code, *expectedExpansions) }
-    }
-
-    fun doTest(
+    protected fun doTest(
         @Language("Rust") code: String,
         @Language("Rust") vararg expectedExpansions: String
     ) {
@@ -64,25 +56,23 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
             }
     }
 
-    fun checkSingleMacro(@Language("Rust") code: String, @Language("Rust") expectedExpansion: String) {
+    protected fun checkSingleMacro(@Language("Rust") code: String, @Language("Rust") expectedExpansion: String) {
         InlineFile(code)
         val call = findElementInEditor<RsMacroCall>("^")
         checkMacroExpansion(call, expectedExpansion, "Macro comparison failed")
     }
 
-    fun checkSingleMacroByTree(@Language("Rust") code: String, @Language("Rust") expectedExpansion: String) {
+    protected fun checkSingleMacroByTree(@Language("Rust") code: String, @Language("Rust") expectedExpansion: String) {
         fileTreeFromText(code).createAndOpenFileWithCaretMarker()
         val call = findElementInEditor<RsMacroCall>("^")
         checkMacroExpansion(call, expectedExpansion, "Macro comparison failed")
     }
 
-    fun doErrorTest(@Language("Rust") code: String, mark: Testmark) {
+    protected fun doErrorTest(@Language("Rust") code: String) {
         InlineFile(code)
-        mark.checkHit {
-            val call = findElementInEditor<RsMacroCall>("^")
-            val def = call.resolveToMacro() ?: error("Failed to resolve macro ${call.path.text}")
-            check(expandMacroAsTextWithErr(call, RsDeclMacroData(def)).isErr)
-        }
+        val call = findElementInEditor<RsMacroCall>("^")
+        val def = call.resolveToMacro() ?: error("Failed to resolve macro ${call.path.text}")
+        check(expandMacroAsTextWithErr(call, RsDeclMacroData(def)).isErr)
     }
 
     private fun checkMacroExpansion(

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
@@ -294,7 +294,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() {}
     """)
 
-    fun `test empty group`() = doTest(MacroExpansionMarks.groupInputEnd1, """
+    @CheckTestmarkHit(MacroExpansionMarks.GroupInputEnd1::class)
+    fun `test empty group`() = doTest("""
         macro_rules! foo {
             ($ ($ i:item)*) => ($ ( $ i )*)
         }
@@ -313,7 +314,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() {}
     """)
 
-    fun `test group with $crate usage`() = doTest(MacroExpansionMarks.groupInputEnd1, """
+    @CheckTestmarkHit(MacroExpansionMarks.GroupInputEnd1::class)
+    fun `test group with $crate usage`() = doTest("""
         macro_rules! foo {
             ($ ($ i:item)*; $ ($ j:item)*) => ($ ( use $ crate::$ i; )* $ ( use $ crate::$ i; )*)
         }
@@ -376,7 +378,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn bar() {}
     """)
 
-    fun `test match pattern by first token`() = doTest(MacroExpansionMarks.failMatchPatternByToken, """
+    @CheckTestmarkHit(MacroExpansionMarks.FailMatchPatternByToken::class)
+    fun `test match pattern by first token`() = doTest("""
         macro_rules! foo {
             ($ i:ident) => (
                 mod $ i {}
@@ -399,7 +402,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         struct Baz;
     """)
 
-    fun `test match pattern by last token`() = doTest(MacroExpansionMarks.failMatchPatternByToken, """
+    @CheckTestmarkHit(MacroExpansionMarks.FailMatchPatternByToken::class)
+    fun `test match pattern by last token`() = doTest("""
         macro_rules! foo {
             ($ i:ident) => (
                 mod $ i {}
@@ -422,7 +426,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         struct Baz;
     """)
 
-    fun `test match pattern by word token 1`() = doTest(MacroExpansionMarks.failMatchPatternByToken, """
+    @CheckTestmarkHit(MacroExpansionMarks.FailMatchPatternByToken::class)
+    fun `test match pattern by word token 1`() = doTest("""
         macro_rules! foo {
             ($ i:ident) => (
                 mod $ i {}
@@ -445,7 +450,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         struct Baz;
     """)
 
-    fun `test match pattern by word token 2`() = doTest(MacroExpansionMarks.failMatchPatternByToken, """
+    @CheckTestmarkHit(MacroExpansionMarks.FailMatchPatternByToken::class)
+    fun `test match pattern by word token 2`() = doTest("""
         macro_rules! foo {
             ($ i:ident) => (
                 mod $ i {}
@@ -468,7 +474,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         struct Baz;
     """)
 
-    fun `test match pattern by word token 3`() = doTest(MacroExpansionMarks.failMatchPatternByToken, """
+    @CheckTestmarkHit(MacroExpansionMarks.FailMatchPatternByToken::class)
+    fun `test match pattern by word token 3`() = doTest("""
         macro_rules! foo {
             ($ i:ident) => (
                 mod $ i {}
@@ -491,7 +498,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         struct Baz;
     """)
 
-    fun `test match pattern by binding type 1`() = doTest(MacroExpansionMarks.failMatchPatternByExtraInput, """
+    @CheckTestmarkHit(MacroExpansionMarks.FailMatchPatternByExtraInput::class)
+    fun `test match pattern by binding type 1`() = doTest("""
         macro_rules! foo {
             ($ i:ident) => (
                 fn $ i() {}
@@ -508,7 +516,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         struct Bar { field: Baz<u8> }
     """)
 
-    fun `test match pattern by binding type 2`() = doTest(MacroExpansionMarks.failMatchPatternByBindingType, """
+    @CheckTestmarkHit(MacroExpansionMarks.FailMatchPatternByBindingType::class)
+    fun `test match pattern by binding type 2`() = doTest("""
         macro_rules! foo {
             ($ i:item) => (
                 $ i
@@ -547,10 +556,10 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """ to null, """
         fn foo() {}
         fn bar() {}
-    """ to MacroExpansionMarks.failMatchGroupBySeparator, """
+    """ to MacroExpansionMarks.FailMatchGroupBySeparator, """
         struct Foo;
         struct Bar;
-    """ to MacroExpansionMarks.failMatchPatternByExtraInput)
+    """ to MacroExpansionMarks.FailMatchPatternByExtraInput)
 
     fun `test match 'asterisk' vs 'plus' group pattern`() = doTest("""
         macro_rules! foo {
@@ -565,12 +574,13 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         foo! { foo }
     """, """
         mod asterisk_matched {}
-    """ to MacroExpansionMarks.failMatchGroupTooFewElements, """
+    """ to MacroExpansionMarks.FailMatchGroupTooFewElements, """
         mod plus_matched {}
     """ to null)
 
     // TODO should work only on 2018 edition
-    fun `test match 'asterisk' vs 'q' group pattern`() = doTest(MacroExpansionMarks.questionMarkGroupEnd, """
+    @CheckTestmarkHit(MacroExpansionMarks.QuestionMarkGroupEnd::class)
+    fun `test match 'asterisk' vs 'q' group pattern`() = doTest("""
         macro_rules! foo {
             ($ ($ i:ident)?) => (
                 mod question_matched {}
@@ -629,10 +639,10 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """, """
         mod foo {}
         mod bar {}
-    """ to MacroExpansionMarks.groupInputEnd3, """
+    """ to MacroExpansionMarks.GroupInputEnd3, """
         struct Foo;
         struct Bar;
-    """ to MacroExpansionMarks.failMatchPatternByExtraInput)
+    """ to MacroExpansionMarks.FailMatchPatternByExtraInput)
 
     fun `test multiple groups with reversed variables order`() = doTest("""
         macro_rules! foo {
@@ -692,7 +702,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
          fn foo() { 2; }
     """)
 
-    fun `test group with the separator the same as the next token 1`() = doTest(MacroExpansionMarks.groupInputEnd1, """
+    @CheckTestmarkHit(MacroExpansionMarks.GroupInputEnd1::class)
+    fun `test group with the separator the same as the next token 1`() = doTest("""
         macro_rules! foo {
             ($($ i:item)=* =) => {
                 $($ i)*
@@ -706,7 +717,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
          fn foo() {}
     """)
 
-    fun `test group with the separator the same as the next token 2`() = doTest(MacroExpansionMarks.groupInputEnd2, """
+    @CheckTestmarkHit(MacroExpansionMarks.GroupInputEnd2::class)
+    fun `test group with the separator the same as the next token 2`() = doTest("""
         macro_rules! foo {
             ($($ i:item)=* = #) => {
                 $($ i)*
@@ -888,7 +900,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """, """
         macro_rules! bar { ($ b:item) => { $ b }; }
         fn foo() {}
-    """ to MacroExpansionMarks.substMetaVarNotFound)
+    """ to MacroExpansionMarks.SubstMetaVarNotFound)
 
     fun `test expand macro defined in function`() = doTest("""
         fn main() {
@@ -912,8 +924,9 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         foo!();
     """, """
         fn foo() {}
-    """ to NameResolutionTestmarks.dollarCrateMagicIdentifier)
+    """ to NameResolutionTestmarks.DollarCrateMagicIdentifier)
 
+    @CheckTestmarkHit(MacroExpansionMarks.GroupMatchedEmptyTT::class)
     fun `test incorrect 'vis' group does not cause OOM`() = doErrorTest("""
         // error: repetition matches empty token tree
         macro_rules! foo {
@@ -921,7 +934,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         }
         foo!(a);
         //^
-    """, MacroExpansionMarks.groupMatchedEmptyTT)
+    """)
 
     fun `test two sequential groups starting with the same token`() = doTest("""
         macro_rules! foobar {
@@ -1065,7 +1078,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """, """
         #[doc = " Some docs"]
         fn foo() {}
-    """ to MacroExpansionMarks.docsLowering)
+    """ to MacroExpansionMarks.DocsLowering)
 
     fun `test docs lowering`() = doTest("""
         macro_rules! foo {
@@ -1080,7 +1093,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """, """
         #[doc = " Some docs"]
         fn foo() {}
-    """ to MacroExpansionMarks.docsLowering)
+    """ to MacroExpansionMarks.DocsLowering)
 
     fun `test comment in macro definition`() = doTest("""
         macro_rules! foobar {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.ignoreInNewResolve
-
 class RsMacroResolveTest : RsResolveTestBase() {
     fun `test resolve simple matching with multiple pattern definition`() = checkByCode("""
         macro_rules! test {
@@ -217,7 +215,7 @@ class RsMacroResolveTest : RsResolveTestBase() {
             foo_bar!();
             //^ unresolved
         }
-    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve(project))
+    """)
 
     fun `test macro_export macro is visible in the same crate without macro_use`() = checkByCode("""
         // #[macro_use] is not needed here
@@ -229,7 +227,7 @@ class RsMacroResolveTest : RsResolveTestBase() {
             foo_bar!();
             //^
         }
-    """, NameResolutionTestmarks.processSelfCrateExportedMacros.ignoreInNewResolve(project))
+    """)
 
     fun `test resolve macro missing macro_use mod`() = checkByCode("""
         // Missing #[macro_use] here
@@ -242,7 +240,7 @@ class RsMacroResolveTest : RsResolveTestBase() {
                 //^ unresolved
             }
         }
-    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve(project))
+    """)
 
     fun `test raw identifier 1`() = checkByCode("""
         macro_rules! r#match { () => () }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -110,7 +110,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
     //- lib.rs
         #[macro_export]
         macro_rules! foo_bar { () => {} }
-    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve(project))
+    """)
 
     fun `test macro rules in mod 1`() = stubOnlyResolve("""
     //- main.rs
@@ -281,7 +281,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo {
             () => {};
         }
-    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve(project))
+    """)
 
     fun `test import macro by use item wildcard`() = stubOnlyResolve("""
     //- lib.rs
@@ -295,7 +295,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo {
             () => {};
         }
-    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve(project))
+    """)
 
     fun `test import macro by use item without extern crate`() = stubOnlyResolve("""
     //- lib.rs
@@ -840,7 +840,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         use dep_lib_target;
         use dep_lib_target::Foo;
                           //^ dep-lib/lib.rs
-    """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve(project))
+    """)
 
     fun `test 'extra use of crate name 1' with alias`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
@@ -858,7 +858,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         use dep_lib_target::{self};
         use dep_lib_target::Foo;
                           //^ dep-lib/lib.rs
-    """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve(project))
+    """)
 
     fun `test import the same name as a crate name`() = stubOnlyResolve("""
     //- dep-lib/lib.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.CheckTestmarkHit
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 
 class RsPreciseTraitMatchingTest : RsResolveTestBase() {
@@ -114,6 +115,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickCheckBounds::class)
     fun `test trait bound satisfied for struct`() = checkByCode("""
         trait Tr1 { fn some_fn(&self) {} }
         trait Tr2 { fn some_fn(&self) {} }
@@ -129,8 +131,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             v.some_fn();
             //^
         }
-    """, TypeInferenceMarks.methodPickCheckBounds)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickCheckBounds::class)
     fun `test trait bound satisfied for dyn trait`() = checkByCode("""
         #[lang = "sized"]
         trait Sized {}
@@ -147,8 +150,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             v.some_fn();
             //^
         }
-    """, TypeInferenceMarks.methodPickCheckBounds)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickCheckBounds::class)
     fun `test trait bound satisfied for other bound`() = checkByCode("""
         trait Tr1 { fn some_fn(&self) {} }
         trait Tr2 { fn some_fn(&self) {} }
@@ -166,8 +170,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
                 //^
             }
         }
-    """, TypeInferenceMarks.methodPickCheckBounds)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickCheckBounds::class)
     fun `test Sized trait bound satisfied`() = checkByCode("""
         #[lang = "sized"] trait Sized {}
         trait Tr1 { fn some_fn(&self) {} }
@@ -182,7 +187,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             v.some_fn();
             //^
         }
-    """, TypeInferenceMarks.methodPickCheckBounds)
+    """)
 
     fun `test allow ambiguous trait bounds for postponed selection`() = checkByCode("""
         trait Into<A> { fn into(&self) -> A; }
@@ -203,6 +208,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickTraitScope::class)
     fun `test method defined in out of scope trait 1`() = checkByCode("""
         struct S;
 
@@ -223,8 +229,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             use a::A;
             S.foo();
         }   //^
-    """, TypeInferenceMarks.methodPickTraitScope)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickTraitScope::class)
     fun `test method defined in out of scope trait 2`() = checkByCode("""
         struct S;
 
@@ -245,8 +252,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             use b::B;
             S.foo();
         }   //^
-    """, TypeInferenceMarks.methodPickTraitScope)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickTraitScope::class)
     fun `test method defined in out of scope trait (with aliased import)`() = checkByCode("""
         struct S;
 
@@ -267,8 +275,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             use a::A as _A;
             S.foo();
         }   //^
-    """, TypeInferenceMarks.methodPickTraitScope)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickTraitScope::class)
     fun `test method defined in out of scope trait (with underscore import)`() = checkByCode("""
         struct S;
 
@@ -289,8 +298,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             use a::A as _;
             S.foo();
         }   //^
-    """, TypeInferenceMarks.methodPickTraitScope)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickTraitScope::class)
     fun `test method defined in out of scope trait (with underscore re-export)`() = checkByCode("""
         struct S;
 
@@ -315,8 +325,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             use c::*;
             S.foo();
         }   //^
-    """, TypeInferenceMarks.methodPickTraitScope)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickTraitScope::class)
     fun `test method defined in out of scope trait (inside impl)`() = checkByCode("""
         mod foo {
             pub trait Foo { fn foo(&self) {} }
@@ -333,8 +344,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
                 self.0.foo()
             }        //^
         }
-    """, TypeInferenceMarks.methodPickTraitScope)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.TraitSelectionSpecialization::class)
     fun `test specialization simple`() = checkByCode("""
         trait Tr { fn foo(&self); }
         struct S;
@@ -344,8 +356,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         fn main() {
             S.foo();
         }   //^
-    """, TypeInferenceMarks.traitSelectionSpecialization)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickTraitsOutOfScope::class)
     fun `test pick correct method from out of scope traits`() = checkByCode("""
         struct Foo;
         struct Bar;
@@ -377,7 +390,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             Bar.do_x();
                //^
         }
-    """, TypeInferenceMarks.methodPickTraitsOutOfScope)
+    """)
 
     fun `test filter associated functions by trait visibility`() = checkByCode("""
         struct S;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
@@ -7,14 +7,15 @@ package org.rust.lang.core.resolve
 
 import com.intellij.psi.PsiDocumentManager
 import org.intellij.lang.annotations.Language
+import org.rust.CheckTestmarkHit
 import org.rust.RsTestBase
 import org.rust.checkedResolve
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.resolve.ref.RsResolveCache.Testmarks
-import org.rust.openapiext.Testmark
 
 class RsResolveCacheTest : RsTestBase() {
+    @CheckTestmarkHit(Testmarks.RustStructureDependentCacheCleared::class)
     fun `test cache invalidated on rust structure change`() = checkResolvedToXY("""
         mod a { pub struct S; }
                          //X
@@ -23,8 +24,9 @@ class RsResolveCacheTest : RsTestBase() {
         use a/*caret*/::S;
         type T = S;
                //^
-    """, "\bb", Testmarks.rustStructureDependentCacheCleared)
+    """, "\bb")
 
+    @CheckTestmarkHit(Testmarks.RemoveChangedElement::class)
     fun `test resolve correctly without global cache invalidation 1`() = checkResolvedToXY("""
         struct S1;
              //X
@@ -33,8 +35,9 @@ class RsResolveCacheTest : RsTestBase() {
         fn main() {
             let a: S1/*caret*/;
         }        //^
-    """, "\b2", Testmarks.removeChangedElement)
+    """, "\b2")
 
+    @CheckTestmarkHit(Testmarks.RemoveChangedElement::class)
     fun `test resolve correctly without global cache invalidation 2`() = checkResolvedToXY("""
         mod a { pub struct S; }
                          //X
@@ -45,8 +48,9 @@ class RsResolveCacheTest : RsTestBase() {
                 ::S;
                 //^
         }
-    """, "\bb", Testmarks.removeChangedElement)
+    """, "\bb")
 
+    @CheckTestmarkHit(Testmarks.RemoveChangedElement::class)
     fun `test resolve correctly without global cache invalidation 3`() = checkResolvedToXY("""
         struct S;
         trait Trait1 { type Item; }
@@ -60,7 +64,7 @@ class RsResolveCacheTest : RsTestBase() {
                 ::Item;
                 //^
         }
-    """, "\b2", Testmarks.removeChangedElement)
+    """, "\b2")
 
     fun `test resolve correctly without global cache invalidation 4`() = checkResolvedToXY("""
         mod really_long_name { pub struct S; }
@@ -244,10 +248,6 @@ class RsResolveCacheTest : RsTestBase() {
         check(refElement.isValid)
 
         refElement.checkResolvedTo("Y", offset)
-    }
-
-    private fun checkResolvedToXY(@Language("Rust") code: String, textToType: String, mark: Testmark) = mark.checkHit {
-        checkResolvedToXY(code, textToType)
     }
 
     private fun checkResolvedAndThenUnresolved(@Language("Rust") code: String, textToType: String) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.resolve
 
 import org.rust.MockRustcVersion
-import org.rust.ignoreInNewResolve
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.ext.RsFieldDecl
 
@@ -1456,7 +1455,7 @@ class RsResolveTest : RsResolveTestBase() {
 
         use self::Foo;
                 //^
-    """, ItemResolutionTestmarks.externCrateSelfWithoutAlias.ignoreInNewResolve(project))
+    """)
 
     fun `test const generic in fn`() = checkByCode("""
         fn f<const AAA: usize>() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
@@ -15,7 +15,6 @@ import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.psi.ext.RsReferenceElementBase
 import org.rust.lang.core.psi.ext.contextualFile
-import org.rust.openapiext.TestmarkPred
 
 abstract class RsResolveTestBase : RsTestBase() {
     protected open fun checkByCode(@Language("Rust") code: String) =
@@ -59,15 +58,6 @@ abstract class RsResolveTestBase : RsTestBase() {
             "$refElement `${refElement.text}` should resolve to $target (${target.text}), was $resolved (${resolved.text}) instead"
         }
     }
-
-    protected fun checkByCode(@Language("Rust") code: String, mark: TestmarkPred) =
-        mark.checkHit { checkByCode(code) }
-
-    protected fun stubOnlyResolve(
-        @Language("Rust") code: String,
-        mark: TestmarkPred,
-        resolveFileProducer: (PsiElement) -> VirtualFile = this::getActualResolveFile
-    ) = mark.checkHit { stubOnlyResolve(code, resolveFileProducer) }
 
     protected fun stubOnlyResolve(
         @Language("Rust") code: String,

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -532,6 +532,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.QuestionOperator::class)
     fun `test try operator with option`() = checkByCode("""
         struct S { field: u32 }
                     //X
@@ -542,7 +543,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
             s.field;
             //^
         }
-    """, TypeInferenceMarks.questionOperator)
+    """)
 
     fun `test try! macro with aliased Result`() = checkByCode("""
         mod io {
@@ -563,6 +564,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickTraitScope::class)
     fun `test method defined in out of scope trait from prelude`() = stubOnlyResolve("""
     //- a.rs
         use super::S;
@@ -578,7 +580,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         fn main() {
             let _: u8 = S.into();
         }               //^ a.rs
-    """, TypeInferenceMarks.methodPickTraitScope)
+    """)
 
     fun `test &str into String`() = stubOnlyResolve("""
     //- main.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
@@ -9,7 +9,6 @@ import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
-import org.rust.ignoreInNewResolve
 
 @MockEdition(Edition.EDITION_2018)
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
@@ -28,7 +27,7 @@ class RsStdlibResolveTestEdition2018 : RsResolveTestBase() {
         fn main() {
             let a = Vec::<i32>::new();
         }         //^ .../vec.rs|...vec/mod.rs
-    """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve(project))
+    """)
 
     fun `test resolve core crate without extern crate`() = stubOnlyResolve("""
     //- main.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.ignoreInNewResolve
+import org.rust.CheckTestmarkHit
 
 class RsStubOnlyResolveTest : RsResolveTestBase() {
     fun `test child mod`() = stubOnlyResolve("""
@@ -86,7 +86,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     //- foo/baz.rs
         pub fn baz() {}
-    """, NameResolutionTestmarks.modDeclExplicitPathInNonInlineModule.ignoreInNewResolve(project))
+    """)
 
     fun `test module path in non crate root`() = stubOnlyResolve("""
     //- main.rs
@@ -101,7 +101,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     //- baz.rs
         pub fn baz() {}
-    """, NameResolutionTestmarks.modDeclExplicitPathInNonInlineModule.ignoreInNewResolve(project))
+    """)
 
     fun `test module path to different directory 1`() = stubOnlyResolve("""
     //- main.rs
@@ -114,7 +114,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub mod bar;
     //- src2/bar/mod.rs
         pub struct S;
-    """, NameResolutionTestmarks.modDeclExplicitPathInNonInlineModule.ignoreInNewResolve(project))
+    """)
 
     fun `test module path to different directory 2`() = stubOnlyResolve("""
     //- main.rs
@@ -309,7 +309,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     //- foo/baz.rs
         pub fn foo() {}
-    """, NameResolutionTestmarks.modDeclExplicitPathInInlineModule.ignoreInNewResolve(project))
+    """)
 
     fun `test path inside inline module in mod rs`() = stubOnlyResolve("""
     //- main.rs
@@ -326,7 +326,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     //- foo/bar/qwe.rs
         pub fn baz() {}
-    """, NameResolutionTestmarks.modDeclExplicitPathInInlineModule.ignoreInNewResolve(project))
+    """)
 
     fun `test path inside inline module in non crate root`() = stubOnlyResolve("""
     //- main.rs
@@ -343,7 +343,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     //- foo/bar/qwe.rs
         pub fn baz() {}
-    """, NameResolutionTestmarks.modDeclExplicitPathInInlineModule.ignoreInNewResolve(project))
+    """)
 
     fun `test inline module path in non crate root`() = stubOnlyResolve("""
     //- main.rs
@@ -592,6 +592,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub struct Bar;
     """)
 
+    @CheckTestmarkHit(NameResolutionTestmarks.ModRsFile::class)
     fun `test module structure without mod rs 2`() = stubOnlyResolve("""
     //- main.rs
         mod foo;
@@ -603,8 +604,9 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub struct Bar;
     //- foo/foo/bar.rs
         pub struct Baz;
-    """, NameResolutionTestmarks.modRsFile)
+    """)
 
+    @CheckTestmarkHit(NameResolutionTestmarks.CrateRootModule::class)
     fun `test module structure without mod rs 3`() = stubOnlyResolve("""
     //- main.rs
         mod foo;
@@ -613,7 +615,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub struct Foo;
     //- main/foo.rs
         pub struct Bar;
-    """, NameResolutionTestmarks.crateRootModule)
+    """)
 
     fun `test scoped resolve inside stubbed function body`() = stubOnlyResolve("""
     //- main.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.CheckTestmarkHit
 import org.rust.lang.core.psi.ext.ArithmeticOp
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 
@@ -411,6 +412,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickDerefOrder::class)
     fun `test method with same name on different deref levels`() = checkByCode("""
         #[lang = "deref"]
         trait Deref { type Target; }
@@ -426,8 +428,9 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         fn main() {
             A.foo();
         }   //^
-    """, TypeInferenceMarks.methodPickDerefOrder)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickDerefOrder::class)
     fun `test non inherent impl 2`() = checkByCode("""
         trait T { fn foo(&self); }
         struct S;
@@ -440,8 +443,9 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             (&S).foo()
                //^
         }
-    """, TypeInferenceMarks.methodPickDerefOrder)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickDerefOrder::class)
     fun `test non inherent impl 3`() = checkByCode("""
         trait T { fn foo(&self); }
         struct S;
@@ -454,8 +458,9 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             (&&S).foo()
                 //^
         }
-    """, TypeInferenceMarks.methodPickDerefOrder)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickDerefOrder::class)
     fun `test non inherent impl 4`() = checkByCode("""
         trait T1 { fn foo(&mut self); }
         trait T2 { fn foo(&self); }
@@ -468,8 +473,9 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             (&S).foo()
                //^
         }
-    """, TypeInferenceMarks.methodPickDerefOrder)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickDerefOrder::class)
     fun `test non inherent impl 5`() = checkByCode("""
         trait T1 { fn foo(&self); }
         trait T2 { fn foo(self); }
@@ -481,7 +487,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         fn main() {
             (&S).foo();
         }      //^ unresolved
-    """, TypeInferenceMarks.methodPickDerefOrder)
+    """)
 
     fun `test indexing`() = checkByCode("""
         #[lang = "index"]
@@ -861,6 +867,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickCollapseTraits::class)
     fun `test resolve method call with multiple impls of the same trait`() = checkByCode("""
         struct S; struct S1; struct S2;
         trait T<A> { fn foo(&self, _: A); }
@@ -870,7 +877,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         fn main() {
             S.foo(S2)
         }    //^
-    """, TypeInferenceMarks.methodPickCollapseTraits)
+    """)
 
     fun `test resolve UFCS method call with multiple impls of the same trait`() = checkByCode("""
         struct S; struct S1; struct S2;
@@ -905,6 +912,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }    //^
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickCollapseTraits::class)
     fun `test method with multiple impls of the same trait on multiple deref levels`() = checkByCode("""
         #[lang = "deref"]
         trait Deref { type Target; }
@@ -920,8 +928,9 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         fn main() {
             A.foo(0u16);
         }    //^
-    """, TypeInferenceMarks.methodPickCollapseTraits)
+    """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickCollapseTraits::class)
     fun `test method with multiple impls of the same trait on 2nd deref level`() = checkByCode("""
         #[lang = "deref"]
         trait Deref { type Target; }
@@ -936,7 +945,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         fn main() {
             A.foo(0u16);
         }    //^
-    """, TypeInferenceMarks.methodPickCollapseTraits)
+    """)
 
     // https://github.com/intellij-rust/intellij-rust/issues/1649
     fun `test issue 1649`() = checkByCode("""
@@ -953,7 +962,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
-    // https://github.com/intellij-rust/intellij-rust/issues/1927
+    @CheckTestmarkHit(TypeInferenceMarks.CyclicType::class)
     fun `test no stack overflow with cyclic type of infinite size`() = checkByCode("""
         struct S<T>(T);
         fn foo<T>() -> T { unimplemented!() }
@@ -965,7 +974,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             b.bar();
             //^ unresolved
         }
-    """, TypeInferenceMarks.cyclicType)
+    """)
 
     fun `test resolve generic impl from impl trait`() = checkByCode("""
         trait Foo {}
@@ -1027,6 +1036,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
+    @CheckTestmarkHit(NameResolutionTestmarks.SkipAssocTypeFromImpl::class)
     fun `test 'impl for generic type' is NOT used for associated type resolve`() = checkByCode("""
         trait Bound {}
         trait Tr { type Item; }
@@ -1034,7 +1044,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         fn foo<B: Bound>(b: B) {
             let a: B::Item;
         }           //^ unresolved
-    """, NameResolutionTestmarks.skipAssocTypeFromImpl)
+    """)
 
     fun `test 'impl for generic type' is USED for associated type resolve UFCS 1`() = checkByCode("""
         trait Bound {}
@@ -1134,6 +1144,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
+    @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 1)`() = checkByCode("""
         struct S;
         trait Trait1<T> { type Item; }
@@ -1148,8 +1159,9 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         impl Trait2<i32> for S {
             fn foo() -> Self::Item { unreachable!() }
         }                   //^
-    """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
+    """)
 
+    @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 2)`() = checkByCode("""
         struct S;
         trait Trait1<T=u8> { type Item; }
@@ -1164,7 +1176,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         impl Trait2<i32> for S {
             fn foo() -> Self::Item { unreachable!() }
         }                   //^
-    """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
+    """)
 
     fun `test non-UFCS associated type in type alias with bound`() = checkByCode("""
         trait Trait {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.CheckTestmarkHit
 import org.rust.lang.core.psi.RsTupleFieldDecl
 
 class RsTypeAwareResolveTest : RsResolveTestBase() {
@@ -760,6 +761,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is resolved to assoc type of current impl`() = checkByCode("""
         struct S;
         trait Trait {
@@ -772,8 +774,9 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
                 //X
             fn foo() -> Self::Item { unreachable!() }
         }                    //^
-    """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
+    """)
 
+    @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is not resolved to assoc type of another trait`() = checkByCode("""
         struct S;
         trait Trait1 { type Item; }
@@ -786,8 +789,9 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         impl Trait2 for S {
             fn foo() -> Self::Item { unreachable!() }
         }                    //^ unresolved
-    """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
+    """)
 
+    @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is resolved to assoc type of super trait`() = checkByCode("""
         struct S;
         trait Trait1 { type Item; }
@@ -800,7 +804,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         impl Trait2 for S {
             fn foo() -> Self::Item { unreachable!() }
         }                    //^
-    """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
+    """)
 
     fun `test explicit UFCS-like type-qualified path`() = checkByCode("""
         struct S;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.CheckTestmarkHit
 import org.rust.MockEdition
 import org.rust.UseOldResolve
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
@@ -109,6 +110,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(NameResolutionTestmarks.SelfInGroup::class)
     fun `test view path glob self`() = checkByCode("""
         mod foo {
             use crate::bar::{self};
@@ -116,7 +118,7 @@ class RsUseResolveTest : RsResolveTestBase() {
 
         pub mod bar { }
                //X
-    """, NameResolutionTestmarks.selfInGroup)
+    """)
 
     fun `test view path glob self fn`() = checkByCode("""
         fn f() {}

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.type
 
+import org.rust.CheckTestmarkHit
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 
 class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
@@ -1223,6 +1224,7 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }                       //^ u8
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickCollapseTraits::class)
     fun `test infer method arg with multiple impls of the same trait`() = testExpr("""
         pub trait Tr<T> { fn foo(&self, _: T); }
         struct S; struct S1;
@@ -1231,7 +1233,7 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         fn main() {
             S.foo(0)
         }       //^ u8
-    """, TypeInferenceMarks.methodPickCollapseTraits)
+    """)
 
     fun `test infer method arg with multiple impls of the same trait UFCS`() = testExpr("""
         pub trait Tr<T> { fn foo(&self, _: T); }
@@ -1244,6 +1246,7 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }             //^ u8
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MethodPickCollapseTraits::class)
     fun `test infer method arg with multiple impls of the same trait on multiple deref levels`() = testExpr("""
         #[lang = "deref"]
         trait Deref { type Target; }
@@ -1263,7 +1266,7 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = A.foo(0u16);
             a;
         } //^ i16
-    """, TypeInferenceMarks.methodPickCollapseTraits)
+    """)
 
     fun `test infer type by reference coercion`() = testExpr("""
         #[lang = "deref"]

--- a/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.type
 
+import org.rust.CheckTestmarkHit
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 
 class RsMacroTypeInferenceTest : RsTypificationTestBase() {
@@ -127,13 +128,14 @@ class RsMacroTypeInferenceTest : RsTypificationTestBase() {
         } //^ <unknown>
     """)
 
+    @CheckTestmarkHit(TypeInferenceMarks.MacroExprDepthLimitReached::class)
     fun `test infinite recursion`() = testExpr("""
         macro_rules! foo { () => { foo!(); }; }
         fn main() {
             let a = foo!();
             a;
         } //^ <unknown>
-    """, TypeInferenceMarks.macroExprDepthLimitReached)
+    """)
 
     fun `test custom log-like macro`() = testExpr("""
         enum Data {

--- a/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.type
 
+import org.rust.CheckTestmarkHit
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.types.infer.PatternMatchingTestMarks
@@ -290,6 +291,7 @@ class RsPatternMatchingTest : RsTypificationTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(PatternMatchingTestMarks.NegativeRestSize::class)
     fun `test let array too few elements for rest pat`() = testExpr("""
         struct S;
         fn main() {
@@ -297,8 +299,9 @@ class RsPatternMatchingTest : RsTypificationTestBase() {
             (x1, x2, x3, x4, xs);
           //^ (S, S, S, S, [S; <unknown>])
         }
-    """, PatternMatchingTestMarks.negativeRestSize)
+    """)
 
+    @CheckTestmarkHit(PatternMatchingTestMarks.MultipleRestPats::class)
     fun `test let array multiple rest pats`() = testExpr("""
         struct S;
         fn main() {
@@ -306,7 +309,7 @@ class RsPatternMatchingTest : RsTypificationTestBase() {
             (x1, xs1, x2, xs2, x3);
           //^ (S, [S; <unknown>], S, [S; <unknown>], S)
         }
-    """, PatternMatchingTestMarks.multipleRestPats)
+    """)
 
     fun `test let or pattern 1`() = testExpr("""
         enum E { L(i32), M(i32), R(i32) }

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
@@ -19,7 +19,6 @@ import org.rust.lang.core.psi.ext.macroName
 import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.type
 import org.rust.lang.utils.Severity
-import org.rust.openapiext.Testmark
 
 abstract class RsTypificationTestBase : RsTestBase() {
     protected fun testExpr(@Language("Rust") code: String, description: String = "", allowErrors: Boolean = false) {
@@ -28,13 +27,6 @@ abstract class RsTypificationTestBase : RsTestBase() {
         if (!allowErrors) checkNoInferenceErrors()
         checkAllExpressionsTypified()
     }
-
-    protected fun testExpr(
-        @Language("Rust") code: String,
-        mark: Testmark,
-        description: String = "",
-        allowErrors: Boolean = false
-    ) = mark.checkHit { testExpr(code, description, allowErrors) }
 
     protected fun stubOnlyTypeInfer(@Language("Rust") code: String, description: String = "", allowErrors: Boolean = false) {
         val testProject = fileTreeFromText(code)

--- a/src/test/kotlin/org/rust/utils.kt
+++ b/src/test/kotlin/org/rust/utils.kt
@@ -6,11 +6,26 @@
 package org.rust
 
 import junit.framework.TestCase
+import org.rust.openapiext.EmptyTestmark
+import org.rust.openapiext.TestmarkPred
+import org.rust.openapiext.not
 
 
 /** Tries to find the specified annotation on the current test method and then on the current class */
 inline fun <reified T : Annotation> TestCase.findAnnotationInstance(): T? =
     javaClass.getMethod(name).getAnnotation(T::class.java) ?: javaClass.getAnnotation(T::class.java)
+
+fun TestCase.collectTestmarksFromAnnotations(): TestmarkPred {
+    val testmarks = mutableListOf<TestmarkPred>()
+    findAnnotationInstance<CheckTestmarkHit>()?.testmarkClasses?.mapNotNullTo(testmarks) { it.objectInstance }
+    findAnnotationInstance<CheckTestmarkNotHit>()?.testmarkClasses?.mapNotNullTo(testmarks) { it.objectInstance?.not() }
+    return when (testmarks.size) {
+        0 -> EmptyTestmark
+        1 -> testmarks.single()
+        else -> error("Using multiple testmarks is not supported, but it should be easy! " +
+            "just make an implementation of `TestmarkPred` for a list of `TestmarkPred`s")
+    }
+}
 
 inline fun <reified X : Throwable> expect(f: () -> Unit) {
     try {

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
@@ -19,7 +19,6 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.impl.testCargoProjects
 import org.rust.lang.core.crate.impl.CrateGraphTestmarks
 import org.rust.lang.core.psi.RsPath
-import org.rust.lang.core.resolve.NameResolutionTestmarks
 import org.rust.openapiext.pathAsPath
 
 class CargoProjectResolveTest : RsWithToolchainTestBase() {
@@ -92,9 +91,7 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
                 }
             }
         }
-        NameResolutionTestmarks.shadowingStdCrates.ignoreInNewResolve(project).checkHit {
-            testProject.checkReferenceIsResolved<RsPath>("foo/src/lib.rs")
-        }
+        testProject.checkReferenceIsResolved<RsPath>("foo/src/lib.rs")
     }
 
     fun `test resolve local package`() = buildProject {
@@ -930,7 +927,7 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
             }
         }
     }.run {
-        CrateGraphTestmarks.cyclicDevDependency.checkHit {
+        CrateGraphTestmarks.CyclicDevDependency.checkHit {
             checkReferenceIsResolved<RsPath>("tests/main.rs")
             checkReferenceIsResolved<RsPath>("src/lib.rs")
         }


### PR DESCRIPTION

Before:

```kotlin
object PatternMatchingTestMarks {
    val negativeRestSize = Testmark("negativeRestSize")
}
```

```kotlin
fun `test let array too few elements for rest pat`() = testExpr("""
    struct S;
    fn main() {
        let [x1, x2, x3, x4, xs @ ..] = [S, S, S];
        (x1, x2, x3, x4, xs);
      //^ (S, S, S, S, [S; <unknown>])
    }
""", PatternMatchingTestMarks.negativeRestSize)
```


After:

```kotlin
object PatternMatchingTestMarks {
    object NegativeRestSize : Testmark()
}
```

```kotlin
@CheckTestmarkHit(PatternMatchingTestMarks.NegativeRestSize::class)
fun `test let array too few elements for rest pat`() = testExpr("""
    struct S;
    fn main() {
        let [x1, x2, x3, x4, xs @ ..] = [S, S, S];
        (x1, x2, x3, x4, xs);
      //^ (S, S, S, S, [S; <unknown>])
    }
""")
```

Also removed old testmarks for old name resolution because they are not used in real tests anyway
