### PR TITLE
Fix exception during indexing in RsCfgNotTestIndex

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsCfgNotTestIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsCfgNotTestIndex.kt
@@ -19,8 +19,9 @@ import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsMetaItemArgs
-import org.rust.lang.core.psi.ext.ancestors
 import org.rust.lang.core.psi.ext.name
+import org.rust.lang.core.psi.ext.stubAncestors
+import org.rust.lang.core.psi.ext.stubParent
 import org.rust.lang.core.psi.rustStructureModificationTracker
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsMetaItemStub
@@ -72,9 +73,9 @@ class RsCfgNotTestIndex : StringStubIndexExtension<RsMetaItem>() {
         @VisibleForTesting
         fun isCfgNotTest(psi: RsMetaItem): Boolean {
             if (psi.name != "test") return false
-            val parent = psi.parent as? RsMetaItemArgs ?: return false
-            val not = parent.ancestors.find { it is RsMetaItem && it.name == "not" } ?: return false
-            return not.ancestors.any { it is RsMetaItem && RsPsiPattern.anyCfgCondition.accepts(it) }
+            val parent = psi.stubParent as? RsMetaItemArgs ?: return false
+            val not = parent.stubAncestors.find { it is RsMetaItem && it.name == "not" } ?: return false
+            return not.stubAncestors.any { it is RsMetaItem && RsPsiPattern.anyCfgCondition.accepts(it) }
         }
     }
 }


### PR DESCRIPTION

<details>
  <summary>Stacktrace</summary>
  
  ```
  java.lang.AssertionError: file=FILE; tree=Element(FILE)
 each of class class org.rust.lang.core.psi.impl.RsBlockImpl; valid=true; ref=com.intellij.psi.impl.source.SubstrateRef$StubRef@135b2bf9
 each of class class org.rust.lang.core.psi.impl.RsBlockImpl; valid=true; ref=com.intellij.psi.impl.source.SubstrateRef$StubRef@e8579b5
 each of class class org.rust.lang.core.psi.impl.RsFunctionImpl; valid=true; ref=com.intellij.psi.impl.source.SubstrateRef$StubRef@5fe21154
 each of class class org.rust.lang.core.psi.impl.RsMembersImpl; valid=true; ref=com.intellij.psi.impl.source.SubstrateRef$StubRef@49911eb6
 each of class class org.rust.lang.core.psi.impl.RsImplItemImpl; valid=true; ref=com.intellij.psi.impl.source.SubstrateRef$StubRef@3dff09e
 each of class class org.rust.lang.core.psi.RsFile; valid=true; same file=true; current tree= Element(FILE); stubTree=null; physical=false
 each stub RsPlaceholderStub
 each stub RsPlaceholderStub
 each stub RsFunctionStub
 each stub RsPlaceholderStub
 each stub RsImplItemStub
 each stub RsFileStub(file='FILE', invalidationReason=null, stubRoots='[RsFileStub]', stubTree='null')
	at com.intellij.extapi.psi.StubBasedPsiElementBase.notBoundInExistingAst(StubBasedPsiElementBase.java:212)
	at com.intellij.extapi.psi.StubBasedPsiElementBase.getNode(StubBasedPsiElementBase.java:125)
	at com.intellij.extapi.psi.StubBasedPsiElementBase.getParent(StubBasedPsiElementBase.java:319)
	at org.rust.lang.core.psi.ext.PsiElementKt$ancestors$1.invoke(PsiElement.kt:33)
	at org.rust.lang.core.psi.ext.PsiElementKt$ancestors$1.invoke(PsiElement.kt:32)
	at kotlin.sequences.GeneratorSequence$iterator$1.calcNext(Sequences.kt:591)
	at kotlin.sequences.GeneratorSequence$iterator$1.hasNext(Sequences.kt:609)
	at org.rust.lang.core.stubs.index.RsCfgNotTestIndex$Companion.isCfgNotTest(RsCfgNotTestIndex.kt:76)
	at org.rust.lang.core.stubs.index.RsCfgNotTestIndex$Companion.index(RsCfgNotTestIndex.kt:44)
	at org.rust.lang.core.stubs.StubIndexingKt.indexMetaItem(StubIndexing.kt:105)
	at org.rust.lang.core.stubs.RsMetaItemStub$Type.indexStub(StubImplementations.kt:1800)
	at org.rust.lang.core.stubs.RsMetaItemStub$Type.indexStub(StubImplementations.kt:1783)
	at com.intellij.psi.stubs.ObjectStubTree.indexStubTree(ObjectStubTree.java:57)
	at com.intellij.psi.stubs.SerializedStubTree.indexTree(SerializedStubTree.java:191)
	at com.intellij.psi.stubs.SerializedStubTree.serializeStub(SerializedStubTree.java:60)
	at com.intellij.psi.stubs.StubUpdatingIndex$1.computeValue(StubUpdatingIndex.java:195)
	at com.intellij.psi.stubs.StubUpdatingIndex$1.computeValue(StubUpdatingIndex.java:158)
	at com.intellij.psi.stubs.StubUpdatingIndex$1.computeValue(StubUpdatingIndex.java:125)
	at com.intellij.util.indexing.SingleEntryIndexer.map(SingleEntryIndexer.java:30)
	at com.intellij.util.indexing.SingleEntryIndexer.map(SingleEntryIndexer.java:19)
	at com.intellij.util.indexing.impl.MapReduceIndex.mapByIndexer(MapReduceIndex.java:308)
	at com.intellij.util.indexing.impl.MapReduceIndex.mapInput(MapReduceIndex.java:299)
	at com.intellij.util.indexing.impl.storage.VfsAwareMapReduceIndex.mapInput(VfsAwareMapReduceIndex.java:176)
	at com.intellij.util.indexing.impl.storage.VfsAwareMapReduceIndex.mapInput(VfsAwareMapReduceIndex.java:40)
	at com.intellij.util.indexing.impl.MapReduceIndex.mapInputAndPrepareUpdate(MapReduceIndex.java:244)
	at com.intellij.psi.stubs.StubUpdatingIndexStorage.mapInputAndPrepareUpdate(StubUpdatingIndexStorage.java:62)
	at com.intellij.psi.stubs.StubUpdatingIndexStorage.mapInputAndPrepareUpdate(StubUpdatingIndexStorage.java:21)
	at com.intellij.util.indexing.FileBasedIndexImpl.createSingleIndexValueApplier(FileBasedIndexImpl.java:1593)
	at com.intellij.util.indexing.FileBasedIndexImpl.lambda$doIndexFileContent$27(FileBasedIndexImpl.java:1459)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.freezeFileTypeTemporarilyIn(FileTypeManagerImpl.java:650)
	at com.intellij.util.indexing.FileBasedIndexImpl.doIndexFileContent(FileBasedIndexImpl.java:1406)
	at com.intellij.util.indexing.FileBasedIndexImpl.indexFileContent(FileBasedIndexImpl.java:1382)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.lambda$indexOneFileOfJob$4(IndexUpdateRunner.java:272)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.insideReadAction(NonBlockingReadActionImpl.java:536)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$attemptComputation$3(NonBlockingReadActionImpl.java:501)

  ```
</details>
