### PR TITLE
RUN: Fix external linter when more than one file opened

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
@@ -83,7 +83,9 @@ class RsExternalLinterPass(
             return
         }
 
-        val update = object : Update(file) {
+        class RsUpdate: Update(file) {
+            val updateFile: RsFile = file
+
             override fun setRejected() {
                 super.setRejected()
                 doFinish(highlights)
@@ -102,9 +104,10 @@ class RsExternalLinterPass(
                 })
             }
 
-            override fun canEat(update: Update?): Boolean = true
+            override fun canEat(update: Update?): Boolean = updateFile == (update as? RsUpdate)?.updateFile
         }
 
+        val update = RsUpdate()
         if (isUnitTestMode) {
             update.run()
         } else {


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/8541.
Fixes https://github.com/intellij-rust/intellij-rust/issues/8698.

changelog: Fix external linter when more than one file opened
