### PR TITLE
Add missing logs

### DIFF
--- a/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
+++ b/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
@@ -58,9 +58,13 @@ fun GeneralCommandLine.execute(
     runner: CapturingProcessHandler.() -> ProcessOutput = { runProcessWithGlobalProgress(timeoutInMilliseconds = null) },
     listener: ProcessListener? = null
 ): RsProcessResult<ProcessOutput> {
+    LOG.info("Executing `$commandLineString`")
 
     val handler = RsCapturingProcessHandler.startProcess(this) // The OS process is started here
-        .unwrapOrElse { return Err(RsProcessExecutionException.Start(commandLineString, it)) }
+        .unwrapOrElse {
+            LOG.warn("Failed to run executable", it)
+            return Err(RsProcessExecutionException.Start(commandLineString, it))
+        }
 
     val cargoKiller = Disposable {
         // Don't attempt a graceful termination, Cargo can be SIGKILLed safely.


### PR DESCRIPTION
After e210aa0b9da7ad73c624a98eaa8d30f8f4399d32 only one implementation of `GeneralCommandLine.execute` prints logs

This change fixes adds logs into the second version of the method
