### PR TITLE
CARGO: build all targets during build script evaluation

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -209,10 +209,10 @@ class Cargo(
         projectDirectory: Path,
         listener: ProcessListener?
     ): BuildMessages {
-        // `--tests` is needed here to compile dev dependencies during build script evaluation.
-        // `--all-targets` also can help to build dev dependencies,
-        // but it may force unnecessary compilation of examples, benches and other targets
-        val additionalArgs = listOf("--message-format", "json", "--workspace", "--tests")
+        // `--all-targets` is needed here to compile:
+        //   - build scripts even if a crate doesn't contain library or binary targets
+        //   - dev dependencies during build script evaluation
+        val additionalArgs = listOf("--message-format", "json", "--workspace", "--all-targets")
         val nativeHelper = RsPathManager.nativeHelper(toolchain is RsWslToolchain)
         val envs = if (nativeHelper != null && Registry.`is`("org.rust.cargo.evaluate.build.scripts.wrapper")) {
             EnvironmentVariablesData.create(mapOf(RUSTC_WRAPPER to nativeHelper.toString()), true)

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
@@ -873,6 +873,22 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }.checkReferenceIsResolved<RsMethodCall>("src/main.rs", toFile = ".../hello.rs")
     }
 
+    fun `test crate with examples only`() {
+        buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "intellij-rust-test"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("examples") {
+                rust("foo.rs", MAIN_RS)
+            }
+            rust("build.rs", BUILD_RS)
+        }.checkReferenceIsResolved<RsPath>("examples/foo.rs", toFile = ".../hello.rs")
+    }
+
     companion object {
         @Language("Rust")
         private const val MAIN_RS = """


### PR DESCRIPTION
Previously, the plugin didn't build example and bench targets. But if a crate didn't contain any lib, bin or test target, build scripts were not built and run at all and as a result - the plugin didn't know about generated items

Now, the plugin compiles all targets (i.e. passes `--all-targets` flag)

Fixes #8620

changelog: Properly evaluate build scripts even if a crate doesn't contain binary or library targets. Note, build script evaluation is disabled by default. To turn it on, enable `org.rust.cargo.evaluate.build.scripts` [experimental feature](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features)
