### PR TITLE
Fix integration with EduTools plugin

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -56,8 +56,10 @@ val CargoCommandConfiguration.hasRemoteTarget: Boolean
  * This class describes a Run Configuration.
  * It is basically a bunch of values which are persisted to .xml files inside .idea,
  * or displayed in the GUI form. It has to be mutable to satisfy various IDE's APIs.
+ *
+ * Class is open not to break [EduTools](https://plugins.jetbrains.com/plugin/10081-edutools) plugin
  */
-class CargoCommandConfiguration(
+open class CargoCommandConfiguration(
     project: Project,
     name: String,
     factory: ConfigurationFactory

--- a/src/test/kotlin/org/rust/cargo/runconfig/command/TestCargoCommandConfiguration.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/command/TestCargoCommandConfiguration.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.command
+
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.openapi.project.Project
+
+/**
+ * Checks that `CargoCommandConfiguration` is open
+ * not to break other plugins that has child classes like [EduTools](https://plugins.jetbrains.com/plugin/10081-edutools) plugin
+ */
+@Suppress("unused")
+class TestCargoCommandConfiguration(
+    project: Project,
+    name: String,
+    factory: ConfigurationFactory
+) : CargoCommandConfiguration(project, name, factory)


### PR DESCRIPTION
Make `CargoCommandConfiguration` open not to break [EduTools](https://plugins.jetbrains.com/plugin/10081-edutools) plugin integration with Rust plugin that was broken in #6836
Also add `TestCargoCommandConfiguration` child class to prevent similar bugs in the future


changelog: Fix integration of [EduTools](https://plugins.jetbrains.com/plugin/10081-edutools) plugin with Rust plugin
