### PR TITLE
DBG: Hide filtering button

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsLocalDebugProcess.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsLocalDebugProcess.kt
@@ -13,4 +13,6 @@ class RsLocalDebugProcess(
     val runParameters: RsDebugRunParameters,
     debugSession: XDebugSession,
     consoleBuilder: TextConsoleBuilder
-) : CidrLocalDebugProcess(runParameters, debugSession, consoleBuilder)
+) : CidrLocalDebugProcess(runParameters, debugSession, consoleBuilder) {
+    override fun isLibraryFrameFilterSupported() = false
+}


### PR DESCRIPTION
In IDEA 221 in CidrDebugProcess there will be a filtering functionality for frames with unavailble sources. See https://youtrack.jetbrains.com/issue/CPP-28132

For Rust this approach introduces some not very usefull button since library sources are availble.

Just in case: 
 - review  https://jetbrains.team/p/ij/reviews/19787/timeline 
 - commit: https://jetbrains.team/p/ij/repositories/intellij/revision/43d15360d0e679b741d241455bd8560fb99b2308 