### PR TITLE
GRD: drop default `languageSupport` extension for 221

### DIFF
--- a/debugger/src/213/main/resources/META-INF/platform-native-debug-only.xml
+++ b/debugger/src/213/main/resources/META-INF/platform-native-debug-only.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="cidr.debugger">
+        <!-- Default implementation not to produce NPE for non-Rust stack frames -->
+        <!-- Workaround for https://github.com/intellij-rust/intellij-rust/issues/8122 -->
+        <languageSupport language="" implementationClass="org.rust.debugger.lang.RsDebuggerLanguageSupport" order="last"/>
+    </extensions>
+</idea-plugin>

--- a/debugger/src/221/main/resources/META-INF/platform-native-debug-only.xml
+++ b/debugger/src/221/main/resources/META-INF/platform-native-debug-only.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/debugger/src/main/resources/META-INF/native-debug-only.xml
+++ b/debugger/src/main/resources/META-INF/native-debug-only.xml
@@ -1,10 +1,4 @@
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
     <xi:include href="/META-INF/debugger-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
-
-    <extensions defaultExtensionNs="cidr.debugger">
-        <!-- Default implementation not to produce NPE for non-Rust stack frames -->
-        <!-- Workaround for https://github.com/intellij-rust/intellij-rust/issues/8122 -->
-        <!-- BACKCOMPAT: 2021.3 -->
-        <languageSupport language="" implementationClass="org.rust.debugger.lang.RsDebuggerLanguageSupport" order="last"/>
-    </extensions>
+    <xi:include href="/META-INF/platform-native-debug-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
 </idea-plugin>


### PR DESCRIPTION
It was introduced as workaround for https://github.com/intellij-rust/intellij-rust/issues/8122
Now, it's fixed in 221 platform so we don't need this workaround anymore