### PR TITLE
UI: Take into account line breaks in rustfmt errors

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
@@ -147,7 +147,8 @@ class Rustfmt(toolchain: RsToolchainBase) : RustupComponent(NAME, toolchain) {
         private fun RsProcessExecutionException.showRustfmtError(project: Project) {
             val message = message.orEmpty().trimEnd('\n')
             if (message.isNotEmpty()) {
-                project.showBalloon("Rustfmt", message, NotificationType.ERROR, RustfmtEditSettingsAction("Show settings..."))
+                val html = "<html>${message.escaped.replace("\n", "<br>")}</html>"
+                project.showBalloon("Rustfmt", html, NotificationType.ERROR, RustfmtEditSettingsAction("Show settings..."))
             }
         }
     }


### PR DESCRIPTION
changelog: Take into account line breaks in `rustfmt` errors

Before:

<img width="416" alt="Screen Shot 2022-04-21 at 17 37 49" src="https://user-images.githubusercontent.com/6079006/164482985-fbc0f367-8c8a-4df6-b058-4f63a34fa59c.png">

After:

<img width="403" alt="Screen Shot 2022-04-21 at 17 38 42" src="https://user-images.githubusercontent.com/6079006/164483002-30dd5519-2106-40e7-ae86-366099a35b39.png">
