### PR TITLE
TY: infer associated types on supertraits if possible

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1521,6 +1521,28 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ u8
     """)
 
+    fun `test infer associated type binding from supertrait`() = testExpr("""
+        trait Parent {
+            type Item;
+            fn item(&self) -> Self::Item;
+        }
+        trait Child : Parent {}
+
+        struct Foo;
+        struct Bar;
+        impl Parent for Foo {
+            type Item = Bar;
+            fn item(&self) -> Self::Item { unimplemented!() }
+        }
+        impl Child for Foo {}
+
+        fn new() -> impl Child<Item = Bar> { unimplemented!() }
+        fn main() {
+            let bar = new().item();
+            bar;
+        } //^ Bar
+    """)
+
     fun `test select trait from unconstrained integer`() = testExpr("""
         struct X;
         trait Tr<A> {}


### PR DESCRIPTION
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

Fixes #8660

changelog: Fix type inference of associated types that are referenced from a cast to a supertrait.

Consider the following code:

```rust
trait Mascot {
    type Species;

    fn get_species(&self) -> Self::Species;

    fn get_species_name(&self) -> &'static str {
        std::any::type_name::<Self::Species>()
    }
}

trait LanguageMascot : Mascot {}

#[derive(Debug)]
struct Crab;

struct Ferris;

impl Mascot for Ferris {
    type Species = Crab;

    fn get_species(&self) -> Self::Species {
        Crab
    }
}

impl LanguageMascot for Ferris {}

fn crab_language_mascot() -> impl LanguageMascot<Species = Crab> {
    Ferris
}

fn main() {
    let crab = crab_language_mascot().get_species();
    println!("{:?}", crab);
}
```

The compiler successfully infers that `crab` has type `Crab`, but previously intellij-rust resolved its type to `<impl LanguageMascot<Species=Crab> as Mascot>::Species`, which breaks any further type inference on `crab`.

<details>
<summary>Original Behavior</summary>

![image](https://user-images.githubusercontent.com/45273859/162113718-5e6f4d36-694c-4fb2-bc80-63ee77bee2ab.png)

</details>

This PR fixes this by allowing subtrait items to paste their associated types onto supertrait items as applicable in `BoundElement<RsTraitItem>.flattenHierarchy`.

<details>
<summary>Fixed Behavior</summary>

![image](https://user-images.githubusercontent.com/45273859/162114509-a77685c1-b7fc-44f2-a737-713c9a77fd0e.png)

</details>
