### PR TITLE
GRD: provide `buildNumber` in `eventScheme.json`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -342,6 +342,10 @@ project(":plugin") {
     task<RunIdeTask>("buildEventsScheme") {
         dependsOn(tasks.prepareSandbox)
         args("buildEventsScheme", "--outputFile=${buildDir.resolve("eventScheme.json").absolutePath}", "--pluginId=org.rust.lang")
+        // BACKCOMPAT: 2021.3. Update value to 221 and this comment
+        // `IDEA_BUILD_NUMBER` variable is used by `buildEventsScheme` task to write `buildNumber` to output json.
+        // It will be used by TeamCity automation to set minimal IDE version for new events
+        environment("IDEA_BUILD_NUMBER", "213")
     }
 }
 


### PR DESCRIPTION
It should help statistics automation set a proper minimal IDE version for new event rules