### PR TITLE
ANN: don't highlight safe intrinsics as unsafe

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -147,15 +147,58 @@ val RsFunction.isActuallyUnsafe: Boolean
         val context = context
         return if (context is RsForeignModItem) {
             // functions inside `extern` block are unsafe in most cases
-            //
-            // #[wasm_bindgen] is a procedural macro that removes the following
-            // extern block, so all function inside it become safe.
-            // See https://github.com/rustwasm/wasm-bindgen
-            !context.queryAttributes.hasAttribute("wasm_bindgen")
+            when {
+                // #[wasm_bindgen] is a procedural macro that removes the following
+                // extern block, so all function inside it become safe.
+                // See https://github.com/rustwasm/wasm-bindgen
+                context.queryAttributes.hasAttribute("wasm_bindgen") -> false
+                // Some Rust intrinsics are safe. This info is hardcoded in compiler
+                context.externAbi.litExpr?.stringValue == "rust-intrinsic" -> name !in SAFE_INTRINSICS
+                else -> true
+            }
         } else {
             false
         }
     }
+
+// Taken from https://github.com/rust-lang/rust/blob/6b4563bf93f4b103ed22507ed825008b89e4f5d9/compiler/rustc_typeck/src/check/intrinsic.rs#L65-L108
+private val SAFE_INTRINSICS: Set<String> = hashSetOf(
+    "abort",
+    "size_of",
+    "min_align_of",
+    "needs_drop",
+    "caller_location",
+    "add_with_overflow",
+    "sub_with_overflow",
+    "mul_with_overflow",
+    "wrapping_add",
+    "wrapping_sub",
+    "wrapping_mul",
+    "saturating_add",
+    "saturating_sub",
+    "rotate_left",
+    "rotate_right",
+    "ctpop",
+    "ctlz",
+    "cttz",
+    "bswap",
+    "bitreverse",
+    "discriminant_value",
+    "type_id",
+    "likely",
+    "unlikely",
+    "ptr_guaranteed_eq",
+    "ptr_guaranteed_ne",
+    "minnumf32",
+    "minnumf64",
+    "maxnumf32",
+    "rustc_peek",
+    "maxnumf64",
+    "type_name",
+    "forget",
+    "black_box",
+    "variant_count",
+)
 
 val RsFunction.isBangProcMacroDef: Boolean
     get() = queryAttributes.hasAtomAttribute("proc_macro")

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionErrorAnnotatorTest.kt
@@ -168,4 +168,27 @@ class RsUnsafeExpressionErrorAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpress
             asm!();
         }
     """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test unsafe intrinsics`() = checkErrors("""
+        #![feature(core_intrinsics)]
+
+        use std::intrinsics::atomic_fence;
+
+        fn main() {
+            <error descr="Call to unsafe function requires unsafe function or block [E0133]">atomic_fence()</error>;
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test safe intrinsics`() = checkErrors("""
+        #![feature(core_intrinsics)]
+
+        use std::intrinsics::{add_with_overflow, likely};
+
+        fn main() {
+            if likely(true) {}
+            let x = add_with_overflow(1, 2);
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #3129

changelog: Don't highlight safe [intrinsics](https://doc.rust-lang.org/std/intrinsics/index.html) as unsafe
