### PR TITLE
RES: improve ambiguity resolution for type parameters between types and values with same names

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -175,10 +175,11 @@ fun resolvePath(path: RsPath, lookup: ImplLookup? = null): List<BoundElementWith
             0 -> emptyList()
             1 -> result
             else -> {
-                val withoutConstants = result.filter {
-                    it.inner.element !is RsConstant && it.inner.element !is RsConstParameter
+                val types = result.filter {
+                    val element = it.inner.element as? RsNamedElement ?: return@filter false
+                    Namespace.Types in element.namespaces
                 }
-                withoutConstants.ifEmpty { result }
+                types.ifEmpty { result }
             }
         }
     } else {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsConstArgumentResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsConstArgumentResolveTest.kt
@@ -33,13 +33,33 @@ class RsConstArgumentResolveTest : RsResolveTestBase() {
                    //^
     """)
 
-    fun `test in the case of ambiguity const argument is resolved to a type`() = checkByCode("""
+    fun `test in the case of ambiguity const argument is resolved to a type 1`() = checkByCode("""
         const A: i32 = 0;
         type A = i32;
            //X
         struct Foo<const S: i32>();
         type T = Foo<A>;
                    //^
+    """)
+
+    fun `test in the case of ambiguity const argument is resolved to a type 2`() = checkByCode("""
+        struct S {}
+             //X
+        fn S() {}
+        struct Foo<const C: i32>();
+        type Bar = Foo<S>;
+                     //^
+    """)
+
+    fun `test in the case of ambiguity const argument is resolved to a type 3`() = checkByCode("""
+        enum E { S, B }
+        struct S {}
+             //X
+
+        use E::*;
+        struct Foo<const C: i32>();
+        type Bar = Foo<S>;
+                     //^
     """)
 
     // Expression path arguments:


### PR DESCRIPTION
Previously, the plugin filtered out only constants and const parameters but did nothing with other elements from values namespace

Fixes #8635
Closes #8638

changelog: Improve ambiguity resolution for type parameters between types and values with same names
