### PR TITLE
TY: implement unsizing

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -115,6 +115,7 @@ class KnownItems(
     val Drop: RsTraitItem? get() = findLangItem("drop")
     val Sized: RsTraitItem? get() = findLangItem("sized")
     val Unsize: RsTraitItem? get() = findLangItem("unsize")
+    val CoerceUnsized: RsTraitItem? get() = findLangItem("coerce_unsized")
     val Fn: RsTraitItem? get() = findLangItem("fn")
     val FnMut: RsTraitItem? get() = findLangItem("fn_mut")
     val FnOnce: RsTraitItem? get() = findLangItem("fn_once")

--- a/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
@@ -19,6 +19,7 @@ import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTypeParameter
+import org.rust.lang.core.types.ty.TyUnknown
 
 /**
  * Represents a potentially generic Psi Element, like `fn make_t<T>() { }`,
@@ -63,6 +64,9 @@ val BoundElement<RsGenericDeclaration>.positionalTypeArguments: List<Ty>
 
 val BoundElement<RsGenericDeclaration>.positionalConstArguments: List<Const>
     get() = element.constParameters.map { subst[it] ?: CtConstParameter(it) }
+
+val BoundElement<RsGenericDeclaration>.singleParamValue: Ty
+    get() = element.typeParameters.singleOrNull()?.let { subst[it] } ?: TyUnknown
 
 data class BoundElementWithVisibility<T : RsElement>(
     val inner: BoundElement<T>,

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Expectation.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Expectation.kt
@@ -1,0 +1,104 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.types.infer
+
+import org.rust.lang.core.types.ty.*
+
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * When type-checking an expression, we propagate downward
+ * whatever type hint we are able in the form of an `org.rust.lang.core.types.infer.Expectation`
+ *
+ * Follows https://github.com/rust-lang/rust/blob/master/compiler/rustc_typeck/src/check/expectation.rs#L11
+ */
+sealed class Expectation {
+    /** We know nothing about what type this expression should have */
+    object NoExpectation : Expectation()
+
+    /** This expression should have the type given (or some subtype) */
+    class ExpectHasType(val ty: Ty) : Expectation()
+
+    /** This expression will be cast to the `Ty` */
+    class ExpectCastableToType(val ty: Ty) : Expectation()
+
+    /**
+     * This rvalue expression will be wrapped in `&` or `Box` and coerced
+     * to `&Ty` or `Box<Ty>`, respectively. `Ty` is `[A]` or `Trait`
+     */
+    class ExpectRvalueLikeUnsized(val ty: Ty) : Expectation()
+
+    private fun resolve(ctx: RsInferenceContext): Expectation {
+        return when (this) {
+            is ExpectHasType -> ExpectHasType(ctx.resolveTypeVarsIfPossible(ty))
+            is ExpectCastableToType -> ExpectCastableToType(ctx.resolveTypeVarsIfPossible(ty))
+            is ExpectRvalueLikeUnsized -> ExpectRvalueLikeUnsized(ctx.resolveTypeVarsIfPossible(ty))
+            else -> this
+        }
+    }
+
+    fun tyAsNullable(ctx: RsInferenceContext): Ty? {
+        return when (val resolved = this.resolve(ctx)) {
+            is ExpectHasType -> resolved.ty
+            is ExpectCastableToType -> resolved.ty
+            is ExpectRvalueLikeUnsized -> resolved.ty
+            else -> null
+        }
+    }
+
+    /**
+     * It sometimes happens that we want to turn an expectation into
+     * a **hard constraint** (i.e., something that must be satisfied
+     * for the program to type-check). `only_has_type` will return
+     * such a constraint, if it exists
+     */
+    fun onlyHasTy(ctx: RsInferenceContext): Ty? {
+        return when (this) {
+            is ExpectHasType -> ctx.resolveTypeVarsIfPossible(ty)
+            else -> null
+        }
+    }
+
+    companion object {
+        /**
+         * Provides an expectation for an rvalue expression given an *optional*
+         * hint, which is not required for type safety (the resulting type might
+         * be checked higher up, as is the case with `&expr` and `box expr`), but
+         * is useful in determining the concrete type.
+         *
+         * The primary use case is where the expected type is a fat pointer,
+         * like `&[isize]`. For example, consider the following statement:
+         *
+         *    let x: &[isize] = &[1, 2, 3];
+         *
+         * In this case, the expected type for the `&[1, 2, 3]` expression is
+         * `&[isize]`. If however we were to say that `[1, 2, 3]` has the
+         * expectation `ExpectHasType([isize])`, that would be too strong --
+         * `[1, 2, 3]` does not have the type `[isize]` but rather `[isize; 3]`.
+         * It is only the `&[1, 2, 3]` expression as a whole that can be coerced
+         * to the type `&[isize]`. Therefore, we propagate this more limited hint,
+         * which still is useful, because it informs integer literals and the like
+         */
+        fun rvalueHint(ty: Ty): Expectation {
+            return when (ty.structTail()) {
+                is TyUnknown -> NoExpectation
+                is TySlice, is TyTraitObject, is TyStr -> ExpectRvalueLikeUnsized(ty)
+                else -> ExpectHasType(ty)
+            }
+        }
+
+        fun maybeHasType(ty: Ty?): Expectation {
+            return if (ty == null || ty is TyUnknown) {
+                NoExpectation
+            } else {
+                ExpectHasType(ty)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt
@@ -204,6 +204,16 @@ fun <T> TypeFoldable<T>.visitInferTys(visitor: (TyInfer) -> Boolean): Boolean {
     })
 }
 
+fun <T> TypeFoldable<T>.visitTypeParameters(visitor: (TyTypeParameter) -> Boolean): Boolean {
+    return visitWith(object : TypeVisitor {
+        override fun visitTy(ty: Ty): Boolean = when {
+            ty is TyTypeParameter -> visitor(ty)
+            ty.hasTyTypeParameters -> ty.superVisitWith(this)
+            else -> false
+        }
+    })
+}
+
 private data class HasTypeFlagVisitor(val flag: TypeFlags) : TypeVisitor {
     override fun visitTy(ty: Ty): Boolean = BitUtil.isSet(ty.flags, flag)
     override fun visitRegion(region: Region): Boolean = BitUtil.isSet(region.flags, flag)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -17,6 +17,8 @@ import org.rust.lang.core.resolve.ref.pathPsiSubst
 import org.rust.lang.core.resolve.ref.resolvePathRaw
 import org.rust.lang.core.types.*
 import org.rust.lang.core.types.consts.*
+import org.rust.lang.core.types.infer.TypeError.ConstMismatch
+import org.rust.lang.core.types.infer.TypeError.TypeMismatch
 import org.rust.lang.core.types.regions.Region
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.utils.RsDiagnostic
@@ -24,6 +26,10 @@ import org.rust.lang.utils.snapshot.CombinedSnapshot
 import org.rust.lang.utils.snapshot.Snapshot
 import org.rust.openapiext.Testmark
 import org.rust.openapiext.recursionGuard
+import org.rust.stdext.RsResult
+import org.rust.stdext.RsResult.Err
+import org.rust.stdext.RsResult.Ok
+import org.rust.stdext.dequeOf
 import org.rust.stdext.mapToSet
 import org.rust.stdext.zipValues
 
@@ -416,11 +422,11 @@ class RsInferenceContext(
         return res
     }
 
-    fun combineTypes(ty1: Ty, ty2: Ty): CoerceResult {
+    fun combineTypes(ty1: Ty, ty2: Ty): RelateResult {
         return combineTypesResolved(shallowResolve(ty1), shallowResolve(ty2))
     }
 
-    private fun combineTypesResolved(ty1: Ty, ty2: Ty): CoerceResult {
+    private fun combineTypesResolved(ty1: Ty, ty2: Ty): RelateResult {
         return when {
             ty1 is TyInfer.TyVar -> combineTyVar(ty1, ty2)
             ty2 is TyInfer.TyVar -> combineTyVar(ty2, ty1)
@@ -432,7 +438,7 @@ class RsInferenceContext(
         }
     }
 
-    private fun combineTyVar(ty1: TyInfer.TyVar, ty2: Ty): CoerceResult {
+    private fun combineTyVar(ty1: TyInfer.TyVar, ty2: Ty): RelateResult {
         when (ty2) {
             is TyInfer.TyVar -> varUnificationTable.unifyVarVar(ty1, ty2)
             else -> {
@@ -453,31 +459,31 @@ class RsInferenceContext(
                 }
             }
         }
-        return CoerceResult.Ok
+        return Ok(Unit)
     }
 
-    private fun combineIntOrFloatVar(ty1: TyInfer, ty2: Ty): CoerceResult {
+    private fun combineIntOrFloatVar(ty1: TyInfer, ty2: Ty): RelateResult {
         when (ty1) {
             is TyInfer.IntVar -> when (ty2) {
                 is TyInfer.IntVar -> intUnificationTable.unifyVarVar(ty1, ty2)
                 is TyInteger -> intUnificationTable.unifyVarValue(ty1, ty2)
-                else -> return CoerceResult.TypeMismatch(ty1, ty2)
+                else -> return Err(TypeMismatch(ty1, ty2))
             }
             is TyInfer.FloatVar -> when (ty2) {
                 is TyInfer.FloatVar -> floatUnificationTable.unifyVarVar(ty1, ty2)
                 is TyFloat -> floatUnificationTable.unifyVarValue(ty1, ty2)
-                else -> return CoerceResult.TypeMismatch(ty1, ty2)
+                else -> return Err(TypeMismatch(ty1, ty2))
             }
             is TyInfer.TyVar -> error("unreachable")
         }
-        return CoerceResult.Ok
+        return Ok(Unit)
     }
 
-    fun combineTypesNoVars(ty1: Ty, ty2: Ty): CoerceResult =
+    fun combineTypesNoVars(ty1: Ty, ty2: Ty): RelateResult =
         when {
-            ty1 === ty2 -> CoerceResult.Ok
-            ty1 is TyPrimitive && ty2 is TyPrimitive && ty1.javaClass == ty2.javaClass -> CoerceResult.Ok
-            ty1 is TyTypeParameter && ty2 is TyTypeParameter && ty1 == ty2 -> CoerceResult.Ok
+            ty1 === ty2 -> Ok(Unit)
+            ty1 is TyPrimitive && ty2 is TyPrimitive && ty1.javaClass == ty2.javaClass -> Ok(Unit)
+            ty1 is TyTypeParameter && ty2 is TyTypeParameter && ty1 == ty2 -> Ok(Unit)
             ty1 is TyProjection && ty2 is TyProjection && ty1.target == ty2.target && combineBoundElements(ty1.trait, ty2.trait) -> {
                 combineTypes(ty1.type, ty2.type)
             }
@@ -503,48 +509,48 @@ class RsInferenceContext(
             }
             ty1 is TyTraitObject && ty2 is TyTraitObject &&
                 // TODO: Use all trait bounds
-                combineBoundElements(ty1.traits.first(), ty2.traits.first()) -> CoerceResult.Ok
-            ty1 is TyAnon && ty2 is TyAnon && ty1.definition != null && ty1.definition == ty2.definition -> CoerceResult.Ok
-            ty1 is TyNever || ty2 is TyNever -> CoerceResult.Ok
-            else -> CoerceResult.TypeMismatch(ty1, ty2)
+                combineBoundElements(ty1.traits.first(), ty2.traits.first()) -> Ok(Unit)
+            ty1 is TyAnon && ty2 is TyAnon && ty1.definition != null && ty1.definition == ty2.definition -> Ok(Unit)
+            ty1 is TyNever || ty2 is TyNever -> Ok(Unit)
+            else -> Err(TypeMismatch(ty1, ty2))
         }
 
-    fun combineConsts(const1: Const, const2: Const): CoerceResult {
+    fun combineConsts(const1: Const, const2: Const): RelateResult {
         return combineConstsResolved(shallowResolve(const1), shallowResolve(const2))
     }
 
-    private fun combineConstsResolved(const1: Const, const2: Const): CoerceResult =
+    private fun combineConstsResolved(const1: Const, const2: Const): RelateResult =
         when {
             const1 is CtInferVar -> combineConstVar(const1, const2)
             const2 is CtInferVar -> combineConstVar(const2, const1)
             else -> combineConstsNoVars(const1, const2)
         }
 
-    private fun combineConstVar(const1: CtInferVar, const2: Const): CoerceResult {
+    private fun combineConstVar(const1: CtInferVar, const2: Const): RelateResult {
         if (const2 is CtInferVar) {
             constUnificationTable.unifyVarVar(const1, const2)
         } else {
             val const1r = constUnificationTable.findRoot(const1)
             constUnificationTable.unifyVarValue(const1r, const2)
         }
-        return CoerceResult.Ok
+        return Ok(Unit)
     }
 
-    private fun combineConstsNoVars(const1: Const, const2: Const): CoerceResult =
+    private fun combineConstsNoVars(const1: Const, const2: Const): RelateResult =
         when {
-            const1 === const2 -> CoerceResult.Ok
-            const1 is CtUnknown || const2 is CtUnknown -> CoerceResult.Ok
-            const1 is CtUnevaluated || const2 is CtUnevaluated -> CoerceResult.Ok
-            const1 == const2 -> CoerceResult.Ok
-            else -> CoerceResult.ConstMismatch(const1, const2)
+            const1 === const2 -> Ok(Unit)
+            const1 is CtUnknown || const2 is CtUnknown -> Ok(Unit)
+            const1 is CtUnevaluated || const2 is CtUnevaluated -> Ok(Unit)
+            const1 == const2 -> Ok(Unit)
+            else -> Err(ConstMismatch(const1, const2))
         }
 
-    fun combineTypePairs(pairs: List<Pair<Ty, Ty>>): CoerceResult = combinePairs(pairs, ::combineTypes)
+    fun combineTypePairs(pairs: List<Pair<Ty, Ty>>): RelateResult = combinePairs(pairs, ::combineTypes)
 
-    fun combineConstPairs(pairs: List<Pair<Const, Const>>): CoerceResult = combinePairs(pairs, ::combineConsts)
+    fun combineConstPairs(pairs: List<Pair<Const, Const>>): RelateResult = combinePairs(pairs, ::combineConsts)
 
-    private fun <T : Kind> combinePairs(pairs: List<Pair<T, T>>, combine: (T, T) -> CoerceResult): CoerceResult {
-        var canUnify: CoerceResult = CoerceResult.Ok
+    private fun <T : Kind> combinePairs(pairs: List<Pair<T, T>>, combine: (T, T) -> RelateResult): RelateResult {
+        var canUnify: RelateResult = Ok(Unit)
         for ((k1, k2) in pairs) {
             canUnify = combine(k1, k2).and { canUnify }
         }
@@ -568,31 +574,88 @@ class RsInferenceContext(
             combineTypePairs(zipValues(be1.assoc, be2.assoc)).isOk
 
     fun tryCoerce(inferred: Ty, expected: Ty): CoerceResult {
+        if (inferred === expected) {
+            return Ok(CoerceOk())
+        }
+        if (inferred == TyNever) {
+            return Ok(CoerceOk())
+        }
+        if (inferred is TyInfer.TyVar) {
+            return combineTypes(inferred, expected).into()
+        }
+        val unsize = commitIfNotNull { coerceUnsized(inferred, expected) }
+        if (unsize != null) {
+            return Ok(unsize)
+        }
         return when {
-            inferred == TyNever -> CoerceResult.Ok
-            // Coerce array to slice
-            inferred is TyReference && inferred.referenced is TyArray &&
-                expected is TyReference && expected.referenced is TySlice -> {
-                combineTypes(inferred.referenced.base, expected.referenced.elementType)
-            }
             // Coerce reference to pointer
             inferred is TyReference && expected is TyPointer &&
                 coerceMutability(inferred.mutability, expected.mutability) -> {
-                combineTypes(inferred.referenced, expected.referenced)
+                combineTypes(inferred.referenced, expected.referenced).into()
             }
             // Coerce mutable pointer to const pointer
             inferred is TyPointer && inferred.mutability.isMut
                 && expected is TyPointer && !expected.mutability.isMut -> {
-                combineTypes(inferred.referenced, expected.referenced)
+                combineTypes(inferred.referenced, expected.referenced).into()
             }
             // Coerce references
             inferred is TyReference && expected is TyReference &&
                 coerceMutability(inferred.mutability, expected.mutability) -> {
-                coerceReference(inferred, expected)
+                coerceReference(inferred, expected).into()
             }
-            // TODO trait object unsizing
-            else -> combineTypes(inferred, expected)
+            else -> combineTypes(inferred, expected).into()
         }
+    }
+
+    // &[T; n] or &mut [T; n] -> &[T]
+    // or &mut [T; n] -> &mut [T]
+    // or &Concrete -> &Trait, etc.
+    // Mirrors rustc's `coerce_unsized`
+    // https://github.com/rust-lang/rust/blob/97d48bec2d/compiler/rustc_typeck/src/check/coercion.rs#L486
+    private fun coerceUnsized(source: Ty, target: Ty): CoerceOk? {
+        if (source is TyInfer.TyVar || target is TyInfer.TyVar) return null
+        val unsizeTrait = items.Unsize ?: return null
+        val coerceUnsizedTrait = items.CoerceUnsized ?: return null
+        val traits = listOf(unsizeTrait, coerceUnsizedTrait)
+
+        // TODO reborrow
+
+        val resultObligations = mutableListOf<Obligation>()
+
+        val queue = dequeOf(Obligation(Predicate.Trait(TraitRef(source, coerceUnsizedTrait.withSubst(target)))))
+
+        while (!queue.isEmpty()) {
+            val obligation = queue.removeFirst()
+            val predicate = resolveTypeVarsIfPossible(obligation.predicate)
+            if (predicate is Predicate.Trait && predicate.trait.trait.element in traits) {
+                when (val selection = lookup.select(predicate.trait, obligation.recursionDepth)) {
+                    SelectionResult.Err -> return null
+                    is SelectionResult.Ok -> queue += selection.result.nestedObligations
+                    SelectionResult.Ambiguous -> if (predicate.trait.trait.element == unsizeTrait) {
+                        val selfTy = predicate.trait.selfTy
+                        val unsizeTy = predicate.trait.trait.singleParamValue
+                        if (selfTy is TyInfer.TyVar && unsizeTy is TyTraitObject && typeVarIsSized(selfTy)) {
+                            resultObligations += obligation
+                        } else {
+                            return null
+                        }
+                    } else {
+                        return null
+                    }
+                }
+            } else {
+                resultObligations += obligation
+                continue
+            }
+        }
+
+        return CoerceOk(resultObligations)
+    }
+
+    private fun typeVarIsSized(ty: TyInfer.TyVar): Boolean {
+        return fulfill.pendingObligations
+            .mapNotNull { it.obligation.predicate as? Predicate.Trait }
+            .any { it.trait.selfTy == ty && it.trait.trait.element == items.Sized }
     }
 
     private fun coerceMutability(from: Mutability, to: Mutability): Boolean =
@@ -602,14 +665,14 @@ class RsInferenceContext(
      * Reborrows `&mut A` to `&mut B` and `&(mut) A` to `&B`.
      * To match `A` with `B`, autoderef will be performed
      */
-    private fun coerceReference(inferred: TyReference, expected: TyReference): CoerceResult {
+    private fun coerceReference(inferred: TyReference, expected: TyReference): RelateResult {
         for (derefTy in lookup.coercionSequence(inferred).drop(1)) {
             // TODO proper handling of lifetimes
             val derefTyRef = TyReference(derefTy, expected.mutability, expected.region)
-            if (combineTypesIfOk(derefTyRef, expected)) return CoerceResult.Ok
+            if (combineTypesIfOk(derefTyRef, expected)) return Ok(Unit)
         }
 
-        return CoerceResult.TypeMismatch(inferred, expected)
+        return Err(TypeMismatch(inferred, expected))
     }
 
     fun <T : TypeFoldable<T>> shallowResolve(value: T): T = value.foldWith(shallowResolver)
@@ -1107,15 +1170,19 @@ data class InferredMethodCallInfo(
 
 }
 
-sealed class CoerceResult {
-    object Ok : CoerceResult()
-    class TypeMismatch(val ty1: Ty, val ty2: Ty) : CoerceResult()
-    class ConstMismatch(val const1: Const, val const2: Const) : CoerceResult()
+typealias RelateResult = RsResult<Unit, TypeError>
 
-    val isOk: Boolean get() = this is Ok
+private inline fun RelateResult.and(rhs: () -> RelateResult): RelateResult = if (isOk) rhs() else this
+
+sealed class TypeError {
+    class TypeMismatch(val ty1: Ty, val ty2: Ty) : TypeError()
+    class ConstMismatch(val const1: Const, val const2: Const) : TypeError()
 }
 
-inline fun CoerceResult.and(rhs: () -> CoerceResult): CoerceResult = if (isOk) rhs() else this
+typealias CoerceResult = RsResult<CoerceOk, TypeError>
+data class CoerceOk(val obligations: List<Obligation> = emptyList())
+
+fun RelateResult.into(): CoerceResult = map { CoerceOk() }
 
 data class ExpectedType(val ty: Ty, val coercable: Boolean = false) : TypeFoldable<ExpectedType> {
     override fun superFoldWith(folder: TypeFolder): ExpectedType = copy(ty = ty.foldWith(folder))
@@ -1137,4 +1204,8 @@ object TypeInferenceMarks {
     object MethodPickCollapseTraits : Testmark()
     object TraitSelectionSpecialization : Testmark()
     object MacroExprDepthLimitReached : Testmark()
+    object UnsizeToTraitObject : Testmark()
+    object UnsizeArrayToSlice : Testmark()
+    object UnsizeStruct : Testmark()
+    object UnsizeTuple : Testmark()
 }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -19,6 +19,8 @@ import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.consts.CtInferVar
 import org.rust.lang.core.types.consts.CtUnknown
+import org.rust.lang.core.types.infer.Expectation.ExpectHasType
+import org.rust.lang.core.types.infer.Expectation.NoExpectation
 import org.rust.lang.core.types.regions.ReStatic
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.utils.RsDiagnostic
@@ -55,7 +57,7 @@ class RsTypeInferenceWalker(
         fulfill.selectWherePossible()
     }
 
-    private fun inferBlockExprType(blockExpr: RsBlockExpr, expected: Ty? = null): Ty =
+    private fun inferBlockExprType(blockExpr: RsBlockExpr, expected: Expectation = NoExpectation): Ty =
         when {
             blockExpr.isTry -> inferTryBlockExprType(blockExpr, expected)
             blockExpr.isAsync -> inferAsyncBlockExprType(blockExpr, expected)
@@ -65,11 +67,11 @@ class RsTypeInferenceWalker(
             }
         }
 
-    private fun inferTryBlockExprType(blockExpr: RsBlockExpr, expected: Ty? = null): Ty {
+    private fun inferTryBlockExprType(blockExpr: RsBlockExpr, expected: Expectation = NoExpectation): Ty {
         require(blockExpr.isTry)
         val oldTryTy = tryTy
         try {
-            tryTy = expected ?: TyInfer.TyVar()
+            tryTy = expected.onlyHasTy(ctx) ?: TyInfer.TyVar()
             val resultTy = tryTy ?: TyUnknown
             val okTy = blockExpr.block.inferType()
             registerTryProjection(resultTy, "Ok", okTy)
@@ -79,15 +81,16 @@ class RsTypeInferenceWalker(
         }
     }
 
-    private fun inferAsyncBlockExprType(blockExpr: RsBlockExpr, expected: Ty? = null): Ty {
+    private fun inferAsyncBlockExprType(blockExpr: RsBlockExpr, expected: Expectation = NoExpectation): Ty {
         require(blockExpr.isAsync)
         val retTy = expected
+            .tyAsNullable(ctx)
             ?.let(::resolveTypeVarsWithObligations)
             .takeUnless { it is TyInfer.TyVar }
             ?.lookupFutureOutputTy(lookup)
             ?: TyInfer.TyVar()
         RsTypeInferenceWalker(ctx, retTy).apply {
-            blockExpr.block.inferType(retTy, coerce = true)
+            blockExpr.block.inferType(ExpectHasType(retTy), coerce = true)
         }
         return items.makeFuture(resolveTypeVarsWithObligations(retTy))
     }
@@ -98,16 +101,20 @@ class RsTypeInferenceWalker(
     fun inferLambdaBody(expr: RsExpr): Ty = expr.inferTypeCoercableTo(returnTy)
 
     private fun RsBlock.inferTypeCoercableTo(expected: Ty): Ty =
-        inferType(expected, true)
+        inferType(ExpectHasType(expected), true)
 
-    private fun RsBlock.inferType(expected: Ty? = null, coerce: Boolean = false): Ty {
+    private fun RsBlock.inferType(expected: Expectation = NoExpectation, coerce: Boolean = false): Ty {
         var isDiverging = false
         val (expandedStmts, tailExpr) = expandedStmtsAndTailExpr
         for (stmt in expandedStmts) {
             val result = processStatement(stmt)
             isDiverging = result || isDiverging
         }
-        val type = (if (coerce) tailExpr?.inferTypeCoercableTo(expected!!) else tailExpr?.inferType(expected)) ?: TyUnit.INSTANCE
+        val type = if (coerce && expected is ExpectHasType) {
+            tailExpr?.inferTypeCoercableTo(expected.ty)
+        } else {
+            tailExpr?.inferType(expected)
+        } ?: TyUnit.INSTANCE
         return if (isDiverging) TyNever else type
     }
 
@@ -128,7 +135,7 @@ class RsTypeInferenceWalker(
             // We need to know type before coercion to correctly identify if expr is always diverging
             // so we can't call `inferTypeCoercableTo` directly here
             val (inferredTy, coercedInferredTy) = if (expr != null) {
-                val inferredTy = expr.inferType(explicitTy)
+                val inferredTy = expr.inferType(Expectation.maybeHasType(explicitTy))
                 val coercedTy = if (explicitTy != null && coerce(expr, inferredTy, explicitTy)) {
                     explicitTy
                 } else {
@@ -139,27 +146,30 @@ class RsTypeInferenceWalker(
                 TyUnknown to TyInfer.TyVar()
             }
             psi.pat?.extractBindings(explicitTy ?: resolveTypeVarsWithObligations(coercedInferredTy))
-            psi.letElseBranch?.block?.inferType(TyNever, coerce = true)
+            psi.letElseBranch?.block?.inferType(ExpectHasType(TyNever), coerce = true)
             inferredTy == TyNever
         }
         is RsExprStmt -> psi.expr.inferType() == TyNever
         else -> false
     }
 
-    private fun RsExpr.inferType(expected: Ty? = null): Ty {
+    private fun RsExpr.inferType(expected: Ty?): Ty =
+        inferType(Expectation.maybeHasType(expected))
+
+    private fun RsExpr.inferType(expected: Expectation = NoExpectation): Ty {
         ProgressManager.checkCanceled()
         if (ctx.isTypeInferred(this)) error("Trying to infer expression type twice")
 
-        if (expected != null) {
+        expected.tyAsNullable(ctx)?.let {
             when (this) {
-                is RsPathExpr, is RsDotExpr, is RsCallExpr -> ctx.writeExpectedExprTy(this, expected)
+                is RsPathExpr, is RsDotExpr, is RsCallExpr -> ctx.writeExpectedExprTy(this, it)
             }
         }
 
         val ty = when (this) {
             is RsPathExpr -> inferPathExprType(this)
             is RsStructLiteral -> inferStructLiteralType(this, expected)
-            is RsTupleExpr -> inferRsTupleExprType(this, expected)
+            is RsTupleExpr -> inferTupleExprType(this, expected)
             is RsParenExpr -> expr?.inferType(expected) ?: TyUnknown
             is RsUnitExpr -> TyUnit.INSTANCE
             is RsCastExpr -> inferCastExprType(this)
@@ -192,8 +202,7 @@ class RsTypeInferenceWalker(
     }
 
     private fun RsExpr.inferTypeCoercableTo(expected: Ty): Ty {
-        val inferred = inferType(expected)
-        ctx.writeExpectedExprTyCoercable(this)
+        val inferred = inferType(Expectation.maybeHasType(expected))
         return if (coerce(this, inferred, expected)) expected else inferred
     }
 
@@ -208,8 +217,11 @@ class RsTypeInferenceWalker(
             resolveTypeVarsWithObligations(expected)
         )
 
-    private fun coerceResolved(element: RsElement, inferred: Ty, expected: Ty): Boolean =
-        when (val result = ctx.tryCoerce(inferred, expected)) {
+    private fun coerceResolved(element: RsElement, inferred: Ty, expected: Ty): Boolean {
+        if (element is RsExpr) {
+            ctx.writeExpectedExprTyCoercable(element)
+        }
+        return when (val result = ctx.tryCoerce(inferred, expected)) {
             CoerceResult.Ok -> true
 
             is CoerceResult.TypeMismatch -> {
@@ -225,6 +237,7 @@ class RsTypeInferenceWalker(
                 false
             }
         }
+    }
 
     private fun checkTypeMismatch(result: CoerceResult.TypeMismatch, element: RsElement, inferred: Ty, expected: Ty) {
         if (result.ty1.javaClass in IGNORED_TYS || result.ty2.javaClass in IGNORED_TYS) return
@@ -246,7 +259,7 @@ class RsTypeInferenceWalker(
         }
     }
 
-    private fun inferLitExprType(expr: RsLitExpr, expected: Ty?): Ty {
+    private fun inferLitExprType(expr: RsLitExpr, expected: Expectation): Ty {
         return when (val stubKind = expr.stubKind) {
             is RsStubLiteralKind.Boolean -> TyBool.INSTANCE
             is RsStubLiteralKind.Char -> if (stubKind.isByte) TyInteger.U8.INSTANCE else TyChar.INSTANCE
@@ -262,8 +275,8 @@ class RsTypeInferenceWalker(
             }
             is RsStubLiteralKind.Integer -> {
                 val ty = stubKind.ty
-                ty ?: when (expected) {
-                    is TyInteger -> expected
+                ty ?: when (val ety = expected.tyAsNullable(ctx)) {
+                    is TyInteger -> ety
                     is TyChar -> TyInteger.U8.INSTANCE
                     is TyPointer, is TyFunction -> TyInteger.USize.INSTANCE
                     else -> TyInfer.IntVar()
@@ -271,7 +284,7 @@ class RsTypeInferenceWalker(
             }
             is RsStubLiteralKind.Float -> {
                 val ty = stubKind.ty
-                ty ?: (expected?.takeIf { it is TyFloat } ?: TyInfer.FloatVar())
+                ty ?: (expected.tyAsNullable(ctx)?.takeIf { it is TyFloat } ?: TyInfer.FloatVar())
             }
             null -> TyUnknown
         }
@@ -491,7 +504,7 @@ class RsTypeInferenceWalker(
         // TODO take into account the lifetimes
     }
 
-    private fun inferStructLiteralType(expr: RsStructLiteral, expected: Ty?): Ty {
+    private fun inferStructLiteralType(expr: RsStructLiteral, expected: Expectation): Ty {
         val boundElement = expr.path.reference?.advancedDeepResolve()
 
         if (boundElement == null) {
@@ -513,7 +526,9 @@ class RsTypeInferenceWalker(
 
         val typeParameters = genericDecl?.let { ctx.instantiateBounds(it) } ?: emptySubstitution
         unifySubst(subst, typeParameters)
-        if (expected != null) unifySubst(typeParameters, expected.typeParameterValues)
+        expected.onlyHasTy(ctx)?.let {
+            unifySubst(typeParameters, it.typeParameterValues)
+        }
 
         val type = when (element) {
             is RsStructItem -> element.declaredType
@@ -543,8 +558,11 @@ class RsTypeInferenceWalker(
         }
     }
 
-    private fun inferRsTupleExprType(expr: RsTupleExpr, expected: Ty?): Ty {
-        return TyTuple(inferExprList(expr.exprList, (expected as? TyTuple)?.types))
+    private fun inferTupleExprType(expr: RsTupleExpr, expected: Expectation): Ty {
+        val fields = expected.onlyHasTy(ctx)?.let {
+            (resolveTypeVarsWithObligations(it) as? TyTuple)?.types
+        }
+        return TyTuple(inferExprList(expr.exprList, fields))
     }
 
     private fun inferExprList(exprs: List<RsExpr>, expected: List<Ty>?): List<Ty> {
@@ -557,7 +575,7 @@ class RsTypeInferenceWalker(
         return expr.typeReference.type
     }
 
-    private fun inferCallExprType(expr: RsCallExpr, expected: Ty?): Ty {
+    private fun inferCallExprType(expr: RsCallExpr, expected: Expectation): Ty {
         val calleeExpr = expr.expr
         val baseTy = resolveTypeVarsWithObligations(calleeExpr.inferType()) // or error
         // TODO add adjustment
@@ -568,17 +586,43 @@ class RsTypeInferenceWalker(
             ctx.addDiagnostic(RsDiagnostic.ExpectedFunction(expr))
         }
         val argExprs = expr.valueArgumentList.exprList
-        val calleeType = (derefTy?.register() ?: unknownTyFunction(argExprs.size))
-            .foldWith(associatedTypeNormalizer) as TyFunction
-        if (expected != null) ctx.combineTypes(expected, calleeType.retType)
-        inferArgumentTypes(calleeType.paramTypes, argExprs)
+        val calleeType = ctx.resolveTypeVarsIfPossible(
+            (derefTy?.register() ?: unknownTyFunction(argExprs.size))
+                .foldWith(associatedTypeNormalizer)
+        ) as TyFunction
+        val expectedInputTys = expectedInputsForExpectedOutput(expected, calleeType.retType, calleeType.paramTypes)
+        inferArgumentTypes(calleeType.paramTypes, expectedInputTys, argExprs)
         return calleeType.retType
+    }
+
+    /**
+     * Unifies the output type with the expected type early, for more coercions
+     * and forward type information on the input expressions
+     */
+    private fun expectedInputsForExpectedOutput(
+        expectedRet: Expectation,
+        formalRet: Ty,
+        formalArgs: List<Ty>,
+    ): List<Ty> {
+        @Suppress("NAME_SHADOWING")
+        val formalRet = resolveTypeVarsWithObligations(formalRet)
+        val retTy = expectedRet.onlyHasTy(ctx) ?: return emptyList()
+        // Rustc does `fudge` instead of `probe` here. But `fudge` seems useless in our simplified type inference
+        // because we don't produce new type variables during unification
+        // https://github.com/rust-lang/rust/blob/50cf76c24bf6f266ca6d253a/compiler/rustc_infer/src/infer/fudge.rs#L98
+        return ctx.probe {
+            if (ctx.combineTypes(retTy, formalRet).isOk) {
+                formalArgs.map { ctx.resolveTypeVarsIfPossible(it) }
+            } else {
+                emptyList()
+            }
+        }
     }
 
     private fun inferMethodCallExprType(
         receiver: Ty,
         methodCall: RsMethodCall,
-        expected: Ty?
+        expected: Expectation
     ): Ty {
         val argExprs = methodCall.valueArgumentList.exprList
         val callee = run {
@@ -592,7 +636,7 @@ class RsTypeInferenceWalker(
         }
         if (callee == null) {
             val methodType = unknownTyFunction(argExprs.size)
-            inferArgumentTypes(methodType.paramTypes, argExprs)
+            inferArgumentTypes(methodType.paramTypes, methodType.paramTypes, argExprs)
             return methodType.retType
         }
 
@@ -628,10 +672,15 @@ class RsTypeInferenceWalker(
         val methodType = (callee.element.type)
             .substitute(newSubst)
             .foldWith(associatedTypeNormalizer) as TyFunction
-        if (expected != null && !callee.element.isAsync) ctx.combineTypes(expected, methodType.retType)
         // drop first element of paramTypes because it's `self` param
         // and it doesn't have value in `methodCall.valueArgumentList.exprList`
-        inferArgumentTypes(methodType.paramTypes.drop(1), argExprs)
+        val formalInputTys = methodType.paramTypes.drop(1)
+        val expectedInputTys = if (!callee.element.isAsync) {
+            expectedInputsForExpectedOutput(expected, methodType.retType, formalInputTys)
+        } else {
+            emptyList()
+        }
+        inferArgumentTypes(formalInputTys, expectedInputTys, argExprs)
         ctx.writeResolvedMethodSubst(methodCall, newSubst, methodType)
 
         return methodType.retType
@@ -724,7 +773,11 @@ class RsTypeInferenceWalker(
     private fun unknownTyFunction(arity: Int): TyFunction =
         TyFunction(generateSequence { TyUnknown }.take(arity).toList(), TyUnknown)
 
-    private fun inferArgumentTypes(argDefs: List<Ty>, argExprs: List<RsExpr>) {
+    private fun inferArgumentTypes(
+        formalInputTys: List<Ty>,
+        expectedInputTys: List<Ty>,
+        argExprs: List<RsExpr>
+    ) {
         // We do this just like rustc, and comments copied from rustc too
 
         // We do this in a pretty awful way: first we typecheck any arguments
@@ -739,15 +792,18 @@ class RsTypeInferenceWalker(
                 selectObligationsWherePossible()
             }
 
-            val argDefsExt = argDefs.asSequence()
-                .map(ctx::resolveTypeVarsIfPossible)
-                // extending argument definitions to be sure that type inference launched for each arg expr
-                .infiniteWithTyUnknown()
-            for ((type, expr) in argDefsExt.zip(argExprs.asSequence().map(::unwrapParenExprs))) {
-                val isLambda = expr is RsLambdaExpr
-                if (isLambda != checkLambdas) continue
+            argExprs.forEachIndexed { index, expr ->
+                val isLambda = unwrapParenExprs(expr) is RsLambdaExpr
+                if (isLambda != checkLambdas) return@forEachIndexed
 
-                expr.inferTypeCoercableTo(type)
+                val formalInputTy = formalInputTys.getOrNull(index) ?: TyUnknown
+                val expectedInputTy = expectedInputTys.getOrNull(index) ?: formalInputTy
+
+                val expectation = Expectation.rvalueHint(expectedInputTy)
+                val inferredTy = expr.inferType(expectation)
+                val coercedTy = resolveTypeVarsWithObligations(expectation.onlyHasTy(ctx) ?: formalInputTy)
+                coerce(expr, inferredTy, coercedTy)
+                ctx.combineTypes(formalInputTy, coercedTy)
             }
         }
     }
@@ -797,7 +853,7 @@ class RsTypeInferenceWalker(
         return raw.substitute(field.selfTy.typeParameterValues).foldWith(associatedTypeNormalizer)
     }
 
-    private fun inferDotExprType(expr: RsDotExpr, expected: Ty?): Ty {
+    private fun inferDotExprType(expr: RsDotExpr, expected: Expectation): Ty {
         val receiver = resolveTypeVarsWithObligations(expr.expr.inferType())
         val methodCall = expr.methodCall
         val fieldLookup = expr.fieldLookup
@@ -839,7 +895,7 @@ class RsTypeInferenceWalker(
         return TyUnit.INSTANCE
     }
 
-    private fun inferMatchExprType(expr: RsMatchExpr, expected: Ty?): Ty {
+    private fun inferMatchExprType(expr: RsMatchExpr, expected: Expectation): Ty {
         val matchingExprTy = resolveTypeVarsWithObligations(expr.expr?.inferType() ?: TyUnknown)
         val arms = expr.arms
         for (arm in arms) {
@@ -849,7 +905,7 @@ class RsTypeInferenceWalker(
             val guard = arm.matchArmGuard
             if (guard != null) {
                 val expectedGuardTy = if (guard.let == null) TyBool.INSTANCE else null
-                val guardTy = guard.expr?.inferType(expectedGuardTy) ?: TyUnknown
+                val guardTy = guard.expr?.inferType(Expectation.maybeHasType(expectedGuardTy)) ?: TyUnknown
                 guard.pat?.extractBindings(guardTy)
             }
         }
@@ -857,13 +913,13 @@ class RsTypeInferenceWalker(
         return getMoreCompleteType(arms.mapNotNull { it.expr?.let(ctx::getExprType) })
     }
 
-    private fun inferUnaryExprType(expr: RsUnaryExpr, expected: Ty?): Ty {
+    private fun inferUnaryExprType(expr: RsUnaryExpr, expected: Expectation): Ty {
         val innerExpr = expr.expr ?: return TyUnknown
         return when (expr.operatorType) {
-            UnaryOperator.REF -> inferRefType(innerExpr, expected, Mutability.IMMUTABLE)
-            UnaryOperator.REF_MUT -> inferRefType(innerExpr, expected, Mutability.MUTABLE)
-            UnaryOperator.RAW_REF_CONST -> inferRawRefType(innerExpr, expected, Mutability.IMMUTABLE)
-            UnaryOperator.RAW_REF_MUT -> inferRawRefType(innerExpr, expected, Mutability.MUTABLE)
+            UnaryOperator.REF -> inferRefType(innerExpr, expected, Mutability.IMMUTABLE, BorrowKind.REF)
+            UnaryOperator.REF_MUT -> inferRefType(innerExpr, expected, Mutability.MUTABLE, BorrowKind.REF)
+            UnaryOperator.RAW_REF_CONST -> inferRefType(innerExpr, expected, Mutability.IMMUTABLE, BorrowKind.RAW)
+            UnaryOperator.RAW_REF_MUT -> inferRefType(innerExpr, expected, Mutability.MUTABLE, BorrowKind.RAW)
             UnaryOperator.DEREF -> {
                 // expectation must NOT be used for deref
                 val base = resolveTypeVarsWithObligations(innerExpr.inferType())
@@ -876,19 +932,50 @@ class RsTypeInferenceWalker(
             UnaryOperator.MINUS -> innerExpr.inferType(expected)
             UnaryOperator.NOT -> innerExpr.inferType(expected)
             UnaryOperator.BOX -> {
-                val expectedInner = (expected as? TyAdt)?.takeIf { it.item == items.Box }?.typeArguments?.getOrNull(0)
+                val expectedInner = (expected.tyAsNullable(ctx) as? TyAdt)
+                    ?.takeIf { it.item == items.Box }
+                    ?.typeArguments
+                    ?.getOrNull(0)
+                    ?.let { Expectation.rvalueHint(it) }
+                    ?: NoExpectation
                 items.makeBox(innerExpr.inferType(expectedInner))
             }
         }
     }
 
-    private fun inferRefType(expr: RsExpr, expected: Ty?, mutable: Mutability): Ty =
-        TyReference(expr.inferType((expected as? TyReference)?.referenced), mutable) // TODO infer the actual lifetime
+    private fun inferRefType(expr: RsExpr, expected: Expectation, mutable: Mutability, kind: BorrowKind): Ty {
+        val hint = expected.onlyHasTy(ctx)?.let {
+            val referenced = when (it) {
+                is TyReference -> it.referenced
+                is TyPointer -> it.referenced
+                else -> null
+            }
+            if (referenced != null) {
+                val isPlace = when (expr) {
+                    is RsPathExpr, is RsIndexExpr -> true
+                    is RsUnaryExpr -> expr.operatorType == UnaryOperator.DEREF
+                    is RsDotExpr -> expr.fieldLookup != null
+                    else -> false
+                }
+                if (isPlace) {
+                    ExpectHasType(referenced)
+                } else {
+                    Expectation.rvalueHint(referenced)
+                }
+            } else {
+                NoExpectation
+            }
+        } ?: NoExpectation
 
-    private fun inferRawRefType(expr: RsExpr, expected: Ty?, mutable: Mutability): Ty =
-        TyPointer(expr.inferType((expected as? TyPointer)?.referenced), mutable)
+        val ty = expr.inferType(hint)
 
-    private fun inferIfExprType(expr: RsIfExpr, expected: Ty?): Ty {
+        return when (kind) {
+            BorrowKind.REF -> TyReference(ty, mutable) // TODO infer the actual lifetime
+            BorrowKind.RAW -> TyPointer(ty, mutable)
+        }
+    }
+
+    private fun inferIfExprType(expr: RsIfExpr, expected: Expectation): Ty {
         expr.condition?.inferTypes()
         val blockTys = mutableListOf<Ty?>()
         blockTys.add(expr.block?.inferType(expected))
@@ -1095,7 +1182,7 @@ class RsTypeInferenceWalker(
         return result
     }
 
-    private fun inferMacroExprType(macroExpr: RsMacroExpr, expected: Ty?): Ty {
+    private fun inferMacroExprType(macroExpr: RsMacroExpr, expected: Expectation): Ty {
         if (macroExprDepth > DEFAULT_RECURSION_LIMIT) {
             TypeInferenceMarks.MacroExprDepthLimitReached.hit()
             return TyUnknown
@@ -1108,7 +1195,7 @@ class RsTypeInferenceWalker(
         }
     }
 
-    private fun inferMacroExprType0(macroExpr: RsMacroExpr, expected: Ty?): Ty {
+    private fun inferMacroExprType0(macroExpr: RsMacroExpr, expected: Expectation): Ty {
         val macroCall = macroExpr.macroCall
         val name = macroCall.macroName
         val exprArg = macroCall.exprMacroArgument
@@ -1122,7 +1209,7 @@ class RsTypeInferenceWalker(
 
         val vecArg = macroCall.vecMacroArgument
         if (vecArg != null) {
-            val expectedElemTy = (expected as? TyAdt)?.takeIf { it.item == items.Vec }?.typeArguments?.getOrNull(0)
+            val expectedElemTy = (expected.tyAsNullable(ctx) as? TyAdt)?.takeIf { it.item == items.Vec }?.typeArguments?.getOrNull(0)
             val elementType = if (vecArg.semicolon != null) {
                 // vec![value; repeat]
                 run {
@@ -1192,9 +1279,10 @@ class RsTypeInferenceWalker(
         }
     }
 
-    private fun inferLambdaExprType(expr: RsLambdaExpr, expected: Ty?): Ty {
+    private fun inferLambdaExprType(expr: RsLambdaExpr, expected: Expectation): Ty {
         val params = expr.valueParameters
         val expectedFnTy = expected
+            .tyAsNullable(ctx)
             ?.let(this::deduceLambdaType)
             ?: unknownTyFunction(params.size)
         val extendedArgs = expectedFnTy.paramTypes.asSequence().infiniteWithTyUnknown()
@@ -1239,16 +1327,16 @@ class RsTypeInferenceWalker(
         }
     }
 
-    private fun inferArrayType(expr: RsArrayExpr, expected: Ty?): Ty {
-        val expectedElemTy = when (expected) {
-            is TyArray -> expected.base
-            is TySlice -> expected.elementType
+    private fun inferArrayType(expr: RsArrayExpr, expected: Expectation): Ty {
+        val expectedElemTy = when (val ty = expected.tyAsNullable(ctx)) {
+            is TyArray -> ty.base
+            is TySlice -> ty.elementType
             else -> null
         }
         val (elementType, size) = if (expr.semicolon != null) {
             // It is "repeat expr", e.g. `[1; 5]`
             val elementType = expectedElemTy
-                ?.let { expr.initializer?.inferTypeCoercableTo(expectedElemTy) }
+                ?.let { expr.initializer?.inferTypeCoercableTo(it) }
                 ?: expr.initializer?.inferType()
                 ?: return TySlice(TyUnknown)
             val sizeExpr = expr.sizeExpr
@@ -1256,7 +1344,7 @@ class RsTypeInferenceWalker(
             val size = sizeExpr?.evaluate(TyInteger.USize.INSTANCE, PathExprResolver.fromContext(ctx)) ?: CtUnknown
             elementType to size
         } else {
-            val elementTypes = expr.arrayElements?.map { it.inferType(expectedElemTy) }
+            val elementTypes = expr.arrayElements?.map { it.inferType(Expectation.maybeHasType(expectedElemTy)) }
             val size = if (elementTypes != null) {
                 val size = elementTypes.size.toLong()
                 ConstExpr.Value.Integer(size, TyInteger.USize.INSTANCE).toConst()

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -404,4 +404,26 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
             S::<<error descr="mismatched types [E0308]expected `usize`, found `&str`">""</error>>.bar();
         }
     """)
+
+    fun `test no errors about unsizing`() = checkErrors("""
+        #![feature(unsized_tuple_coercion)]
+
+        #[lang = "sized"]  pub trait Sized {}
+        #[lang = "unsize"] pub trait Unsize<T: ?Sized> {}
+        #[lang = "coerce_unsized"] pub trait CoerceUnsized<T: ?Sized> {}
+        impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'a T {}
+
+        struct S<T: ?Sized> {
+            head: i32,
+            tail: T,
+        }
+
+        fn main() {
+            let _: &S<[i32]> = &S { head: 0, tail: [1, 2] };
+            let _: &(i32, [u8]) = &(1, [2, 3]);
+            foo(&bar([1, 2, 3]));
+        }
+        fn foo(_: &[u8]) {}
+        fn bar<T>(t: T) -> T { t }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -952,4 +952,13 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ ()
     """)
+
+    fun `test box unsizing`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            foo(Box::new([1, 2, 3]));
+        }             //^ Box<[u8; 3], Global>|Box<[u8; 3]>
+
+        fn foo(a: Box<[u8]>) {}
+    """)
 }


### PR DESCRIPTION
Fixes #5141, fixes #6484, fixes #4578

changelog: Implement value unsizing in type inference. This fixes false-positive errors like type mismatch between `Box<[u8]>` and `Box<[u8; 4]>`