### PR TITLE
DBG: avoid `NoClassDefFoundError` in Rider 2021.3

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/debuggingIntegration.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/debuggingIntegration.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
+
+private val CIDR_DEBUGGER_PLUGIN_ID: PluginId = PluginId.getId("com.intellij.cidr.debugger")
+
+private fun cidrDebuggerPlugin(): IdeaPluginDescriptor? =
+    PluginManagerCore.getPlugin(CIDR_DEBUGGER_PLUGIN_ID)
+
+// BACKCOMPAT: 2021.3. Since 2022.1 Rider for Unreal Engine is merged into Rider
+//  so `isDebuggingIntegrationEnabled` is always true
+fun isDebuggingIntegrationEnabled(): Boolean {
+    return cidrDebuggerPlugin() != null || nativeDebuggingSupportPlugin() != null
+}

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -11,13 +11,15 @@ import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.runconfig.BuildResult
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.wsl.RsWslToolchain
+import org.rust.debugger.isDebuggingIntegrationEnabled
 
 class RsDebugRunner : RsDebugRunnerBase() {
 
     override fun canRun(executorId: String, profile: RunProfile): Boolean =
         super.canRun(executorId, profile) &&
             profile is CargoCommandConfiguration &&
-            profile.project.toolchain !is RsWslToolchain
+            profile.project.toolchain !is RsWslToolchain &&
+            isDebuggingIntegrationEnabled()
 
     override fun checkToolchainSupported(project: Project, host: String): BuildResult.ToolchainError? =
         RsDebugRunnerUtils.checkToolchainSupported(project, host)

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/legacy/RsDebugRunnerLegacy.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/legacy/RsDebugRunnerLegacy.kt
@@ -11,6 +11,7 @@ import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.runconfig.BuildResult
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.wsl.RsWslToolchain
+import org.rust.debugger.isDebuggingIntegrationEnabled
 import org.rust.debugger.runconfig.RsDebugRunnerUtils
 
 class RsDebugRunnerLegacy : RsDebugRunnerLegacyBase() {
@@ -18,7 +19,8 @@ class RsDebugRunnerLegacy : RsDebugRunnerLegacyBase() {
     override fun canRun(executorId: String, profile: RunProfile): Boolean =
         super.canRun(executorId, profile) &&
             profile is CargoCommandConfiguration &&
-            profile.project.toolchain !is RsWslToolchain
+            profile.project.toolchain !is RsWslToolchain &&
+            isDebuggingIntegrationEnabled()
 
     override fun checkToolchainSupported(project: Project, host: String): BuildResult.ToolchainError? =
         RsDebugRunnerUtils.checkToolchainSupported(project, host)

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
@@ -14,6 +14,7 @@ import com.intellij.xdebugger.settings.XDebuggerSettings
 import org.rust.debugger.GDBRenderers
 import org.rust.debugger.LLDBRenderers
 import org.rust.debugger.RsDebuggerBundle
+import org.rust.debugger.isDebuggingIntegrationEnabled
 
 class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
 
@@ -32,6 +33,7 @@ class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
     }
 
     override fun createConfigurables(category: DebuggerSettingsCategory): Collection<Configurable> {
+        if (!isDebuggingIntegrationEnabled()) return emptyList()
         val configurable = when (category) {
             DebuggerSettingsCategory.DATA_VIEWS -> createDataViewConfigurable()
             DebuggerSettingsCategory.GENERAL -> createGeneralSettingsConfigurable()


### PR DESCRIPTION
After #8265 the plugin provides debugger integration for Rider. But Rider 2021.3 has basic debugging classes only in Rider 4UE edition. But the platform doesn't take into account additional dependencies in optional dependency manifest. As a result, debugging optional dependency is loaded in common Rider edition as well that leads to `NoClassDefFoundError` in some places

These changes add runtime checks for the necessary plugins not to load debugger classes in Rider 2021.3

Fixes #8622

changelog: Fix `NoClassDefFoundError` exceptions in Rider 2021.3 and show debugger settings properly
