### PR TITLE
PERF: Reuse single thread pool in name resolution

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -17,12 +17,10 @@ import org.rust.lang.core.macros.MacroExpansionFileSystem.FSItem
 import org.rust.lang.core.resolve2.CrateDefMap
 import org.rust.lang.core.resolve2.MacroIndex
 import org.rust.lang.core.resolve2.updateDefMapForAllCrates
-import org.rust.openapiext.checkReadAccessNotAllowed
 import org.rust.openapiext.testAssert
 import org.rust.openapiext.toThreadSafeProgressIndicator
 import org.rust.stdext.HashCode
 import org.rust.stdext.mapToSet
-import java.util.concurrent.ExecutorService
 
 /**
  * Overview of macro expansion process:
@@ -45,7 +43,6 @@ import java.util.concurrent.ExecutorService
 class MacroExpansionTask(
     project: Project,
     private val modificationTracker: SimpleModificationTracker,
-    private val pool: ExecutorService,
     private val lastUpdatedMacrosAt: MutableMap<CratePersistentId, Long>,
     private val projectDirectoryName: String,
     override val taskType: RsTask.TaskType,
@@ -60,7 +57,7 @@ class MacroExpansionTask(
 
         val allDefMaps = try {
             indicator.text = "Preparing resolve data"
-            updateDefMapForAllCrates(project, pool, subTaskIndicator)
+            updateDefMapForAllCrates(project, subTaskIndicator)
         } catch (e: ProcessCanceledException) {
             throw e
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefMapsBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefMapsBuilder.kt
@@ -168,7 +168,7 @@ class DefMapsBuilder(
  * We use [ForkJoinPool.invokeAll] there, which can execute tasks
  * from completely different thread pool (associated with current thread).
  * That's why we need to be sure that we build DefMaps on thread associated with our [ForkJoinPool].
- * Also see [org.rust.lang.core.macros.MacroExpansionServiceImplInner.pool].
+ * Also see [ResolveCommonThreadPool.pool].
  */
 private fun invokeWithoutHelpingOtherForkJoinPools(forkJoinPool: ExecutorService, action: () -> Unit) {
     val future = SettableFuture.create<Unit>()

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ResolveCommonThreadPool.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ResolveCommonThreadPool.kt
@@ -1,0 +1,44 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.testFramework.ThreadTracker
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory
+import java.util.concurrent.ForkJoinTask
+
+@Service
+class ResolveCommonThreadPool : Disposable {
+
+    /**
+     * We must use a separate pool because:
+     * - [ForkJoinPool.commonPool] is heavily used by the platform
+     * - [ForkJoinPool] can start execute a task when joining ([ForkJoinTask.get]) another task
+     */
+    private val pool: ExecutorService = createPool()
+
+    private fun createPool(): ExecutorService {
+        val parallelism = Runtime.getRuntime().availableProcessors()
+        val threadFactory = ForkJoinWorkerThreadFactory { pool ->
+            val thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool)
+            ThreadTracker.longRunningThreadCreated(this, thread.name)
+            thread
+        }
+        return ForkJoinPool(parallelism, threadFactory, null, true)
+    }
+
+    override fun dispose() {
+        pool.shutdown()
+    }
+
+    companion object {
+        fun get(): ExecutorService = service<ResolveCommonThreadPool>().pool
+    }
+}


### PR DESCRIPTION
Previously we have static thread pool in `MacroExpansionService` which was used in name resolution, and sometimes we create new thread pool for name resolution. Now single thread pool will be used always.