### PR TITLE
IDE: Enable converting JSON to Rust struct after paste by default

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteProcessor.kt
@@ -39,8 +39,6 @@ import org.rust.openapiext.toPsiFile
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 
-val CONVERT_JSON_ON_PASTE: RegistryValue = Registry.get("org.rust.ide.json.paste.processor")
-
 class RsConvertJsonToStructCopyPasteProcessor : CopyPastePostProcessor<TextBlockTransferableData>() {
     override fun collectTransferableData(
         file: PsiFile?,
@@ -50,7 +48,6 @@ class RsConvertJsonToStructCopyPasteProcessor : CopyPastePostProcessor<TextBlock
     ): List<TextBlockTransferableData> = emptyList()
 
     override fun extractTransferableData(content: Transferable): List<TextBlockTransferableData> {
-        if (!CONVERT_JSON_ON_PASTE.asBoolean()) return emptyList()
         try {
             if (content.isDataFlavorSupported(DataFlavor.stringFlavor)) {
                 val text = content.getTransferData(DataFlavor.stringFlavor) as String

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1197,8 +1197,6 @@
                      description="Expand macros in parallel"/>
         <registryKey key="org.rust.external.linter.max.duration" defaultValue="3000" restartRequired="false"
                      description="Show notification warning if the external linter is running longer than the set value (ms)"/>
-        <registryKey key="org.rust.ide.json.paste.processor" defaultValue="false" restartRequired="false"
-                     description="Enable converting JSON to Rust struct on paste"/>
 
         <!-- Move refactoring -->
 

--- a/src/test/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteTest.kt
@@ -759,11 +759,6 @@ class RsConvertJsonToStructCopyPasteTest : RsTestBase() {
   ]
 }""")
 
-    override fun setUp() {
-        super.setUp()
-        CONVERT_JSON_ON_PASTE.setValue(true, testRootDisposable)
-    }
-
     private fun doCopyPasteTest(
         @Language("Rust") before: String,
         @Language("Rust") after: String,

--- a/src/test/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteToolchainTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteToolchainTest.kt
@@ -101,11 +101,6 @@ class RsConvertJsonToStructCopyPasteToolchainTest : RsWithToolchainTestBase() {
     """, """{"a": {"b": true}}"""
     )
 
-    override fun setUp() {
-        super.setUp()
-        CONVERT_JSON_ON_PASTE.setValue(true, testRootDisposable)
-    }
-
     private fun doCopyPasteTest(
         @Language("Rust") before: String,
         @Language("Rust") after: String,


### PR DESCRIPTION
I took the changelog from #7816

changelog: You can now paste JSON objects into Rust files and convert them to a Rust struct.
