### PR TITLE
MACRO: early discard too large macro expansions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
@@ -61,6 +61,7 @@ sealed class GetMacroExpansionError {
         is ExpansionPipelineError.ExpansionError -> when (e) {
             BuiltinMacroExpansionError -> "built-in macro expansion is not supported"
             DeclMacroExpansionError.DefSyntax -> "there is an error in the macro definition syntax"
+            DeclMacroExpansionError.TooLargeExpansion -> "the macro expansion is too large"
             is DeclMacroExpansionError.Matching -> "can't match the macro call body against the " +
                 "macro definition pattern(s)"
             is ProcMacroExpansionError.ServerSideError -> "a procedural macro error occurred:\n${e.message}"

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
@@ -21,6 +21,7 @@ sealed class MacroExpansionError
 sealed class DeclMacroExpansionError : MacroExpansionError() {
     data class Matching(val errors: List<MacroMatchingError>) : DeclMacroExpansionError()
     object DefSyntax : DeclMacroExpansionError()
+    object TooLargeExpansion : DeclMacroExpansionError()
 }
 
 sealed class MacroMatchingError {
@@ -107,6 +108,7 @@ fun DataOutput.writeMacroExpansionError(err: MacroExpansionError) {
         ProcMacroExpansionError.ExecutableNotFound -> 7
         ProcMacroExpansionError.ProcMacroExpansionIsDisabled -> 8
         BuiltinMacroExpansionError -> 9
+        DeclMacroExpansionError.TooLargeExpansion -> 10
     }
     writeByte(ordinal)
 
@@ -138,6 +140,7 @@ fun DataInput.readMacroExpansionError(): MacroExpansionError = when (val ordinal
     7 -> ProcMacroExpansionError.ExecutableNotFound
     8 -> ProcMacroExpansionError.ProcMacroExpansionIsDisabled
     9 -> BuiltinMacroExpansionError
+    10 -> DeclMacroExpansionError.TooLargeExpansion
     else -> throw IOException("Unknown expansion error code $ordinal")
 }
 

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -147,5 +147,6 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
             }
         }
         DeclMacroExpansionError.DefSyntax -> "syntax error in the macro definition"
+        DeclMacroExpansionError.TooLargeExpansion -> "too large expansion"
     }
 }


### PR DESCRIPTION
Currently we save macro expansion on a disc regardless its size, so too large expansion can just OOM the IDE. 

"large" means "more than `FileUtilRt.LARGE_FOR_CONTENT_LOADING`, usually 20 Mb"

changelog: Early discard too large macro expansions