### PR TITLE
REF: Fix inline function dialog

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
@@ -443,4 +443,11 @@ class RsInlineFunctionProcessor(
     private fun PsiElement.addLeftSibling(element: PsiElement) {
         this.parent.addBefore(element, this)
     }
+
+    override fun getElementsToWrite(descriptor: UsageViewDescriptor): Collection<PsiElement> =
+        when {
+            inlineThisOnly -> listOfNotNull(ref?.element)
+            function.isWritable -> listOfNotNull(ref?.element, function)
+            else -> emptyList()
+        }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/ui.kt
@@ -15,23 +15,24 @@ import org.rust.lang.core.resolve.ref.RsReference
 class RsInlineFunctionDialog(
     private val function: RsFunction,
     private val refElement: RsReference?,
+    /** If true, we can't inline other usages */
     private val allowInlineThisOnly: Boolean,
     project: Project = function.project,
-    occurrencesNumber: Int = initOccurrencesNumber(function)
+    private val occurrencesNumber: Int = initOccurrencesNumber(function)
 ) : RsInlineDialog(function, refElement, project, occurrencesNumber) {
     init {
         init()
     }
 
+    override fun canInlineThisOnly(): Boolean = allowInlineThisOnly
+
+    override fun allowInlineAll(): Boolean = true
+
     public override fun doAction() {
-        val inlineThisOnly = allowInlineThisOnly && isInlineThisOnly
-        invokeRefactoring(RsInlineFunctionProcessor(
-            project,
-            function,
-            refElement,
-            inlineThisOnly,
-            !inlineThisOnly && !isKeepTheDeclaration
-        ))
+        val inlineThisOnly = allowInlineThisOnly || isInlineThisOnly
+        val removeDefinition = myRbInlineAll.isSelected && function.isWritable
+        val processor = RsInlineFunctionProcessor(project, function, refElement, inlineThisOnly, removeDefinition)
+        invokeRefactoring(processor)
     }
 
     override fun getBorderTitle(): String =
@@ -46,23 +47,22 @@ class RsInlineFunctionDialog(
     }
 
     override fun getInlineAllText(): String {
-        val text =
-            if (function.isWritable && !allowInlineThisOnly) {
-                "all.invocations.and.remove.the.method"
-            } else {
-                "all.invocations.in.project"
-            }
+        val text = if (function.isWritable) {
+            "all.invocations.and.remove.the.method"
+        } else {
+            "all.invocations.in.project"
+        }
         return RefactoringBundle.message(text)
     }
 
     override fun getInlineThisText(): String =
         RefactoringBundle.message("this.invocation.only.and.keep.the.method")
 
-    override fun getKeepTheDeclarationText(): String =
-        if (function.isWritable) {
-            "Inline all references and keep the method"
+    override fun getKeepTheDeclarationText(): String? =
+        if (function.isWritable && (occurrencesNumber > 1 || !myInvokedOnReference)) {
+            "Inline all and keep the method"
         } else {
-            super.getKeepTheDeclarationText()
+            null
         }
 
     override fun getHelpId(): String =


### PR DESCRIPTION
Fixes #8257
Fixes #8249
Meta: #5511

Inline function dialog has three options:
1. Inline all  + remove function
2. Inline all  + keep function
3. Inline this + keep function

Now it works as follows:
* If there is one usage, we don't show option (2)
* If the function is recursive, only option (3) is available
* If the function is read-only, only options (2) and (3) are available

changelog: 1. Fix handling of recursive functions in "Inline function" refactoring 2. Fix "Inline function" refactoring for single occurence
