### PR TITLE
#6411: Provide context features and more element features for ML-completion

### DIFF
--- a/ml-completion/src/main/kotlin/org/rust/ml/RsCompletionFeaturesPolicy.kt
+++ b/ml-completion/src/main/kotlin/org/rust/ml/RsCompletionFeaturesPolicy.kt
@@ -7,6 +7,7 @@ package org.rust.ml
 
 import com.intellij.completion.ml.features.CompletionFeaturesPolicy
 
+@Suppress("UnstableApiUsage")
 class RsCompletionFeaturesPolicy : CompletionFeaturesPolicy {
     override fun useNgramModel(): Boolean = true
 }

--- a/ml-completion/src/main/kotlin/org/rust/ml/RsContextFeatureProvider.kt
+++ b/ml-completion/src/main/kotlin/org/rust/ml/RsContextFeatureProvider.kt
@@ -1,0 +1,49 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ml
+
+import com.intellij.codeInsight.completion.ml.CompletionEnvironment
+import com.intellij.codeInsight.completion.ml.ContextFeatureProvider
+import com.intellij.codeInsight.completion.ml.MLFeatureValue
+import org.rust.lang.core.completion.RsCompletionContributor
+import org.rust.lang.core.macros.findExpansionElementOrSelf
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.isInAsyncContext
+import org.rust.lang.core.psi.ext.isInConstContext
+import org.rust.lang.core.psi.ext.isInUnsafeContext
+
+/**
+ * Note that there is a common context feature provider for all languages:
+ * [com.intellij.completion.ml.common.CommonLocationFeatures].
+ *
+ * @see RsElementFeatureProvider
+ */
+@Suppress("UnstableApiUsage")
+class RsContextFeatureProvider : ContextFeatureProvider {
+    override fun getName(): String = "rust"
+
+    override fun calculateFeatures(environment: CompletionEnvironment): Map<String, MLFeatureValue> {
+        // BACKCOMPAT: 2021.3
+        if (!RsCompletionContributor.isAtLeast221Platform) return emptyMap()
+
+        val result = hashMapOf<String, MLFeatureValue>()
+        val position = environment.parameters.position.findExpansionElementOrSelf()
+        val ancestorExpr = position.ancestorOrSelf<RsExpr>()
+
+        result[IS_UNSAFE_CONTEXT] = MLFeatureValue.binary(ancestorExpr?.isInUnsafeContext == true)
+        result[IS_ASYNC_CONTEXT] = MLFeatureValue.binary(ancestorExpr?.isInAsyncContext == true)
+        result[IS_CONST_CONTEXT] = MLFeatureValue.binary(ancestorExpr?.isInConstContext == true)
+
+        return result
+    }
+
+    companion object {
+        private const val IS_UNSAFE_CONTEXT: String = "is_unsafe_context"
+        private const val IS_ASYNC_CONTEXT: String = "is_async_context"
+        private const val IS_CONST_CONTEXT: String = "is_const_context"
+    }
+}

--- a/ml-completion/src/main/resources/META-INF/ml-completion-only.xml
+++ b/ml-completion/src/main/resources/META-INF/ml-completion-only.xml
@@ -3,6 +3,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <completion.ml.ranking.features.policy language="Rust" implementationClass="org.rust.ml.RsCompletionFeaturesPolicy"/>
         <completion.ml.elementFeatures language="Rust" implementationClass="org.rust.ml.RsElementFeatureProvider"/>
+        <completion.ml.contextFeatures language="Rust" implementationClass="org.rust.ml.RsContextFeatureProvider"/>
         <completion.ml.model implementation="org.rust.ml.RsMLRankingProvider"/>
     </extensions>
 </idea-plugin>

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -367,7 +367,7 @@ private val RsItemElement.declarationModifiers: List<String>
                 if (isUnsafe) {
                     modifiers += "unsafe"
                 }
-                if (isExtern) {
+                if (isActuallyExtern) {
                     modifiers += "extern"
                     abiName?.let { modifiers += "\"$it\"" }
                 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
@@ -229,7 +229,7 @@ class RsFunctionNamingInspection : RsSnakeCaseNamingInspection("Function") {
         if (super.isSuppressedFor(element)) return true
 
         val function = element.parent as? RsFunction ?: return false
-        return function.isExtern && function.findOuterAttr("no_mangle") != null
+        return function.isActuallyExtern && function.findOuterAttr("no_mangle") != null
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -83,7 +83,7 @@ open class RsPsiRenderer(
         if (fn.isUnsafe) {
             sb.append("unsafe ")
         }
-        if (fn.isExtern) {
+        if (fn.isActuallyExtern) {
             sb.append("extern ")
             val abiName = fn.abiName
             if (abiName != null) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsLookupElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsLookupElement.kt
@@ -119,6 +119,97 @@ data class RsLookupElementProperties(
      * Some classification of an element
      */
     val elementKind: ElementKind = ElementKind.DEFAULT,
+
+    /**
+     * `true` if the lookup element is a method that implements an overloaded operator like `add`,
+     * `eq`, `partial_cmp`, etc.
+     *
+     * ```
+     * use std::ops::Add;
+     * use std::convert::AsRef;
+     *
+     * struct S(i32);
+     *
+     * impl Add for S {
+     *     type Output = S;
+     *     fn add(self, rhs: Self) -> S {       // isOperatorMethod = true
+     *         S(self.0 + rhs.0)
+     *     }
+     * }
+     * impl AsRef<i32> for S {
+     *     fn as_ref(&self) -> &i32 { &self.0 } // isOperatorMethod = false
+     * }
+     *
+     * fn main() {
+     *     let a = S(0);
+     *     a.  // <-- complete here
+     *     S:: // <-- complete here
+     * }
+     * ```
+     */
+    val isOperatorMethod: Boolean = false,
+
+    /**
+     * `true` if the lookup element is a member of a blanket impl, i.e. an impl for a type parameter.
+     *
+     * ```
+     * impl<T: Bound> Trait for T {
+     *     fn foo(&self) {}    // isBlanketImplMember = true
+     *     fn bar() {}         // isBlanketImplMember = true
+     *     const BAZ: i32 = 1; // isBlanketImplMember = true
+     * }
+     */
+    val isBlanketImplMember: Boolean = false,
+
+    /**
+     * `true` if the lookup element is a function that requires an `unsafe` block to be called.
+     *
+     * ```
+     * unsafe fn foo() {}     // isUnsafeFn = true
+     * extern "C" {
+     *     fn bar();          // isUnsafeFn = true
+     * }
+     * fn baz() {}            // isUnsafeFn = false
+     * extern "C" fn qux() {} // isUnsafeFn = false
+     * ```
+     */
+    val isUnsafeFn: Boolean = false,
+
+    /**
+     * `true` if the lookup element is a function with `async` modifier.
+     *
+     * ```
+     * async fn foo() {} // isAsyncFn = true
+     * fn bar() {}       // isAsyncFn = false
+     * ```
+     */
+    val isAsyncFn: Boolean = false,
+
+    /**
+     * `true` if the lookup element is a function with `const` modifier or a `const`.
+     *
+     * ```
+     * const fn foo() {}  // isConstFnOrConst = true
+     * const C: i32 = 1;  // isConstFnOrConst = true
+     * fn bar() {}        // isConstFnOrConst = false
+     * static S: i32 = 1; // isConstFnOrConst = false
+     * ```
+     */
+    val isConstFnOrConst: Boolean = false,
+
+    /**
+     * `true` if the lookup element is a function with `extern` keyword.
+     * Don't confuse with a function inside an `extern` block.
+     *
+     * ```
+     * extern "C" fn foo() {} // isExternFn = true
+     * fn bar() {}            // isExternFn = false
+     * extern "C" {
+     *     fn baz();          // isExternFn = false
+     * }
+     * ```
+     */
+    val isExternFn: Boolean = false,
 ) {
     enum class KeywordKind {
         // Top Priority

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -13,6 +13,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.KnownItems
 import org.rust.lang.core.stubs.RsPlaceholderStub
 import org.rust.lang.core.stubs.RsUnaryExprStub
+import org.rust.stdext.buildList
 
 enum class UnaryOperator {
     REF, // `&a`
@@ -58,6 +59,15 @@ interface OverloadableBinaryOperator {
 
     fun findTrait(items: KnownItems): RsTraitItem? =
         items.findLangItem(itemName)
+
+    companion object {
+        fun values(): List<OverloadableBinaryOperator> = buildList {
+            addAll(ArithmeticOp.values())
+            addAll(EqualityOp.values())
+            addAll(ComparisonOp.values())
+            addAll(ArithmeticAssignmentOp.values())
+        }
+    }
 }
 
 sealed class BinaryOperator
@@ -119,7 +129,7 @@ sealed class ComparisonOp(
     object GTEQ : ComparisonOp(">=") // `a >= b`
 
     override val traitName: String = "PartialOrd"
-    override val itemName: String = "ord"
+    override val itemName: String = "partial_ord"
     override val fnName: String = "partial_cmp"
 
     override fun findTrait(items: KnownItems): RsTraitItem? = items.PartialOrd

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -43,10 +43,15 @@ val RsFunction.isConst: Boolean
         return stub?.isConst ?: (const != null)
     }
 
+/** Returns `true` if the function has `extern` modifier or located inside a certain `extern {}` block */
+val RsFunction.isActuallyExtern: Boolean
+    get() = isExtern || stubParent is RsForeignModItem
+
+/** Returns `true` if the function has `extern` modifier */
 val RsFunction.isExtern: Boolean
     get() {
         val stub = greenStub
-        return stub?.isExtern ?: (abi != null)
+        return stub?.isExtern ?: (externAbi != null)
     }
 
 val RsFunction.isVariadic: Boolean

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -72,7 +72,7 @@ class RsFileStub(
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 224
+        private const val STUB_VERSION = 225
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION


### PR DESCRIPTION
Related to #6411

New element features:
- IS_OPERATOR_METHOD
- IS_BLANKET_IMPL_MEMBER
- IS_UNSAFE_FN
- IS_ASYNC_FN
- IS_CONST_FN_OR_CONST
- IS_EXTERN_FN

New context features:
- IS_UNSAFE_CONTEXT
- IS_ASYNC_CONTEXT
- IS_CONST_CONTEXT