### PR TITLE
ACT: Fix rendering of assoc type bindings in `Implement members` action

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -737,6 +737,7 @@ class ImportingPsiRenderer(
     override fun appendPathWithoutArgs(sb: StringBuilder, path: RsPath) {
         val pathReferenceName = path.referenceName
         val tryImportPath1 = path.parent !is RsPath &&
+            path.parent !is RsAssocTypeBinding &&
             TyPrimitive.fromPath(path) == null &&
             path.basePath().referenceName != "Self" &&
             path.basePath().typeQual == null

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -1157,6 +1157,40 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test implement assoc type binding`() = doTest("""
+        trait A {
+            type B;
+        }
+
+        trait C<D> {
+            fn e<F: A<B=D>>();
+        }
+
+        struct G;
+        struct H;
+
+        impl C<G> for H {/*caret*/}
+    """, listOf(
+        ImplementMemberSelection("e<F: A<B=D>>()", true)
+    ), """
+        trait A {
+            type B;
+        }
+
+        trait C<D> {
+            fn e<F: A<B=D>>();
+        }
+
+        struct G;
+        struct H;
+
+        impl C<G> for H {
+            fn e<F: A<B=G>>() {
+                todo!()
+            }
+        }
+    """)
+
     fun `test do not implement methods already present`() = doTest("""
         trait T {
             fn f1();


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/8858.

changelog: Fix rendering of assoc type bindings in `Implement members` action
