### PR TITLE
CI: stick cargo-generate version to 1.13.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -153,7 +153,7 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: install
-                  args: cargo-generate --locked
+                  args: cargo-generate --locked --version 0.13.1
 
             - name: Check environment
               run: |


### PR DESCRIPTION
This fixes CI builds on Rust nightly