### PR TITLE
IDE: add Don't ask again option to JSON to Rust conversion

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1196,6 +1196,12 @@
             <description>Show settings gutter icon near [features] section in `Cargo.toml` where you can enable or disable all features</description>
         </experimentalFeature>
 
+        <advancedSetting
+            id="org.rust.convert.json.to.struct"
+            enumClass="org.rust.ide.typing.paste.StoredPreference"
+            default="ASK_EVERY_TIME"
+            groupKey="advanced.setting.rust.group"
+        />
     </extensions>
 
     <extensions defaultExtensionNs="org.rust">

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -223,3 +223,5 @@ untrusted.project.notification.execution.error=Cargo project is untrusted, so it
 
 copy.paste.convert.json.to.struct.dialog.title=Generate Rust Struct from JSON
 copy.paste.convert.json.to.struct.dialog.text=The inserted text seems to be a JSON object. Do you want to generate a Rust struct from it?
+advanced.setting.rust.group=Rust
+advanced.setting.org.rust.convert.json.to.struct=Enable JSON to Rust conversion on paste


### PR DESCRIPTION
Improvement of https://github.com/intellij-rust/intellij-rust/pull/7816.

I couldn't find any documentation for the AdvancedSettings and didn't even find many usage examples, so I'm not sure if I'm using it properly. But mainly I don't know how to recognize the situation when the setting wasn't set yet - do we really have to use a tri-state enum for this? I would expect that there would be some API that would give me "unset"/"set true"/"set false".
