### PR TITLE
LI: Dont inject doctests if there are unbalanced code fences in prev doc

### DIFF
--- a/src/main/kotlin/org/rust/lang/doc/psi/Psi.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/Psi.kt
@@ -170,6 +170,7 @@ interface RsDocLinkDestination : RsDocElement
  */
 interface RsDocCodeFence : RsDocElement, PsiLanguageInjectionHost, InjectionBackgroundSuppressor {
     val start: RsDocCodeFenceStartEnd
+    val end: RsDocCodeFenceStartEnd?
     val lang: RsDocCodeFenceLang?
 }
 

--- a/src/main/kotlin/org/rust/lang/doc/psi/impl/Psi.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/impl/Psi.kt
@@ -94,6 +94,9 @@ class RsDocCodeFenceImpl(type: IElementType) : RsDocElementImpl(type), RsDocCode
     override val start: RsDocCodeFenceStartEnd
         get() = notNullChild(childOfType())
 
+    override val end: RsDocCodeFenceStartEnd?
+        get() = childrenOfType<RsDocCodeFenceStartEnd>().getOrNull(1)
+
     override val lang: RsDocCodeFenceLang?
         get() = childOfType()
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.ide.annotator
 
+import org.rust.CheckTestmarkHit
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
+import org.rust.ide.injected.DoctestInfo
 
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
 class RsDoctestAnnotatorTest : RsAnnotatorTestBase(RsDoctestAnnotator::class) {
@@ -176,6 +178,30 @@ class RsDoctestAnnotatorTest : RsAnnotatorTestBase(RsDoctestAnnotator::class) {
         |</inject></info>///<info> <inject>let b = 0;
         |</inject></info>///  ```
         |fn foo() {}
+        |""")
+
+    @CheckTestmarkHit(DoctestInfo.Testmarks.UnbalancedCodeFence::class)
+    fun `test injection broken into two parts 1`() = doTest("""
+        |/// ```
+        |///<info> <inject>let a = 0;</inject></info>
+        |//
+        |/// let b = 1;
+        |/// ```
+        |/// no injection here
+        |/// ```
+        |fn foo() {}
+        |""")
+
+    @CheckTestmarkHit(DoctestInfo.Testmarks.UnbalancedCodeFence::class)
+    fun `test injection broken into two parts 2`() = doTest("""
+        |/// ```
+        |///<info> <inject>let a = 0;</inject></info>
+        |fn foo() {
+        |    //! let b = 1;
+        |    //! ```
+        |    //! no injection here
+        |    //! ```
+        }
         |""")
 
     fun doTest(code: String) = checkByFileTree(


### PR DESCRIPTION
A workaround. The real bug is that we considering each doc comment independently when parsing markdown.

````rust
/// ```
/// let a = 0;
//  <-- two slashes here!
/// let b = a;
/// ```
/// not a doctest
/// ```
/// a doctest
fn foo() {}
````

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/3221931/160899573-22c3fb22-a1bc-4d31-a255-f2c0018b28b2.png) | ![image](https://user-images.githubusercontent.com/3221931/160899757-9f221d0d-512f-4b0a-b9c8-80370e694f40.png) |