### PR TITLE
GRD: update 2022.1 IDE dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,8 @@ val baseVersion = when (baseIDE) {
     else -> error("Unexpected IDE name: `$baseIDE`")
 }
 
-val tomlPlugin = if (platformVersion >= 221 && baseIDE == "idea") "org.toml.lang" else "org.toml.lang:${prop("tomlPluginVersion")}"
+// BACKCOMPAT: 2021.3
+val tomlPlugin = if (platformVersion >= 221) "org.toml.lang" else "org.toml.lang:${prop("tomlPluginVersion")}"
 val nativeDebugPlugin = "com.intellij.nativeDebug:${prop("nativeDebugPluginVersion")}"
 val graziePlugin = "tanvd.grazi"
 val psiViewerPlugin = "PsiViewer:${prop("psiViewerPluginVersion")}"

--- a/gradle-221.properties
+++ b/gradle-221.properties
@@ -1,13 +1,11 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-221.4501-EAP-CANDIDATE-SNAPSHOT
-clionVersion=CL-221.4501-EAP-CANDIDATE-SNAPSHOT
+ideaVersion=IU-221.4906-EAP-CANDIDATE-SNAPSHOT
+clionVersion=CL-221.4906-EAP-CANDIDATE-SNAPSHOT
 
-# https://plugins.jetbrains.com/plugin/8195-toml/versions
-tomlPluginVersion=221.4501.59
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=221.4501.94
+nativeDebugPluginVersion=221.4906.8
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPluginVersion=221-SNAPSHOT
 


### PR DESCRIPTION
Note, since 221.4906, CLion has bundled TOML plugin so we don't need to download TOML plugin from Marketplace anymore