### PR TITLE
Fix auto-import options for 2022.1

### DIFF
--- a/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
@@ -7,36 +7,30 @@ package org.rust.ide.settings
 
 import com.intellij.application.options.editor.AutoImportOptionsProvider
 import com.intellij.openapi.application.ApplicationBundle
-import com.intellij.openapi.options.UiDslConfigurable
-import com.intellij.ui.ContextHelpLabel
-import com.intellij.ui.layout.RowBuilder
+import com.intellij.openapi.options.UiDslUnnamedConfigurable
+import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.RightGap
+import com.intellij.ui.dsl.builder.bindSelected
 import org.rust.RsBundle
 
-class RsAutoImportOptions : UiDslConfigurable.Simple(), AutoImportOptionsProvider {
+class RsAutoImportOptions : UiDslUnnamedConfigurable.Simple(), AutoImportOptionsProvider {
 
-    override fun RowBuilder.createComponentRow() {
+    override fun Panel.createContent() {
         val settings = RsCodeInsightSettings.getInstance()
-        titledRow(RsBundle.message("settings.rust.auto.import.title")) {
+        group(RsBundle.message("settings.rust.auto.import.title")) {
             row {
-                checkBox(
-                    RsBundle.message("settings.rust.auto.import.show.popup"),
-                    settings::showImportPopup
-                )
+                checkBox(RsBundle.message("settings.rust.auto.import.show.popup"))
+                    .bindSelected(settings::showImportPopup)
             }
             row {
-                checkBox(
-                    RsBundle.message("settings.rust.auto.import.on.completion"),
-                    settings::importOutOfScopeItems
-                )
+                checkBox(RsBundle.message("settings.rust.auto.import.on.completion"))
+                    .bindSelected(settings::importOutOfScopeItems)
             }
             row {
-                cell {
-                    checkBox(
-                        ApplicationBundle.message("checkbox.add.unambiguous.imports.on.the.fly"),
-                        settings::addUnambiguousImportsOnTheFly
-                    )
-                    ContextHelpLabel.create(ApplicationBundle.message("help.add.unambiguous.imports"))()
-                }
+                checkBox(ApplicationBundle.message("checkbox.add.unambiguous.imports.on.the.fly"))
+                    .bindSelected(settings::addUnambiguousImportsOnTheFly)
+                    .gap(RightGap.SMALL)
+                contextHelp(ApplicationBundle.message("help.add.unambiguous.imports"))
             }
         }
     }


### PR DESCRIPTION
Auto-import options (`Settings | Editor | General | Auto Import`) doesn't work in 2022.1.
Thanks @neonaot for finding this.
The fix is to replace deprecated `UiDslConfigurable` with `UiDslUnnamedConfigurable`.

changelog: Fix auto-import options for 2022.1 platform
