### PR TITLE
CARGO: Ignore parsing for directories starting with dot

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
@@ -602,12 +602,15 @@ private class CratesLocalIndexUpdateTask(
             val objectIds = mutableListOf<Pair<ObjectId, String>>()
             while (treeWalk.next()) {
                 if (treeWalk.isSubtree) continue
-                val nameString = treeWalk.nameString
-                if (nameString == "config.json") continue
+
+                val path = treeWalk.pathString
+                // Ignore paths starting with dot (e.g. .github/) and config.json
+                if (path.startsWith(".") || path == "config.json") continue
+
                 indicator.checkCanceled()
 
                 val objectId = treeWalk.getObjectId(0)
-                objectIds.add(objectId to nameString)
+                objectIds.add(objectId to treeWalk.nameString)
             }
             objectIds
         }


### PR DESCRIPTION
Fixes parsing errors happening during crates local index update because of created `.github/` dir in [crates.io-index](https://github.com/rust-lang/crates.io-index) repository.

This PR adds a condition to skip all the paths starting with dots.

changelog: Fix parsing errors when updating crates local index