### PR TITLE
add --respect-source-config to Cargo vendor

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -183,7 +183,8 @@ class Cargo(
         dstPath: Path,
         listener: ProcessListener? = null
     ): RsProcessResult<Unit> {
-        val commandLine = CargoCommandLine("vendor", projectDirectory, listOf(dstPath.toString()))
+        val additionalArgs = listOf("--respect-source-config", dstPath.toString())
+        val commandLine = CargoCommandLine("vendor", projectDirectory, additionalArgs)
         commandLine.execute(owner, listener = listener).unwrapOrElse { return Err(it) }
         return Ok(Unit)
     }


### PR DESCRIPTION
changelog: Add `--respect-source-config` to `cargo vendor` command  to respect `[source]` config in `.cargo/config`.
This fixes the problem when using another source of cargo registry but still stuck in 'updating crates.io index' 