### PR TITLE
TY: tolerate types with functions of the same name

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -72,7 +72,7 @@ class RsPathReferenceImpl(
     }
 
     override fun advancedResolve(): BoundElement<RsElement>? =
-        advancedMultiResolve().singleOrNull()?.inner
+        advancedMultiResolve().singleOrNull { it.inner.element !is RsFunction }?.inner
 
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
         advancedMultiResolve().map2Array { it.inner }
@@ -87,9 +87,9 @@ class RsPathReferenceImpl(
         }
 
     private fun advancedMultiResolve(): List<BoundElementWithVisibility<RsElement>> =
-        advancedMultiresolveUsingInferenceCache() ?: advancedCachedMultiResolve()
+        advancedMultiResolveUsingInferenceCache() ?: advancedCachedMultiResolve()
 
-    private fun advancedMultiresolveUsingInferenceCache(): List<BoundElementWithVisibility<RsElement>>? {
+    private fun advancedMultiResolveUsingInferenceCache(): List<BoundElementWithVisibility<RsElement>>? {
         val path = element.parent as? RsPathExpr ?: return null
         return path.inference?.getResolvedPath(path)?.map { result ->
             val element = BoundElement(result.element, result.subst)

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -530,6 +530,14 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
                              //^ <unknown>
     """)
 
+    fun `test resolve types with functions of the same name`() = testType("""
+        struct S;
+        fn S() {}
+        type Foo<T> = T;
+        type Bar = Foo<S>;
+                 //^ S
+    """)
+
     /**
      * Checks the type of the element in [code] pointed to by `//^` marker.
      */


### PR DESCRIPTION
fix #8635 