### PR TITLE
REF: Create public trait if needed in "Extract trait" refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitProcessor.kt
@@ -131,8 +131,9 @@ class RsExtractTraitProcessor(
         }
         val traitBody = members.joinToString(separator = "\n") { it.text }
 
+        val visibility = getTraitVisibility()
         val trait = psiFactory.tryCreateTraitItem(
-            "trait $traitName $typeParameters $whereClause {\n$traitBody\n}"
+            "${visibility}trait $traitName $typeParameters $whereClause {\n$traitBody\n}"
         ) ?: return null
 
         copyAttributes(traitOrImpl, trait)
@@ -153,6 +154,15 @@ class RsExtractTraitProcessor(
 
         copyAttributes(traitOrImpl, newImpl)
         return impl.parent.addAfter(newImpl, impl) as? RsImplItem
+    }
+
+    private fun getTraitVisibility(): String {
+        val unitedVisibility = when (traitOrImpl) {
+            is RsTraitItem -> traitOrImpl.visibility
+            is RsImplItem -> members.map { it.visibility }.reduce(RsVisibility::unite)
+            else -> error("unreachable")
+        }
+        return unitedVisibility.format()
     }
 
     private fun extractMembersFromOldImpl(impl: RsImplItem): String {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
@@ -96,6 +96,30 @@ fun RsVisibility.intersect(other: RsVisibility): RsVisibility = when (this) {
     }
 }
 
+fun RsVisibility.unite(other: RsVisibility): RsVisibility = when {
+    this is RsVisibility.Restricted && other is RsVisibility.Restricted -> {
+        val commonParent = commonParentMod(inMod, other.inMod)
+        if (commonParent != null) {
+            RsVisibility.Restricted(commonParent)
+        } else {
+            RsVisibility.Public
+        }
+    }
+    this == RsVisibility.Private && other is RsVisibility.Private -> RsVisibility.Private
+    else -> RsVisibility.Public
+}
+
+fun RsVisibility.format(): String = when (this) {
+    RsVisibility.Private -> ""
+    RsVisibility.Public -> "pub "
+    is RsVisibility.Restricted ->
+        if (inMod.isCrateRoot) {
+            "pub(crate) "
+        } else {
+            "pub(in crate${inMod.crateRelativePath}) "
+        }
+}
+
 val RsVis.visibility: RsVisibility
     get() = when (stubKind) {
         RsVisStubKind.PUB -> RsVisibility.Public

--- a/src/test/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractSuperTraitTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractSuperTraitTest.kt
@@ -48,6 +48,50 @@ class RsExtractSuperTraitTest : RsExtractTraitBaseTest() {
         }
     """)
 
+    fun `test public trait`() = doTest("""
+        pub trait Derived {
+            /*caret*/fn a(&self);
+        }
+    """, """
+        pub trait Derived: Trait {}
+
+        pub trait Trait {
+            fn a(&self);
+        }
+    """)
+
+    fun `test restricted trait 1`() = doTest("""
+        pub(crate) trait Derived {
+            /*caret*/fn a(&self);
+        }
+    """, """
+        pub(crate) trait Derived: Trait {}
+
+        pub(crate) trait Trait {
+            fn a(&self);
+        }
+    """)
+
+    fun `test restricted trait 2`() = doTest("""
+        mod inner1 {
+            mod inner2 {
+                pub(super) trait Derived {
+                    /*caret*/fn a(&self);
+                }
+            }
+        }
+    """, """
+        mod inner1 {
+            mod inner2 {
+                pub(super) trait Derived: Trait {}
+
+                pub(in crate::inner1) trait Trait {
+                    fn a(&self);
+                }
+            }
+        }
+    """)
+
     fun `test impl in same mod`() = doTest("""
         trait Derived {
             /*caret*/fn a(&self);


### PR DESCRIPTION
Fixes #8468

changelog: Fix visibility of created trait in "Extract trait" refactoring
