### PR TITLE
UI: Render generic parameters for assoc types if any

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/PresentationInfo.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/PresentationInfo.kt
@@ -51,7 +51,7 @@ val RsNamedElement.presentationInfo: PresentationInfo?
             is RsEnumItem -> Pair("enum", createDeclarationInfo(this, identifier, false, listOf(whereClause)))
             is RsEnumVariant -> Pair("enum variant", createDeclarationInfo(this, identifier, false, listOf(tupleFields)))
             is RsTraitItem -> Pair("trait", createDeclarationInfo(this, identifier, false, listOf(whereClause)))
-            is RsTypeAlias -> Pair("type alias", createDeclarationInfo(this, identifier, false, listOf(typeReference, typeParamBounds, whereClause), eq))
+            is RsTypeAlias -> Pair("type alias", createDeclarationInfo(this, identifier, false, listOf(typeReference, typeParamBounds, whereClause, typeParameterList), eq))
             is RsConstant -> Pair("constant", createDeclarationInfo(this, identifier, false, listOf(expr, typeReference), eq))
             is RsSelfParameter -> Pair("parameter", createDeclarationInfo(this, self, false, listOf(typeReference)))
             is RsTypeParameter -> Pair("type parameter", createDeclarationInfo(this, identifier, true))

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -1794,25 +1794,33 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
     fun `test associated type`() = doTest("""
         trait Foo {
-            type A<'a, T> where T: 'a;
-            type B: Sized;
+            type A<'a, T: 'a>;
+            type B<'a, T> where T: 'a;
+            type C: Sized;
+            type D = ();
         }
         struct S;
         impl Foo for S {
             /*caret*/
         }
     """, listOf(
-        ImplementMemberSelection("A<'a, T> where T: 'a", byDefault = true),
-        ImplementMemberSelection("B: Sized", byDefault = true)
+        ImplementMemberSelection("A<'a, T: 'a>", byDefault = true),
+        ImplementMemberSelection("B<'a, T> where T: 'a", byDefault = true),
+        ImplementMemberSelection("C: Sized", byDefault = true),
+        ImplementMemberSelection("D", byDefault = false, isSelected = true)
     ), """
         trait Foo {
-            type A<'a, T> where T: 'a;
-            type B: Sized;
+            type A<'a, T: 'a>;
+            type B<'a, T> where T: 'a;
+            type C: Sized;
+            type D = ();
         }
         struct S;
         impl Foo for S {
-            type A<'a, T> where T: 'a = ();
-            type B = ();
+            type A<'a, T: 'a> = ();
+            type B<'a, T> where T: 'a = ();
+            type C = ();
+            type D = ();
         }
     """)
 


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/issues/6633.

changelog: Render generic parameters for type aliases / associated types in UI
