### PR TITLE
TY: Support type inference for GATs

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt
@@ -47,7 +47,7 @@ class RsTypeDeclarationProvider : TypeDeclarationProvider {
                     else -> null
                 }
             }
-            is TyProjection -> target
+            is TyProjection -> target.element
             is TyReference -> referenced.baseTypeDeclaration()
             is TyPointer -> referenced.baseTypeDeclaration()
             is TyArray -> base.baseTypeDeclaration()

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -168,7 +168,8 @@ private data class TypeRenderer(
                     if (includeTypeArguments) append(formatTraitGenerics(ty.trait, render, false))
                     append(">::")
                 }
-                append(ty.target.name)
+                append(ty.target.element.name)
+                if (includeTypeArguments) append(formatProjectionGenerics(ty, render))
             }
             is TyTraitObject -> ty.traits.joinToString("+", "dyn ") { formatTrait(it, render) }
             is TyAnon -> ty.traits.joinToString("+", "impl ") { formatTrait(it, render) }
@@ -227,6 +228,11 @@ private data class TypeRenderer(
 
     private fun formatAdtGenerics(adt: TyAdt, render: (Ty) -> String): String {
         val visibleTypes = formatGenerics(adt.item, adt.typeParameterValues, render)
+        return if (visibleTypes.isEmpty()) "" else visibleTypes.joinToString(", ", "<", ">")
+    }
+
+    private fun formatProjectionGenerics(projection: TyProjection, render: (Ty) -> String): String {
+        val visibleTypes = formatGenerics(projection.target.element, projection.typeParameterValues, render)
         return if (visibleTypes.isEmpty()) "" else visibleTypes.joinToString(", ", "<", ">")
     }
 

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -157,7 +157,7 @@ object RsImportHelper {
                     is TyTraitObject -> result += ty.traits.map { it.element }
                     is TyProjection -> {
                         result += ty.trait.element
-                        result += ty.target
+                        result += ty.target.element
                     }
                 }
                 return ty.superVisitWith(this)

--- a/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
@@ -68,14 +68,14 @@ object RsAwaitCompletionProvider : RsCompletionProvider() {
     private fun Ty.lookupRawFutureOutputTy(lookup: ImplLookup): Ty {
         val futureTrait = lookup.items.Future ?: return TyUnknown
         val outputType = futureTrait.findAssociatedType("Output") ?: return TyUnknown
-        val selection = lookup.selectProjectionStrict(TraitRef(this, futureTrait.withSubst()), outputType)
+        val selection = lookup.selectProjectionStrict(TraitRef(this, futureTrait.withSubst()), outputType.withSubst())
         return selection.ok()?.value ?: TyUnknown
     }
 
     private fun Ty.lookupIntoFutureOutputTy(lookup: ImplLookup): Ty {
         val intoFutureTrait = lookup.items.IntoFuture ?: return TyUnknown
         val outputType = intoFutureTrait.findAssociatedType("Output") ?: return TyUnknown
-        val selection = lookup.selectProjectionStrict(TraitRef(this, intoFutureTrait.withSubst()), outputType)
+        val selection = lookup.selectProjectionStrict(TraitRef(this, intoFutureTrait.withSubst()), outputType.withSubst())
         return selection.ok()?.value ?: TyUnknown
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
@@ -7,8 +7,13 @@ package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.psi.RsAssocTypeBinding
 import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.types.BoundElement
 
 // Current grammar allows to write assoc type bindings in method calls, e.g.
 // `a.foo::<Item = i32>()`, so it's nullable
 val RsAssocTypeBinding.parentPath: RsPath?
     get() = ancestorStrict()
+
+fun RsAssocTypeBinding.resolveToBoundAssocType(): BoundElement<RsTypeAlias>? =
+    path.reference?.advancedResolve()?.downcast()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -19,9 +19,7 @@ import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.resolve.ref.RsMacroBodyReferenceDelegateImpl
 import org.rust.lang.core.stubs.RsTraitItemStub
 import org.rust.lang.core.types.*
-import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.infer.substitute
-import org.rust.lang.core.types.regions.ReEarlyBound
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTypeParameter
 import org.rust.openapiext.filterIsInstanceQuery
@@ -119,25 +117,6 @@ private val RsTraitItem.superTraits: Sequence<BoundElement<RsTraitItem>>
             .filter { !it.hasQ } // ignore `?Sized`
             .mapNotNull { it.bound.traitRef?.resolveToBoundTrait() }
     }
-
-fun RsTraitItem.withDefaultSubst(): BoundElement<RsTraitItem> =
-    BoundElement(this, defaultSubstitution(this))
-
-private fun defaultSubstitution(item: RsTraitItem): Substitution {
-    val typeSubst = item.typeParameters.associate {
-        val parameter = TyTypeParameter.named(it)
-        parameter to parameter
-    }
-    val regionSubst = item.lifetimeParameters.associate {
-        val parameter = ReEarlyBound(it)
-        parameter to parameter
-    }
-    val constSubst = item.constParameters.associate {
-        val parameter = CtConstParameter(it)
-        parameter to parameter
-    }
-    return Substitution(typeSubst, regionSubst, constSubst)
-}
 
 abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>, RsTraitItem {
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -301,7 +301,7 @@ class ImplLookup(
                 }
             }
             is TyProjection -> {
-                val subst = ty.trait.subst + mapOf(TyTypeParameter.self() to ty.type).toTypeSubst()
+                val subst = ty.trait.subst + ty.target.subst + mapOf(TyTypeParameter.self() to ty.type).toTypeSubst()
                 implsAndTraits += ty.trait.element.bounds.asSequence()
                     .filter { ctx.probe { ctx.combineTypes(it.selfTy.substitute(subst), ty) }.isOk }
                     .flatMap { it.trait.getFlattenHierarchy().asSequence() }
@@ -758,7 +758,7 @@ class ImplLookup(
     private fun assembleCandidatesFromProjectedTys(ref: TraitRef, candidates: SelectionCandidateSet) {
         val selfTy = ref.selfTy
         if (selfTy is TyProjection) {
-            val subst = selfTy.trait.subst + mapOf(TyTypeParameter.self() to selfTy.type).toTypeSubst()
+            val subst = selfTy.trait.subst + selfTy.target.subst + mapOf(TyTypeParameter.self() to selfTy.type).toTypeSubst()
             selfTy.trait.element.bounds.asSequence()
                 .filter { ctx.probe { ctx.combineTypes(it.selfTy.substitute(subst), selfTy) }.isOk }
                 .flatMap { it.trait.getFlattenHierarchy().asSequence() }
@@ -968,7 +968,7 @@ class ImplLookup(
 
     private fun confirmProjectionCandidate(ref: TraitRef, candidate: ProjectionCandidate): Selection {
         ref.selfTy as TyProjection
-        val subst = ref.selfTy.trait.subst + mapOf(TyTypeParameter.self() to ref.selfTy.type).toTypeSubst()
+        val subst = ref.selfTy.trait.subst + ref.selfTy.target.subst + mapOf(TyTypeParameter.self() to ref.selfTy.type).toTypeSubst()
         ctx.combineTraitRefs(ref, TraitRef(ref.selfTy, candidate.bound.substitute(subst)))
         return Selection(ref.trait.element, emptyList())
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -553,7 +553,7 @@ private fun pathTypeParameters(path: RsPath): RsPsiPathParameters? {
     }
 }
 
-private fun resolveAssocTypeBinding(trait: RsTraitItem, binding: RsAssocTypeBinding): RsTypeAlias? =
+fun resolveAssocTypeBinding(trait: RsTraitItem, binding: RsAssocTypeBinding): RsTypeAlias? =
     collectResolveVariants(binding.path.referenceName) { processAssocTypeVariants(trait, it) }
         .singleOrNull() as? RsTypeAlias?
 
@@ -633,9 +633,8 @@ private fun RsPathReference.tryAdvancedResolveTypeAliasToImpl(): BoundElement<Rs
 
     // 3. Try to select a concrete impl for the associated type
     val lookup = ImplLookup.relativeTo(element)
-    val selection = lookup.selectStrict(
-        (TyProjection.valueOf(resolved).substitute(resolvedBoundElement.subst) as TyProjection).traitRef
-    ).ok()
+    val projection = TyProjection.valueOf(resolved.withDefaultSubst()).substitute(resolvedBoundElement.subst) as TyProjection
+    val selection = lookup.selectStrict(projection.traitRef).ok()
     if (selection?.impl !is RsImplItem) return null
     val element = selection.impl.expandedMembers.types.find { it.name == resolved.name } ?: return null
     val newSubst = lookup.ctx.fullyResolveWithOrigins(selection.subst)

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -131,7 +131,7 @@ val PsiElement.inferenceContextOwner: RsInferenceContextOwner?
         }?.first as? RsInferenceContextOwner
 
 private fun PsiElement.isAllowedPathParent() =
-    this is RsPathType || this is RsTraitRef || this is RsStructLiteral || this is RsPath
+    this is RsPathType || this is RsTraitRef || this is RsStructLiteral || this is RsAssocTypeBinding || this is RsPath
 
 val PsiElement.inference: RsInferenceResult?
     get() = inferenceContextOwner?.selfInferenceResult

--- a/src/main/kotlin/org/rust/lang/core/types/RsPsiTypeImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RsPsiTypeImplUtil.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.types
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.owner
+import org.rust.lang.core.psi.ext.withDefaultSubst
 import org.rust.lang.core.types.infer.TyLowering
 import org.rust.lang.core.types.ty.*
 import org.rust.openapiext.recursionGuard
@@ -24,7 +25,7 @@ object RsPsiTypeImplUtil {
         if (typeReference != null) return typeReference.typeWithRecursionGuard
         return when (psi.owner) {
             is RsAbstractableOwner.Free -> TyUnknown
-            is RsAbstractableOwner.Trait -> TyProjection.valueOf(psi)
+            is RsAbstractableOwner.Trait -> TyProjection.valueOf(psi.withDefaultSubst())
             is RsAbstractableOwner.Impl -> TyUnknown
             is RsAbstractableOwner.Foreign -> TyUnknown
         }

--- a/src/main/kotlin/org/rust/lang/core/types/Substitution.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Substitution.kt
@@ -27,7 +27,7 @@ open class Substitution(
     @Suppress("MemberVisibilityCanBePrivate")
     val regionSubst: Map<ReEarlyBound, Region> = emptyMap(),
     val constSubst: Map<CtConstParameter, Const> = emptyMap()
-): TypeFoldable<Substitution> {
+) : TypeFoldable<Substitution> {
     val types: Collection<Ty> get() = typeSubst.values
     val regions: Collection<Region> get() = regionSubst.values
     val consts: Collection<Const> get() = constSubst.values
@@ -81,14 +81,20 @@ open class Substitution(
 
     fun zipConstValues(other: Substitution): List<Pair<Const, Const>> = zipValues(constSubst, other.constSubst)
 
+    fun mapTypeKeys(transform: (Map.Entry<TyTypeParameter, Ty>) -> TyTypeParameter): Substitution =
+        Substitution(typeSubst.mapKeys(transform), regionSubst, constSubst)
+
     fun mapTypeValues(transform: (Map.Entry<TyTypeParameter, Ty>) -> Ty): Substitution =
         Substitution(typeSubst.mapValues(transform), regionSubst, constSubst)
+
+    fun mapConstKeys(transform: (Map.Entry<CtConstParameter, Const>) -> CtConstParameter): Substitution =
+        Substitution(typeSubst, regionSubst, constSubst.mapKeys(transform))
 
     fun mapConstValues(transform: (Map.Entry<CtConstParameter, Const>) -> Const): Substitution =
         Substitution(typeSubst, regionSubst, constSubst.mapValues(transform))
 
     fun visitValues(visitor: TypeVisitor): Boolean =
-            types.any { it.visitWith(visitor) } ||
+        types.any { it.visitWith(visitor) } ||
             regions.any { it.visitWith(visitor) } ||
             consts.any { it.visitWith(visitor) }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.*
 import org.rust.lang.core.resolve.ref.MethodResolveVariant
 import org.rust.lang.core.resolve.ref.pathPsiSubst
+import org.rust.lang.core.resolve.ref.resolveAssocTypeBinding
 import org.rust.lang.core.resolve.ref.resolvePathRaw
 import org.rust.lang.core.types.*
 import org.rust.lang.core.types.consts.*
@@ -241,7 +242,13 @@ class RsInferenceContext(
                 RsTypeInferenceWalker(this, TyUnknown).inferReplCodeFragment(element)
             }
             is RsPath -> {
-                val declaration = resolvePathRaw(element, lookup).singleOrNull()?.element as? RsGenericDeclaration
+                val parent = element.parent
+                val declaration = if (parent is RsAssocTypeBinding) {
+                    val trait = parent.parentPath?.let { resolvePathRaw(it, lookup) }?.singleOrNull()?.element as? RsTraitItem
+                    trait?.let { resolveAssocTypeBinding(it, parent) }
+                } else {
+                    resolvePathRaw(element, lookup).singleOrNull()?.element as? RsGenericDeclaration
+                }
                 if (declaration != null) {
                     val constParameters = mutableListOf<RsConstParameter>()
                     val constArguments = mutableListOf<RsElement>()
@@ -558,7 +565,9 @@ class RsInferenceContext(
             ty1 === ty2 -> Ok(Unit)
             ty1 is TyPrimitive && ty2 is TyPrimitive && ty1.javaClass == ty2.javaClass -> Ok(Unit)
             ty1 is TyTypeParameter && ty2 is TyTypeParameter && ty1 == ty2 -> Ok(Unit)
-            ty1 is TyProjection && ty2 is TyProjection && ty1.target == ty2.target && combineBoundElements(ty1.trait, ty2.trait) -> {
+            ty1 is TyProjection && ty2 is TyProjection &&
+                combineBoundElements(ty1.trait, ty2.trait) &&
+                combineBoundElements(ty1.target, ty2.target) -> {
                 combineTypes(ty1.type, ty2.type)
             }
             ty1 is TyReference && ty2 is TyReference && ty1.mutability == ty2.mutability -> {
@@ -1262,11 +1271,11 @@ private fun RsGenericDeclaration.doGetPredicates(): List<Predicate> {
         it.typeParamBounds?.polyboundList.toPredicates(selfTy)
     }
     val assocTypes = if (this is RsTraitItem) {
-        expandedMembers.types.map { TyProjection.valueOf(it) }
+        expandedMembers.types.map { TyProjection.valueOf(it.withDefaultSubst()) }
     } else {
         emptyList()
     }
-    val assocTypeBounds = assocTypes.asSequence().flatMap { it.target.typeParamBounds?.polyboundList.toPredicates(it) }
+    val assocTypeBounds = assocTypes.asSequence().flatMap { it.target.element.typeParamBounds?.polyboundList.toPredicates(it) }
     val explicitPredicates = (bounds + whereBounds + assocTypeBounds).toList()
     val sized = knownItems.Sized
     val implicitPredicates = if (sized != null) {
@@ -1299,8 +1308,7 @@ private fun List<RsPolybound>?.toPredicates(selfTy: Ty): Sequence<PsiPredicate> 
 
         val assocTypeBounds = traitRef.path.assocTypeBindings.asSequence()
             .flatMap nestedFlatMap@{
-                val assoc = it.path.reference?.resolve() as? RsTypeAlias
-                    ?: return@nestedFlatMap emptySequence<PsiPredicate>()
+                val assoc = it.resolveToBoundAssocType() ?: return@nestedFlatMap emptySequence<PsiPredicate>()
                 val projectionTy = TyProjection.valueOf(selfTy, assoc)
                 val typeRef = it.typeReference
                 if (typeRef != null) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1156,8 +1156,8 @@ class RsTypeInferenceWalker(
         val okType = tryItem.findAssociatedType("Output")
             ?: tryItem.findAssociatedType("Ok")
             ?: return TyUnknown
-        return ctx.normalizeAssociatedTypesIn(TyProjection.valueOf(base, BoundElement(tryItem), okType))
-            .register()
+        val projection = TyProjection.valueOf(base, BoundElement(tryItem), BoundElement(okType))
+        return ctx.normalizeAssociatedTypesIn(projection).register()
     }
 
     private fun inferRangeType(expr: RsRangeExpr): Ty {
@@ -1458,7 +1458,7 @@ class RsTypeInferenceWalker(
         val assocType = tryTrait.findAssociatedType("Output")
             ?: tryTrait.findAssociatedType("Ok")
             ?: return
-        val projection = TyProjection.valueOf(resultTy, assocType)
+        val projection = TyProjection.valueOf(resultTy, BoundElement(assocType))
         val obligation = Obligation(Predicate.Projection(projection, assocTypeTy))
         fulfill.registerPredicateObligation(obligation)
     }
@@ -1497,14 +1497,14 @@ class RsTypeInferenceWalker(
     private fun Ty.lookupRawFutureOutputTy(lookup: ImplLookup): Ty {
         val futureTrait = lookup.items.Future ?: return TyUnknown
         val outputType = futureTrait.findAssociatedType("Output") ?: return TyUnknown
-        val selection = lookup.selectProjection(TraitRef(this, futureTrait.withSubst()), outputType)
+        val selection = lookup.selectProjection(TraitRef(this, futureTrait.withSubst()), outputType.withSubst())
         return selection.ok()?.register() ?: TyUnknown
     }
 
     private fun Ty.lookupIntoFutureOutputTy(lookup: ImplLookup): Ty {
         val intoFutureTrait = lookup.items.IntoFuture ?: return TyUnknown
         val outputType = intoFutureTrait.findAssociatedType("Output") ?: return TyUnknown
-        val selection = lookup.selectProjection(TraitRef(this, intoFutureTrait.withSubst()), outputType)
+        val selection = lookup.selectProjection(TraitRef(this, intoFutureTrait.withSubst()), outputType.withSubst())
         return selection.ok()?.register() ?: TyUnknown
     }
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1688,6 +1688,24 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    fun `test generic associated type is sized E0277`() = checkErrors("""
+        #[lang = "sized"] trait Sized {}
+        pub trait Deref { type Target: ?Sized; }
+        pub struct Rc<T>(T);
+        impl<T> Deref for Rc<T> { type Target = T; }
+
+        trait PointerFamily {
+            type Pointer<T>: Deref<Target = T>;
+        }
+        struct RcFamily;
+        impl PointerFamily for RcFamily {
+            type Pointer<T> = Rc<T>;
+        }
+        fn foo<T: PointerFamily>() -> T::Pointer<i32> { // No error here
+            todo!()
+        }
+    """)
+
     fun `test supertrait is not implemented E0277 simple trait`() = checkErrors("""
         trait A {}
         trait B: A {}

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -33,12 +33,14 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
         #![feature(const_generics_defaults)]
         struct S<const N: usize = <error>1u8</error>>;
         trait T<const N: usize = <error>1u8</error>> {
+            type Item<const N: usize>;
             fn foo<const N: usize>(&self) -> S<N>;
         }
         impl T<<error>1u8</error>> for S<<error>1u8</error>> {
+            type Item<const N: usize> = ();
             fn foo<const N: usize>(self) -> S<<error>1u8</error>> { self }
         }
-        fn bar(x: S<<error>1u8</error>>) -> S<<error>1u8</error>> {
+        fn bar(x: S<<error>1u8</error>>, y: &dyn T<Item<<error>1u8</error>>=u8>) -> S<<error>1u8</error>> {
             let s: S<<error>1u8</error>> = S::<<error>1u8</error>>;
             s.foo::<<error>1u8</error>>()
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1187,6 +1187,18 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
+    fun `test generic assoc type bound method`() = checkByCode("""
+        trait Foo { type Item<A>: Bar; }
+        trait Bar: Baz {}
+        trait Baz {
+            fn baz(&self) {}
+        }    //X
+
+        fn foobar<T: Foo>(a: T::Item<i32>) {
+            a.baz();
+        }   //^
+    """)
+
     // The go-to-declaration behavior differs in this case. See `RsGotoDeclarationTest`
     @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 1)`() = checkByCode("""

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -2314,6 +2314,31 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ X
     """)
 
+    fun `test generic assoc type bound selection 1`() = testExpr("""
+        struct X;
+        trait Foo<T> {}
+        fn foo<A: Foo<B>, B>(_: A) -> B { unimplemented!() }
+        trait Bar { type Item<T>: Foo<T>; }
+        fn bar<T: Bar>(_: T, b: T::Item<X>) {
+            let a = foo(b);
+            a;
+        } //^ X
+    """)
+
+    fun `test generic assoc type bound selection 2`() = testExpr("""
+        struct X;
+        trait Foo { type Item<T>: Bar1<T> + Bar2<T>; }
+        trait Bar1<T>: Baz<T> {}
+        trait Bar2<T>: Baz<T> {}
+        trait Baz<T> {}
+        fn baz<A: Baz<B>, B>(t: A) -> B { unimplemented!() }
+
+        fn foobar<T: Foo>(a: T::Item<X>) {
+            let b = baz(a);
+            b;
+        } //^ X
+    """)
+
     fun `test infer type parameter from associated type binding`() = testExpr("""
         trait Foo { type Item; }
         fn foo<A, B>(a: A) -> B where A: Foo<Item = B> { unimplemented!() }
@@ -2711,5 +2736,17 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let b = foo(a);
             b;
         } //^ X
+    """)
+
+    fun `test method from generic assoc type bound`() = testExpr("""
+        trait Foo { type Item<A>: Bar<A>; }
+        trait Bar<B>: Baz<B> {}
+        trait Baz<C> {
+            fn baz(&self) -> C { todo!() }
+        }
+        fn foobar<D: Foo>(a: D::Item<i32>) {
+            let b = a.baz();
+            b;
+        } //^ i32
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -863,6 +863,21 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ u8
     """)
 
+    fun `test bound generic associated type`() = testExpr("""
+        trait Tr { type Item<A>; }
+        struct S<B>(B);
+        impl<C: Tr> S<C> { fn foo(self) -> C::Item<u8> { unimplemented!() } }
+
+        struct X;
+        struct Vec<T>(T);
+        impl Tr for X { type Item<D> = Vec<D>; }
+
+        fn main() {
+            let a = S(X).foo();
+            a;
+        } //^ Vec<u8>
+    """)
+
     fun `test bound associated type in explicit UFCS form`() = testExpr("""
         trait Tr { type Item; }
         struct S<A>(A);
@@ -874,6 +889,20 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = S(X).foo();
             a;
         } //^ u8
+    """)
+
+    fun `test bound generic associated type in explicit UFCS form`() = testExpr("""
+        trait Tr { type Item<A>; }
+        struct S<B>(B);
+        impl<C: Tr> S<C> { fn foo(self) -> <C as Tr>::Item<u8> { unimplemented!() } }
+
+        struct X;
+        impl Tr for X { type Item<D> = Vec<D>; }
+        struct Vec<T>(T);
+        fn main() {
+            let a = S(X).foo();
+            a;
+        } //^ Vec<u8>
     """)
 
     fun `test bound inherited associated type`() = testExpr("""
@@ -891,6 +920,22 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ u8
     """)
 
+    fun `test bound inherited generic associated type`() = testExpr("""
+        trait Tr1 { type Item<A>; }
+        trait Tr2: Tr1 {}
+        struct S<B>(B);
+        impl<C: Tr2> S<C> { fn foo(self) -> C::Item<u8> { unimplemented!() } }
+
+        struct X;
+        struct Vec<T>(T);
+        impl Tr1 for X { type Item<D> = Vec<D>; }
+        impl Tr2 for X {}
+        fn main() {
+            let a = S(X).foo();
+            a;
+        } //^ Vec<u8>
+    """)
+
     fun `test bound inherited associated type in explicit UFCS form`() = testExpr("""
         trait Tr1 { type Item; }
         trait Tr2: Tr1 {}
@@ -906,6 +951,22 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ u8
     """)
 
+    fun `test bound inherited generic associated type in explicit UFCS form`() = testExpr("""
+        trait Tr1 { type Item<A>; }
+        trait Tr2: Tr1 {}
+        struct S<B>(B);
+        impl<C: Tr2> S<C> { fn foo(self) -> <C as Tr1>::Item<u8> { unimplemented!() } }
+
+        struct X;
+        struct Vec<T>(T);
+        impl Tr1 for X { type Item<D> = Vec<D>; }
+        impl Tr2 for X {}
+        fn main() {
+            let a = S(X).foo();
+            a;
+        } //^ Vec<u8>
+    """)
+
     fun `test 2 bound associated types`() = testExpr("""
         trait Tr { type Item; }
         struct S<A, B>(A, B);
@@ -919,6 +980,23 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = S(X, Y).foo();
             a;
         } //^ (u8, u16)
+    """)
+
+    fun `test 2 bound generic associated types`() = testExpr("""
+        trait Tr { type Item<A>; }
+        struct S<B, C>(B, C);
+        impl<D: Tr, E: Tr> S<D, E> { fn foo(self) -> (D::Item<u8>, E::Item<u16>) { unimplemented!() } }
+
+        struct X;
+        struct Y;
+        struct Vec<T>(T);
+        struct Option<T>(T);
+        impl Tr for X { type Item<F> = Vec<F>; }
+        impl Tr for Y { type Item<G> = Option<G>; }
+        fn main() {
+            let a = S(X, Y).foo();
+            a;
+        } //^ (Vec<u8>, Option<u16>)
     """)
 
     fun `test recursive receiver substitution using associated type`() = testExpr("""
@@ -939,6 +1017,27 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = S1(X).wrap().wrap().wrap().fold();
             a;
         } //^ X
+    """)
+
+    fun `test recursive receiver substitution using generic associated type`() = testExpr("""
+        trait Tr {
+            type Item<A>;
+            fn wrap(self) -> S<Self> where Self: Sized { unimplemented!() }
+            fn fold(self) -> Self::Item<Y> where Self: Sized { unimplemented!() }
+        }
+
+        struct X; struct Y;
+        struct S1<B>(B);
+        struct S<C>(C);
+        struct Result<A, B>(A, B);
+
+        impl<D> Tr for S1<D> { type Item<E> = Result<D, E>; }
+        impl<F: Tr> Tr for S<F> { type Item<G> = F::Item<G>; }
+
+        fn main() {
+            let a = S1(X).wrap().wrap().wrap().fold();
+            a;
+        } //^ Result<X, Y>
     """)
 
     fun `test recursive receiver substitution using inherited associated type`() = testExpr("""
@@ -963,6 +1062,30 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = S1(X).wrap().wrap().wrap().fold();
             a;
         } //^ X
+    """)
+
+    fun `test recursive receiver substitution using inherited generic associated type`() = testExpr("""
+        trait Tr1 { type Item<A>; }
+        trait Tr: Tr1 {
+            fn wrap(self) -> S<Self> where Self: Sized { unimplemented!() }
+            fn fold(self) -> Self::Item<Y> where Self: Sized { unimplemented!() }
+        }
+
+        struct X; struct Y;
+        struct S1<A>(A);
+        struct S<B>(B);
+        struct Result<A, B>(A, B);
+
+        impl<C>     Tr1 for S1<C> { type Item<D> = Result<C, D>; }
+        impl<E: Tr> Tr1 for S<E>  { type Item<F> = E::Item<F>; }
+
+        impl<G>     Tr for S1<G> {}
+        impl<H: Tr> Tr for S<H>  {}
+
+        fn main() {
+            let a = S1(X).wrap().wrap().wrap().fold();
+            a;
+        } //^ Result<X, Y>
     """)
 
     // https://github.com/intellij-rust/intellij-rust/issues/1549
@@ -1002,6 +1125,17 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ <T as Tr>::Item
     """)
 
+    fun `test non-inferable generic associated type`() = testExpr("""
+        trait Tr {
+            type Item<A>;
+            fn bar<B>(&self, x: B) -> Self::Item<B> { unimplemented!() }
+        }
+        fn foo<T: Tr>(t: T) {
+            let a = t.bar(0);
+            a;
+        } //^ <T as Tr>::Item<i32>
+    """)
+
     fun `test fn return associated type`() = testExpr("""
         trait Tr { type Item; }
         struct S;
@@ -1013,6 +1147,21 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let x = foo(S);
             x;
           //^ i32
+        }
+    """)
+
+    fun `test fn return generic associated type`() = testExpr("""
+        trait Tr { type Item<A>; }
+        struct S;
+        struct Vec<T>(T);
+        impl Tr for S {
+            type Item<B> = Vec<B>;
+        }
+        fn foo<T: Tr, C>(t: T, i: C) -> T::Item<C> { unimplemented!() }
+        fn main() {
+            let x = foo(S, 0);
+            x;
+          //^ Vec<i32>
         }
     """)
 
@@ -1030,6 +1179,22 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let b = get2(0usize);
             (a, b);
         } //^ (X, Y)
+    """)
+
+    fun `test fn return generic associated type with generic trait bound`() = testExpr("""
+        trait SliceIndex<T> { type Output<A>; }
+        struct S1; struct S2;
+        struct X<B>(B); struct Y<B>(B);
+        fn get1<I: SliceIndex<S1>, U>(index: I, x: U) -> I::Output<U> { unimplemented!() }
+        fn get2<I: SliceIndex<S2>, U>(index: I, x: U) -> <I as SliceIndex<S2>>::Output<U>
+        { unimplemented!() }
+        impl SliceIndex<S1> for usize { type Output<C> = X<C>; }
+        impl SliceIndex<S2> for usize { type Output<C> = Y<C>; }
+        fn main() {
+            let a = get1(0usize, 1u8);
+            let b = get2(0usize, 1u16);
+            (a, b);
+        } //^ (X<u8>, Y<u16>)
     """)
 
     fun `test associated type bound`() = testExpr("""
@@ -1503,6 +1668,26 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ u8
     """)
 
+    fun `test generic associated type binding in trait bound 1`() = testExpr("""
+        trait Tr { type Item<A>; }
+
+        fn foo<B: Tr<Item<u8>=u16>>(_: B) {
+            let a: B::Item<u8> = 0;
+            a;
+        } //^ u16
+    """)
+
+    fun `test generic associated type binding in trait bound 2`() = expect<Throwable> {
+        testExpr("""
+            trait Tr { type Item<A>; }
+
+            fn foo<B: Tr<Item<i8>=u16>>(_: B) {
+                let a: B::Item<u8> = 0;
+                a
+            } //^ <unknown>
+        """)
+    }
+
     fun `test associated type binding in trait object`() = testExpr("""
         trait Tr {
             type Item;
@@ -1515,6 +1700,31 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ u8
     """)
 
+    fun `test generic associated type binding in trait object 1`() = testExpr("""
+        trait Tr {
+            type Item<A>;
+            fn foo(&self) -> Self::Item<u8>;
+        }
+
+        fn foo(a: &Tr<Item<u8>=u16>) {
+            let b = a.foo();
+            b;
+        } //^ u16
+    """)
+
+    fun `test generic associated type binding in trait object 2`() = expect<Throwable> {
+        testExpr("""
+            trait Tr {
+                type Item<A>;
+                fn foo(&self) -> Self::Item<u8>;
+            }
+
+            fn foo(a: &Tr<Item<i8>=u16>) {
+                let b = a.foo();
+                b;
+            } //^ <unknown>
+        """)
+    }
     fun `test aliased associated type binding in trait object`() = testExpr("""
         trait Tr {
             type Item;
@@ -1528,6 +1738,36 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             b;
         } //^ u8
     """)
+
+    fun `test aliased generic associated type binding in trait object 1`() = testExpr("""
+        trait Tr {
+            type Item<A>;
+            fn foo(&self) -> Self::Item<u8>;
+        }
+
+        type TrAlias<T> = Tr<Item<u8>=T>;
+
+        fn foo(a: &TrAlias<u8>) {
+            let b = a.foo();
+            b;
+        } //^ u8
+    """)
+
+    fun `test aliased generic associated type binding in trait object 2`() = expect<Throwable> {
+        testExpr("""
+            trait Tr {
+                type Item<A>;
+                fn foo(&self) -> Self::Item<u8>;
+            }
+
+            type TrAlias<T> = Tr<Item<i8>=T>;
+
+            fn foo(a: &TrAlias<u8>) {
+                let b = a.foo();
+                b;
+            } //^ <unknown>
+        """)
+    }
 
     fun `test associated type binding in 'impl Trait'`() = testExpr("""
         trait Tr {
@@ -1563,6 +1803,34 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             bar;
         } //^ Bar
     """)
+
+    fun `test generic associated type binding in 'impl Trait' 1`() = testExpr("""
+        trait Tr {
+            type Item<A>;
+            fn foo(&self) -> Self::Item<u8>;
+        }
+
+        fn new() -> impl Tr<Item<u8>=u16> { unimplemented!() }
+        fn main() {
+            let b = new().foo();
+            b;
+        } //^ u16
+    """)
+
+    fun `test generic associated type binding in 'impl Trait' 2`() = expect<Throwable> {
+        testExpr("""
+            trait Tr {
+                type Item<A>;
+                fn foo(&self) -> Self::Item<u8>;
+            }
+
+            fn new() -> impl Tr<Item<i8>=u16> { unimplemented!() }
+            fn main() {
+                let b = new().foo();
+                b;
+            } //^ <unknown>
+        """)
+    }
 
     fun `test select trait from unconstrained integer`() = testExpr("""
         struct X;
@@ -1727,6 +1995,24 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }      //^ X
     """)
 
+    fun `test struct field with generic associated type`() = testExpr("""
+        struct Foo<V: Trait, U, const N: usize> {
+            input: <V as Trait>::Item<U, N>,
+        }
+        trait Trait { type Item<U, const N: usize>; }
+        struct S; struct X<U, const N: usize>;
+        impl Trait for S {
+            type Item<U, const N: usize> = X<U, N>;
+        }
+        fn main() {
+            let foo1 = Foo::<S, u8, 0> {
+                input: X,
+            };
+
+            foo1.input;
+        }      //^ X<u8, 0>
+    """)
+
     // Issue https://github.com/intellij-rust/intellij-rust/issues/4026
     fun `test tuple struct field with associated type`() = testExpr("""
         struct Foo<V: Trait>(<V as Trait>::Item);
@@ -1740,6 +2026,20 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
 
             foo1.0;
         }      //^ X
+    """)
+
+    fun `test tuple struct field with generic associated type`() = testExpr("""
+        struct Foo<V: Trait, U, const N: usize>(<V as Trait>::Item<U, N>);
+        trait Trait { type Item<U, const N: usize>; }
+        struct S; struct X<U, const N: usize>;
+        impl Trait for S {
+            type Item<U, const N: usize> = X<U, N>;
+        }
+        fn main() {
+            let foo1 = Foo::<S, u8, 0>(X);
+
+            foo1.0;
+        }      //^ X<u8, 0>
     """)
 
     // Issue https://github.com/intellij-rust/intellij-rust/issues/3999


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/issues/6633.

Depends on https://github.com/intellij-rust/intellij-rust/pull/8542.

changelog: Provide initial type inference support for [GATs](https://blog.rust-lang.org/2022/10/28/gats-stabilization.html)
