### PR TITLE
RUN: support Cargo command debugging from `Run Anything` popup

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/runAnything/RsRunAnythingProvider.kt
+++ b/src/main/kotlin/org/rust/ide/actions/runAnything/RsRunAnythingProvider.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.actions.runAnything
 
+import com.intellij.execution.Executor
+import com.intellij.execution.executors.DefaultRunExecutor
+import com.intellij.ide.actions.runAnything.RunAnythingAction
 import com.intellij.ide.actions.runAnything.RunAnythingContext
 import com.intellij.ide.actions.runAnything.activity.RunAnythingProviderBase
 import com.intellij.ide.actions.runAnything.getPath
@@ -25,7 +28,13 @@ abstract class RsRunAnythingProvider : RunAnythingProviderBase<String>() {
 
     abstract override fun getMainListItem(dataContext: DataContext, value: String): RunAnythingItem
 
-    abstract fun run(command: String, params: List<String>, workingDirectory: Path, cargoProject: CargoProject)
+    protected abstract fun run(
+        executor: Executor,
+        command: String,
+        params: List<String>,
+        workingDirectory: Path,
+        cargoProject: CargoProject
+    )
 
     abstract fun getCompletionProvider(project: Project, dataContext: DataContext) : RsCommandCompletionProvider
 
@@ -56,7 +65,8 @@ abstract class RsRunAnythingProvider : RunAnythingProviderBase<String>() {
         val params = ParametersListUtil.parse(trimStart(value, helpCommand))
         val executionContext = dataContext.getData(EXECUTING_CONTEXT) ?: RunAnythingContext.ProjectContext(project)
         val path = executionContext.getPath()?.toPath() ?: return
-        run(params.firstOrNull() ?: "--help", params.drop(1), path, cargoProject)
+        val executor = dataContext.getData(RunAnythingAction.EXECUTOR_KEY) ?: DefaultRunExecutor.getRunExecutorInstance()
+        run(executor, params.firstOrNull() ?: "--help", params.drop(1), path, cargoProject)
     }
 
     abstract override fun getHelpCommand(): String

--- a/src/main/kotlin/org/rust/ide/actions/runAnything/cargo/CargoRunAnythingProvider.kt
+++ b/src/main/kotlin/org/rust/ide/actions/runAnything/cargo/CargoRunAnythingProvider.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.actions.runAnything.cargo
 
+import com.intellij.execution.Executor
 import com.intellij.ide.actions.runAnything.items.RunAnythingItem
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.project.Project
@@ -24,8 +25,8 @@ class CargoRunAnythingProvider : RsRunAnythingProvider() {
     override fun getMainListItem(dataContext: DataContext, value: String): RunAnythingItem =
         RunAnythingCargoItem(getCommand(value), getIcon(value))
 
-    override fun run(command: String, params: List<String>, workingDirectory: Path, cargoProject: CargoProject) {
-        CargoCommandLine(command, workingDirectory, params).run(cargoProject)
+    override fun run(executor: Executor, command: String, params: List<String>, workingDirectory: Path, cargoProject: CargoProject) {
+        CargoCommandLine(command, workingDirectory, params).run(cargoProject, executor = executor)
     }
 
     override fun getCompletionProvider(project: Project, dataContext: DataContext): RsCommandCompletionProvider =

--- a/src/main/kotlin/org/rust/ide/actions/runAnything/wasmpack/WasmPackRunAnythingProvider.kt
+++ b/src/main/kotlin/org/rust/ide/actions/runAnything/wasmpack/WasmPackRunAnythingProvider.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.actions.runAnything.wasmpack
 
+import com.intellij.execution.Executor
 import com.intellij.ide.actions.runAnything.items.RunAnythingItem
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.project.Project
@@ -24,8 +25,8 @@ class WasmPackRunAnythingProvider : RsRunAnythingProvider() {
     override fun getMainListItem(dataContext: DataContext, value: String): RunAnythingItem =
         RunAnythingWasmPackItem(getCommand(value), getIcon(value))
 
-    override fun run(command: String, params: List<String>, workingDirectory: Path, cargoProject: CargoProject) {
-        WasmPackCommandLine(command, workingDirectory, params).run(cargoProject)
+    override fun run(executor: Executor, command: String, params: List<String>, workingDirectory: Path, cargoProject: CargoProject) {
+        WasmPackCommandLine(command, workingDirectory, params).run(cargoProject, executor = executor)
     }
 
     override fun getCompletionProvider(project: Project, dataContext: DataContext): RsCommandCompletionProvider =

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -72,6 +72,8 @@ dialog.create.project.custom.add.template.title=Add Custom Template
 dialog.create.project.custom.add.template.url.description=cargo-generate supported template. <a href="https://github.com/cargo-generate/cargo-generate/blob/master/TEMPLATES.md">Available templates</a>
 dialog.create.project.custom.add.template.url=Template URL:
 
+# for example: Debug action is not available for `cargo help` command
+notification.0.action.is.not.available.for.1.command={0} action is not available for `{1}` command
 notification.action.attach.manually.text=Attach manually
 notification.action.attach.text=Attach
 notification.action.do.not.show.again.text=Do not show again


### PR DESCRIPTION
Previously, the Cargo and wasm-pack commands invoked from `Run Anything` popup ignored given executor and always use `run` mode
Now, they respect run/debug modes (if possible)

Closes #8696

changelog: Respect run/debug modes in [Run Anything](https://www.jetbrains.com/help/idea/running-anything.html) by Cargo commands
