### PR TITLE
RUN: Use proper terminal if `Emulate terminal in output console` option is enabled

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -6,7 +6,6 @@
 package org.rust.cargo.runconfig
 
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.psi.search.ExecutionSearchScopes
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.console.CargoConsoleBuilder
 
@@ -16,8 +15,7 @@ class CargoRunState(
     config: CargoCommandConfiguration.CleanConfiguration.Ok
 ) : CargoRunStateBase(environment, runConfiguration, config) {
     init {
-        val scope = ExecutionSearchScopes.executionScope(project, environment.runProfile)
-        consoleBuilder = CargoConsoleBuilder(project, scope)
+        consoleBuilder = CargoConsoleBuilder(project, runConfiguration)
         createFilters(cargoProject).forEach { consoleBuilder.addFilter(it) }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -354,7 +354,7 @@ open class CargoCommandConfiguration(
         }
 
         val emulateTerminalDefault: Boolean
-            get() = isFeatureEnabled(RsExperiments.EMULATE_TERMINAL) && (SystemInfo.isLinux || SystemInfo.isMac) && !isUnitTestMode
+            get() = isFeatureEnabled(RsExperiments.EMULATE_TERMINAL) && !isUnitTestMode
     }
 }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleBuilder.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleBuilder.kt
@@ -12,12 +12,22 @@ import com.intellij.execution.filters.TextConsoleBuilderImpl
 import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil
 import com.intellij.execution.ui.ConsoleView
 import com.intellij.openapi.project.Project
-import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.ExecutionSearchScopes
+import com.intellij.terminal.TerminalExecutionConsole
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
 import org.rust.cargo.runconfig.test.CargoTestConsoleProperties.Companion.TEST_FRAMEWORK_NAME
 
-open class CargoConsoleBuilder(project: Project, scope: GlobalSearchScope) : TextConsoleBuilderImpl(project, scope) {
-    override fun createConsole(): ConsoleView = CargoConsoleView(project, scope, isViewer, true)
+open class CargoConsoleBuilder(
+    project: Project,
+    val config: CargoCommandConfiguration
+) : TextConsoleBuilderImpl(project, ExecutionSearchScopes.executionScope(project, config)) {
+    override fun createConsole(): ConsoleView =
+        if (config.emulateTerminal && !config.hasRemoteTarget) {
+            TerminalExecutionConsole(project, null)
+        } else {
+            CargoConsoleView(project, scope, isViewer, true)
+        }
 }
 
 class CargoTestConsoleBuilder(

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -144,7 +144,7 @@ class CargoCommandConfigurationEditor(project: Project)
         configuration.channel = configChannel
         configuration.requiredFeatures = requiredFeatures.isSelected
         configuration.allFeatures = allFeatures.isSelected
-        configuration.emulateTerminal = emulateTerminal.isSelected && SystemInfo.isUnix
+        configuration.emulateTerminal = emulateTerminal.isSelected
         configuration.withSudo = withSudo.isSelected
         configuration.buildTarget = if (buildOnRemoteTarget.isSelected) BuildTarget.REMOTE else BuildTarget.LOCAL
         configuration.backtrace = BacktraceMode.fromIndex(backtraceMode.selectedIndex)
@@ -172,10 +172,7 @@ class CargoCommandConfigurationEditor(project: Project)
 
         row { requiredFeatures() }
         row { allFeatures() }
-
-        if (SystemInfo.isUnix) {
-            row { emulateTerminal() }
-        }
+        row { emulateTerminal() }
         row { withSudo() }
         row { buildOnRemoteTarget() }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunState.kt
@@ -5,9 +5,11 @@
 
 package org.rust.cargo.runconfig.wasmpack
 
+import com.intellij.execution.filters.TextConsoleBuilderImpl
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.ui.ConsoleView
 import com.intellij.psi.search.ExecutionSearchScopes
-import org.rust.cargo.runconfig.console.CargoConsoleBuilder
+import org.rust.cargo.runconfig.console.CargoConsoleView
 import org.rust.cargo.toolchain.tools.WasmPack
 import java.io.File
 
@@ -18,7 +20,9 @@ class WasmPackCommandRunState(
     workingDirectory: File
 ): WasmPackCommandRunStateBase(environment, runConfiguration, wasmPack, workingDirectory) {
     init {
-        val scope = ExecutionSearchScopes.executionScope(environment.project, environment.runProfile)
-        consoleBuilder = CargoConsoleBuilder(environment.project, scope)
+        val scope = ExecutionSearchScopes.executionScope(environment.project, runConfiguration)
+        consoleBuilder = object : TextConsoleBuilderImpl(environment.project, scope) {
+            override fun createConsole(): ConsoleView = CargoConsoleView(project, scope, isViewer, true)
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/intellij-rust/intellij-rust/issues/1973.
Closes https://github.com/intellij-rust/intellij-rust/issues/6867.

The `Emulate terminal in output console` options is taken into account only for simple runs. In other words, it does not affect Build/Test tool windows or Run Targets.

changelog: Use proper terminal if `Emulate terminal in output console` option is enabled. Also, this option is now available on Windows.
