### PR TITLE
Fix #8735 cargo build/test through button failed with no error message.

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -309,7 +309,7 @@ object CargoBuildManager {
             remove("--quiet")
             // If `json-diagnostic-rendered-ansi` is used, `rendered` field of JSON messages contains
             // embedded ANSI color codes for respecting rustc's default color scheme.
-            addFormatJsonOption(this, "--message-format", "json-diagnostic-rendered-ansi")
+            // addFormatJsonOption(this, "--message-format", "json-diagnostic-rendered-ansi")
         }
 
         val oldVariables = commandLine.environmentVariables


### PR DESCRIPTION
I found that if I remove [this line](https://github.com/intellij-rust/intellij-rust/blob/master/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt#L312) of code it works. If this is not appropriate, any better suggestions? 

changelog: Fix cargo build/test through button failed with no error message. #8735 
