### PR TITLE
GRD: make 2022.1 platform default for development

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
 # Supported platforms: 213, 221
-platformVersion=213
+platformVersion=221
 # Supported IDEs: idea, clion
 baseIDE=idea
 


### PR DESCRIPTION
changelog: Make 2022.1 platform default for development
