### PR TITLE
GRD: update gradle-intellij-plugin to 1.5.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ val compileNativeCodeTaskName = "compileNativeCode"
 plugins {
     idea
     kotlin("jvm") version "1.6.10"
-    id("org.jetbrains.intellij") version "1.4.0"
+    id("org.jetbrains.intellij") version "1.5.2"
     id("org.jetbrains.grammarkit") version "2021.2.2"
     id("net.saliman.properties") version "1.5.2"
     id("org.gradle.test-retry") version "1.3.1"


### PR DESCRIPTION
It should fix the bootstrap error caused by `java.lang.NoClassDefFoundError: com/intellij/openapi/util/SystemInfoRt` with latest 2022.1 builds during `runIde` task