### PR TITLE
REF: Offer "Extract trait" refactoring only in Rust files

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitAction.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitAction.kt
@@ -5,14 +5,18 @@
 
 package org.rust.ide.refactoring.extractTrait
 
+import com.intellij.lang.Language
 import com.intellij.lang.refactoring.RefactoringSupportProvider
 import com.intellij.refactoring.actions.ExtractSuperActionBase
+import org.rust.lang.RsLanguage
 
 class RsExtractTraitAction : ExtractSuperActionBase() {
 
     init {
         setInjectedContext(true)
     }
+
+    override fun isAvailableForLanguage(language: Language): Boolean = language == RsLanguage
 
     override fun getRefactoringHandler(provider: RefactoringSupportProvider): RsExtractTraitHandler =
         RsExtractTraitHandler()


### PR DESCRIPTION
changelog: Fix that "Extract trait" refactoring can be offered in non-Rust files
