### PR TITLE
CPP-28240: provide statistics about Cargo project model in CLion projects in 2022.1

### DIFF
--- a/clion/src/213/main/resources/META-INF/platform-clion-only.xml
+++ b/clion/src/213/main/resources/META-INF/platform-clion-only.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/clion/src/221/main/kotlin/org/rust/clion/statistics/CargoProjectModelTypeProvider.kt
+++ b/clion/src/221/main/kotlin/org/rust/clion/statistics/CargoProjectModelTypeProvider.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.statistics
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.cidr.fus.CidrProjectModelTypeProvider
+import com.jetbrains.cidr.fus.CidrProjectModelTypeProvider.Type
+import org.rust.cargo.runconfig.hasCargoProject
+
+class CargoProjectModelTypeProvider : CidrProjectModelTypeProvider {
+    override fun getTypes(project: Project): List<Type> {
+        return if (project.hasCargoProject) listOf(Type.Cargo) else emptyList()
+    }
+}

--- a/clion/src/221/main/resources/META-INF/platform-clion-only.xml
+++ b/clion/src/221/main/resources/META-INF/platform-clion-only.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.jetbrains.cidr">
+        <fus.projectModelTypeProvider implementation="org.rust.clion.statistics.CargoProjectModelTypeProvider"/>
+    </extensions>
+</idea-plugin>

--- a/clion/src/main/resources/META-INF/clion-only.xml
+++ b/clion/src/main/resources/META-INF/clion-only.xml
@@ -3,6 +3,7 @@
     <depends>com.intellij.clion</depends>
 
     <xi:include href="/META-INF/core-debugger-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
+    <xi:include href="/META-INF/platform-clion-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
     <extensions defaultExtensionNs="cidr">
         <buildConfigurationProvider implementation="org.rust.clion.cargo.CargoBuildConfigurationProvider"/>


### PR DESCRIPTION
Note, the statistics are collected only if you [explicitly allow](https://www.jetbrains.com/help/idea/settings-usage-statistics.html) it