### PR TITLE
REF: move cursor after generated constructor in GenerateConstructor action

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/generate/constructor/GenerateConstructorHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/constructor/GenerateConstructorHandler.kt
@@ -15,6 +15,7 @@ import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.lang.core.psi.ext.endOffset
 import org.rust.lang.core.psi.ext.isTupleStruct
 import org.rust.lang.core.types.Substitution
 import org.rust.openapiext.checkWriteAccessAllowed
@@ -46,8 +47,8 @@ class GenerateConstructorHandler : BaseGenerateHandler() {
 
         val anchor = impl.lastChild.lastChild
         val constructor = createConstructor(struct, chosenFields, psiFactory, substitution)
-        impl.lastChild.addBefore(constructor, anchor)
-        editor.caretModel.moveToOffset(impl.textOffset + impl.textLength - 1)
+        val inserted = impl.lastChild.addBefore(constructor, anchor)
+        editor.caretModel.moveToOffset(inserted.endOffset)
     }
 
     private fun createConstructor(

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateConstructorActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateConstructorActionTest.kt
@@ -25,7 +25,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl<T> S<T> {
             pub fn new(n: i32, m: T) -> Self {
                 Self { n, m }
-            }
+            }/*caret*/
         }
     """)
 
@@ -46,7 +46,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl S {
             pub fn new(n: i32, m: ()) -> Self {
                 Self { n, m }
-            }
+            }/*caret*/
         }
     """)
 
@@ -74,7 +74,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl Color {
             pub fn new(field0: i32, field1: i32, field2: i32) -> Self {
                 Self(field0, field1, field2)
-            }
+            }/*caret*/
         }
     """)
 
@@ -95,7 +95,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl S {
             pub fn new() -> Self {
                 Self { n: (), m: () }
-            }
+            }/*caret*/
         }
     """)
 
@@ -116,7 +116,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl S {
             pub fn new(n: i32, m: i64) -> Self {
                 Self { n, m }
-            }
+            }/*caret*/
         }
     """)
 
@@ -137,7 +137,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl S {
             pub fn new(n: i32) -> Self {
                 Self { n, m: () }
-            }
+            }/*caret*/
         }
     """)
 
@@ -162,7 +162,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl S {
             pub fn new(n: i32, m: i64) -> Self {
                 Self { n, m }
-            }
+            }/*caret*/
         }
     """)
 
@@ -203,7 +203,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl S<i32> {
             pub fn new(field0: i32) -> Self {
                 Self(field0)
-            }
+            }/*caret*/
         }
     """)
 
@@ -219,7 +219,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl <'a> S<'a, i32> {
             pub fn new(field0: &'a i32) -> Self {
                 Self(field0)
-            }
+            }/*caret*/
         }
     """)
 
@@ -239,7 +239,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl System {
             pub fn new(point: Coordinates) -> Self {
                 Self { point }
-            }
+            }/*caret*/
         }
     """)
 
@@ -263,7 +263,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl System {
             pub fn new(s: foo::S) -> Self {
                 Self { s }
-            }
+            }/*caret*/
         }
     """)
 
@@ -283,7 +283,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
         impl System {
             pub fn new(field0: foo::S) -> Self {
                 Self(field0)
-            }
+            }/*caret*/
         }
     """)
 
@@ -304,7 +304,7 @@ class GenerateConstructorActionTest : RsGenerateBaseTest() {
             fn foo(&self) {}
             pub fn new(s: u32) -> Self {
                 Self { s }
-            }
+            }/*caret*/
         }
     """)
 }


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/8534

changelog: The `Generate constructor` action will now place the cursor after the generated constructor.