### PR TITLE
RUN: Enable `Emulate terminal in console` option by default in nightly plugin on macOS and Linux

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -44,6 +44,7 @@ import org.rust.cargo.toolchain.tools.Cargo
 import org.rust.cargo.toolchain.tools.isRustupAvailable
 import org.rust.ide.experiments.RsExperiments
 import org.rust.openapiext.isFeatureEnabled
+import org.rust.openapiext.isUnitTestMode
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -68,7 +69,7 @@ class CargoCommandConfiguration(
     var channel: RustChannel = RustChannel.DEFAULT
     var requiredFeatures: Boolean = true
     var allFeatures: Boolean = false
-    var emulateTerminal: Boolean = false
+    var emulateTerminal: Boolean = CargoCommandConfiguration.emulateTerminalDefault
     var withSudo: Boolean = false
     var buildTarget: BuildTarget = BuildTarget.REMOTE
     var backtrace: BacktraceMode = BacktraceMode.SHORT
@@ -349,6 +350,9 @@ class CargoCommandConfiguration(
                 }
             }
         }
+
+        val emulateTerminalDefault: Boolean
+            get() = isFeatureEnabled(RsExperiments.EMULATE_TERMINAL) && (SystemInfo.isLinux || SystemInfo.isMac) && !isUnitTestMode
     }
 }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -98,7 +98,7 @@ class CargoCommandConfigurationEditor(project: Project)
     private val environmentVariables = EnvironmentVariablesComponent()
     private val requiredFeatures = CheckBox("Implicitly add required features if possible", true)
     private val allFeatures = CheckBox("Use all features in tests", false)
-    private val emulateTerminal = CheckBox("Emulate terminal in output console", false)
+    private val emulateTerminal = CheckBox("Emulate terminal in output console", CargoCommandConfiguration.emulateTerminalDefault)
     private val withSudo = CheckBox(
         if (SystemInfo.isWindows) "Run with Administrator privileges" else "Run with root privileges",
         false
@@ -144,7 +144,7 @@ class CargoCommandConfigurationEditor(project: Project)
         configuration.channel = configChannel
         configuration.requiredFeatures = requiredFeatures.isSelected
         configuration.allFeatures = allFeatures.isSelected
-        configuration.emulateTerminal = emulateTerminal.isSelected && !SystemInfo.isWindows
+        configuration.emulateTerminal = emulateTerminal.isSelected && SystemInfo.isUnix
         configuration.withSudo = withSudo.isSelected
         configuration.buildTarget = if (buildOnRemoteTarget.isSelected) BuildTarget.REMOTE else BuildTarget.LOCAL
         configuration.backtrace = BacktraceMode.fromIndex(backtraceMode.selectedIndex)
@@ -173,7 +173,7 @@ class CargoCommandConfigurationEditor(project: Project)
         row { requiredFeatures() }
         row { allFeatures() }
 
-        if (!SystemInfo.isWindows) {
+        if (SystemInfo.isUnix) {
             row { emulateTerminal() }
         }
         row { withSudo() }

--- a/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
@@ -17,6 +17,7 @@ import org.rust.RsBundle
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.runconfig.createCargoCommandRunConfiguration
 import org.rust.cargo.runconfig.wasmpack.WasmPackCommandConfiguration
@@ -79,7 +80,7 @@ data class CargoCommandLine(
     val environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT,
     val requiredFeatures: Boolean = true,
     val allFeatures: Boolean = false,
-    val emulateTerminal: Boolean = false,
+    val emulateTerminal: Boolean = CargoCommandConfiguration.emulateTerminalDefault,
     val withSudo: Boolean = false
 ) : RsCommandLineBase() {
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
@@ -9,7 +9,6 @@ import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.PtyCommandLine
 import com.intellij.execution.wsl.WslPath
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.io.exists
 import com.intellij.util.net.HttpConfigurable
 import org.rust.cargo.CargoConstants
@@ -105,9 +104,7 @@ abstract class RsToolchainBase(val location: Path) {
         environmentVariables.configureCommandLine(commandLine, true)
 
         if (emulateTerminal) {
-            if (!SystemInfo.isWindows) {
-                commandLine.environment["TERM"] = "xterm-256color"
-            }
+            commandLine.environment["TERM"] = "xterm-256color"
             commandLine = PtyCommandLine(commandLine).withInitialColumns(PtyCommandLine.MAX_COLUMNS)
         }
 

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -29,6 +29,8 @@ object RsExperiments {
 
     @EnabledInStable
     const val WSL_TOOLCHAIN = "org.rust.wsl"
+
+    const val EMULATE_TERMINAL = "org.rust.cargo.emulate.terminal"
 }
 
 /**

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -21,5 +21,8 @@
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="100">
             <description>Enables crates local index</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.cargo.emulate.terminal" percentOfUsers="100">
+            <description>Emulate terminal in output console by default</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -21,5 +21,8 @@
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="100">
             <description>Enables crates local index</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.cargo.emulate.terminal" percentOfUsers="0">
+            <description>Emulate terminal in output console by default</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
changelog: Enable `Emulate terminal in console` option by default in the nightly version of the plugin on macOS and Linux
