### PR TITLE
TY: improve type inference around call expressions

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -443,12 +443,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkCallExpr(holder: RsAnnotationHolder, o: RsCallExpr) {
-        val path = (o.expr as? RsPathExpr)?.path ?: return
         checkNotCallingDrop(o, holder)
-        val owner = path.reference?.deepResolve() as? RsFieldsOwner ?: return
-        if (owner.tupleFields == null && !owner.implLookup.isAnyFn(owner.asTy())) {
-            RsDiagnostic.ExpectedFunction(o).addToHolder(holder)
-        }
     }
 
     private fun checkTraitRef(holder: RsAnnotationHolder, o: RsTraitRef) {

--- a/src/main/kotlin/org/rust/lang/core/types/RsPsiSubstitution.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RsPsiSubstitution.kt
@@ -21,7 +21,7 @@ open class RsPsiSubstitution(
     val typeSubst: Map<RsTypeParameter, Value<TypeValue, TypeDefault>> = emptyMap(),
     val regionSubst: Map<RsLifetimeParameter, Value<RsLifetime, Nothing>> = emptyMap(),
     val constSubst: Map<RsConstParameter, Value<RsElement, RsExpr>> = emptyMap(),
-    val assoc: Map<RsTypeAlias, RsTypeReference> = emptyMap(),
+    val assoc: Map<RsTypeAlias, AssocValue> = emptyMap(),
 ) {
     sealed class Value<out P, out D> {
         object RequiredAbsent : Value<Nothing, Nothing>()
@@ -35,6 +35,11 @@ open class RsPsiSubstitution(
         class FnSugar(val inputArgs: List<RsTypeReference?>) : TypeValue()
     }
     data class TypeDefault(val value: RsTypeReference, val selfTy: Ty?)
+
+    sealed class AssocValue {
+        class Present(val value: RsTypeReference) : AssocValue()
+        object FnSugarImplicitRet : AssocValue()
+    }
 }
 
 fun RsPsiSubstitution.toSubst(resolver: PathExprResolver? = PathExprResolver.default): Substitution {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -552,6 +552,9 @@ class RsTypeInferenceWalker(
         val derefTy = lookup.coercionSequence(baseTy).mapNotNull {
             lookup.asTyFunction(it)
         }.firstOrNull()
+        if (baseTy != TyUnknown && derefTy == null) {
+            ctx.addDiagnostic(RsDiagnostic.ExpectedFunction(expr))
+        }
         val argExprs = expr.valueArgumentList.exprList
         val calleeType = (derefTy?.register() ?: unknownTyFunction(argExprs.size))
             .foldWith(associatedTypeNormalizer) as TyFunction

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -546,18 +546,14 @@ class RsTypeInferenceWalker(
     }
 
     private fun inferCallExprType(expr: RsCallExpr, expected: Ty?): Ty {
-        val callee = expr.expr
-        val ty = resolveTypeVarsWithObligations(callee.inferType()) // or error
-        // `struct S; S();`
-        if (callee is RsPathExpr) {
-            ctx.getResolvedPath(callee).singleOrNull()?.element?.let {
-                if (it is RsFieldsOwner && it.isFieldless) {
-                    return ty
-                }
-            }
-        }
+        val calleeExpr = expr.expr
+        val baseTy = resolveTypeVarsWithObligations(calleeExpr.inferType()) // or error
+        // TODO add adjustment
+        val derefTy = lookup.coercionSequence(baseTy).mapNotNull {
+            lookup.asTyFunction(it)
+        }.firstOrNull()
         val argExprs = expr.valueArgumentList.exprList
-        val calleeType = (lookup.asTyFunction(ty)?.register() ?: unknownTyFunction(argExprs.size))
+        val calleeType = (derefTy?.register() ?: unknownTyFunction(argExprs.size))
             .foldWith(associatedTypeNormalizer) as TyFunction
         if (expected != null) ctx.combineTypes(expected, calleeType.retType)
         inferArgumentTypes(calleeType.paramTypes, argExprs)

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -2192,40 +2192,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
-    fun `test expected function on a impl FnMut E0618`() = checkErrors("""
-        struct Foo;
-        #[lang = "fn_mut"]
-        trait FnMut<Args> {
-            type Output;
-            fn call(&mut self, args: Args) -> Self::Output;
-        }
-        impl FnMut<()> for Foo {
-            type Output = ();
-            fn call(&mut self, (): ()) {}
-        }
-
-        fn bar() {
-            Foo();
-        }
-    """)
-
-    fun `test expected function on a impl Fn E0618`() = checkErrors("""
-        struct Foo;
-        #[lang = "fn"]
-        trait Fn<Args> {
-            type Output;
-            fn call(&self, args: Args) -> Self::Output;
-        }
-        impl Fn<()> for Foo {
-            type Output = ();
-            fn call(&self, (): ()) {}
-        }
-
-        fn bar() {
-            Foo();
-        }
-    """)
-
     @MockRustcVersion("1.34.0")
     fun `test label_break_value 1`() = checkErrors("""
         fn main() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -551,7 +551,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }
         fn foo<T>(xs: Foo<T>) -> T { unimplemented!() }
         fn main() {
-            let x = foo(Foo(Bar()));
+            let x = foo(Foo(Bar));
             x.bar();
              //^
         }
@@ -570,7 +570,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
 
         fn foo<F1, F2, F3>(x: FooBar<Foo<F1, F2>, Bar<F3>>) -> Foo<F2, F3> { unimplemented!() }
         fn main() {
-            let x = foo(FooBar(Foo(123, "foo"), Bar::V(S())));
+            let x = foo(FooBar(Foo(123, "foo"), Bar::V(S)));
             x.1.bar();
               //^
         }
@@ -592,7 +592,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }
 
         fn main() {
-            let x = Foo(123).foo(Bar::V(S()));
+            let x = Foo(123).foo(Bar::V(S));
             x.1.bar();
               //^
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -532,7 +532,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
               //X
         }
         fn main() {
-            let t = (1, Foo());
+            let t = (1, Foo);
             t.1.foo();
                //^
         }
@@ -546,7 +546,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }
         fn foo<T>(xs: &[T]) -> T { unimplemented!() }
         fn main() {
-            let x = foo(&[Foo(), Foo()]);
+            let x = foo(&[Foo, Foo]);
             x.foo()
              //^
         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -1175,14 +1175,44 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    // TODO
-    fun `test Self tuple struct init`() = testExpr("""
+    fun `test Self tuple struct init 1`() = testExpr("""
         struct S();
         impl S {
             fn new() {
                 let a = Self();
                 a;
-            } //^ <unknown>
+            } //^ S
+        }
+    """)
+
+    fun `test Self tuple struct init 2`() = testExpr("""
+        struct S(i32);
+        impl S {
+            fn new() {
+                let b = Self;
+                let a = b(1);
+                a;
+            } //^ S
+        }
+    """)
+
+    fun `test Self tuple struct init 3`() = testExpr("""
+        struct S<A>(i32);
+        impl<B> S<B> {
+            fn new() {
+                let a = Self(1);
+                a;
+            } //^ S<B>
+        }
+    """)
+
+    fun `test Self unit struct`() = testExpr("""
+        struct S;
+        impl S {
+            fn new() {
+                let a = Self;
+                a;
+            } //^ S
         }
     """)
 
@@ -1538,7 +1568,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             let b = a();
             b;
         } //^ <unknown>
-    """)
+    """, allowErrors = true)
 
     fun `test call expr with callee of struct without fields type 2`() = testExpr("""
         struct S;
@@ -1546,7 +1576,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = S();
             b;
         } //^ <unknown>
-    """)
+    """, allowErrors = true)
 
     fun `test call expr with callee of struct without fields type 3`() = testExpr("""
         struct S();

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -935,4 +935,13 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ i32
     """)
+
+    fun `test call an fn pointer under Rc`() = stubOnlyTypeInfer("""
+    //- main.rs
+        use std::rc::Rc;
+        fn foo(f: Rc<fn() -> i32>) {
+            let a = f();
+            a;
+        } //^ i32
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -907,4 +907,32 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
           //^ *mut i32
         }
     """)
+
+    fun `test iter map using std identity`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            let a = vec![1, 2]
+                .into_iter()
+                .map(std::convert::identity)
+                .next()
+                .unwrap();
+            a;
+        } //^ i32
+    """)
+
+    fun `test call an fn pointer reference`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn foo(f: &fn() -> i32) {
+            let a = f();
+            a;
+        } //^ i32
+    """)
+
+    fun `test call an fn pointer 2-reference`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn foo(f: &&fn() -> i32) {
+            let a = f();
+            a;
+        } //^ i32
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -944,4 +944,12 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ i32
     """)
+
+    fun `test call type parameter with FnOnce with implicit return type`() = stubOnlyTypeInfer("""
+    //- main.rs
+        pub fn foo<F: FnOnce(i32)>(f: F) -> Self {
+            let a = f(1);
+            a;
+        } //^ ()
+    """)
 }


### PR DESCRIPTION
Not the plugin should support these cases:

```rust
fn foo(f: &&fn() -> i32) {
    let a = f();
    a;
} //^ i32
```

and

```rust
use std::rc::Rc;
fn foo(f: Rc<fn() -> i32>) {
    let a = f();
    a;
} //^ i32
```

and

```rust
struct S();
impl S {
    fn new() {
        let a = Self();
        a;
    } //^ S
}
```

Also, I moved E0618 implementation into the type inference engine, so it should work more precisely. 

Fixes #6682
Fixes #8311