### PR TITLE
UI: fix wrong indents in new project panel with new project wizard

### DIFF
--- a/src/main/kotlin/org/rust/ide/module/CargoConfigurationWizardStep.kt
+++ b/src/main/kotlin/org/rust/ide/module/CargoConfigurationWizardStep.kt
@@ -13,12 +13,14 @@ import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.layout.panel
+import com.intellij.util.ui.JBUI
 import org.rust.cargo.CargoConstants
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.setup
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
 import org.rust.ide.newProject.ui.RsNewProjectPanel
+import org.rust.openapiext.isFeatureEnabled
 import org.rust.openapiext.pathAsPath
 import javax.swing.JComponent
 
@@ -31,7 +33,7 @@ class CargoConfigurationWizardStep(
 
     override fun getComponent(): JComponent = panel {
         newProjectPanel.attachTo(this)
-    }
+    }.withBorderIfNeeded()
 
     override fun disposeUIResources() = Disposer.dispose(newProjectPanel)
 
@@ -53,6 +55,19 @@ class CargoConfigurationWizardStep(
         newProjectPanel.validateSettings()
         return true
     }
+
+    // It's simple hack to imitate new UI style if new project wizard is enabled
+    // TODO: drop it and support new project wizard properly
+    //  see https://github.com/intellij-rust/intellij-rust/issues/8585
+    private fun <T : JComponent> T.withBorderIfNeeded(): T {
+        if (isNewWizard()) {
+            // border size is taken from `com.intellij.ide.wizard.NewProjectWizardStepPanel`
+            border = JBUI.Borders.empty(14, 20)
+        }
+        return this
+    }
+
+    private fun isNewWizard(): Boolean = isFeatureEnabled("new.project.wizard")
 
     private object ConfigurationUpdater : ModuleConfigurationUpdater() {
         var data: RustProjectSettingsPanel.Data? = null


### PR DESCRIPTION
It's a temporary workaround. The proper solution should be done as part of https://github.com/intellij-rust/intellij-rust/issues/8585

| Before | After |
| - | - |
| <img width="889" alt="Screen Shot 2022-02-21 at 15 58 18" src="https://user-images.githubusercontent.com/2539310/154959839-c43eb073-2a8d-46d0-b206-ad9d62cde61b.png"> | <img width="890" alt="Screen Shot 2022-02-21 at 15 55 52" src="https://user-images.githubusercontent.com/2539310/154959488-26d3712a-5ca6-4451-b6ae-cd8edfa08d41.png"> |


Fixes #8508



changelog: Fix wrong indents in UI during creation of a new Rust project in IDEA
