### PR TITLE
Refactor completion variants sorting: use weighers

### DIFF
--- a/ml-completion/src/main/kotlin/org/rust/ml/RsElementFeatureProvider.kt
+++ b/ml-completion/src/main/kotlin/org/rust/ml/RsElementFeatureProvider.kt
@@ -11,10 +11,20 @@ import com.intellij.codeInsight.completion.ml.ElementFeatureProvider
 import com.intellij.codeInsight.completion.ml.MLFeatureValue
 import com.intellij.codeInsight.lookup.LookupElement
 import org.rust.ide.utils.import.isStd
+import org.rust.lang.core.completion.sort.RS_COMPLETION_WEIGHERS
+import org.rust.lang.core.completion.sort.RsCompletionWeigher
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
 import kotlin.reflect.KClass
 
+/**
+ * Note that any (Boolean, Number or Enum) value returned from [RsCompletionWeigher] (see [RS_COMPLETION_WEIGHERS])
+ * is automatically added as an "element feature" ([RsCompletionWeigher.id] is used as a key),
+ * so there is no sense to add it again in [calculateFeatures].
+ *
+ * Also note that there is a common feature provider for all languages:
+ * [com.intellij.completion.ml.common.CommonElementLocationFeatures]
+ */
 @Suppress("UnstableApiUsage")
 class RsElementFeatureProvider : ElementFeatureProvider {
     override fun getName(): String = "rust"

--- a/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
@@ -14,6 +14,7 @@ import com.intellij.patterns.PatternCondition
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
+import org.rust.lang.core.completion.RsLookupElementProperties.KeywordKind
 import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsFieldLookup
 import org.rust.lang.core.psi.ext.findAssociatedType
@@ -55,7 +56,7 @@ object RsAwaitCompletionProvider : RsCompletionProvider() {
             .create("await")
             .bold()
             .withTypeText(awaitTy.toString())
-        result.addElement(awaitBuilder.withPriority(KEYWORD_PRIORITY * 1.0001))
+        result.addElement(awaitBuilder.toKeywordElement(KeywordKind.AWAIT))
     }
 
     private fun Ty.lookupFutureOutputTy(lookup: ImplLookup): Ty {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsBoolCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsBoolCompletionProvider.kt
@@ -24,7 +24,7 @@ object RsBoolCompletionProvider : RsCompletionProvider() {
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         if (parameters.position.safeGetOriginalOrSelf().ancestorOrSelf<RsPathExpr>()?.expectedType is TyBool) {
             for (value in listOf("true", "false")) {
-                result.addElement(LookupElementBuilder.create(value).bold().withPriority(KEYWORD_PRIORITY))
+                result.addElement(LookupElementBuilder.create(value).bold().toKeywordElement())
             }
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -5,14 +5,20 @@
 
 package org.rust.lang.core.completion
 
-import com.intellij.codeInsight.completion.CompletionContributor
-import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementWeigher
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.util.BuildNumber
 import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.RsPsiPattern.declarationPattern
 import org.rust.lang.core.RsPsiPattern.inherentImplDeclarationPattern
 import org.rust.lang.core.completion.lint.RsClippyLintCompletionProvider
 import org.rust.lang.core.completion.lint.RsRustcLintCompletionProvider
+import org.rust.lang.core.completion.sort.RS_COMPLETION_WEIGHERS
+import org.rust.lang.core.completion.sort.RsCompletionWeigher
 import org.rust.lang.core.or
+import org.rust.stdext.exhaustive
 
 class RsCompletionContributor : CompletionContributor() {
 
@@ -44,5 +50,77 @@ class RsCompletionContributor : CompletionContributor() {
 
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {
         extend(type, provider.elementPattern, provider)
+    }
+
+    override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
+        super.fillCompletionVariants(parameters, withRustSorter(parameters, result))
+    }
+
+    companion object {
+        private val RS_COMPLETION_WEIGHERS_GROUPED: List<AnchoredWeigherGroup> = splitIntoGroups(RS_COMPLETION_WEIGHERS)
+        // BACKCOMPAT: 2021.3
+        private val BUILD_221 = BuildNumber.fromString("221")!!
+        val isAtLeast221Platform get() = ApplicationInfo.getInstance().build >= BUILD_221
+
+        /**
+         * Applies [RS_COMPLETION_WEIGHERS] to [result]
+         */
+        fun withRustSorter(parameters: CompletionParameters, result: CompletionResultSet): CompletionResultSet {
+            return if (isAtLeast221Platform) {
+                var sorter = CompletionSorter.defaultSorter(parameters, result.prefixMatcher)
+                for (weigherGroups in RS_COMPLETION_WEIGHERS_GROUPED) {
+                    sorter = sorter.weighAfter(weigherGroups.anchor, *weigherGroups.weighers)
+                }
+                result.withRelevanceSorter(sorter)
+            } else {
+                // BACKCOMPAT: 2021.3
+                result
+            }
+        }
+
+        private fun splitIntoGroups(weighersWithAnchors: List<Any>): List<AnchoredWeigherGroup> {
+            val firstEntry = weighersWithAnchors.firstOrNull() ?: return emptyList()
+            check(firstEntry is String) {
+                "The first element in the weigher list must be a string placeholder like \"priority\"; " +
+                    "actually it is `${firstEntry}`"
+            }
+            val result = mutableListOf<AnchoredWeigherGroup>()
+            val weigherIds = hashSetOf<String>()
+            var currentAnchor: String = firstEntry
+            var currentWeighers = mutableListOf<LookupElementWeigher>()
+            // Add "dummy weigher" in order to execute `is String ->` arm in the last iteration
+            for (weigherOrAnchor in weighersWithAnchors.asSequence().drop(1).plus(sequenceOf("dummy weigher"))) {
+                when (weigherOrAnchor) {
+                    is String -> {
+                        if (currentWeighers.isNotEmpty()) {
+                            result += AnchoredWeigherGroup(currentAnchor, currentWeighers.toTypedArray())
+                            currentWeighers = mutableListOf()
+                        }
+                        currentAnchor = weigherOrAnchor
+                    }
+                    is RsCompletionWeigher -> {
+                        if (!weigherIds.add(weigherOrAnchor.id)) {
+                            error("Found a ${RsCompletionWeigher::class.simpleName}.id duplicate: " +
+                                "`${weigherOrAnchor.id}`")
+                        }
+                        currentWeighers += RsCompletionWeigherAsLookupElementWeigher(weigherOrAnchor)
+                    }
+                    else -> error("The weigher list must consists of String placeholders and instances of " +
+                        "${RsCompletionWeigher::class.simpleName}, got ${weigherOrAnchor.javaClass}")
+                }.exhaustive
+            }
+            return result
+        }
+
+        private class AnchoredWeigherGroup(val anchor: String, val weighers: Array<LookupElementWeigher>)
+
+        private class RsCompletionWeigherAsLookupElementWeigher(
+            private val weigher: RsCompletionWeigher
+        ) : LookupElementWeigher(weigher.id, /* negated = */ false, /* dependsOnPrefix = */ false) {
+            override fun weigh(element: LookupElement): Comparable<*> {
+                val rsElement = element.`as`(RsLookupElement::class.java)
+                return weigher.weigh(rsElement ?: element)
+            }
+        }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
@@ -16,6 +16,7 @@ import org.rust.ide.icons.RsIcons
 import org.rust.ide.icons.multiple
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.RsPsiPattern
+import org.rust.lang.core.completion.RsLookupElementProperties.ElementKind
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
 import org.rust.lang.core.psi.ext.ancestorStrict
@@ -29,10 +30,6 @@ import org.rust.lang.core.types.TraitRef
 import org.rust.lang.core.with
 
 object RsDeriveCompletionProvider : RsCompletionProvider() {
-
-    private const val DEFAULT_PRIORITY = 5.0
-    private const val GROUP_PRIORITY = DEFAULT_PRIORITY + 0.1
-
     override fun addCompletions(parameters: CompletionParameters,
                                 context: ProcessingContext,
                                 result: CompletionResultSet) {
@@ -61,11 +58,11 @@ object RsDeriveCompletionProvider : RsCompletionProvider() {
                 if (traitWithDependencies.size > 1) {
                     val element = LookupElementBuilder.create(traitWithDependencies.joinToString(", "))
                         .withIcon(RsIcons.TRAIT.multiple())
-                    result.addElement(element.withPriority(GROUP_PRIORITY))
+                    result.addElement(element.toRsLookupElement(RsLookupElementProperties(elementKind = ElementKind.DERIVE_GROUP)))
                 }
                 val element = LookupElementBuilder.create(derivable.name)
                     .withIcon(RsIcons.TRAIT)
-                result.addElement(element.withPriority(DEFAULT_PRIORITY))
+                result.addElement(element.toRsLookupElement(RsLookupElementProperties(elementKind = ElementKind.DERIVE)))
             }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsFragmentSpecifierCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsFragmentSpecifierCompletionProvider.kt
@@ -25,7 +25,7 @@ object RsFragmentSpecifierCompletionProvider : RsCompletionProvider() {
         result: CompletionResultSet
     ) {
         FragmentKind.kinds.forEach {
-            result.addElement(LookupElementBuilder.create(it).bold().withPriority(FRAGMENT_SPECIFIER_PRIORITY))
+            result.addElement(LookupElementBuilder.create(it).bold().toKeywordElement())
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
@@ -82,7 +82,7 @@ object RsImplTraitMemberCompletionProvider : RsCompletionProvider() {
         for (item in parentItems) {
             val lookup = getCompletion(item, implBlock, subst, memberGenerator, keyword?.first)
             result.addElement(
-                lookup.withPriority(KEYWORD_PRIORITY + 1)
+                lookup.toRsLookupElement(RsLookupElementProperties(isImplMemberFullLineCompletion = true))
             )
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
@@ -24,6 +24,7 @@ import org.rust.lang.core.RsPsiPattern.baseDeclarationPattern
 import org.rust.lang.core.RsPsiPattern.baseInherentImplDeclarationPattern
 import org.rust.lang.core.RsPsiPattern.baseTraitOrImplDeclaration
 import org.rust.lang.core.RsPsiPattern.declarationPattern
+import org.rust.lang.core.completion.RsLookupElementProperties.KeywordKind
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.ext.*
@@ -66,25 +67,29 @@ class RsKeywordCompletionContributor : CompletionContributor(), DumbAware {
                 val elseBuilder = elseLookupElement()
                 val elseIfBuilder = conditionLookupElement("else if")
                 // `else` is more common than `else if`
-                result.addElement(elseBuilder.withPriority(KEYWORD_PRIORITY * 1.0001))
-                result.addElement(elseIfBuilder.withPriority(KEYWORD_PRIORITY))
+                result.addElement(elseBuilder.toKeywordElement(KeywordKind.ELSE_BRANCH))
+                result.addElement(elseIfBuilder.toKeywordElement())
             }
         })
 
         extend(CompletionType.BASIC, letElsePattern(), object : CompletionProvider<CompletionParameters>() {
             override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
                 val elseBuilder = elseLookupElement()
-                result.addElement(elseBuilder.withPriority(KEYWORD_PRIORITY))
+                result.addElement(elseBuilder.toKeywordElement())
             }
         })
 
         extend(CompletionType.BASIC, pathExpressionPattern(), object : CompletionProvider<CompletionParameters>() {
             override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
                 for (keyword in CONDITION_KEYWORDS) {
-                    result.addElement(conditionLookupElement(keyword).withPriority(KEYWORD_PRIORITY))
+                    result.addElement(conditionLookupElement(keyword).toKeywordElement())
                 }
             }
         })
+    }
+
+    override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
+        super.fillCompletionVariants(parameters, RsCompletionContributor.withRustSorter(parameters, result))
     }
 
     private fun conditionLookupElement(lookupString: String): LookupElementBuilder {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
@@ -25,7 +25,7 @@ class RsKeywordCompletionProvider(
         for (keyword in keywords) {
             var builder = LookupElementBuilder.create(keyword).bold()
             builder = addInsertionHandler(keyword, builder, parameters)
-            result.addElement(builder.withPriority(KEYWORD_PRIORITY))
+            result.addElement(builder.toKeywordElement())
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsLambdaExprCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsLambdaExprCompletionProvider.kt
@@ -17,6 +17,7 @@ import com.intellij.psi.util.parentOfType
 import com.intellij.util.ProcessingContext
 import org.rust.ide.refactoring.suggestedNames
 import org.rust.ide.utils.template.newTemplateBuilder
+import org.rust.lang.core.completion.RsLookupElementProperties.KeywordKind
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.OR
 import org.rust.lang.core.psi.ext.elementType
@@ -59,7 +60,7 @@ object RsLambdaExprCompletionProvider : RsCompletionProvider() {
                 .bold()
                 .withPresentableText("|| {}")
                 .withInsertHandler { ctx, _ -> handleInsert(ctx) }
-                .withPriority(KEYWORD_PRIORITY * 1.01)
+                .toKeywordElement(KeywordKind.LAMBDA_EXPR)
         )
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsLookupElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsLookupElement.kt
@@ -1,0 +1,152 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementDecorator
+import org.rust.lang.core.completion.RsLookupElementProperties.KeywordKind
+
+class RsLookupElement(
+    delegate: LookupElement,
+    val props: RsLookupElementProperties,
+) : LookupElementDecorator<LookupElement>(delegate) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as RsLookupElement
+
+        if (props != other.props) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + props.hashCode()
+        return result
+    }
+}
+
+/**
+ * Some known [lookup element][RsLookupElement] properties used in
+ * [completion sorting][org.rust.lang.core.completion.sort.RS_COMPLETION_WEIGHERS]
+ * and [Machine Learning-Assisted Completion sorting][org.rust.ml.RsElementFeatureProvider]
+ */
+data class RsLookupElementProperties(
+    /**
+     * `true` if the lookup element is created by [RsImplTraitMemberCompletionProvider].
+     * This kind of completion suggests an entire trait member when typing in a trait impl.
+     * See tests in `RsImplTraitMemberCompletionProviderTest`.
+     */
+    val isImplMemberFullLineCompletion: Boolean = false,
+
+    /**
+     * [KeywordKind.NOT_A_KEYWORD] if the lookup element is *not* a keyword.
+     * Some another [KeywordKind] variant if the lookup element *is* a keyword.
+     */
+    val keywordKind: KeywordKind = KeywordKind.NOT_A_KEYWORD,
+
+    /**
+     * `false` if the lookup element is a method that has a `self` type incompatible with a receiver type,
+     * for example when a `self` has `&mut T` type and a receiver has `&T` type.
+     * `true` otherwise.
+     *
+     * ```
+     * struct S;
+     * impl S {
+     *     fn foo(&mut self) {} // isMethodSelfTypeCompatible = false
+     *     fn foo(&self) {}     // isMethodSelfTypeCompatible = true
+     * }
+     * fn foo(a: &S) {
+     *     a. // <-- complete here
+     * }
+     * ```
+     */
+    val isSelfTypeCompatible: Boolean = false,
+
+    /**
+     * `true` if after insertion of the lookup element it will form an expression with a type
+     * that conforms to the expected type of that expression.
+     *
+     * ```
+     * fn foo() -> String { ... } // isReturnTypeConformsToExpectedType = true
+     * fn bar() -> i32 { ... }    // isReturnTypeConformsToExpectedType = false
+     * fn main() {
+     *     let a: String = // <-- complete here
+     * }
+     * ```
+     */
+    val isReturnTypeConformsToExpectedType: Boolean = false,
+
+    /**
+     * `true` if the lookup element refers to a local declaration, e.g. inside a function body or
+     * a `static` initializer.
+     *
+     * ```
+     * fn foo() {}      // isLocal = false
+     * fn main() {
+     *     fn bar()     // isLocal = true
+     *     let baz = 1; // isLocal = true
+     *     // <-- complete here
+     * }
+     * ```
+     */
+    val isLocal: Boolean = false,
+
+    /**
+     * `true` if the lookup element is a member of an inherent impl (i.e. an `impl` without a trait)
+     *
+     * ```
+     * struct S
+     * impl S {
+     *     fn foo();           // isInherentImplMember = true
+     *     const BAR: i32 = 1; // isInherentImplMember = true
+     * }
+     * trait Trait { fn baz(); }
+     * impl Trait for S {
+     *     fn baz() {}         // isInherentImplMember = false
+     * }
+     * ```
+     */
+    val isInherentImplMember: Boolean = false,
+
+    /**
+     * Some classification of an element
+     */
+    val elementKind: ElementKind = ElementKind.DEFAULT,
+) {
+    enum class KeywordKind {
+        // Top Priority
+        PUB,
+        PUB_CRATE,
+        PUB_PARENS,
+        LAMBDA_EXPR,
+        ELSE_BRANCH,
+        AWAIT,
+        KEYWORD,
+        NOT_A_KEYWORD,
+        // Least priority
+    }
+
+    enum class ElementKind {
+        // Top Priority
+        DERIVE_GROUP,
+        DERIVE,
+        LINT,
+        LINT_GROUP,
+
+        VARIABLE,
+        ENUM_VARIANT,
+        FIELD_DECL,
+        ASSOC_FN,
+        DEFAULT,
+        MACRO,
+        DEPRECATED,
+        // Least priority
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/completion/RsPrimitiveTypeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsPrimitiveTypeCompletionProvider.kt
@@ -35,7 +35,7 @@ object RsPrimitiveTypeCompletionProvider : RsCompletionProvider() {
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         primitives.forEach {
-            result.addElement(LookupElementBuilder.create(it).bold().withPriority(PRIMITIVE_TYPE_PRIORITY))
+            result.addElement(LookupElementBuilder.create(it).bold().toKeywordElement())
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsReprCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsReprCompletionProvider.kt
@@ -52,7 +52,7 @@ object RsReprCompletionProvider : RsCompletionProvider() {
                     }
                 } else this
             }
-            result.addElement(element.withPriority(DEFAULT_PRIORITY))
+            result.addElement(element)
         }
 
         // Layouts common to struct, enum and union

--- a/src/main/kotlin/org/rust/lang/core/completion/RsTupleFieldCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsTupleFieldCompletionProvider.kt
@@ -53,7 +53,9 @@ object RsTupleFieldCompletionProvider : RsCompletionProvider() {
         val elements = type.types.withIndex().map { (index, ty) ->
             createLookupElement(object : CompletionEntity {
                 override val ty: Ty get() = ty
-                override fun getBasePriority(context: RsCompletionContext): Double = FIELD_DECL_PRIORITY
+                override fun getBaseLookupElementProperties(context: RsCompletionContext): RsLookupElementProperties =
+                    RsLookupElementProperties(elementKind = RsLookupElementProperties.ElementKind.FIELD_DECL)
+
                 override fun createBaseLookupElement(context: RsCompletionContext): LookupElementBuilder {
                     return LookupElementBuilder
                         .create(index)

--- a/src/main/kotlin/org/rust/lang/core/completion/RsVisRestrictionCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsVisRestrictionCompletionProvider.kt
@@ -49,7 +49,7 @@ object RsVisRestrictionCompletionProvider : RsCompletionProvider() {
                     .create(name)
                     .withIcon(RsIcons.MODULE)
                     .bold()
-                    .withPriority(KEYWORD_PRIORITY)
+                    .toKeywordElement()
             )
         }
         result.addElement(LookupElementBuilder.create("in ").withPresentableText("in"))

--- a/src/main/kotlin/org/rust/lang/core/completion/RsVisibilityCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsVisibilityCompletionProvider.kt
@@ -12,6 +12,7 @@ import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.util.ProcessingContext
+import org.rust.lang.core.completion.RsLookupElementProperties.KeywordKind
 
 class RsVisibilityCompletionProvider : CompletionProvider<CompletionParameters>() {
     override fun addCompletions(
@@ -20,8 +21,8 @@ class RsVisibilityCompletionProvider : CompletionProvider<CompletionParameters>(
         result: CompletionResultSet
     ) {
         val items = listOf(
-            "pub" to 3,
-            "pub(crate)" to 2
+            "pub" to KeywordKind.PUB,
+            "pub(crate)" to KeywordKind.PUB_CRATE
         )
         for ((name, priority) in items) {
             result.addElement(
@@ -31,7 +32,7 @@ class RsVisibilityCompletionProvider : CompletionProvider<CompletionParameters>(
                         insertSpaceIfNeeded(ctx)
                         ctx.editor.caretModel.moveToOffset(ctx.selectionEndOffset)
                     }
-                    .withPriority(KEYWORD_PRIORITY + priority)
+                    .toKeywordElement(priority)
             )
         }
         result.addElement(
@@ -45,7 +46,7 @@ class RsVisibilityCompletionProvider : CompletionProvider<CompletionParameters>(
                     // Trigger auto-completion for vis restriction
                     AutoPopupController.getInstance(ctx.project).scheduleAutoPopup(ctx.editor)
                 }
-                .withPriority(KEYWORD_PRIORITY + 1)
+                .toKeywordElement(KeywordKind.PUB_PARENS)
         )
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/lint/RsLintCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/lint/RsLintCompletionProvider.kt
@@ -18,7 +18,9 @@ import org.rust.ide.icons.multiple
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.completion.RsCompletionProvider
-import org.rust.lang.core.completion.withPriority
+import org.rust.lang.core.completion.RsLookupElementProperties
+import org.rust.lang.core.completion.RsLookupElementProperties.ElementKind
+import org.rust.lang.core.completion.toRsLookupElement
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.ext.qualifier
@@ -52,7 +54,7 @@ abstract class RsLintCompletionProvider : RsCompletionProvider() {
         val element = LookupElementBuilder.create(text)
             .withPresentableText(lint.name)
             .withIcon(getIcon(lint))
-            .withPriority(getPriority(lint))
+            .toRsLookupElement(RsLookupElementProperties(elementKind = getElementKind(lint)))
         result.addElement(element)
     }
 
@@ -72,10 +74,10 @@ abstract class RsLintCompletionProvider : RsCompletionProvider() {
         RsIcons.ATTRIBUTE
     }
 
-    private fun getPriority(lint: Lint): Double = if (lint.isGroup) {
-        GROUP_PRIORITY
+    private fun getElementKind(lint: Lint) = if (lint.isGroup) {
+        ElementKind.LINT_GROUP
     } else {
-        LINT_PRIORITY
+        ElementKind.LINT
     }
 
     protected fun getPathPrefix(path: RsPath): String {
@@ -84,9 +86,6 @@ abstract class RsLintCompletionProvider : RsCompletionProvider() {
     }
 
     companion object {
-        private const val LINT_PRIORITY = 5.0
-        private const val GROUP_PRIORITY = 4.0
-
         private val GROUP_ICON = RsIcons.ATTRIBUTE.multiple()
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/sort/RsCompletionWeigher.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/sort/RsCompletionWeigher.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion.sort
+
+import com.intellij.codeInsight.lookup.LookupElement
+
+/**
+ * A weigher for Rust completion variants.
+ *
+ * @see RS_COMPLETION_WEIGHERS
+ */
+interface RsCompletionWeigher {
+    /**
+     * Returned values are sorted in ascending order, i.e.
+     * - `0`, `1`, `2`,
+     * - `false`, `true`,
+     * - upper enum variants before bottom ones.
+     *
+     * Note that any (Boolean, Number or Enum) value returned from [weigh] is automatically added
+     * as an "element feature" in ML-Assisted Completion (identified by [id]), see
+     * [org.rust.ml.RsElementFeatureProvider] for more details.
+     */
+    fun weigh(element: LookupElement): Comparable<*>
+
+    /**
+     * The [id] turns into [com.intellij.codeInsight.lookup.LookupElementWeigher.myId], which then turns into
+     * [com.intellij.codeInsight.lookup.ClassifierFactory.getId] which is used for comparison of
+     * [com.intellij.codeInsight.completion.CompletionSorter]s.
+     *
+     * Also, [id] identifies the value returned from [weigh] when the value is used as an "element feature"
+     * in ML-Assisted Completion (see [org.rust.ml.RsElementFeatureProvider]).
+     */
+    val id: String
+}

--- a/src/main/kotlin/org/rust/lang/core/completion/sort/RsCompletionWeighers.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/sort/RsCompletionWeighers.kt
@@ -1,0 +1,128 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion.sort
+
+import com.intellij.codeInsight.lookup.LookupElement
+import org.rust.lang.core.completion.RsLookupElement
+import org.rust.lang.core.completion.RsLookupElementProperties
+
+/**
+ * A list of weighers that sort completion variants in the Rust plugin.
+ *
+ * # Explanation
+ *
+ * Let's see how this list of weighers
+ * ```
+ * preferFalse(P::isMethodSelfTypeIncompatible, ...),
+ * preferTrue(P::isReturnTypeConformsToExpectedType, ...),
+ * ```
+ *
+ * will sort methods in this case
+ *
+ * ```
+ * struct S;
+ * impl S {
+ *     fn f1(&mut self) -> i32 {}    // isMethodSelfTypeIncompatible = true,  isReturnTypeConformsToExpectedType = false
+ *     fn f2(&mut self) -> String {} // isMethodSelfTypeIncompatible = true,  isReturnTypeConformsToExpectedType = true
+ *     fn f3(&self) -> i32 {}        // isMethodSelfTypeIncompatible = false, isReturnTypeConformsToExpectedType = false
+ *     fn f4(&self) -> String {}     // isMethodSelfTypeIncompatible = false, isReturnTypeConformsToExpectedType = true
+ * }
+ * fn foo(a: &S) {
+ *     let b: String = a. // <-- complete here
+ * }
+ * ```
+ * Initially, we have a completion list consisting of `[f1, f2, f3, f4]` methods.
+ * The first weigher prefers methods with compatible receiver type, i.e. methods with
+ * `isMethodSelfTypeIncompatible = false`, i.e. `f3` and `f4` (because `f1` and `f2` require `&mut self` but we
+ * have `&S`, so inserting `f1` or `f2` will cause a compilation error). After applying this weigher,
+ * the completion list will look like `[f3, f4, f1, f2]`. Note that `f3` and `f4` are now prioritized.
+ * Next weighers can swap `f3` <-> `f4` and/or `f1` <-> `f2`, but not `f3` <-> `f1`, for example.
+ * Effectively, the first weigher splits the list into two sublists: `[f3, f4]` and `[f1, f2]`, where
+ * the list `[f3, f4]` is strictly more preferred than `[f1, f2]`, and next weighers can reorder elements only
+ * within a sublist, but not between them.
+ * The second weigher prefers methods that return a type that conforms to the expected type, i.e. `f2` and `f4`
+ * (because in our case, these methods return `String` which is the expected type here).
+ * So, it places `f2` before `f1` and `f4` before `f3`: `[f4, f3, f2, f1]`. Note that `f3` is still before `f2`.
+ *
+ * # Notes
+ *
+ * The [RS_COMPLETION_WEIGHERS] list consists of [RsCompletionWeigher] instances and string placeholders which
+ * refer to IntelliJ platform weighers. Our weighers can be inserted after a specific IntelliJ platform weigher
+ * (e.g. "priority" or "prefix").
+ *
+ * The list of weighers is not final - there can be other weighers registered with
+ * `<com.intellij.weigher key="completion">` extension point.
+ *
+ * The IntelliJ platform provides other completion variants sorting mechanisms that may reorder
+ * everything. For example, "Machine Learning-Assisted Completion".
+ *
+ * Values returned from these weighers are automatically used as "element features" in ML-Assisted Completion
+ * (identified by [RsCompletionWeigher.id]), see [org.rust.ml.RsElementFeatureProvider] for more details.
+ *
+ * This list must not be changed within a major IDE release because it breaks "Machine Learning-Assisted Completion"
+ * model. The "change" is understood as adding or removing weighers, or changing their ID.
+ */
+val RS_COMPLETION_WEIGHERS: List<Any> = listOf(
+    /**
+     * Based on the value passed via [com.intellij.codeInsight.completion.PrioritizedLookupElement.withPriority].
+     * Unused in our case.
+     * @see com.intellij.codeInsight.completion.PriorityWeigher
+     */
+    "priority",
+
+    // HINT: jump to `P::isImplMemberFullLineCompletion` docs
+    preferTrue(P::isImplMemberFullLineCompletion, id = "rust-impl-member-full-line-completion"),
+    preferUpperVariant(P::keywordKind, id = "rust-prefer-keywords"),
+    preferTrue(P::isSelfTypeCompatible, id = "rust-prefer-compatible-self-type"),
+    preferTrue(P::isReturnTypeConformsToExpectedType, id = "rust-prefer-matching-expected-type"),
+    // TODO these weighers most likely should be after "stats"
+    preferTrue(P::isLocal, id = "rust-prefer-locals"),
+    preferUpperVariant(P::elementKind, id = "rust-prefer-by-kind"),
+    preferTrue(P::isInherentImplMember, id = "rust-prefer-inherent-impl-member"),
+
+    /**
+     * Checks prefix matching.
+     * @see com.intellij.codeInsight.completion.impl.RealPrefixMatchingWeigher
+     */
+    "prefix",
+
+    /**
+     * Bubbles up the most frequently used items.
+     * @see com.intellij.codeInsight.completion.StatisticsWeigher.LookupStatisticsWeigher
+     */
+    "stats",
+
+    /**
+     * Puts closer elements above more distant ones (relative to the location where completion is invoked).
+     * For example, elements from workspace packages considered closer than elements from from external packages.
+     * Specific rules are defined by [com.intellij.psi.util.proximity.ProximityWeigher] implementations
+     * registered using `<com.intellij.weigher key="proximity">` extension point.
+     * @see com.intellij.codeInsight.completion.LookupElementProximityWeigher
+     */
+    "proximity",
+)
+
+private typealias P = RsLookupElementProperties
+
+private fun preferTrue(
+    property: (P) -> Boolean,
+    id: String
+): RsCompletionWeigher = object : RsCompletionWeigher {
+    override fun weigh(element: LookupElement): Boolean =
+        if (element is RsLookupElement) !property(element.props) else true
+
+    override val id: String get() = id
+}
+
+private fun preferUpperVariant(
+    property: (P) -> Enum<*>,
+    id: String
+): RsCompletionWeigher = object : RsCompletionWeigher {
+    override fun weigh(element: LookupElement): Int =
+        if (element is RsLookupElement) property(element.props).ordinal else Int.MAX_VALUE
+
+    override val id: String get() = id
+}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
@@ -496,12 +496,12 @@ class RsCompletionSortingTest : RsTestBase() {
         }
         for ((actual, e) in elements.zip(expected)) {
             val lookupObject = actual.psiElement ?: actual.`object`
-            val (klass, name) = e
+            val (klass, expectedName) = e
+            val actualName = actual.lookupString
+            assertEquals(expectedName, actualName)
             check(klass.isInstance(lookupObject)) {
                 "Expected a ${klass.java.name}, found ${lookupObject.javaClass}"
             }
-            val actualName = actual.lookupString
-            assertEquals(name, actualName)
         }
     }
 }


### PR DESCRIPTION
This PR changes nothing for the end-user (i.e. the new sorting should work exactly like the old one).
For us, this tidies up completion variants sorting. Please read docs for `RS_COMPLETION_WEIGHERS`