### PR TITLE
RES: resolve RsPathBinding to a unit structs

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
@@ -320,6 +320,8 @@ class RsVariableNamingInspection : RsSnakeCaseNamingInspection("Variable") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitPatBinding(el: RsPatBinding) {
+                if (el.isReferenceToConstant) return
+
                 val pattern = PsiTreeUtil.getTopmostParentOfType(el, RsPat::class.java) ?: return
                 when (pattern.parent) {
                     is RsLetDecl -> inspect(el.identifier, holder)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -22,7 +22,10 @@ import org.rust.lang.core.completion.getOriginalOrSelf
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.findDependency
 import org.rust.lang.core.macros.findNavigationTargetIfMacroExpansion
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsConstant
+import org.rust.lang.core.psi.RsElementTypes
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.resolve.*
 
 interface RsElement : PsiElement {
@@ -83,7 +86,7 @@ val PsiElement.isAtLeastEdition2018: Boolean
  * Constant-like element can be: real constant, static variable, and enum variant without fields.
  */
 val RsElement.isConstantLike: Boolean
-    get() = this is RsConstant || (this is RsEnumVariant && isFieldless)
+    get() = this is RsConstant || (this is RsFieldsOwner && isFieldless)
 
 fun RsElement.findDependencyCrateRoot(dependencyName: String): RsFile? {
     return containingCrate

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
@@ -44,13 +44,15 @@ val RsPat.isIrrefutable: Boolean
 private val RsPath.isIrrefutable: Boolean
     get() = when (val item = reference?.deepResolve()) {
         is RsStructItem -> true
-        is RsEnumVariant -> item.parentEnum.enumBody?.enumVariantList?.size == 1
+        is RsEnumVariant -> item.parentEnum.variants.size == 1
         else -> false
     }
 
 private val RsPatBinding.isIrrefutable: Boolean
-    get() = when (reference.resolve()) {
-        is RsStructItem, is RsEnumVariant, is RsConstant -> false
+    get() = when (val resolved = reference.resolve()) {
+        is RsConstant -> false
+        is RsStructItem -> true
+        is RsEnumVariant -> resolved.parentEnum.variants.size == 1
         else -> true
     }
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsVariableNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsVariableNamingInspectionTest.kt
@@ -98,4 +98,11 @@ class RsVariableNamingInspectionTest : RsInspectionsTestBase(RsVariableNamingIns
             let (一, 二) = (1, 2);
         }
     """)
+
+    fun `test not a variable - unit struct`() = checkByText("""
+        struct Foo;
+        fn main() {
+            let Foo = Foo;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -1286,6 +1286,30 @@ class RsResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test pattern constant binding ambiguity enum variant`() = checkByCode("""
+        enum Enum { Var1, Var2 }
+                  //X
+        use Enum::Var1;
+        fn main() {
+            match Enum::Var1 {
+                Var1 => {}
+                //^
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test pattern constant binding ambiguity unit struct`() = checkByCode("""
+        struct Foo;
+             //X
+        fn main() {
+            match Foo {
+                Foo => {}
+                //^
+            }
+        }
+    """)
+
     fun `test match enum path`() = checkByCode("""
         enum Enum { Var1, Var2 }
                   //X


### PR DESCRIPTION
1.
```rust
struct Foo;
     //X
fn main() {
    match Foo {
        Foo => {}
        //^
    }
}
```
2. Treat patterns like `let Foo = Foo;` as irrefutable
3. Don't trigger naming warning for let declarations that refers to a unit struct like `let Foo = Foo;`