### PR TITLE
ANN: don't suggest adding `unsafe` to main function in build scripts

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt
@@ -17,6 +17,7 @@ import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.cargoWorkspace
+import org.rust.lang.core.psi.ext.isMain
 import org.rust.openapiext.toPsiFile
 
 class CargoExecutableRunConfigurationProducer : CargoRunConfigurationProducer() {
@@ -55,8 +56,9 @@ class CargoExecutableRunConfigurationProducer : CargoRunConfigurationProducer() 
 
     companion object {
         fun isMainFunction(fn: RsFunction): Boolean {
+            if (!fn.isMain) return false
             val ws = fn.cargoWorkspace ?: return false
-            return fn.parent is RsFile && fn.name == "main" && findBinaryTarget(ws, fn.containingFile.virtualFile) != null
+            return findBinaryTarget(ws, fn.containingFile.virtualFile) != null
         }
 
         private fun findBinaryTarget(location: Location<*>): ExecutableTarget? {

--- a/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
+++ b/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
@@ -24,10 +24,12 @@ import org.rust.cargo.runconfig.RsDefaultProgramRunnerBase
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.debugger.NATIVE_DEBUGGING_SUPPORT_PLUGIN_ID
 import org.rust.debugger.nativeDebuggingSupportPlugin
+import org.rust.openapiext.isUnitTestMode
 
 class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
 
     override fun canRun(executorId: String, profile: RunProfile): Boolean {
+        if (isUnitTestMode) return false
         if (executorId != DefaultDebugExecutor.EXECUTOR_ID) return false
         if (profile !is CargoCommandConfiguration) return false
         if (!isSupportedPlatform()) return false

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFix.kt
@@ -11,11 +11,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
-import org.rust.cargo.runconfig.command.CargoExecutableRunConfigurationProducer
 import org.rust.lang.core.psi.RsBlockExpr
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.isMain
 
 class AddUnsafeFix private constructor(element: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
     private val _text = run {
@@ -51,7 +51,7 @@ class AddUnsafeFix private constructor(element: PsiElement) : LocalQuickFixAndIn
             ) ?: return null
 
             return when {
-                parent is RsFunction && CargoExecutableRunConfigurationProducer.isMainFunction(parent) -> null
+                parent is RsFunction && parent.isMain -> null
                 else -> AddUnsafeFix(parent)
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -31,6 +31,15 @@ val RsFunction.isMethod: Boolean get() = hasSelfParameters && owner.isImplOrTrai
 val RsFunction.isTest: Boolean
     get() = queryAttributes.isTest
 
+val RsFunction.isMain: Boolean get() {
+    if (name != "main") return false
+    val parent = parent
+    if (parent !is RsFile || !parent.isCrateRoot) return false
+    if (parent.queryAttributes.hasAttribute("no_main")) return false
+    val targetKind = containingCargoTarget?.kind ?: return false
+    return targetKind.isBin || targetKind.isExampleBin || targetKind.isCustomBuild
+}
+
 private val QueryAttributes<*>.isTest
     get() = metaItems.mapNotNull { it.path?.referenceName }.any { it.contains("test") } || hasAtomAttribute("quickcheck")
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFixTest.kt
@@ -138,6 +138,19 @@ class AddUnsafeFixTest : RsAnnotationTestBase() {
         }
     """)
 
+    fun `test do not provide 'add unsafe to function' in the main function 1`() = checkNoAddUnsafeFixOnMainFun("main.rs")
+    fun `test do not provide 'add unsafe to function' in the main function 2`() = checkNoAddUnsafeFixOnMainFun("build.rs")
+    fun `test do not provide 'add unsafe to function' in the main function 3`() = checkNoAddUnsafeFixOnMainFun("example/a.rs")
+
+    private fun checkNoAddUnsafeFixOnMainFun(filePath: String) = checkFixIsUnavailableByFileTree("Add unsafe to function", """
+    //- $filePath
+        unsafe fn foo() {}
+
+        fn main() {
+            <error descr="Call to unsafe function requires unsafe function or block [E0133]">foo()/*caret*/</error>;
+        }
+    """)
+
     fun `test add unsafe to function (similar main function)`() = checkFixByText("Add unsafe to function", """
         unsafe fn foo() {}
 
@@ -156,11 +169,21 @@ class AddUnsafeFixTest : RsAnnotationTestBase() {
         }
     """)
 
-    fun `test do not provide 'add unsafe to function' in the main function`() = checkFixIsUnavailable("Add unsafe to function", """
+    fun `test add unsafe to main function with no_main attr`() = checkFixByText("Add unsafe to function", """
+        #![no_main]
+
         unsafe fn foo() {}
 
         fn main() {
-            <error descr="Call to unsafe function requires unsafe function or block [E0133]">foo()/*caret*/</error>;
+            <error>foo()/*caret*/</error>;
+        }
+    """, """
+        #![no_main]
+
+        unsafe fn foo() {}
+
+        unsafe fn main() {
+            foo()/*caret*/;
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
@@ -56,22 +56,19 @@ class CargoBenchRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         }
     """)
 
-    fun `test mod decl`() = doTestFromFile(
-        "lib.rs",
-        fileTree {
-            rust("tests.rs", """
-                #[bench]
-                fn bench() {}
-            """)
+    fun `test mod decl`() = doTestByFileTree("lib.rs") {
+        rust("tests.rs", """
+            #[bench]
+            fn bench() {}
+        """)
 
-            rust("no_tests.rs", "")
+        rust("no_tests.rs", "")
 
-            rust("lib.rs", """
-                mod tests; // - Bench lib::tests
-                mod no_tests;
-            """)
-        }
-    )
+        rust("lib.rs", """
+            mod tests; // - Bench lib::tests
+            mod no_tests;
+        """)
+    }
 
     fun `test function in a module with test function`() = doTestByText("""
         #[cfg(test)]

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoExecutableRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoExecutableRunLineMarkerContributorTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.lineMarkers
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.util.PathUtil
+import org.intellij.lang.annotations.Language
+
+class CargoExecutableRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
+
+    fun `test main binary`() = doTest("main.rs", """
+        fn main() {} // - Run 'Run test-package'
+    """)
+
+    fun `test additional binary`() = doTest("bin/a.rs", """
+        fn main() {} // - Run 'Run test-package'
+    """)
+
+    fun `test binary example`() = doTest("example/a.rs", """
+        fn main() {} // - Run 'Run test-package'
+    """)
+
+    fun `test build script`() = doTest("build.rs", """
+        fn main() {}
+    """)
+
+    fun `test library`() = doTest("lib.rs", """
+        fn main() {}
+    """)
+
+    fun `test inner main`() = doTest("main.rs", """
+        fn foo() {
+            fn main() {}
+        }
+    """)
+
+    fun `test no_main attribute`() = doTest("main.rs", """
+        #![no_main]
+
+        fn main() {}
+    """)
+
+    private fun doTest(filePath: String, @Language("Rust") text: String) {
+        val dirs = PathUtil.getParentPath(filePath)
+        val fileName = PathUtil.getFileName(filePath)
+
+        val rootDir = myFixture.findFileInTempDir(".")
+        var dir = rootDir
+        if (dirs.isNotEmpty()) {
+            dir = runWriteAction { VfsUtil.createDirectoryIfMissing(rootDir, dirs) }
+        }
+        val file = runWriteAction {
+            val file = dir.createChildData(dir.fileSystem, fileName)
+            VfsUtil.saveText(file, text)
+            file
+        }
+        lineMarkerTestHelper.doTestFromFile(file)
+    }
+}

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -64,22 +64,19 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         }
     """)
 
-    fun `test mod decl`() = doTestFromFile(
-        "lib.rs",
-        fileTree {
-            rust("tests.rs", """
-                #[test]
-                fn test() {}
-            """)
+    fun `test mod decl`() = doTestByFileTree("lib.rs") {
+        rust("tests.rs", """
+            #[test]
+            fn test() {}
+        """)
 
-            rust("no_tests.rs", "")
+        rust("no_tests.rs", "")
 
-            rust("lib.rs", """
-                mod tests; // - Test lib::tests
-                mod no_tests;
-            """)
-        }
-    )
+        rust("lib.rs", """
+            mod tests; // - Test lib::tests
+            mod no_tests;
+        """)
+    }
 
     fun `test show a test mark as default for test function`() = checkElement<RsFunction>("""
         #[test]

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsLineMarkerProviderTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsLineMarkerProviderTestBase.kt
@@ -6,8 +6,9 @@
 package org.rust.ide.lineMarkers
 
 import org.intellij.lang.annotations.Language
-import org.rust.FileTree
+import org.rust.FileTreeBuilder
 import org.rust.RsTestBase
+import org.rust.fileTree
 
 abstract class RsLineMarkerProviderTestBase : RsTestBase() {
 
@@ -22,8 +23,8 @@ abstract class RsLineMarkerProviderTestBase : RsTestBase() {
         lineMarkerTestHelper.doTestByText("lib.rs", source)
     }
 
-    protected fun doTestFromFile(filePath: String, fileTree: FileTree) {
-        val testProject = fileTree.create()
+    protected fun doTestByFileTree(filePath: String, builder: FileTreeBuilder.() -> Unit) {
+        val testProject = fileTree(builder).create()
         lineMarkerTestHelper.doTestFromFile(testProject.file(filePath))
     }
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsLineMarkerProviderTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsLineMarkerProviderTestBase.kt
@@ -12,7 +12,7 @@ import org.rust.fileTree
 
 abstract class RsLineMarkerProviderTestBase : RsTestBase() {
 
-    private lateinit var lineMarkerTestHelper: LineMarkerTestHelper
+    protected lateinit var lineMarkerTestHelper: LineMarkerTestHelper
 
     override fun setUp() {
         super.setUp()

--- a/toml/src/test/kotlin/org/rust/toml/CargoFeatureLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoFeatureLineMarkerProviderTest.kt
@@ -58,7 +58,7 @@ class CargoFeatureLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
     """)
 
     private fun doTest(featureName: FeatureName, @Language("Toml") source: String) {
-        val fileTree = fileTree {
+        doTestByFileTree("Cargo.toml") {
             toml("Cargo.toml", source)
             dir("src") {
                 rust("lib.rs", "")
@@ -75,8 +75,6 @@ class CargoFeatureLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
                 }
             }
         }
-
-        doTestFromFile("Cargo.toml", fileTree)
 
         val beforeState = featureState(featureName)
         @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Also:
- introduce a proper API to check if the function is `main` one. Use it in `AddUnsafeFix` to support all cases and not to depend on `org.rust.cargo.runconfig` package
- don't show run line marker for `main` function in file with `no_main` attribute

Improvement of #8571

changelog: Don't show run line marker for `main` function in file with [`no_main`](https://doc.rust-lang.org/reference/crates-and-source-files.html#the-no_main-attribute) attribute