### PR TITLE
QDOC: avoid NPE during documentation generation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -77,6 +77,9 @@ val PsiElement.childrenWithLeaves: Sequence<PsiElement>
  * Extracts node's element type
  */
 val PsiElement.elementType: IElementType
+    get() = elementTypeOrNull!!
+
+val PsiElement.elementTypeOrNull: IElementType?
     // XXX: be careful not to switch to AST
     get() = if (this is RsFile) RsFileStub.Type else PsiUtilCore.getElementType(this)
 
@@ -304,7 +307,7 @@ inline val <T : StubElement<*>> StubBasedPsiElement<T>.greenStub: T?
     get() = (this as? StubBasedPsiElementBase<T>)?.greenStub
 
 fun PsiElement.isKeywordLike(): Boolean {
-    return when (elementType) {
+    return when (elementTypeOrNull) {
         in RS_KEYWORDS,
         RsElementTypes.BOOL_LITERAL -> true
         RsElementTypes.IDENTIFIER -> {

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -1336,6 +1336,14 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='content'><p>Some docs</p></div>
     """)
 
+    // https://github.com/intellij-rust/intellij-rust/issues/8732
+    fun `test do not throw exceptions on fake psi elements`() = doTest("""
+        fn main() {
+            let s = "http://localhost:8080";
+                             //^
+        }
+    """, null)
+
     private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String?)
         = doTest(code, expected, block = RsDocumentationProvider::generateDoc)
 


### PR DESCRIPTION
Fixes the bug introduced in #6492

Fixes #8732

changelog: Don't throw `NullPointerException` during quick documentation generation in some cases
