### PR TITLE
CARGO: use the same project toolchain to get info about stdlib as project uses

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -118,7 +118,12 @@ interface CargoProject : UserDataHolderEx {
     }
 }
 
-data class RustcInfo(val sysroot: String, val version: RustcVersion?, val targets: List<String>? = null)
+data class RustcInfo(
+    val sysroot: String,
+    val version: RustcVersion?,
+    val rustupActiveToolchain: String? = null,
+    val targets: List<String>? = null
+)
 
 fun guessAndSetupRustProject(project: Project, explicitRequest: Boolean = false): Boolean {
     if (!explicitRequest) {

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -306,9 +306,12 @@ private fun fetchRustcInfo(context: CargoSyncTask.SyncContext): TaskResult<Rustc
         val rustcVersion = childContext.toolchain.rustc().queryVersion(workingDirectory)
         val sysroot = UnitTestRustcCacheService.cached(rustcVersion) { childContext.toolchain.rustc().getSysroot(workingDirectory) }
             ?: return@runWithChildProgress TaskResult.Err("failed to get project sysroot")
+        val rustupActiveToolchain = UnitTestRustcCacheService.cached(rustcVersion) {
+            childContext.toolchain.rustup(workingDirectory)?.activeToolchainName()
+        }
         val rustcTargets = UnitTestRustcCacheService.cached(rustcVersion) { childContext.toolchain.rustc().getTargets(workingDirectory) }
 
-        TaskResult.Ok(RustcInfo(sysroot, rustcVersion, rustcTargets))
+        TaskResult.Ok(RustcInfo(sysroot, rustcVersion, rustupActiveToolchain, rustcTargets))
     }
 }
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -384,7 +384,7 @@ class Cargo(
                 if (channel != RustChannel.DEFAULT) {
                     add("+$channel")
                 } else if (toolchain != null) {
-                    add(toolchain)
+                    add("+$toolchain")
                 }
                 if (project.rustSettings.useOffline) {
                     val cargoProject = findCargoProject(project, additionalArguments, workingDirectory)

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustup.kt
@@ -108,6 +108,17 @@ class Rustup(toolchain: RsToolchainBase, private val projectDirectory: Path) : R
             workingDirectory = projectDirectory
         ).execute(owner).convertResult()
 
+    fun activeToolchainName(): String? {
+        val output = createBaseCommandLine("show", "active-toolchain", workingDirectory = projectDirectory)
+            .execute(toolchain.executionTimeoutInMilliseconds) ?: return null
+        if (!output.isSuccess) return null
+        // Expected outputs:
+        //  1.48.0-x86_64-apple-darwin (default)
+        //  stable-x86_64-apple-darwin (overridden by '/path/to/rust-toolchain.toml')
+        //  nightly-x86_64-apple-darwin (directory override for '/path/to/override/dir')
+        return output.stdout.substringBefore("(").trim()
+    }
+
     private fun RsProcessResult<ProcessOutput>.convertResult() =
         when (this) {
             is RsResult.Ok -> DownloadResult.Ok(Unit)

--- a/src/main/kotlin/org/rust/cargo/util/TestUnitTestRustcCacheService.kt
+++ b/src/main/kotlin/org/rust/cargo/util/TestUnitTestRustcCacheService.kt
@@ -18,11 +18,11 @@ class TestUnitTestRustcCacheService : UnitTestRustcCacheService {
     @Suppress("UNCHECKED_CAST")
     override fun <T> cachedInner(
         rustcVersion: RustcVersion?,
-        cls: Class<T>,
         cacheIf: () -> Boolean,
         computation: () -> T
     ): T {
         if (rustcVersion == null || !cacheIf()) return computation()
+        val cls = computation.javaClass
         return cache.getOrPut(rustcVersion to cls) { Optional.ofNullable(computation()) }.orNull() as T
     }
 }

--- a/src/main/kotlin/org/rust/cargo/util/UnitTestRustcCacheService.kt
+++ b/src/main/kotlin/org/rust/cargo/util/UnitTestRustcCacheService.kt
@@ -18,18 +18,17 @@ import org.rust.cargo.toolchain.impl.RustcVersion
 interface UnitTestRustcCacheService {
     fun <T> cachedInner(
         rustcVersion: RustcVersion?,
-        cls: Class<T>,
         cacheIf: () -> Boolean,
         computation: () -> T
     ): T
 
     companion object {
-        inline fun <reified T> cached(
+        fun <T> cached(
             rustcVersion: RustcVersion?,
-            noinline cacheIf: () -> Boolean = { true },
-            noinline computation: () -> T
+            cacheIf: () -> Boolean = { true },
+            computation: () -> T
         ): T {
-            return service<UnitTestRustcCacheService>().cachedInner(rustcVersion, T::class.java, cacheIf, computation)
+            return service<UnitTestRustcCacheService>().cachedInner(rustcVersion, cacheIf, computation)
         }
     }
 }
@@ -37,7 +36,6 @@ interface UnitTestRustcCacheService {
 class UnitTestRustcCacheServiceImpl : UnitTestRustcCacheService {
     override fun <T> cachedInner(
         rustcVersion: RustcVersion?,
-        cls: Class<T>,
         cacheIf: () -> Boolean,
         computation: () -> T
     ): T {

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
@@ -82,7 +82,7 @@ class CargoTest : RsTestBase() {
     """)
 
     fun `test use +nightly explicitly`() = checkCommandLine(
-        cargo.toColoredCommandLine(project, CargoCommandLine("run", wd, toolchain = "+nightly")), """
+        cargo.toColoredCommandLine(project, CargoCommandLine("run", wd, toolchain = "nightly")), """
         cmd: /usr/bin/cargo +nightly run --color=always
         env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=short, TERM=ansi
         """, """
@@ -91,7 +91,7 @@ class CargoTest : RsTestBase() {
     """)
 
     fun `test override explicitly used +toolchain flag if channel is set`() = checkCommandLine(
-        cargo.toColoredCommandLine(project, CargoCommandLine("run", wd, toolchain = "+nightly", channel = RustChannel.BETA)), """
+        cargo.toColoredCommandLine(project, CargoCommandLine("run", wd, toolchain = "nightly", channel = RustChannel.BETA)), """
         cmd: /usr/bin/cargo +beta run --color=always
         env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=short, TERM=ansi
         """, """


### PR DESCRIPTION
Previously, the plugin used a toolchain related to stdlib source directory to get info about stdlib (dependencies, edition, etc.). And usually, it's a default toolchain from `rustup` point of view.
But if a user [overrides](https://rust-lang.github.io/rustup/overrides.html) toolchain for the project, the plugin didn't use it for stdlib that sometimes produced errors like https://github.com/intellij-rust/intellij-rust/issues/8517

Now, the plugin retrieves the actual toolchain name (from `rustup` point of view) and passes it to all commands used to get stdlib info

Fixes #8517

changelog: Use the project toolchain to retrieve info about stdlib. Previously, the plugin used the default toolchain for it that sometimes produced errors
