### PR TITLE
Rename a URL scheme for macro expansions rust_macros -> rust-macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
@@ -446,7 +446,7 @@ class MacroExpansionFileSystem : NewVirtualFileSystem() {
     class IllegalPathException(path: String) : FSException(path)
 
     companion object {
-        private const val PROTOCOL: String = "rust_macros"
+        private const val PROTOCOL: String = "rust-macros"
 
         fun getInstance(): MacroExpansionFileSystem {
             return VirtualFileManager.getInstance().getFileSystem(PROTOCOL) as MacroExpansionFileSystem

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1118,7 +1118,7 @@
                         serviceImplementation="org.rust.lang.core.macros.MacroExpansionManagerImpl"/>
         <writingAccessProvider implementation="org.rust.lang.core.macros.RsMacroExpansionWritingAccessProvider"/>
         <cachesInvalidator implementation="org.rust.lang.core.macros.RsMacroExpansionCachesInvalidator"/>
-        <virtualFileSystem key="rust_macros" implementationClass="org.rust.lang.core.macros.MacroExpansionFileSystem"/>
+        <virtualFileSystem key="rust-macros" implementationClass="org.rust.lang.core.macros.MacroExpansionFileSystem"/>
         <fileTypeOverrider implementation="org.rust.lang.core.macros.RsFileTypeOverriderForMacroExpansionFileSystem"/>
         <globalIndexFilter implementation="org.rust.lang.core.macros.RsGlobalIndexFilterForMacroExpansionFileSystem"/>
         <filetype.prebuiltStubsProvider filetype="Rust"


### PR DESCRIPTION
It looks like the char `_` is illegal in a URL scheme, so I replaced it with allowed `-`: `rust_macros://` -> `rust-macros://`.

I paid attention to it when I got this exception:

```
java.net.URISyntaxException: Illegal character in scheme name at index 4: rust_macros:///
	at java.base/java.net.URI$Parser.fail(URI.java:2913)
	at java.base/java.net.URI$Parser.checkChars(URI.java:3084)
	at java.base/java.net.URI$Parser.parse(URI.java:3110)
	at java.base/java.net.URI.<init>(URI.java:685)
	at java.base/java.net.URI.<init>(URI.java:786)
	at com.android.ide.common.util.PathStringUtil.createRootUri(PathString.kt:871)
	at com.android.ide.common.util.PathStringUtil.getUri(PathString.kt:867)
	at com.android.ide.common.util.PathStringUtil.access$getUri(PathString.kt:1)
	at com.android.ide.common.util.PathString.<init>(PathString.kt:88)
	at com.android.tools.idea.util.FileExtensions.toPathString(FileExtensions.kt:76)
	at com.android.tools.idea.util.PoliteAndroidVirtualFileListener.fileDeleted(PoliteAndroidVirtualFileListener.kt:121)
	at jdk.internal.reflect.GeneratedMethodAccessor679.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.intellij.util.EventDispatcher.dispatchVoidMethod(EventDispatcher.java:120)
	at com.intellij.util.EventDispatcher.lambda$createMulticaster$1(EventDispatcher.java:85)
	at com.sun.proxy.$Proxy25.fileDeleted(Unknown Source)
	at com.intellij.openapi.vfs.impl.BulkVirtualFileListenerAdapter.fireAfter(BulkVirtualFileListenerAdapter.java:67)
```

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

changelog:
