### PR TITLE
Decouple associated type refinement from `RsPathReference.resolve()`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -904,7 +904,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
         val traitRef = impl.traitRef ?: return
         val typeRef = impl.typeReference ?: return
-        val type = typeRef.type
+        val type = typeRef.normType
         // If type is not fully known, the plugin should produce some another error, like E0412
         if (type.containsTyOfClass(TyUnknown::class.java)) return
         val supertraits = trait.typeParamBounds?.polyboundList?.mapNotNull { it.bound } ?: return
@@ -949,7 +949,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         if (impl.`for` != null) return
         val typeRef = impl.typeReference ?: return
         if (typeRef.skipParens() is RsTraitType) return
-        val type = typeRef.type
+        val type = typeRef.rawType
         if (impl.queryAttributes.langAttribute != null) {
             // There are some special rules for #[lang] items, see:
             // https://doc.rust-lang.org/unstable-book/language-features/lang-items.html)
@@ -981,13 +981,13 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     ) {
         if (trait != trait.knownItems.Drop) return
 
-        if (impl.typeReference?.type is TyAdt?) return
+        if (impl.typeReference?.normType is TyAdt?) return
 
         RsDiagnostic.ImplDropForNonAdtError(traitRef).addToHolder(holder)
     }
 
     private fun checkImplBothCopyAndDrop(holder: RsAnnotationHolder, impl: RsImplItem, trait: RsTraitItem) {
-        checkImplBothCopyAndDrop(holder, impl.typeReference?.type ?: return, impl.traitRef ?: return, trait)
+        checkImplBothCopyAndDrop(holder, impl.typeReference?.normType ?: return, impl.traitRef ?: return, trait)
     }
 
     private fun checkImplBothCopyAndDrop(holder: RsAnnotationHolder, attr: RsAttr) {
@@ -1014,11 +1014,11 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         RsDiagnostic.ImplBothCopyAndDropError(element).addToHolder(holder)
     }
 
-    // E0116: Cannot define inherent `impl` for a type outside of the crate where the type is defined
+    // E0116: Cannot define inherent `impl` for a type outside the crate where the type is defined
     private fun checkInherentImplSameCrate(holder: RsAnnotationHolder, impl: RsImplItem) {
         if (impl.traitRef != null) return  // checked in [checkTraitImplOrphanRules]
         val typeReference = impl.typeReference ?: return
-        val element = when (val type = typeReference.type) {
+        val element = when (val type = typeReference.rawType) {
             is TyAdt -> type.item
             is TyTraitObject -> type.traits.first().element
             else -> return
@@ -1224,7 +1224,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             is RsFunction -> {
                 // Check if signature matches `fn(isize, *const *const u8) -> isize`
                 val params = owner.valueParameters
-                if (owner.returnType !is TyInteger.ISize) {
+                if (owner.normReturnType !is TyInteger.ISize) {
                     RsDiagnostic.InvalidStartAttrError.ReturnMismatch(owner.retType?.typeReference ?: owner.identifier)
                         .addToHolder(holder)
                 }
@@ -1235,11 +1235,11 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
                     // with errors
                     return
                 }
-                if (params[0].typeReference?.type !is TyInteger.ISize) {
+                if (params[0].typeReference?.normType !is TyInteger.ISize) {
                     RsDiagnostic.InvalidStartAttrError.InvalidParam(params[0].typeReference ?: params[0], 0)
                         .addToHolder(holder)
                 }
-                if (params[1].typeReference?.type?.isEquivalentTo(TyPointer(
+                if (params[1].typeReference?.normType?.isEquivalentTo(TyPointer(
                         TyPointer(TyInteger.U8.INSTANCE, Mutability.IMMUTABLE),
                         Mutability.IMMUTABLE
                     )) == false
@@ -1314,9 +1314,9 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     private fun checkRetExpr(holder: RsAnnotationHolder, ret: RsRetExpr) {
         if (ret.expr != null) return
         val fn = ret.ancestors.find {
-            it is RsFunction || it is RsLambdaExpr || it is RsBlockExpr && it.isAsync
+            it is RsFunctionOrLambda || it is RsBlockExpr && it.isAsync
         } as? RsFunction ?: return
-        val retType = fn.retType?.typeReference?.type ?: return
+        val retType = fn.retType?.typeReference?.normType ?: return
         if (retType is TyUnit) return
         RsDiagnostic.ReturnMustHaveValueError(ret).addToHolder(holder)
     }
@@ -1543,7 +1543,8 @@ private fun checkConstGenerics(holder: RsAnnotationHolder, constParameter: RsCon
     checkConstArguments(holder, listOfNotNull(constParameter.expr))
 
     val typeReference = constParameter.typeReference
-    val ty = typeReference?.type ?: return
+    // Currently, associated type projections can't be used as a const parameter type, so `rawType` is fine here
+    val ty = typeReference?.rawType ?: return
     if (ty !is TyInteger && ty !is TyBool && ty !is TyChar) {
         ADT_CONST_PARAMS.check(holder, typeReference, "adt const params")
     }
@@ -1771,14 +1772,14 @@ private fun checkTypesAreSized(holder: RsAnnotationHolder, fn: RsFunction) {
 
     for (arg in arguments) {
         val typeReference = arg.typeReference ?: continue
-        val ty = typeReference.type
+        val ty = typeReference.normType
         if (isError(ty)) {
             RsDiagnostic.SizedTraitIsNotImplemented(typeReference, ty).addToHolder(holder)
         }
     }
 
     val typeReference = retType?.typeReference ?: return
-    val ty = typeReference.type
+    val ty = typeReference.normType
     if (isError(ty)) {
         RsDiagnostic.SizedTraitIsNotImplemented(typeReference, ty).addToHolder(holder)
     }
@@ -1787,7 +1788,7 @@ private fun checkTypesAreSized(holder: RsAnnotationHolder, fn: RsFunction) {
 private fun checkEmptyFunctionReturnType(holder: RsAnnotationHolder, fn: RsFunction) {
     val block = fn.block ?: return
     val rbrace = block.rbrace ?: return
-    val returnType = fn.returnType
+    val returnType = fn.normReturnType
     if (returnType is TyInfer.TyVar ||
         returnType is TyUnit ||
         returnType is TyAnon ||

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFix.kt
@@ -20,6 +20,7 @@ import org.rust.lang.core.psi.ext.isMethod
 import org.rust.lang.core.psi.ext.valueParameters
 import org.rust.lang.core.types.implLookup
 import org.rust.lang.core.types.inference
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
@@ -67,7 +68,7 @@ class ChangeFunctionSignatureFix private constructor(
                 when (action) {
                     is SignatureAction.InsertArgument -> "<b>${renderType(arguments[action.argumentIndex].type)}</b>"
                     is SignatureAction.KeepParameter -> renderType(
-                        function.valueParameters[action.parameterIndex].typeReference?.type ?: TyUnknown
+                        function.valueParameters[action.parameterIndex].typeReference?.normType ?: TyUnknown
                     )
                     is SignatureAction.ChangeParameterType -> "<b>${renderType(arguments[action.argumentIndex].type)}</b>"
                     SignatureAction.RemoveParameter -> error("unreachable")
@@ -256,7 +257,7 @@ private fun calculateSignatureWithInsertion(
         val parameter = parameterIterator.value
         val argument = argumentIterator.value ?: break
 
-        if (parameter != null && ctx.combineTypes(parameter.typeReference?.type ?: TyUnknown, argument.type).isOk) {
+        if (parameter != null && ctx.combineTypes(parameter.typeReference?.normType(ctx) ?: TyUnknown, argument.type).isOk) {
             insertions.add(SignatureAction.KeepParameter(parameters.indexOf(parameter)))
             parameterIterator.advance()
             argumentIterator.advance()

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
@@ -20,10 +20,10 @@ import org.rust.lang.core.psi.RsLambdaExpr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsRetExpr
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyUnit
 import org.rust.lang.core.types.ty.TyUnknown
-import org.rust.lang.core.types.type
 
 class ChangeReturnTypeFix(
     element: RsElement,
@@ -73,7 +73,7 @@ class ChangeReturnTypeFix(
             return
         }
 
-        val oldTy = oldRetType?.typeReference?.type ?: TyUnknown
+        val oldTy = oldRetType?.typeReference?.rawType ?: TyUnknown
         val (_, useQualifiedName) = getTypeReferencesInfoFromTys(owner, actualTy, oldTy)
         val text = actualTy.renderInsertionSafe(
             context = startElement as? RsElement,

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
@@ -11,12 +11,11 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.ide.presentation.render
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsFunctionOrLambda
 import org.rust.lang.core.psi.ext.withSubst
-import org.rust.lang.core.types.TraitRef
-import org.rust.lang.core.types.implLookupAndKnownItems
+import org.rust.lang.core.types.*
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyAdt
-import org.rust.lang.core.types.type
 
 /**
  * Base class for converting the given `expr` to the type [ty] using trait [traitName]. The conversion process is
@@ -65,14 +64,13 @@ abstract class ConvertToTyUsingTryTraitAndUnpackFix(
     }
 
     private fun findParentFnOrLambdaRetTy(element: RsExpr): Ty? =
-        findParentFunctionOrLambdaRsRetType(element)?.typeReference?.type
+        findParentFunctionOrLambdaRsRetType(element)?.typeReference?.normType
 
     private fun findParentFunctionOrLambdaRsRetType(element: RsExpr): RsRetType? {
         var parent = element.parent
         while (parent != null) {
             when (parent) {
-                is RsFunction -> return parent.retType
-                is RsLambdaExpr -> return parent.retType
+                is RsFunctionOrLambda -> return parent.retType
                 else -> parent = parent.parent
             }
         }

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -21,6 +21,7 @@ import org.rust.ide.presentation.render
 import org.rust.lang.core.crate.crateGraph
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.ref.resolveTypeAliasToImpl
 import org.rust.lang.core.types.ty.TyPrimitive
 import org.rust.lang.core.types.type
 import org.rust.lang.doc.RsDocRenderMode
@@ -151,7 +152,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
             RsCodeFragmentFactory(context.project)
                 .createPath(link, element)
                 ?.reference
-                ?.resolve()
+                ?.resolveTypeAliasToImpl()
         } else {
             qualifiedName.findPsiElement(psiManager, element)
         }

--- a/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
@@ -23,6 +23,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.declaration
 import org.rust.lang.core.types.implLookup
 import org.rust.lang.core.types.infer.collectInferTys
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.TyInfer
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
@@ -76,7 +77,7 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
     override fun getCollectorFor(file: PsiFile, editor: Editor, settings: Settings, sink: InlayHintsSink): InlayHintsCollector {
         val project = file.project
         val crate = (file as? RsFile)?.crate
-        
+
         return object : FactoryInlayHintsCollector(editor) {
 
             val typeHintsFactory = RsTypeHintsPresentationFactory(factory, settings.showObviousTypes)
@@ -125,7 +126,7 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
             private fun presentTypePlaceholders(declaration: RsLetDecl) {
                 if (!declaration.existsAfterExpansion(crate)) return
                 val inferredType = declaration.pat?.type ?: return
-                val formalType = declaration.typeReference?.type ?: return
+                val formalType = declaration.typeReference?.rawType ?: return
                 val placeholders = formalType.collectInferTys()
                     .mapNotNull {
                         if (it is TyInfer.TyVar && it.origin is RsBaseType) {

--- a/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsTypeHintsPresentationFactory.kt
@@ -17,8 +17,8 @@ import org.rust.lang.core.types.Kind
 import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.consts.CtValue
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.*
-import org.rust.lang.core.types.type
 
 @Suppress("UnstableApiUsage")
 class RsTypeHintsPresentationFactory(
@@ -291,10 +291,10 @@ class RsTypeHintsPresentationFactory(
         level + elementsCount > FOLDING_THRESHOLD
 
     private fun isDefaultTypeParameter(argument: Ty, parameter: RsTypeParameter): Boolean =
-        argument.isEquivalentTo(parameter.typeReference?.type)
+        argument.isEquivalentTo(parameter.typeReference?.normType)
 
     private fun isDefaultTypeAlias(argument: Ty, alias: RsTypeAlias): Boolean =
-        argument.isEquivalentTo(alias.typeReference?.type)
+        argument.isEquivalentTo(alias.typeReference?.normType)
 
     private fun List<InlayPresentation>.join(separator: String = ""): InlayPresentation {
         if (separator.isEmpty()) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsCastToBoolInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsCastToBoolInspection.kt
@@ -7,6 +7,7 @@ package org.rust.ide.inspections
 
 import org.rust.lang.core.psi.RsCastExpr
 import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.TyBool
 import org.rust.lang.core.types.ty.TyPrimitive
 import org.rust.lang.core.types.ty.TyUnit
@@ -19,11 +20,11 @@ class RsCastToBoolInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitCastExpr(castExpr: RsCastExpr) {
             // It is allowed to cast a bool to a bool, so if the expression's type is of bool, ignore this cast.
-            // Casts from non primitive types (and the unit type) emit another error, so we ignore those as well.
+            // Casts from non-primitive types (and the unit type) emit another error, so we ignore those as well.
             val exprType = castExpr.expr.type
             if (exprType is TyBool || exprType !is TyPrimitive || exprType is TyUnit) return
 
-            if (castExpr.typeReference.type is TyBool) {
+            if (castExpr.typeReference.normType is TyBool) {
                 RsDiagnostic.CastAsBoolError(castExpr).addToHolder(holder)
             }
         }

--- a/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
@@ -12,8 +12,8 @@ import org.rust.lang.core.dfa.ExitPoint
 import org.rust.lang.core.psi.RsExprStmt
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.TyUnit
-import org.rust.lang.core.types.type
 
 /**
  * Suggest to remove a semicolon in situations like
@@ -34,7 +34,7 @@ class RsExtraSemicolonInspection : RsLocalInspectionTool() {
 
 private fun inspect(holder: RsProblemsHolder, fn: RsFunction) {
     val retType = fn.retType?.typeReference ?: return
-    if (retType.type is TyUnit) return
+    if (retType.normType is TyUnit) return
     ExitPoint.process(fn) { exitPoint ->
         if (exitPoint is ExitPoint.InvalidTailStatement) {
             holder.registerProblem(

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspection.kt
@@ -13,7 +13,8 @@ import org.rust.RsBundle
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsVisitor
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.findFirstMetaItem
+import org.rust.lang.core.psi.ext.normReturnType
 import org.rust.lang.core.types.ty.TyAdt
 
 private class FixRemoveMustUseAttr : LocalQuickFix {
@@ -34,7 +35,7 @@ class RsDoubleMustUseInspection : RsLintInspection() {
 
             val mustUseAttrName = "must_use"
             val attrFunc = o.findFirstMetaItem(mustUseAttrName)
-            val type = o.returnType as? TyAdt
+            val type = o.normReturnType as? TyAdt
             val attrType = type?.item?.findFirstMetaItem(mustUseAttrName)
             if (attrFunc != null && attrType != null) {
                 val description = RsBundle.message("inspection.DoubleMustUse.description")

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -12,10 +12,10 @@ import org.rust.ide.inspections.fixes.ElideLifetimesFix
 import org.rust.ide.inspections.lints.ReferenceLifetime.*
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.regions.ReEarlyBound
 import org.rust.lang.core.types.regions.ReStatic
 import org.rust.lang.core.types.ty.TyTraitObject
-import org.rust.lang.core.types.type
 import org.rust.openapiext.forEachChild
 import org.rust.stdext.chain
 
@@ -119,7 +119,7 @@ private class LifetimesCollector(val isForInputParams: Boolean = false) : RsRecu
     }
 
     override fun visitTypeReference(ref: RsTypeReference) {
-        val type = ref.type
+        val type = ref.rawType
         if (type is TyTraitObject && (type.region is ReEarlyBound || type.region is ReStatic)) {
             abort = true
         }

--- a/src/main/kotlin/org/rust/ide/intentions/GenerateDocStubIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/GenerateDocStubIntention.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.util.text.CharArrayUtil
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsValueParameter
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.impl.RsFunctionImpl
 import org.rust.lang.core.types.ty.Ty
@@ -34,7 +34,7 @@ class GenerateDocStubIntention : RsElementBaseIntentionAction<GenerateDocStubInt
         if (params.isEmpty()) {
             return null
         }
-        val returnType = targetFunc.returnType
+        val returnType = targetFunc.rawReturnType
         return Context(targetFunc, params, returnType)
     }
 

--- a/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
@@ -13,10 +13,10 @@ import org.rust.ide.intentions.UnElideLifetimesIntention.PotentialLifetimeRef
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.infer.hasReEarlyBounds
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.regions.Region
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyAdt
-import org.rust.lang.core.types.type
 import org.rust.lang.doc.psi.ext.isInDocComment
 
 class UnElideLifetimesIntention : RsElementBaseIntentionAction<LifetimeContext>() {
@@ -94,7 +94,7 @@ class UnElideLifetimesIntention : RsElementBaseIntentionAction<LifetimeContext>(
         data class RefLike(val ref: RsRefLikeType) : PotentialLifetimeRef(ref)
         data class BaseType(val baseType: RsBaseType, val type: Ty) : PotentialLifetimeRef(baseType) {
             val typeLifetimes: List<Region>
-                get() = when (val type = baseType.type) {
+                get() = when (val type = baseType.rawType) {
                     is TyAdt -> type.regionArguments.filter { it.hasReEarlyBounds }
                     else -> emptyList()
                 }
@@ -114,7 +114,7 @@ class UnElideLifetimesIntention : RsElementBaseIntentionAction<LifetimeContext>(
 }
 
 private fun isPotentialLifetimeAdt(ref: RsTypeReference): Boolean {
-    return when (val type = ref.type) {
+    return when (val type = ref.rawType) {
         is TyAdt -> type.regionArguments.all { it.hasReEarlyBounds }
         else -> false
     }
@@ -123,7 +123,7 @@ private fun isPotentialLifetimeAdt(ref: RsTypeReference): Boolean {
 private fun parsePotentialLifetimeType(ref: RsTypeReference): PotentialLifetimeRef? {
     return when {
         ref is RsRefLikeType -> PotentialLifetimeRef.RefLike(ref)
-        ref is RsBaseType && isPotentialLifetimeAdt(ref) -> PotentialLifetimeRef.BaseType(ref, ref.type)
+        ref is RsBaseType && isPotentialLifetimeAdt(ref) -> PotentialLifetimeRef.BaseType(ref, ref.rawType)
         else -> null
     }
 }

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
@@ -18,6 +18,7 @@ import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.expectedType
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 import org.rust.openapiext.createSmartPointer
@@ -80,7 +81,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
                     val parentImpl = methodCall.parentOfType<RsImplItem>()
                     return when {
                         // creating a method inside the same impl
-                        (parentImpl?.typeReference?.type as? TyAdt)?.item == item && parentImpl.traitRef == null -> ""
+                        (parentImpl?.typeReference?.rawType as? TyAdt)?.item == item && parentImpl.traitRef == null -> ""
                         methodCall.containingCrate != item.containingCrate -> "pub "
                         else -> "pub(crate)"
                     }
@@ -256,7 +257,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
         val owner = sourceFunction.owner
         if (owner is RsAbstractableOwner.Impl) {
             val impl = owner.impl
-            if (impl.traitRef == null && (impl.typeReference?.type as? TyAdt)?.item == item) {
+            if (impl.traitRef == null && (impl.typeReference?.rawType as? TyAdt)?.item == item) {
                 return impl
             }
         }

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
@@ -13,9 +13,7 @@ import com.intellij.util.BitUtil
 import org.rust.lang.core.macros.findExpansionElements
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.resolve.ref.RsPatBindingReferenceImpl
-import org.rust.lang.core.resolve.ref.RsReference
-import org.rust.lang.core.resolve.ref.deepResolve
+import org.rust.lang.core.resolve.ref.*
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.type
 
@@ -32,6 +30,12 @@ class RsTargetElementEvaluator : TargetElementEvaluatorEx2() {
         // prefer pattern binding to its target if element name is accepted
         if (ref is RsPatBindingReferenceImpl && BitUtil.isSet(flags, TargetElementUtil.ELEMENT_NAME_ACCEPTED)) {
             return ref.element
+        }
+
+        if (ref is RsPathReference) {
+            ref.tryResolveTypeAliasToImpl()?.let {
+                return it
+            }
         }
 
         // Filter invocations from CtrlMouseHandler (see RsQuickNavigationInfoTest)

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt
@@ -12,6 +12,7 @@ import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.psi.ext.parentFunction
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
@@ -19,13 +20,13 @@ class RsTypeDeclarationProvider : TypeDeclarationProvider {
 
     override fun getSymbolTypeDeclarations(element: PsiElement): Array<PsiElement>? {
         val type = when (element) {
-            is RsFunction -> element.retType?.typeReference?.type
-            is RsNamedFieldDecl -> element.typeReference?.type
-            is RsConstant -> element.typeReference?.type
+            is RsFunction -> element.retType?.typeReference?.normType
+            is RsNamedFieldDecl -> element.typeReference?.normType
+            is RsConstant -> element.typeReference?.normType
             is RsPatBinding -> element.type
             is RsSelfParameter -> when (val owner = element.parentFunction.owner) {
                 is RsAbstractableOwner.Trait -> owner.trait.declaredType
-                is RsAbstractableOwner.Impl -> owner.impl.typeReference?.type
+                is RsAbstractableOwner.Impl -> owner.impl.typeReference?.normType
                 else -> null
             }
             else -> null

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -13,11 +13,9 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.*
 import org.rust.lang.core.stubs.RsStubLiteralKind
-import org.rust.lang.core.types.RsPsiSubstitution
-import org.rust.lang.core.types.Substitution
+import org.rust.lang.core.types.*
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.consts.CtValue
-import org.rust.lang.core.types.emptySubstitution
 import org.rust.lang.core.types.infer.resolve
 import org.rust.lang.core.types.infer.substitute
 import org.rust.lang.core.types.regions.ReEarlyBound
@@ -25,7 +23,6 @@ import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyInteger
 import org.rust.lang.core.types.ty.TyPrimitive
 import org.rust.lang.core.types.ty.TyTypeParameter
-import org.rust.lang.core.types.type
 import org.rust.lang.utils.escapeRust
 import org.rust.lang.utils.evaluation.evaluate
 import org.rust.stdext.exhaustive
@@ -599,7 +596,7 @@ open class TypeSubstitutingPsiRenderer(
     private val subst: Substitution
 ) : RsPsiRenderer(options) {
     override fun appendTypeReference(sb: StringBuilder, ref: RsTypeReference) {
-        val ty = ref.type
+        val ty = ref.rawType
         if (ty is TyTypeParameter && subst[ty] != null) {
             sb.append(ty.substAndGetText(subst))
         } else {

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -18,12 +18,12 @@ import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.consts.CtUnknown
 import org.rust.lang.core.types.consts.CtValue
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.regions.ReEarlyBound
 import org.rust.lang.core.types.regions.ReStatic
 import org.rust.lang.core.types.regions.ReUnknown
 import org.rust.lang.core.types.regions.Region
 import org.rust.lang.core.types.ty.*
-import org.rust.lang.core.types.type
 import org.rust.stdext.withPrevious
 
 private const val MAX_SHORT_TYPE_LEN = 50
@@ -275,7 +275,7 @@ private data class TypeRenderer(
             if (skipUnchangedDefaultTypeArguments && !nonDefaultParamFound) {
                 if (parameter is RsTypeParameter &&
                     parameter.typeReference != null &&
-                    parameter.typeReference?.type?.isEquivalentTo(subst[parameter]) == true) {
+                    parameter.typeReference?.normType?.isEquivalentTo(subst[parameter]) == true) {
                     continue
                 } else {
                     nonDefaultParamFound = true

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
@@ -15,9 +15,9 @@ import org.rust.lang.RsLanguage
 import org.rust.lang.core.macros.setContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyUnit
-import org.rust.lang.core.types.type
 
 /**
  * This class just holds [config].
@@ -129,7 +129,7 @@ class RsChangeFunctionSignatureConfig private constructor(
     private val originalName: String = function.name.orEmpty()
 
     val returnType: Ty
-        get() = returnTypeDisplay?.type ?: TyUnit.INSTANCE
+        get() = returnTypeDisplay?.rawType ?: TyUnit.INSTANCE
 
     private val parametersText: String
         get() {

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -18,6 +18,7 @@ import org.rust.ide.utils.findStatementsOrExprInRange
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyReference
 import org.rust.lang.core.types.ty.TyTuple
@@ -153,7 +154,7 @@ class RsExtractFunctionConfig private constructor(
             val type = typeParameter.declaredType
             val bounds = mutableSetOf<Ty>()
             typeParameter.bounds.flatMapTo(bounds) { polybound ->
-                polybound.bound.traitRef?.path?.typeArguments?.flatMap { it.type.types() }.orEmpty()
+                polybound.bound.traitRef?.path?.typeArguments?.flatMap { it.rawType.types() }.orEmpty()
             }
             type to bounds
         }

--- a/src/main/kotlin/org/rust/ide/refactoring/functionSignature.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/functionSignature.kt
@@ -7,7 +7,7 @@ package org.rust.ide.refactoring
 
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsTypeParameter
-import org.rust.lang.core.types.type
+import org.rust.lang.core.types.rawType
 
 /**
  * Helper class for storing and formatting information about the signature of a function.
@@ -26,7 +26,7 @@ abstract class RsFunctionSignatureConfig(val function: RsFunction) {
             if (wherePredList.isEmpty()) return ""
             val typeParams = typeParameters().map { it.declaredType }
             if (typeParams.isEmpty()) return ""
-            val filtered = wherePredList.filter { it.typeReference?.type in typeParams }
+            val filtered = wherePredList.filter { it.typeReference?.rawType in typeParams }
             if (filtered.isEmpty()) return ""
             return filtered.joinToString(separator = ", ", prefix = " where ") { it.text }
         }

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
@@ -22,7 +22,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.RsCachedImplItem
 import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.emptySubstitution
-import org.rust.lang.core.types.type
+import org.rust.lang.core.types.rawType
 import org.rust.openapiext.checkWriteAccessNotAllowed
 
 abstract class BaseGenerateAction : CodeInsightAction() {
@@ -63,7 +63,7 @@ abstract class BaseGenerateHandler : LanguageCodeInsightActionHandler {
         }
 
         if (!isStructValid(structItem)) return null
-        val substitution = impl?.typeReference?.type?.typeParameterValues ?: emptySubstitution
+        val substitution = impl?.typeReference?.rawType?.typeParameterValues ?: emptySubstitution
         val fields = StructMember.fromStruct(structItem, substitution).filter { isFieldValid(it, impl) }
         if (fields.isEmpty() && !allowEmptyFields()) return null
 

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
@@ -11,14 +11,20 @@ import org.rust.ide.refactoring.generate.BaseGenerateAction
 import org.rust.ide.refactoring.generate.BaseGenerateHandler
 import org.rust.ide.refactoring.generate.GenerateAccessorHandler
 import org.rust.ide.refactoring.generate.StructMember
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.implLookup
 import org.rust.lang.core.types.infer.substitute
-import org.rust.lang.core.types.ty.*
-import org.rust.lang.core.types.type
+import org.rust.lang.core.types.rawType
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyAdt
+import org.rust.lang.core.types.ty.TyPrimitive
+import org.rust.lang.core.types.ty.isMovesByDefault
 import org.rust.openapiext.checkWriteAccessAllowed
 
 class GenerateGetterAction : BaseGenerateAction() {
@@ -44,7 +50,7 @@ class GenerateGetterHandler : GenerateAccessorHandler() {
         return chosenFields.mapNotNull {
             val fieldName = it.argumentIdentifier
             val typeRef = it.field.typeReference ?: return@mapNotNull null
-            val fieldType = typeRef.type.substitute(substitution)
+            val fieldType = typeRef.rawType.substitute(substitution)
 
             val (borrow, typeStr) = getBorrowAndType(fieldType, it.typeReferenceText, it.field)
             val fnSignature = "pub fn $fieldName(&self) -> $borrow$typeStr"

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -21,8 +21,8 @@ import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.resolve.ref.pathPsiSubst
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.infer.substitute
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.TyUnknown
-import org.rust.lang.core.types.type
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.checkWriteAccessAllowed
 import org.rust.openapiext.checkWriteAccessNotAllowed
@@ -209,7 +209,7 @@ class MembersGenerator(
         return when (element) {
             is RsConstant -> {
                 val initialValue = RsDefaultValueBuilder(element.knownItems, element.containingMod, factory, true)
-                    .buildFor(element.typeReference?.type?.substitute(subst) ?: TyUnknown, emptyMap())
+                    .buildFor(element.typeReference?.normType?.substitute(subst) ?: TyUnknown, emptyMap())
                 "const ${element.nameLikeElement.text}: ${element.typeReference?.renderTypeReference() ?: "_"} = ${initialValue.text};"
             }
             is RsTypeAlias ->

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/RsIntroduceParameterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/RsIntroduceParameterHandler.kt
@@ -15,13 +15,16 @@ import org.rust.ide.refactoring.findCandidateExpressionsToExtract
 import org.rust.ide.refactoring.showErrorMessageForExtractParameter
 import org.rust.ide.refactoring.showExpressionChooser
 import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.types.ty.TyNever
+import org.rust.lang.core.types.ty.TyUnit
+import org.rust.lang.core.types.type
 
 class RsIntroduceParameterHandler : RefactoringActionHandler {
     override fun invoke(project: Project, editor: Editor, file: PsiFile, dataContext: DataContext) {
         if (file !is RsFile) return
 
         val exprs = findCandidateExpressionsToExtract(editor, file)
-            .filter { checkTypeIsExtractable(it) }
+            .filter { it.type !is TyUnit && it.type !is TyNever }
 
         when (exprs.size) {
             0 -> {

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
@@ -17,19 +17,8 @@ import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.refactoring.*
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.types.ty.TyNever
-import org.rust.lang.core.types.ty.TyUnit
 import org.rust.lang.core.types.type
 import org.rust.openapiext.runWriteCommandAction
-
-/**
- * This method is used to filter Unit type and Never type, and exclude expressions where type is not inferred
- */
-fun checkTypeIsExtractable(expr: RsExpr): Boolean {
-    val psiFactory = RsPsiFactory(expr.project)
-    val typeRef = psiFactory.tryCreateType(expr.type.renderInsertionSafe()) ?: return false
-    return typeRef.type !is TyUnit && typeRef.type !is TyNever
-}
 
 fun extractExpression(editor: Editor, expr: RsExpr) {
     val project = expr.project

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
@@ -25,8 +25,8 @@ import org.rust.ide.utils.getTopmostParentInside
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.TyAdt
-import org.rust.lang.core.types.type
 import org.rust.openapiext.isUnitTestMode
 import org.rust.openapiext.toPsiFile
 
@@ -169,7 +169,7 @@ fun groupImplsByStructOrTrait(containingMod: RsMod, items: Set<RsItemElement>): 
     return containingMod
         .childrenOfType<RsImplItem>()
         .mapNotNull { impl ->
-            val struct: RsItemElement? = (impl.typeReference?.type as? TyAdt)?.item
+            val struct: RsItemElement? = (impl.typeReference?.rawType as? TyAdt)?.item
             val trait = impl.traitRef?.path?.reference?.resolve() as? RsTraitItem
             val relatedStruct = struct?.takeIf { items.contains(it) }
             val relatedTrait = trait?.takeIf { items.contains(it) }

--- a/src/main/kotlin/org/rust/ide/typing/assist/FunctionOrStructFixer.kt
+++ b/src/main/kotlin/org/rust/ide/typing/assist/FunctionOrStructFixer.kt
@@ -14,7 +14,7 @@ import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.ext.body
 import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.endOffset
-import org.rust.lang.core.psi.ext.returnType
+import org.rust.lang.core.psi.ext.rawReturnType
 import org.rust.lang.core.types.ty.TyUnknown
 
 class FunctionOrStructFixer : SmartEnterProcessorWithFixers.Fixer<RsSmartEnterProcessor>() {
@@ -37,7 +37,7 @@ class FunctionOrStructFixer : SmartEnterProcessorWithFixers.Fixer<RsSmartEnterPr
                      * fn foo(a: i32, b: i32/*caret*/)
                      * fn foo() -> i32/*caret*/
                      */
-                    parent.returnType !is TyUnknown -> ""
+                    parent.rawReturnType !is TyUnknown -> ""
 
                     else -> null
                 }

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/CheckMatchUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/CheckMatchUtils.kt
@@ -9,6 +9,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.consts.CtValue
 import org.rust.lang.core.types.infer.containsTyOfClass
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.ty.TyUnknown
@@ -179,7 +180,7 @@ private fun createPatternForField(patField: RsPatField?, field: RsFieldDecl): Pa
         val binding = patField.patBinding ?: throw CheckMatchException("Invalid RsPatField")
         Pattern(binding.type, PatternKind.Binding(binding.type, binding.name.orEmpty()))
     } else {
-        val fieldType = field.typeReference?.type ?: throw CheckMatchException("Field type = null")
+        val fieldType = field.typeReference?.normType ?: throw CheckMatchException("Field type = null")
         Pattern(fieldType, PatternKind.Wild)
     }
 

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -19,8 +19,9 @@ import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.emptySubstitution
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.infer.substitute
+import org.rust.lang.core.types.normType
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.*
-import org.rust.lang.core.types.type
 
 object RsImportHelper {
     fun importTypeReferencesFromElements(
@@ -132,7 +133,7 @@ object RsImportHelper {
             }
 
             override fun visitTypeReference(reference: RsTypeReference) =
-                collectImportSubjectsFromTy(reference.type, subst, result, useAliases, skipUnchangedDefaultTypeArguments)
+                collectImportSubjectsFromTy(reference.rawType, subst, result, useAliases, skipUnchangedDefaultTypeArguments)
 
             override fun visitElement(element: RsElement) =
                 element.acceptChildren(this)
@@ -161,7 +162,7 @@ object RsImportHelper {
                         if (skipUnchangedDefaultTypeArguments) {
                             val filteredTypeArguments = ty.typeArguments
                                 .zip(ty.item.typeParameters)
-                                .dropLastWhile { (argumentTy, param) -> argumentTy.isEquivalentTo(param.typeReference?.type) }
+                                .dropLastWhile { (argumentTy, param) -> argumentTy.isEquivalentTo(param.typeReference?.normType) }
                                 .map { (argumentTy, _) -> argumentTy }
                             return ty.copy(typeArguments = filteredTypeArguments).superVisitWith(this)
                         }

--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -28,6 +28,7 @@ import org.rust.lang.core.types.emptySubstitution
 import org.rust.lang.core.types.infer.ExpectedType
 import org.rust.lang.core.types.infer.RsInferenceContext
 import org.rust.lang.core.types.infer.TypeFolder
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 import org.rust.openapiext.Testmark
@@ -169,10 +170,10 @@ private fun RsInferenceContext.getSubstitution(scopeEntry: ScopeEntry): Substitu
 
 private val RsElement.asTy: Ty?
     get() = when (this) {
-        is RsConstant -> typeReference?.type
-        is RsConstParameter -> typeReference?.type
-        is RsFieldDecl -> typeReference?.type
-        is RsFunction -> retType?.typeReference?.type
+        is RsConstant -> typeReference?.normType
+        is RsConstParameter -> typeReference?.normType
+        is RsFieldDecl -> typeReference?.normType
+        is RsFunction -> retType?.typeReference?.normType
         is RsStructItem -> declaredType
         is RsEnumVariant -> parentEnum.declaredType
         is RsPatBinding -> type

--- a/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
@@ -20,6 +20,7 @@ import org.rust.lang.core.psi.ext.RsBindingModeKind.BindByValue
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.lang.core.resolve.VALUES
 import org.rust.lang.core.types.infer.substituteOrUnknown
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.regions.ReScope
 import org.rust.lang.core.types.regions.Scope
 import org.rust.lang.core.types.ty.TyAdt
@@ -116,7 +117,7 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
         val function = body.parent as? RsFunction ?: return
 
         for (parameter in function.valueParameters) {
-            val parameterType = parameter.typeReference?.type ?: continue
+            val parameterType = parameter.typeReference?.normType(mc.lookup) ?: continue
             val parameterPat = parameter.pat ?: continue
 
             val bodyScopeRegion = ReScope(Scope.Node(body))
@@ -433,7 +434,7 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
                     val isMentioned = fields.any { it.referenceName == withField.name }
                     // Consume only needed (not mentioned before) fields of `withExpr`
                     if (!isMentioned) {
-                        val rawWithFieldType = withField.typeReference?.type ?: TyUnknown
+                        val rawWithFieldType = withField.typeReference?.normType(mc.lookup) ?: TyUnknown
                         val withFieldType = rawWithFieldType.substituteOrUnknown(withType.typeParameterValues)
                         val interior = Interior.Field(withCmt, withField.name)
                         val fieldCmt = Cmt(withExpr, interior, withCmt.mutabilityCategory.inherit(), withFieldType)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
@@ -12,9 +12,9 @@ import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.infer.type
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTypeParameter
-import org.rust.lang.core.types.type
 import org.rust.openapiext.filterQuery
 import org.rust.openapiext.mapQuery
 
@@ -98,7 +98,7 @@ val RsAbstractable.canBeAccessedByTraitName: Boolean
                 if (selfParameter != null) return true
                 type
             }
-            is RsConstant -> typeReference?.type ?: return false
+            is RsConstant -> typeReference?.rawType ?: return false
             else -> return false
         }
         return type.visitWith(object : TypeVisitor {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
@@ -9,8 +9,8 @@ import org.rust.lang.core.psi.RsBlockFields
 import org.rust.lang.core.psi.RsNamedFieldDecl
 import org.rust.lang.core.psi.RsTupleFieldDecl
 import org.rust.lang.core.psi.RsTupleFields
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.Ty
-import org.rust.lang.core.types.type
 
 interface RsFieldsOwner : RsElement, RsNameIdentifierOwner, RsQualifiedNamedElement {
     val blockFields: RsBlockFields?
@@ -46,7 +46,7 @@ fun RsFieldsOwner.canBeInstantiatedIn(mod: RsMod): Boolean =
     fields.all { it.isVisibleFrom(mod) }
 
 val RsFieldsOwner.fieldTypes: List<Ty>
-    get() = fields.filter { it.existsAfterExpansionSelf }.mapNotNull { it.typeReference?.type }
+    get() = fields.filter { it.existsAfterExpansionSelf }.mapNotNull { it.typeReference?.normType }
 
 /**
  * True for:

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -17,10 +17,11 @@ import org.rust.ide.icons.addTestMark
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsFunctionStub
+import org.rust.lang.core.types.normType
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyUnit
 import org.rust.lang.core.types.ty.TyUnknown
-import org.rust.lang.core.types.type
 import javax.swing.Icon
 
 val RsFunction.block: RsBlock? get() = PsiTreeUtil.getChildOfType(this, RsBlock::class.java)
@@ -111,10 +112,16 @@ val RsFunction.title: String
             if (isAssocFn) "Associated function `$name`" else "Method `$name`"
     }
 
-val RsFunction.returnType: Ty
+val RsFunction.rawReturnType: Ty
     get() {
         val retType = retType ?: return TyUnit.INSTANCE
-        return retType.typeReference?.type ?: TyUnknown
+        return retType.typeReference?.rawType ?: TyUnknown
+    }
+
+val RsFunction.normReturnType: Ty
+    get() {
+        val retType = retType ?: return TyUnit.INSTANCE
+        return retType.typeReference?.normType ?: TyUnknown
     }
 
 val RsFunction.abi: RsExternAbi? get() = externAbi ?: (parent as? RsForeignModItem)?.externAbi

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -25,8 +25,8 @@ import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.stubs.RsImplItemStub
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.RsPsiTypeImplUtil
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.*
-import org.rust.lang.core.types.type
 
 val RsImplItem.default: PsiElement?
     get() = node.findChildByType(DEFAULT)?.psi
@@ -42,7 +42,7 @@ val IMPL_ITEM_IS_RESERVATION_IMPL_PROP: StubbedAttributeProperty<RsImplItem, RsI
     StubbedAttributeProperty({ it.hasAttribute("rustc_reservation_impl") }, RsImplItemStub::mayBeReservationImpl)
 
 val RsImplItem.implementingType: TyAdt?
-    get() = typeReference?.type as? TyAdt
+    get() = typeReference?.normType as? TyAdt
 
 abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImplItem {
 
@@ -98,7 +98,7 @@ fun checkOrphanRules(impl: RsImplItem, isSameCrate: (RsElement) -> Boolean): Boo
     val traitRef = impl.traitRef ?: return true
     val (trait, subst, _) = traitRef.resolveToBoundTrait() ?: return true
     if (isSameCrate(trait)) return true
-    val typeParameters = subst.typeSubst.values + (impl.typeReference?.type ?: return true)
+    val typeParameters = subst.typeSubst.values + (impl.typeReference?.normType ?: return true)
     return typeParameters.any { tyWrapped ->
         val ty = tyWrapped.unwrapFundamentalTypes()
         ty is TyUnknown

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -996,7 +996,7 @@ class ImplLookup(
                 check(source.item is RsStructItem) { "Guaranteed by assembleCandidates" }
                 val fields = source.item.fields
                 val lastField = fields.lastOrNull() ?: return SelectionResult.Err
-                val lastFieldType = lastField.typeReference?.type ?: return SelectionResult.Err
+                val lastFieldType = lastField.typeReference?.rawType ?: return SelectionResult.Err
                 val unsizingParams = hashSetOf<TyTypeParameter>()
                 // TODO consider const params
                 lastFieldType.visitTypeParameters { ty ->
@@ -1005,7 +1005,7 @@ class ImplLookup(
                 }
                 for (field in fields) {
                     if (field == lastField) break
-                    val fieldType = field.typeReference?.type ?: continue
+                    val fieldType = field.typeReference?.rawType ?: continue
                     fieldType.visitTypeParameters { ty ->
                         unsizingParams -= ty
                         false
@@ -1187,7 +1187,7 @@ class ImplLookup(
     }
 
     private fun lookupAssocTypeInSelection(selection: Selection, assoc: RsTypeAlias): Ty? =
-        selection.impl.associatedTypesTransitively.find { it.name == assoc.name }?.typeReference?.type?.substitute(selection.subst)
+        selection.impl.associatedTypesTransitively.find { it.name == assoc.name }?.typeReference?.rawType?.substitute(selection.subst)
 
     private fun lookupAssocTypeInBounds(
         subst: Sequence<BoundElement<RsTraitItem>>,
@@ -1279,7 +1279,7 @@ class ImplLookup(
                         impl.traitRef?.isAncestorOf(psi) == true || impl.typeReference?.isAncestorOf(psi) == true
                     }
                 if (useLegacy) {
-                    // We should mock ParamEnv here. Otherwise we run into infinite recursion
+                    // We should mock ParamEnv here. Otherwise, we run into infinite recursion
                     // This is mostly a hack. It should be solved in the future somehow
                     ParamEnv.LEGACY
                 } else {

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -501,7 +501,7 @@ private fun processQualifiedPathResolveVariants1(
         val baseTy = if (qualifier.hasCself) {
             when (base) {
                 // impl S { fn foo() { Self::bar() } }
-                is RsImplItem -> base.typeReference?.type ?: TyUnknown
+                is RsImplItem -> base.typeReference?.rawType ?: TyUnknown
                 is RsTraitItem -> TyTypeParameter.self(base)
                 else -> TyUnknown
             }
@@ -552,7 +552,7 @@ private fun processExplicitTypeQualifiedPathResolveVariants(
         // TODO this is a hack to fix completion test `test associated type in explicit UFCS form`.
         // Looks like we should use getOriginalOrSelf during resolve
         ?.let { BoundElement(CompletionUtil.getOriginalOrSelf(it.element), it.subst) }
-    val baseTy = typeQual.typeReference.type
+    val baseTy = typeQual.typeReference.rawType
     return if (trait != null) {
         processTypeAsTraitUFCSQualifiedPathResolveVariants(ns, baseTy, listOf(trait), processor)
     } else {
@@ -1897,6 +1897,7 @@ object NameResolutionTestmarks {
     object SelfRelatedTypeSpecialCase : Testmark()
     object SkipAssocTypeFromImpl : Testmark()
     object UpdateDefMapsForAllCratesWhenFindingModData : Testmark()
+    object TypeAliasToImpl : Testmark()
 }
 
 private data class ImplicitStdlibCrate(val name: String, val crateRoot: RsFile)

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -18,9 +18,9 @@ import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.infer.constGenerics
 import org.rust.lang.core.types.infer.generics
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTypeParameter
-import org.rust.lang.core.types.type
 import kotlin.LazyThreadSafetyMode.PUBLICATION
 
 /**
@@ -45,7 +45,7 @@ class RsCachedImplItem(
 
     val implementedTrait: BoundElement<RsTraitItem>? by recursionSafeLazy { traitRef?.resolveToBoundTrait() }
     val typeAndGenerics: Triple<Ty, List<TyTypeParameter>, List<CtConstParameter>>? by lazy(PUBLICATION) {
-        impl.typeReference?.type?.let { Triple(it, impl.generics, impl.constGenerics) }
+        impl.typeReference?.rawType?.let { Triple(it, impl.generics, impl.constGenerics) }
     }
 
     /** For `impl T for Foo` returns union of impl members and trait `T` members that are not overriden by the impl */

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLitExprReferenceContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLitExprReferenceContributor.kt
@@ -25,13 +25,10 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psiElement
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.KnownItems
-import org.rust.lang.core.types.BoundElement
-import org.rust.lang.core.types.implLookupAndKnownItems
-import org.rust.lang.core.types.positionalTypeArguments
+import org.rust.lang.core.types.*
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.ty.TyAnon
 import org.rust.lang.core.types.ty.TyTypeParameter
-import org.rust.lang.core.types.type
 import org.rust.lang.core.with
 import org.rust.lang.utils.parseRustStringCharacters
 
@@ -93,7 +90,7 @@ private val pathValueLiteral: PsiElementPattern.Capture<RsLitExpr> = psiElement<
 private fun isPathLitExpr(expr: RsLitExpr): Boolean {
     val (function, arguments) = getFunctionAndArguments(expr) ?: return false
     val owner = function.owner as? RsAbstractableOwner.Impl
-    val ownerType = (owner?.impl?.typeReference?.type as? TyAdt)?.item
+    val ownerType = (owner?.impl?.typeReference?.normType as? TyAdt)?.item
     val (implLookup, knownItems) = expr.implLookupAndKnownItems
     val isCallExpr = arguments.parent is RsCallExpr
 
@@ -126,13 +123,13 @@ private fun isPathLitExpr(expr: RsLitExpr): Boolean {
 
 // fn foo<P: AsRef<Path>>(p: P)
 private fun isAsRefPathGeneric(lookup: ImplLookup, knownItems: KnownItems, parameter: RsValueParameter): Boolean {
-    val type = parameter.typeReference?.type as? TyTypeParameter ?: return false
+    val type = parameter.typeReference?.rawType as? TyTypeParameter ?: return false
     return lookup.getEnvBoundTransitivelyFor(type).any { isAsRefPath(knownItems, it) }
 }
 
 // fn foo(p: impl AsRef<Path>)
 private fun isImplAsRefPath(knownItems: KnownItems, parameter: RsValueParameter): Boolean {
-    val type = parameter.typeReference?.type as? TyAnon ?: return false
+    val type = parameter.typeReference?.rawType as? TyAnon ?: return false
     return type.traits.any { isAsRefPath(knownItems, it) }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/RsPsiSubstitution.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RsPsiSubstitution.kt
@@ -47,15 +47,15 @@ fun RsPsiSubstitution.toSubst(resolver: PathExprResolver? = PathExprResolver.def
         val paramTy = TyTypeParameter.named(param)
         val valueTy = when (value) {
             is RsPsiSubstitution.Value.DefaultValue -> if (value.value.selfTy != null) {
-                value.value.value.type.substitute(mapOf(TyTypeParameter.self() to value.value.selfTy).toTypeSubst())
+                value.value.value.rawType.substitute(mapOf(TyTypeParameter.self() to value.value.selfTy).toTypeSubst())
             } else {
-                value.value.value.type
+                value.value.value.rawType
             }
             is RsPsiSubstitution.Value.OptionalAbsent -> paramTy
             is RsPsiSubstitution.Value.Present -> when (value.value) {
-                is RsPsiSubstitution.TypeValue.InAngles -> value.value.value.type
+                is RsPsiSubstitution.TypeValue.InAngles -> value.value.value.rawType
                 is RsPsiSubstitution.TypeValue.FnSugar -> if (value.value.inputArgs.isNotEmpty()) {
-                    TyTuple(value.value.inputArgs.map { it?.type ?: TyUnknown })
+                    TyTuple(value.value.inputArgs.map { it?.rawType ?: TyUnknown })
                 } else {
                     TyUnit.INSTANCE
                 }
@@ -82,11 +82,11 @@ fun RsPsiSubstitution.toSubst(resolver: PathExprResolver? = PathExprResolver.def
             RsPsiSubstitution.Value.OptionalAbsent -> param
             RsPsiSubstitution.Value.RequiredAbsent -> CtUnknown
             is RsPsiSubstitution.Value.Present -> {
-                val expectedTy = psiParam.typeReference?.type ?: TyUnknown
+                val expectedTy = psiParam.typeReference?.normType ?: TyUnknown
                 psiValue.value.toConst(expectedTy, resolver)
             }
             is RsPsiSubstitution.Value.DefaultValue -> {
-                val expectedTy = psiParam.typeReference?.type ?: TyUnknown
+                val expectedTy = psiParam.typeReference?.normType ?: TyUnknown
                 psiValue.value.toConst(expectedTy, resolver)
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -16,12 +16,12 @@ import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.consts.CtUnknown
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.regions.ReEarlyBound
 import org.rust.lang.core.types.regions.ReStatic
 import org.rust.lang.core.types.regions.ReUnknown
 import org.rust.lang.core.types.regions.Region
 import org.rust.lang.core.types.ty.*
-import org.rust.lang.core.types.type
 import org.rust.lang.utils.evaluation.evaluate
 import org.rust.lang.utils.evaluation.tryEvaluate
 
@@ -92,7 +92,7 @@ fun inferTypeReferenceType(type: RsTypeReference, defaultTraitObjectRegion: Regi
         }
 
         is RsArrayType -> {
-            val componentType = type.typeReference?.type ?: TyUnknown
+            val componentType = type.typeReference?.rawType ?: TyUnknown
             if (type.isSlice) {
                 TySlice(componentType)
             } else {
@@ -102,8 +102,8 @@ fun inferTypeReferenceType(type: RsTypeReference, defaultTraitObjectRegion: Regi
         }
 
         is RsFnPointerType -> {
-            val paramTypes = type.valueParameters.map { it.typeReference?.type ?: TyUnknown }
-            TyFunction(paramTypes, type.retType?.let { it.typeReference?.type ?: TyUnknown } ?: TyUnit.INSTANCE)
+            val paramTypes = type.valueParameters.map { it.typeReference?.rawType ?: TyUnknown }
+            TyFunction(paramTypes, type.retType?.let { it.typeReference?.rawType ?: TyUnknown } ?: TyUnit.INSTANCE)
         }
 
         is RsTraitType -> {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -11,9 +11,9 @@ import org.rust.lang.core.psi.ext.RsBindingModeKind.BindByReference
 import org.rust.lang.core.psi.ext.RsBindingModeKind.BindByValue
 import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.CtUnknown
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.ty.Mutability.IMMUTABLE
-import org.rust.lang.core.types.type
 import org.rust.lang.utils.evaluation.ConstExpr
 import org.rust.lang.utils.evaluation.toConst
 import org.rust.openapiext.Testmark
@@ -78,7 +78,7 @@ fun RsPat.extractBindings(fcx: RsTypeInferenceWalker, type: Ty, defBm: RsBinding
                 tupleFields
                     .getOrNull(idx)
                     ?.typeReference
-                    ?.type
+                    ?.normType(fcx.ctx)
                     ?.substituteOrUnknown(expected.typeParameterValues)
                     ?: TyUnknown
             }
@@ -95,7 +95,7 @@ fun RsPat.extractBindings(fcx: RsTypeInferenceWalker, type: Ty, defBm: RsBinding
                 val kind = patField.kind
                 val fieldType = structFields[kind.fieldName]
                     ?.typeReference
-                    ?.type
+                    ?.normType(fcx.ctx)
                     ?.substituteOrUnknown(expected.typeParameterValues)
                     ?: TyUnknown
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -165,7 +165,7 @@ fun Ty.structTail(): Ty? {
             is TyAdt -> {
                 val item = ty.item as? RsStructItem ?: return ty
                 val typeRef = item.fields.lastOrNull()?.typeReference
-                val fieldTy = typeRef?.type?.substitute(ty.typeParameterValues) ?: return null
+                val fieldTy = typeRef?.rawType?.substitute(ty.typeParameterValues) ?: return null
                 if (!ancestors.add(fieldTy)) return null
                 structTailInner(fieldTy)
             }

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprEvaluator.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.types.consts.*
 import org.rust.lang.core.types.infer.TypeFoldable
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.needsEval
+import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyBool
 import org.rust.lang.core.types.ty.TyInteger
@@ -34,7 +35,7 @@ fun RsElement.toConst(
         is RsConstParameter -> CtConstParameter(resolved)
         is RsConstant -> when {
             resolved.isConst -> {
-                val type = resolved.typeReference?.type ?: TyUnknown
+                val type = resolved.typeReference?.normType ?: TyUnknown
                 resolved.expr?.evaluate(type, resolver) ?: CtUnknown
             }
             else -> CtUnknown

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -2813,6 +2813,23 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl <error descr="Can impl only `struct`s, `enum`s, `union`s and trait objects [E0118]">u8</error> {}
     """)
 
+    fun `test E0118 impl for normalizable associated type 1`() = checkErrors("""
+        struct S;
+        struct Struct;
+        trait Trait { type Item; }
+        impl Trait for Struct { type Item = S; }
+
+        impl <error descr="Can impl only `struct`s, `enum`s, `union`s and trait objects [E0118]"><Struct as Trait>::Item</error> {}
+    """)
+
+    fun `test E0118 impl for normalizable associated type 2`() = checkErrors("""
+        struct Struct;
+        trait Trait { type Item; }
+        impl Trait for Struct { type Item = u8; }
+
+        impl <error descr="Can impl only `struct`s, `enum`s, `union`s and trait objects [E0118]"><Struct as Trait>::Item</error> {}
+    """)
+
     fun `test impl sized for struct E0322`() = checkErrors("""
         #[lang = "sized"]
         trait Sized {}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
@@ -356,6 +356,64 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         impl foo::B/*caret*/ for S {}
     """)
+
+    fun `test empty supertrait with an impl for normalizable associated type`() = checkFixByText("Implement missing supertrait(s)", """
+        struct Struct;
+        trait Trait { type Item; }
+        impl Trait for Struct { type Item = S; }
+
+        trait A {}
+        trait B: A {}
+
+        struct S;
+
+        <error>impl <error>B/*caret*/</error> for <Struct as Trait>::Item</error> {}
+    """, """
+        struct Struct;
+        trait Trait { type Item; }
+        impl Trait for Struct { type Item = S; }
+
+        trait A {}
+        trait B: A {}
+
+        struct S;
+
+        impl A for <Struct as Trait>::Item {}
+
+        impl B/*caret*/ for <Struct as Trait>::Item {}
+    """)
+
+    fun `test grandparent supertrait with an impl for normalizable associated type`() = checkFixByText("Implement missing supertrait(s)", """
+        struct Struct;
+        trait Trait { type Item; }
+        impl Trait for Struct { type Item = S; }
+
+        trait A {}
+        trait B: A {}
+        trait C: B {}
+
+        struct S;
+
+        impl A for S {}
+
+        <error>impl <error>C/*caret*/</error> for <Struct as Trait>::Item</error> {}
+    """, """
+        struct Struct;
+        trait Trait { type Item; }
+        impl Trait for Struct { type Item = S; }
+
+        trait A {}
+        trait B: A {}
+        trait C: B {}
+
+        struct S;
+
+        impl A for S {}
+
+        impl B for <Struct as Trait>::Item {}
+
+        impl C/*caret*/ for <Struct as Trait>::Item {}
+    """)
 }
 
 // TODO: all kinds of bounds and generics

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
@@ -13,125 +13,76 @@ import org.rust.WithStdlibRustProjectDescriptor
 
 class RsGotoDeclarationTest : RsTestBase() {
     fun `test struct declaration`() = doTest("""
-        struct S;
-        type T = /*caret*/S;
-    """, """
-        struct /*caret*/S;
-        type T = S;
+        struct /*caret_after*/S;
+        type T = /*caret_before*/S;
     """)
 
     fun `test defined with a macro`() = doTest("""
         macro_rules! foo { ($ i:item) => { $ i } }
-        foo! { struct S; }
-        type T = /*caret*/S;
-    """, """
-        macro_rules! foo { ($ i:item) => { $ i } }
-        foo! { struct /*caret*/S; }
-        type T = S;
+        foo! { struct /*caret_after*/S; }
+        type T = /*caret_before*/S;
     """)
 
     fun `test defined with a macro with doc comment`() = doTest("""
         macro_rules! foo { ($ i:item) => { $ i } }
         /// docs
-        foo! { struct S; }
-        type T = /*caret*/S;
-    """, """
-        macro_rules! foo { ($ i:item) => { $ i } }
-        /// docs
-        foo! { struct /*caret*/S; }
-        type T = S;
+        foo! { struct /*caret_after*/S; }
+        type T = /*caret_before*/S;
     """)
 
     fun `test defined with nested macros`() = doTest("""
         macro_rules! foo { ($ i:item) => { $ i } }
-        foo! { foo! { struct S; } }
-        type T = /*caret*/S;
-    """, """
-        macro_rules! foo { ($ i:item) => { $ i } }
-        foo! { foo! { struct /*caret*/S; } }
-        type T = S;
+        foo! { foo! { struct /*caret_after*/S; } }
+        type T = /*caret_before*/S;
     """)
 
     fun `test defined with a macro indirectly`() = doTest("""
         macro_rules! foo { ($ i:item) => { $ i } }
-        foo! { mod a { struct S; } }
+        foo! { mod a { struct /*caret_after*/S; } }
         use a::S;
-        type T = /*caret*/S;
-    """, """
-        macro_rules! foo { ($ i:item) => { $ i } }
-        foo! { mod a { struct /*caret*/S; } }
-        use a::S;
-        type T = S;
+        type T = /*caret_before*/S;
     """)
 
     fun `test defined with a macro with struct inside macro definition`() = doTest("""
         macro_rules! foo { () => { struct S; } }
-        foo!();
-        type T = /*caret*/S;
-    """, """
-        macro_rules! foo { () => { struct S; } }
-        /*caret*/foo!();
-        type T = S;
+        /*caret_after*/foo!();
+        type T = /*caret_before*/S;
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test resolve path to derive meta item`() = doTest("""
-        #[derive(Default)]
+        #[derive(/*caret_after*/Default)]
         struct S;
-        fn main() { S::/*caret*/default(); }
-    """, """
-        #[derive(/*caret*/Default)]
-        struct S;
-        fn main() { S::default(); }
+        fn main() { S::/*caret_before*/default(); }
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test resolve aliased path to derive meta item`() = doTest("""
-        #[derive(Default)]
+        #[derive(/*caret_after*/Default)]
         struct S;
         type T = S;
-        fn main() { T::/*caret*/default(); }
-    """, """
-        #[derive(/*caret*/Default)]
-        struct S;
-        type T = S;
-        fn main() { T::default(); }
+        fn main() { T::/*caret_before*/default(); }
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test resolve method to derive meta item`() = doTest("""
-        #[derive(Clone)]
+        #[derive(/*caret_after*/Clone)]
         struct S;
-        fn main() { S./*caret*/clone(); }
-    """, """
-        #[derive(/*caret*/Clone)]
-        struct S;
-        fn main() { S.clone(); }
+        fn main() { S./*caret_before*/clone(); }
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test resolve operator to derive meta item`() = doTest("""
-        #[derive(PartialEq)]
+        #[derive(/*caret_after*/PartialEq)]
         struct S;
-        fn main() { S /*caret*/== S; }
-    """, """
-        #[derive(/*caret*/PartialEq)]
-        struct S;
-        fn main() { S == S; }
+        fn main() { S /*caret_before*/== S; }
     """)
 
     fun `test self parameter`() = doTest("""
         struct S;
         impl S {
-            fn foo(&mut self) {
-                /*caret*/self;
-            }
-        }
-    """, """
-        struct S;
-        impl S {
-            fn foo(&mut /*caret*/self) {
-                self;
+            fn foo(&mut /*caret_after*/self) {
+                /*caret_before*/self;
             }
         }
     """)
@@ -139,25 +90,17 @@ class RsGotoDeclarationTest : RsTestBase() {
     fun `test Self type in impl`() = doTest("""
         struct S;
         /// docs
-        impl S {
-            fn foo() -> Self/*caret*/ { unimplemented!() }
-        }
-    """, """
-        struct S;
-        /// docs
-        impl /*caret*/S {
-            fn foo() -> Self { unimplemented!() }
+        impl /*caret_after*/S {
+            fn foo() -> Self/*caret_before*/ { unimplemented!() }
         }
     """)
 
     fun `test associated type binding`() = doTest("""
-        trait Foo { type Item; }
-        type T = dyn Foo</*caret*/Item = i32>;
-    """, """
-        trait Foo { type /*caret*/Item; }
-        type T = dyn Foo<Item = i32>;
+        trait Foo { type /*caret_after*/Item; }
+        type T = dyn Foo</*caret_before*/Item = i32>;
     """)
 
-    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) =
-        checkEditorAction(before, after, IdeActions.ACTION_GOTO_DECLARATION)
+    private fun doTest(@Language("Rust") code: String) = checkCaretMove(code) {
+        myFixture.performEditorAction(IdeActions.ACTION_GOTO_DECLARATION)
+    }
 }

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
@@ -7,9 +7,11 @@ package org.rust.ide.navigation.goto
 
 import com.intellij.openapi.actionSystem.IdeActions
 import org.intellij.lang.annotations.Language
+import org.rust.CheckTestmarkHit
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.resolve.NameResolutionTestmarks
 
 class RsGotoDeclarationTest : RsTestBase() {
     fun `test struct declaration`() = doTest("""
@@ -98,6 +100,104 @@ class RsGotoDeclarationTest : RsTestBase() {
     fun `test associated type binding`() = doTest("""
         trait Foo { type /*caret_after*/Item; }
         type T = dyn Foo</*caret_before*/Item = i32>;
+    """)
+
+    @CheckTestmarkHit(NameResolutionTestmarks.TypeAliasToImpl::class)
+    fun `test Self-qualified path in trait impl is resolved to assoc type of current impl`() = doTest("""
+        struct S;
+        trait Trait {
+            type Item;
+            fn foo() -> Self::Item;
+        }
+
+        impl Trait for S {
+            type /*caret_after*/Item = i32;
+            fn foo() -> Self::/*caret_before*/Item { unreachable!() }
+        }
+    """)
+
+    @CheckTestmarkHit(NameResolutionTestmarks.TypeAliasToImpl::class)
+    fun `test Self-qualified path in trait impl is resolved to assoc type of super trait`() = doTest("""
+        struct S;
+        trait Trait1 { type Item; }
+        trait Trait2: Trait1 { fn foo() -> i32; }
+
+        impl Trait1 for S {
+            type /*caret_after*/Item = i32;
+        }
+
+        impl Trait2 for S {
+            fn foo() -> Self::/*caret_before*/Item { unreachable!() }
+        }
+    """)
+
+    @CheckTestmarkHit(NameResolutionTestmarks.TypeAliasToImpl::class)
+    fun `test 'impl for generic type' is USED for associated type resolve UFCS 1`() = doTest("""
+        trait Bound {}
+        trait Tr { type Item; }
+        impl<A: Bound> Tr for A { type /*caret_after*/Item = (); }
+        fn foo<B: Bound>(b: B) {
+            let a: <B as Tr>::/*caret_before*/Item;
+        }
+    """)
+
+    @CheckTestmarkHit(NameResolutionTestmarks.TypeAliasToImpl::class)
+    fun `test 'impl for generic type' is USED for associated type resolve UFCS 2`() = doTest("""
+        trait Bound { type Item; }
+        impl<A: Bound> Bound for &A { type /*caret_after*/Item = (); }
+        fn foo<B: Bound>(b: B) {
+            let a: <&B as Bound>::/*caret_before*/Item;
+        }
+    """)
+
+    @CheckTestmarkHit(NameResolutionTestmarks.TypeAliasToImpl::class)
+    fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 1)`() = doTest("""
+        struct S;
+        trait Trait1<T> { type Item; }
+        trait Trait2<T>: Trait1<T> { fn foo() -> i32; }
+
+        impl Trait1<i32> for S {
+            type /*caret_after*/Item = i32;
+        }
+        impl Trait1<u8> for S {
+            type Item = u8;
+        }
+        impl Trait2<i32> for S {
+            fn foo() -> Self::/*caret_before*/Item { unreachable!() }
+        }
+    """)
+
+    @CheckTestmarkHit(NameResolutionTestmarks.TypeAliasToImpl::class)
+    fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 2)`() = doTest("""
+        struct S;
+        trait Trait1<T=u8> { type Item; }
+        trait Trait2<T>: Trait1<T> { fn foo() -> i32; }
+
+        impl Trait1<i32> for S {
+            type /*caret_after*/Item = i32;
+        }
+        impl Trait1 for S {
+            type Item = u8;
+        }
+        impl Trait2<i32> for S {
+            fn foo() -> Self::/*caret_before*/Item { unreachable!() }
+        }
+    """)
+
+    @CheckTestmarkHit(NameResolutionTestmarks.TypeAliasToImpl::class)
+    fun `test explicit UFCS-like type-qualified path is resolved to correct impl when inapplicable blanket impl exists`() = doTest("""
+        trait Trait { type Item; }
+        trait Bound {}
+        impl<I: Bound> Trait for I {
+            type Item = I;
+        }
+        struct S;
+        impl Trait for S {
+            type /*caret_after*/Item = ();
+        }
+        fn main() {
+            let a: <S as Trait>::/*caret_before*/Item;
+        }
     """)
 
     private fun doTest(@Language("Rust") code: String) = checkCaretMove(code) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
@@ -54,11 +54,11 @@ class RsResolveCacheTest : RsTestBase() {
     fun `test resolve correctly without global cache invalidation 3`() = checkResolvedToXY("""
         struct S;
         trait Trait1 { type Item; }
+                          //X
         trait Trait2 { type Item; }
+                          //Y
         impl Trait1 for S { type Item = (); }
-                               //X
         impl Trait2 for S { type Item = (); }
-                               //Y
         fn main() {
             let _: <S as Trait1/*caret*/>
                 ::Item;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1046,19 +1046,22 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }           //^ unresolved
     """)
 
+    // The go-to-declaration behavior differs in this case. See `RsGotoDeclarationTest`
     fun `test 'impl for generic type' is USED for associated type resolve UFCS 1`() = checkByCode("""
         trait Bound {}
         trait Tr { type Item; }
+                      //X
         impl<A: Bound> Tr for A { type Item = (); }
-        fn foo<B: Bound>(b: B) {     //X
+        fn foo<B: Bound>(b: B) {
             let a: <B as Tr>::Item;
         }                   //^
     """)
 
+    // The go-to-declaration behavior differs in this case. See `RsGotoDeclarationTest`
     fun `test 'impl for generic type' is USED for associated type resolve UFCS 2`() = checkByCode("""
         trait Bound { type Item; }
+                         //X
         impl<A: Bound> Bound for &A { type Item = (); }
-                                          //X
         fn foo<B: Bound>(b: B) {
             let a: <&B as Bound>::Item;
         }                       //^
@@ -1144,15 +1147,17 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
+    // The go-to-declaration behavior differs in this case. See `RsGotoDeclarationTest`
     @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 1)`() = checkByCode("""
         struct S;
         trait Trait1<T> { type Item; }
+                             //X
         trait Trait2<T>: Trait1<T> { fn foo() -> i32; }
 
         impl Trait1<i32> for S {
             type Item = i32;
-        }       //X
+        }
         impl Trait1<u8> for S {
             type Item = u8;
         }
@@ -1161,15 +1166,17 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }                   //^
     """)
 
+    // The go-to-declaration behavior differs in this case. See `RsGotoDeclarationTest`
     @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 2)`() = checkByCode("""
         struct S;
         trait Trait1<T=u8> { type Item; }
+                                //X
         trait Trait2<T>: Trait1<T> { fn foo() -> i32; }
 
         impl Trait1<i32> for S {
             type Item = i32;
-        }       //X
+        }
         impl Trait1 for S {
             type Item = u8;
         }
@@ -1292,8 +1299,10 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }
     """)
 
+    // The go-to-declaration behavior differs in this case. See `RsGotoDeclarationTest`
     fun `test explicit UFCS-like type-qualified path is resolved to correct impl when inapplicable blanket impl exists`() = checkByCode("""
         trait Trait { type Item; }
+                         //X
         trait Bound {}
         impl<I: Bound> Trait for I {
             type Item = I;
@@ -1301,7 +1310,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         struct S;
         impl Trait for S {
             type Item = ();
-        }      //X
+        }
         fn main() {
             let a: <S as Trait>::Item;
         }                      //^

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -761,17 +761,18 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }
     """)
 
+    // The go-to-declaration behavior differs in this case. See `RsGotoDeclarationTest`
     @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is resolved to assoc type of current impl`() = checkByCode("""
         struct S;
         trait Trait {
             type Item;
+                //X
             fn foo() -> Self::Item;
         }
 
         impl Trait for S {
             type Item = i32;
-                //X
             fn foo() -> Self::Item { unreachable!() }
         }                    //^
     """)
@@ -791,15 +792,17 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }                    //^ unresolved
     """)
 
+    // The go-to-declaration behavior differs in this case. See `RsGotoDeclarationTest`
     @CheckTestmarkHit(NameResolutionTestmarks.SelfRelatedTypeSpecialCase::class)
     fun `test Self-qualified path in trait impl is resolved to assoc type of super trait`() = checkByCode("""
         struct S;
         trait Trait1 { type Item; }
+                          //X
         trait Trait2: Trait1 { fn foo() -> i32; }
 
         impl Trait1 for S {
             type Item = i32;
-        }       //X
+        }
 
         impl Trait2 for S {
             fn foo() -> Self::Item { unreachable!() }

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -16,8 +16,8 @@ import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.TYPES
 import org.rust.lang.core.types.TraitRef
 import org.rust.lang.core.types.infer.TypeInferenceMarks
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.*
-import org.rust.lang.core.types.type
 
 class RsImplicitTraitsTest : RsTypificationTestBase() {
 
@@ -355,13 +355,13 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
             ?: error("Cannot parse path `$traitName`")
         val trait = traitPath.reference?.advancedResolve()?.downcast<RsTraitItem>()
             ?: error("Cannot resolve path `traitName` to a trait")
-        val hasImpl = lookup.canSelect(TraitRef(typeRef.type, trait))
+        val hasImpl = lookup.canSelect(TraitRef(typeRef.rawType, trait))
 
         check(mustHaveImpl == hasImpl) {
             if (mustHaveImpl) {
-                "The trait `$traitName` must be implemented for the type `${typeRef.type}`, but it actually doesn't"
+                "The trait `$traitName` must be implemented for the type `${typeRef.rawType}`, but it actually doesn't"
             } else {
-                "The trait `$traitName` must NOT be implemented for the type `${typeRef.type}`, but it is actually implemented"
+                "The trait `$traitName` must NOT be implemented for the type `${typeRef.rawType}`, but it is actually implemented"
             }
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/type/RsTyTraitObjectRegionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTyTraitObjectRegionTest.kt
@@ -10,9 +10,9 @@ import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.psi.RsTypeReference
+import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.TyTraitObject
 import org.rust.lang.core.types.ty.walk
-import org.rust.lang.core.types.type
 
 class RsTyTraitObjectRegionTest : RsTestBase() {
     fun `test trait under ref`() = doTest("""
@@ -80,7 +80,7 @@ class RsTyTraitObjectRegionTest : RsTestBase() {
     private fun doTest(@Language("Rust") code: String) {
         InlineFile(code)
         val (typeAtCaret, expectedRegion) = findElementAndDataInEditor<RsTypeReference>()
-        val ty = typeAtCaret.type
+        val ty = typeAtCaret.rawType
         val traitObjectTy = ty.walk().asSequence().filterIsInstance<TyTraitObject>().first()
         val actualRegion = traitObjectTy.region.toString()
         check(actualRegion == expectedRegion) {

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -10,7 +10,8 @@ import org.rust.ide.presentation.render
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.lang.core.psi.RsTypeReference
 import org.rust.lang.core.type.RsTypeResolvingTest.RenderMode.*
-import org.rust.lang.core.types.type
+import org.rust.lang.core.types.normType
+import org.rust.lang.core.types.rawType
 
 class RsTypeResolvingTest : RsTypificationTestBase() {
     fun `test path`() = testType("""
@@ -62,8 +63,24 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         }
     """)
 
-    // TODO `<S as T>::Assoc` should be unified to `S`
-    fun `test qualified path`() = testType("""
+    fun `test normalizable associated type path`() = testType("""
+        trait T {
+            type Assoc;
+        }
+
+        struct S;
+
+        impl T for S {
+            type Assoc = S;
+        }
+
+        fn main() {
+            let _: <S as T>::Assoc = S;
+                 //^ <S as T>::Assoc
+        }
+    """)
+
+    fun `test normalizable associated type path normalized`() = testType("""
         trait T {
             type Assoc;
         }
@@ -78,7 +95,7 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
             let _: <S as T>::Assoc = S;
                  //^ S
         }
-    """)
+    """, normalize = true)
 
     fun `test enum`() = testType("""
         enum E { X }
@@ -248,6 +265,15 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         }           //^ <B as Trait<u8>>::Item
     """)
 
+    fun `test associated type is not normalized when not possible`() = testType("""
+        trait Trait<T> {
+            type Item;
+        }
+        fn foo<B: Trait<u8>>(_: B) {
+            let a: B::Item;
+        }           //^ <B as Trait<u8>>::Item
+    """, normalize = true)
+
     fun `test associated types for impl`() = testType("""
         trait A {
             type Item;
@@ -257,7 +283,7 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         impl A for S {
             type Item = S;
             fn foo(self) -> Self::Item { S }
-        }                         //^ S
+        }                         //^ <S as A>::Item
     """)
 
     fun `test inherited associated types for impl`() = testType("""
@@ -269,7 +295,7 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         impl A for S { type Item = S; }
         impl B for S {
             fn foo(self) -> Self::Item { S }
-        }                         //^ S
+        }                         //^ <S as A>::Item
     """)
 
     fun `test generic trait object`() = testType("""
@@ -519,7 +545,7 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
             type f64 = ();
         }
         type A = <S as Trait>::f64;
-                             //^ ()
+                             //^ <S as Trait>::f64
     """)
 
     fun `test unresolved associated type with name f64`() = testType("""
@@ -535,12 +561,17 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
      */
     private fun testType(
         @Language("Rust") code: String,
-        renderMode: RenderMode = DEFAULT
+        renderMode: RenderMode = DEFAULT,
+        normalize: Boolean = false
     ) {
         InlineFile(code)
         val (typeAtCaret, expectedType) = findElementAndDataInEditor<RsTypeReference>()
 
-        val ty = typeAtCaret.type
+        val ty = if (normalize) {
+            typeAtCaret.normType
+        } else {
+            typeAtCaret.rawType
+        }
         val renderedTy = when (renderMode) {
             DEFAULT -> ty.render(useAliasNames = false, skipUnchangedDefaultTypeArguments = false)
             WITH_LIFETIMES -> ty.renderInsertionSafe(includeLifetimeArguments = true, skipUnchangedDefaultTypeArguments = false)


### PR DESCRIPTION
This is a kind of a cleanup after #8058. This change does not affect users.

Consider this code:

```rust
trait Trait {
    type Type;
}
struct S;
impl Trait for S {
    type Type = ();
}
type A = <S as Trait>::Type;
```

Now usual `path.reference.resolve()` always resolves `<S as Trait>::Type` path to the type alias in the trait. To resolve an associated type path to an impl you should use `path.reference.resolveTypeAliasToImpl()` method. It's now used instead of `path.reference.resolve()` in navigation like go-to-declaration.

This should simplify further refactoring and optimization of the name resolution code.