### PR TITLE
Allow configuring experimental features for Rust plugin via Java properties

### DIFF
--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -386,7 +386,17 @@ val DataContext.elementUnderCaretInEditor: PsiElement?
         return psiFile.findElementAt(editor.caretModel.offset)
     }
 
-fun isFeatureEnabled(featureId: String): Boolean = Experiments.getInstance().isFeatureEnabled(featureId)
+fun isFeatureEnabled(featureId: String): Boolean {
+    // Hack to pass values of experimental features in headless IDE run
+    // Should help to configure IDE-based tools like Qodana
+    if (isHeadlessEnvironment) {
+        val value = System.getProperty(featureId)?.toBooleanStrictOrNull()
+        if (value != null) return value
+    }
+
+    return Experiments.getInstance().isFeatureEnabled(featureId)
+}
+
 fun setFeatureEnabled(featureId: String, enabled: Boolean) = Experiments.getInstance().setFeatureEnabled(featureId, enabled)
 
 fun <T> runWithEnabledFeatures(vararg featureIds: String, action: () -> T): T {


### PR DESCRIPTION
Unfortunately, experimental features are not configured via system properties like registry values. It can be important when you want to use IDE-based tool (like Qodana) that runs IDE in headless mode, and you can't configure it using UI

These changes add a small hack to force values of experimental features used by Rust plugin via system properties - just pass `-D%experimental.feature.key%=%value%` to jvm process