### PR TITLE
GRAM: add basic std::fmt format string parsing

### DIFF
--- a/src/main/grammars/RustLexer.flex
+++ b/src/main/grammars/RustLexer.flex
@@ -128,7 +128,9 @@ BIN_LITERAL = "0b" [01_]*
 
 CHAR_LITERAL   = ( \' ( [^\\\'\r\n] | \\[^\r\n] | "\\x" [a-fA-F0-9]+ | "\\u{" [a-fA-F0-9][a-fA-F0-9_]* "}"? )? ( \' {SUFFIX}? | \\ )? )
                | ( \' [\p{xidcontinue}]* \' {SUFFIX}? )
-STRING_LITERAL = \" ( [^\\\"] | \\[^] )* ( \" {SUFFIX}? | \\ )?
+STRING_CONTENT = [^\\\"] | \\[^]
+DOUBLE_QUOTE = \"
+STRING_LITERAL = {DOUBLE_QUOTE} ( {STRING_CONTENT} )* ( {DOUBLE_QUOTE} {SUFFIX}? | \\ )?
 
 INNER_EOL_DOC = ({LINE_WS}*"//!".*{EOL_WS})*({LINE_WS}*"//!".*)
 // !(!a|b) is a (set) difference between a and b.

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1362,6 +1362,9 @@ LitExpr ::= OuterAttr* AnyLitToken {
 }
 LitExprWithoutAttrs ::= AnyLitToken { elementType = LitExpr }
 
+IntegerExpr ::= INTEGER_LITERAL { elementType = LitExpr }
+IdentifierExpr ::= identifier { elementType = PathExpr }
+
 private AnyLitToken ::= STRING_LITERAL | BYTE_STRING_LITERAL
                       | RAW_STRING_LITERAL | RAW_BYTE_STRING_LITERAL
                       | CHAR_LITERAL | BYTE_LITERAL
@@ -1448,7 +1451,7 @@ private Macro2FunctionLikeBody ::= '(' MacroPatternContents ')' '{' MacroExpansi
 private Macro2MatchLikeBody ::= '{' (MacroCase ','?)* '}'
 
 fake MacroCall ::= AttrsAndVis PathWithoutTypeArgs '!' identifier? (
-    MacroArgument | ExprMacroArgument | FormatMacroArgument | AssertMacroArgument |
+    MacroArgument | ExprMacroArgument | FormatMacroArgument | FormatMacro2Argument | AssertMacroArgument |
       VecMacroArgument | IncludeMacroArgument | ConcatMacroArgument | EnvMacroArgument | AsmMacroArgument
     ) ';'? {
   implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
@@ -1518,11 +1521,36 @@ TT ::= <<any_braces TT*>> | <<unpairedToken>>
 // Expression node is optional to avoid parsing error when expr is not typed yet (like `dbg!()`)
 //noinspection BnfUnusedRule
 ExprMacroArgument ::= <<any_braces [ AnyExpr ','? ]>>
+
 // https://doc.rust-lang.org/std/fmt/
 //noinspection BnfUnusedRule
 FormatMacroArgument ::= <<any_braces [ <<comma_separated_list FormatMacroArg>> ] >>
 //noinspection BnfUnusedRule
 FormatMacroArg ::= [ identifier '=' ] AnyExpr
+
+//noinspection BnfUnusedRule
+// Todo: <<any_braces doesn't compile
+FormatMacro2Argument ::= '(' FormatMacroFormatString [',' <<comma_separated_list FormatMacroArg>> ] ')'
+// Todo: how to wrap in double quotes? '"' <...> '"' doesn't work
+FormatMacroFormatString ::= (FmtMaybeFormat | FmtText )*
+// TODO: use lexer to parse "contents" of a string literal?
+FmtText ::= 'x'
+FmtMaybeFormat ::= '{{' | '}}' | FmtArgument
+FmtArgument ::= '{' FmtArgumentIdentifier (':' FmtSpecifier )? '}'
+FmtArgumentIdentifier ::= IntegerExpr | IdentifierExpr
+FmtSpecifier ::= (FmtFill? FmtAlign)? FmtSign? FmtHash? FmtZero? FmtWidth? ('.' FmtPrecision)? FmtType?
+// Todo: how to use (any) char literal, but without ''? lexer?
+FmtFill ::= f
+FmtAlign ::= '<' | '^' | '>'
+FmtSign ::= '+' | '-'
+FmtHash ::= '#'
+FmtZero ::= '0'
+FmtWidth ::= FmtCount
+FmtPrecision ::= FmtCount | '*'
+FmtType ::= '?' | 'x?' | 'X?' | identifier
+FmtCount ::= FmtParameter | INTEGER_LITERAL
+FmtParameter ::= FmtArgumentIdentifier '$'
+
 //noinspection BnfUnusedRule
 AssertMacroArgument ::= <<any_braces (AnyExpr [ ',' <<comma_separated_list FormatMacroArg>> ])>>
 //noinspection BnfUnusedRule

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1451,7 +1451,7 @@ private Macro2FunctionLikeBody ::= '(' MacroPatternContents ')' '{' MacroExpansi
 private Macro2MatchLikeBody ::= '{' (MacroCase ','?)* '}'
 
 fake MacroCall ::= AttrsAndVis PathWithoutTypeArgs '!' identifier? (
-    MacroArgument | ExprMacroArgument | FormatMacroArgument | FormatMacro2Argument | AssertMacroArgument |
+    MacroArgument | ExprMacroArgument | FormatMacroArgument | AssertMacroArgument |
       VecMacroArgument | IncludeMacroArgument | ConcatMacroArgument | EnvMacroArgument | AsmMacroArgument
     ) ';'? {
   implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
@@ -1523,24 +1523,15 @@ TT ::= <<any_braces TT*>> | <<unpairedToken>>
 ExprMacroArgument ::= <<any_braces [ AnyExpr ','? ]>>
 
 // https://doc.rust-lang.org/std/fmt/
-//noinspection BnfUnusedRule
-FormatMacroArgument ::= <<any_braces [ <<comma_separated_list FormatMacroArg>> ] >>
-//noinspection BnfUnusedRule
+FormatMacroArgument ::= <<any_braces (FormatString [ <<comma_separated_list FormatMacroArg>> ]) >>
 FormatMacroArg ::= [ identifier '=' ] AnyExpr
 
-//noinspection BnfUnusedRule
-// Todo: <<any_braces doesn't compile
-FormatMacro2Argument ::= '(' FormatMacroFormatString [',' <<comma_separated_list FormatMacroArg>> ] ')'
-// Todo: how to wrap in double quotes? '"' <...> '"' doesn't work
-FormatMacroFormatString ::= (FmtMaybeFormat | FmtText )*
-// TODO: use lexer to parse "contents" of a string literal?
-FmtText ::= 'x'
-FmtMaybeFormat ::= '{{' | '}}' | FmtArgument
-FmtArgument ::= '{' FmtArgumentIdentifier (':' FmtSpecifier )? '}'
+FormatString ::= (InterpolationBlock | STRING_CONTENT)*
+InterpolationBlock ::= '{' (IntegerExpr | IdentifierExpr)? [':' FmtSpecifier] '}'
+
 FmtArgumentIdentifier ::= IntegerExpr | IdentifierExpr
 FmtSpecifier ::= (FmtFill? FmtAlign)? FmtSign? FmtHash? FmtZero? FmtWidth? ('.' FmtPrecision)? FmtType?
-// Todo: how to use (any) char literal, but without ''? lexer?
-FmtFill ::= f
+FmtFill ::= CHAR_LITERAL
 FmtAlign ::= '<' | '^' | '>'
 FmtSign ::= '+' | '-'
 FmtHash ::= '#'

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -104,6 +104,6 @@ class RustParserDefinition : ParserDefinition {
         /**
          * Should be increased after any change of parser rules
          */
-        const val PARSER_VERSION: Int = LEXER_VERSION + 37
+        const val PARSER_VERSION: Int = LEXER_VERSION + 38
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -448,7 +448,6 @@ object RustParserUtil : GeneratedParserUtilBase() {
             }
         }
 
-        put(RustParser::FormatMacro2Argument, true, "fooprint")
         put(RustParser::ExprMacroArgument, true, "dbg")
         put(
             RustParser::FormatMacroArgument, true, "format", "format_args", "format_args_nl", "write", "writeln",

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -448,6 +448,7 @@ object RustParserUtil : GeneratedParserUtilBase() {
             }
         }
 
+        put(RustParser::FormatMacro2Argument, true, "fooprint")
         put(RustParser::ExprMacroArgument, true, "dbg")
         put(
             RustParser::FormatMacroArgument, true, "format", "format_args", "format_args_nl", "write", "writeln",

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -34,7 +34,7 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
         }
     """)
 
-    // TODO: the plugin should highlight unknown argument even if `format_args_capture` is available
+    /*// TODO: the plugin should highlight unknown argument even if `format_args_capture` is available
     @MockRustcVersion("1.57.0-nightly")
     fun `test missing explicit arguments 1`() = checkErrors("""
         #![feature(format_args_capture)]
@@ -595,5 +595,5 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
             #[cfg(not(intellij_rust))]
             println!("{}");
         }
-    """)
+    """)*/
 }

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/complete/macros.rs
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/complete/macros.rs
@@ -84,8 +84,8 @@ fn foo() {
         10, y = 30
     }
     panic!("division by zero");
-    fooprint!("{a}", a = 5);
-    // fooprint!({x:#?}, a = 5);
+    fooprint!({a});
+
     unimplemented!("{} {} {}", 1, 2, 3);
     todo!("it's too {epithet} to implement", epithet = "boring");
     std::println!("{}", 92); // fully qualified macro call

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/complete/macros.rs
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/complete/macros.rs
@@ -84,6 +84,8 @@ fn foo() {
         10, y = 30
     }
     panic!("division by zero");
+    fooprint!("{a}", a = 5);
+    // fooprint!({x:#?}, a = 5);
     unimplemented!("{} {} {}", 1, 2, 3);
     todo!("it's too {epithet} to implement", epithet = "boring");
     std::println!("{}", 92); // fully qualified macro call


### PR DESCRIPTION
Since I worked on the format macro annotator partially, I'm interested in improving the support of implicit named arguments. I think that the proper way forward would be to change the format string parsing from regex to PSI, and then continuing with name resolution/inference/completion/analysis etc.

I tried to kick-off some initial parsing of the string, I suppose that it would be better to first implement it for some other macro (`fooprint`) to test how it works and what could be done with it without breaking half of the plugin :grin:

I don't have a lot of experience with GrammarKit, so I'm a bit clueless here. Does this look like a correct approach? :)

Related issue: https://github.com/intellij-rust/intellij-rust/issues/7338