### PR TITLE
INSP: Use kotlin-semver to avoid false-positives in version comparison & enable version inspections

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -403,12 +403,12 @@ project(":") {
             exclude(module = "kotlin-stdlib")
             exclude(module = "kotlin-stdlib-common")
         }
-        implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.13.3"){
+        implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.13.3") {
             exclude(module = "jackson-core")
             exclude(module = "jackson-databind")
             exclude(module = "jackson-annotations")
         }
-        api("com.vdurmont:semver4j:3.1.0")
+        api("io.github.z4kn4fein:semver:1.3.3")
         testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
     }
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
@@ -6,8 +6,7 @@
 package org.rust.ide.inspections.lints
 
 import com.intellij.psi.PsiElement
-import com.vdurmont.semver4j.Semver
-import com.vdurmont.semver4j.SemverException
+import io.github.z4kn4fein.semver.toVersionOrNull
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.lang.core.psi.RsElementTypes.CSELF
 import org.rust.lang.core.psi.RsFile
@@ -73,9 +72,9 @@ class RsDeprecationInspection : RsLintInspection() {
 
     // Presently as in not in the future; in the current version
     private fun RsMetaItem.isPresentlyDeprecated(since: String?): Boolean {
-        // In case we can't check if the since version is at least the current version just assume it is
-        val sinceVersion = since?.asVersion() ?: return true
-        val currentVersion = this.containingCargoPackage?.version?.asVersion() ?: return true
+        // In case we can't check if the `sinceVersion` is at least the `currentVersion` just assume it is
+        val sinceVersion = since?.toVersionOrNull(false) ?: return true
+        val currentVersion = this.containingCargoPackage?.version?.toVersionOrNull() ?: return true
 
         return currentVersion >= sinceVersion
     }
@@ -97,13 +96,5 @@ class RsDeprecationInspection : RsLintInspection() {
         private const val SINCE_PARAM_NAME: String = "since"
         private const val NOTE_PARAM_NAME: String = "note"
         private const val REASON_PARAM_NAME: String = "reason"
-    }
-}
-
-private fun String.asVersion(): Semver? {
-    return try {
-        Semver(this, Semver.SemverType.NPM)
-    } catch (e: SemverException) {
-        null
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
@@ -7,8 +7,8 @@ package org.rust.toml.crates.local
 
 import com.intellij.openapi.components.service
 import com.intellij.openapi.components.serviceIfCreated
-import com.vdurmont.semver4j.Semver
-import com.vdurmont.semver4j.SemverException
+import io.github.z4kn4fein.semver.Version
+import io.github.z4kn4fein.semver.toVersionOrNull
 import org.jetbrains.annotations.TestOnly
 import org.rust.stdext.RsResult
 import java.nio.file.Path
@@ -73,10 +73,5 @@ data class CargoRegistryCrateVersion(
     val isYanked: Boolean,
     val features: List<String>
 ) {
-    val semanticVersion: Semver?
-        get() = try {
-            Semver(version, Semver.SemverType.NPM)
-        } catch (e: SemverException) {
-            null
-        }
+    val semanticVersion: Version? get() = version.toVersionOrNull()
 }

--- a/toml/src/main/kotlin/org/rust/toml/inspections/NewCrateVersionAvailableInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/NewCrateVersionAvailableInspection.kt
@@ -7,7 +7,7 @@ package org.rust.toml.inspections
 
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
-import com.vdurmont.semver4j.Semver
+import io.github.z4kn4fein.semver.Version
 import org.rust.toml.crates.local.CargoRegistryCrate
 import org.rust.toml.crates.local.CrateVersionRequirement
 import org.rust.toml.stringValue
@@ -34,9 +34,9 @@ class NewCrateVersionAvailableInspection : CrateVersionInspection() {
 
         holder.registerProblem(
             versionElement,
-            "A newer version is available for crate ${dependency.crateName}: ${newerVersion.value}",
+            "A newer version is available for crate ${dependency.crateName}: $newerVersion",
             ProblemHighlightType.WEAK_WARNING,
-            UpdateCrateVersionFix(versionElement, newerVersion.value)
+            UpdateCrateVersionFix(versionElement, newerVersion.toString())
         )
     }
 }
@@ -44,5 +44,5 @@ class NewCrateVersionAvailableInspection : CrateVersionInspection() {
 /**
  * A lot of Rust crates stay at 0.x.y for a long time, so we consider even major versions 0 to be stable.
  */
-private val Semver.isRustStable: Boolean
-    get() = suffixTokens.isEmpty()
+private val Version.isRustStable: Boolean
+    get() = preRelease == null

--- a/toml/src/main/resources/org.rust.toml.xml
+++ b/toml/src/main/resources/org.rust.toml.xml
@@ -44,19 +44,18 @@
                          level="WARNING"
                          implementationClass="org.rust.toml.inspections.CrateNotFoundInspection"/>
 
-        <!-- Version-related inspections are disabled for now due to false-positives -->
         <localInspection language="TOML"
                          displayName="Invalid crate version"
                          groupPath="Rust"
                          groupName="Cargo.toml"
-                         enabledByDefault="false"
+                         enabledByDefault="true"
                          level="WARNING"
                          implementationClass="org.rust.toml.inspections.CrateVersionInvalidInspection"/>
         <localInspection language="TOML"
                          displayName="New crate version available"
                          groupPath="Rust"
                          groupName="Cargo.toml"
-                         enabledByDefault="false"
+                         enabledByDefault="true"
                          level="WARNING"
                          implementationClass="org.rust.toml.inspections.NewCrateVersionAvailableInspection"/>
 

--- a/toml/src/test/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyVersionCompletionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyVersionCompletionTest.kt
@@ -26,13 +26,30 @@ class LocalCargoTomlDependencyVersionCompletionTest : LocalCargoTomlCompletionTe
     """, "foo" to CargoRegistryCrate.of("0.0.1", "1.0.0", "0.1.0")
     )
 
-    fun `test complete sorted by semver versions`() = completeBasic(
-        """
+    fun `test complete sorted by semver versions`() = completeBasic("""
         [dependencies]
         foo = "<caret>"
-        """,
+    """,
         listOf("0.4.7", "0.4.6", "0.4.5", "0.4.4", "0.4.3", "0.4.2", "0.4.1", "0.4.0", "0.4.0-rc.2", "0.4.0-rc.1", "0.4.0-rc", "0.3.17", "0.3.16", "0.3.15", "0.3.14", "0.3.13", "0.3.12", "0.3.11", "0.3.10", "0.3.9", "0.3.8", "0.3.7", "0.3.6", "0.3.5", "0.3.4", "0.3.3", "0.3.2", "0.3.1", "0.3.0", "0.2.11", "0.2.10", "0.2.9", "0.2.8", "0.2.7", "0.2.6", "0.2.5", "0.2.4", "0.2.3", "0.2.2", "0.2.1", "0.2.0", "0.1.6", "0.1.5", "0.1.4", "0.1.3", "0.1.2", "0.1.1", "0.1.0"),
         "foo" to CargoRegistryCrate.of("0.1.4", "0.4.3", "0.3.0", "0.1.1", "0.4.0", "0.3.5", "0.4.0-rc.1", "0.1.0", "0.4.2", "0.3.3", "0.3.4", "0.2.0", "0.1.3", "0.2.5", "0.3.8", "0.2.6", "0.4.6", "0.1.5", "0.2.11", "0.2.2", "0.4.5", "0.2.1", "0.3.1", "0.3.16", "0.3.6", "0.2.10", "0.4.4", "0.3.12", "0.2.9", "0.3.10", "0.1.6", "0.3.14", "0.2.4", "0.3.2", "0.1.2", "0.3.17", "0.3.9", "0.4.0-rc.2", "0.4.1", "0.3.15", "0.3.7", "0.4.0-rc", "0.2.7", "0.2.3", "0.4.7", "0.3.11", "0.2.8", "0.3.13"),
+    )
+
+    fun `test complete sorted order minor, major and patch sections`() = completeBasic("""
+        [dependencies]
+        foo = "<caret>"
+    """,
+        // source: semver spec (https://semver.org/)
+        listOf("2.1.1", "2.1.0", "2.0.0", "1.0.0"),
+        "foo" to CargoRegistryCrate.of("1.0.0", "2.1.0", "2.1.1", "2.0.0")
+    )
+
+    fun `test complete sorted by semver with pre-release sections`() = completeBasic("""
+        [dependencies]
+        foo = "<caret>"
+    """,
+        // source: semver spec (https://semver.org/)
+        listOf("1.0.0" , "1.0.0-rc.1" , "1.0.0-beta.11" , "1.0.0-beta.2" , "1.0.0-beta" , "1.0.0-alpha.beta" , "1.0.0-alpha.1" , "1.0.0-alpha"),
+        "foo" to CargoRegistryCrate.of("1.0.0-alpha.1" , "1.0.0-beta" , "1.0.0-beta.2" , "1.0.0-rc.1" , "1.0.0-beta.11" , "1.0.0-alpha" , "1.0.0" , "1.0.0-alpha.beta")
     )
 
     fun `test empty value complete without '=' and quotes 1_0`() = doSingleCompletion("""

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CrateVersionInvalidInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CrateVersionInvalidInspectionTest.kt
@@ -313,4 +313,26 @@ class CrateVersionInvalidInspectionTest : CargoTomlCrateInspectionTestBase(Crate
         "foo3" to CargoRegistryCrate.of("1.0.0"),
         "foo4" to CargoRegistryCrate.of("1.0.0"),
     )
+
+    fun `test valid version with numbers in pre-release & build sections`() = doTest("""
+        foo = { version = "0.4.0-2" }
+        bar = { version = "0.4.0-2.1" }
+        baz = { version = "0.4.0-a2.1f" }
+        qux = { version = "0.4.0-a21f+1" }
+        uno = { version = "0.4.0-a2.1f+1" }
+        dos = { version = "^0.4.0-a2.1f+1" }
+        tre = { version = "~0.4.0-a2.1f+1" }
+        qua = { version = "=0.4.0-a2.1f+1" }
+        cin = { version = ">0.4.0-a2.1f+1, <0.4.0-a2.1f+5" }
+    """,
+        "foo" to CargoRegistryCrate.of("0.4.0-2"),
+        "bar" to CargoRegistryCrate.of("0.4.0-2.1"),
+        "baz" to CargoRegistryCrate.of("0.4.0-a2.1f"),
+        "qux" to CargoRegistryCrate.of("0.4.0-a21f+1"),
+        "uno" to CargoRegistryCrate.of("0.4.0-a2.1f+1"),
+        "dos" to CargoRegistryCrate.of("0.4.0-a2.1f+1"),
+        "tre" to CargoRegistryCrate.of("0.4.0-a2.1f+1"),
+        "qua" to CargoRegistryCrate.of("0.4.0-a2.1f+1"),
+        "cin" to CargoRegistryCrate.of("0.4.0-a2.1f+2")
+    )
 }


### PR DESCRIPTION
This PR replaces `semver4j` with [kotlin-semver](https://github.com/z4kn4fein/kotlin-semver) lib as a more appropriate variant that solves the problems we've had with pre-release sections parsing as we were converting versions into npm ones.

In fact, the replacement fixes #7600, and provides correct order for pre-release versions in completion. So, it also enables version-related inspections by default

Closes #7600
Related to #6463

changelog: Handle correctly pre-release dependencies' versions parsing and enable `Invalid crate version` and `New crate version availaible` inspections for `Cargo.toml` by default