### PR TITLE
PRJ: properly validate new Rust project name in minor IDEs

### DIFF
--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -15,12 +15,12 @@ import com.intellij.openapi.wm.impl.welcomeScreen.AbstractActionWithPanel
 import com.intellij.platform.DirectoryProjectGenerator
 import com.intellij.platform.DirectoryProjectGeneratorBase
 import com.intellij.platform.ProjectGeneratorPeer
+import com.intellij.util.PathUtil
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.toolchain.tools.cargo
 import org.rust.ide.icons.RsIcons
 import org.rust.openapiext.computeWithCancelableProgress
 import org.rust.stdext.unwrapOrThrow
-import java.io.File
 import javax.swing.Icon
 
 // We implement `CustomStepProjectGenerator` as well to correctly show settings UI
@@ -35,7 +35,7 @@ class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationD
     override fun createPeer(): ProjectGeneratorPeer<ConfigurationData> = RsProjectGeneratorPeer().also { peer = it }
 
     override fun validate(baseDirPath: String): ValidationResult {
-        val crateName = File(baseDirPath).nameWithoutExtension
+        val crateName = PathUtil.getFileName(baseDirPath)
         val message = peer?.settings?.template?.validateProjectName(crateName) ?: return ValidationResult.OK
         return ValidationResult(message)
     }


### PR DESCRIPTION
Previously, if new project name contained `.` in the name, the plugin validated only name prefix before `.`

Fixes #8680

changelog: Properly validate new Rust project names with `.` symbol
