### PR TITLE
MACRO: Remove Old Macro Expansion Engine

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -20,6 +20,7 @@ import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
 import org.rust.cargo.toolchain.RsToolchainBase
 import org.rust.openapiext.pathAsPath
 import java.nio.file.Paths
+import java.util.*
 import javax.swing.ListCellRenderer
 
 class RsProjectConfigurable(
@@ -32,7 +33,11 @@ class RsProjectConfigurable(
         rustProjectSettings.attachTo(this)
         row(RsBundle.message("settings.rust.toolchain.expand.macros.label")) {
             comboBox(
-                EnumComboBoxModel(MacroExpansionEngine::class.java),
+                object : EnumComboBoxModel<MacroExpansionEngine>(MacroExpansionEngine::class.java) {
+                    override fun createEnumSet(en: Class<MacroExpansionEngine>): EnumSet<MacroExpansionEngine> {
+                        return EnumSet.of(MacroExpansionEngine.DISABLED, MacroExpansionEngine.NEW)
+                    }
+                },
                 state::macroExpansionEngine,
                 createExpansionEngineListRenderer()
             ).comment(RsBundle.message("settings.rust.toolchain.expand.macros.comment"))
@@ -46,8 +51,7 @@ class RsProjectConfigurable(
         return SimpleListCellRenderer.create("") {
             when (it) {
                 MacroExpansionEngine.DISABLED -> RsBundle.message("settings.rust.toolchain.expand.macros.disable.label")
-                MacroExpansionEngine.OLD -> RsBundle.message("settings.rust.toolchain.expand.macros.old.engine.label")
-                MacroExpansionEngine.NEW -> RsBundle.message("settings.rust.toolchain.expand.macros.new.engine.label")
+                MacroExpansionEngine.OLD, MacroExpansionEngine.NEW -> RsBundle.message("settings.rust.toolchain.expand.macros.new.engine.label")
                 null -> error("Unreachable")
             }
         }

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -68,7 +68,9 @@ interface RustProjectSettingsService {
     }
 
     enum class MacroExpansionEngine {
-        DISABLED, OLD, NEW
+        DISABLED,
+        OLD, // `OLD` can't be selected by a user anymore, it exists for backcompat with saved user settings
+        NEW
     }
 
     @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -75,6 +75,10 @@ class RustProjectSettingsServiceImpl(
         val rawState = element.clone()
         rawState.updateToCurrentVersion()
         deserializeInto(_state, rawState)
+
+        if (_state.macroExpansionEngine == MacroExpansionEngine.OLD) {
+            _state.macroExpansionEngine = MacroExpansionEngine.NEW
+        }
     }
 
     override fun modify(action: (State) -> Unit) {

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -933,7 +933,7 @@ sealed class MacroExpansionMode {
 
 private fun RustProjectSettingsService.MacroExpansionEngine.toMode(): MacroExpansionMode = when (this) {
     RustProjectSettingsService.MacroExpansionEngine.DISABLED -> MacroExpansionMode.DISABLED
-    RustProjectSettingsService.MacroExpansionEngine.OLD -> MacroExpansionMode.OLD
+    RustProjectSettingsService.MacroExpansionEngine.OLD,
     RustProjectSettingsService.MacroExpansionEngine.NEW -> MacroExpansionMode.NEW_ALL
 }
 

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -213,7 +213,6 @@ settings.rust.toolchain.expand.macros.comment=Allow the plugin to process macro 
 settings.rust.toolchain.expand.macros.disable.label=Disable (select only if you have problems with macro expansion)
 settings.rust.toolchain.expand.macros.label=Expand macros:
 settings.rust.toolchain.expand.macros.new.engine.label=Use new engine
-settings.rust.toolchain.expand.macros.old.engine.label=Use old engine (some features will not work)
 settings.rust.toolchain.inject.rust.in.doc.comments.checkbox=Inject Rust language into documentation comments
 settings.rust.toolchain.invalid.toolchain.error=Invalid toolchain location: can''t find Cargo in {0}
 settings.rust.toolchain.location.label=Toolchain location:

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
@@ -6,11 +6,14 @@
 package org.rust.ide.inspections
 
 import org.rust.CheckTestmarkHit
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.macros.MacroExpansionScope
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspection::class) {
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test simple assert_eq fix`() = checkFixByText("Convert to assert_eq!", """
         fn main() {
             let x = 10;
@@ -25,6 +28,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test expr assert_eq fix`() = checkFixByText("Convert to assert_eq!", """
         fn answer() -> i32 {
             return 42
@@ -43,6 +47,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test simple assert_eq fix with format_args`() = checkFixByText("Convert to assert_eq!", """
         fn main() {
             let x = 10;
@@ -57,6 +62,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test simple assert_ne fix`() = checkFixByText("Convert to assert_ne!", """
         fn main() {
             let x = 10;
@@ -71,6 +77,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test expr assert_ne fix`() = checkFixByText("Convert to assert_ne!", """
         fn answer() -> i32 {
             return 42;
@@ -89,6 +96,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test simple assert_ne fix with format_args`() = checkFixByText("Convert to assert_ne!", """
         fn main() {
             let x = 10;

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.ide.inspections
 
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmutableInspection::class) {
 
@@ -60,6 +62,7 @@ class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmuta
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test E0594 assign to field of immutable binding while iterating`() = checkByText("""
         struct Foo { a: i32 }
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -5,11 +5,13 @@
 
 package org.rust.ide.inspections.borrowck
 
+import org.rust.ExpandMacros
 import org.rust.MockAdditionalCfgOptions
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection::class) {
     fun `test move by call`() = checkByText("""
@@ -272,6 +274,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move error E0382 on field getter`() = checkByText("""
         struct S {
             data: (u16, u16, u16)
@@ -352,6 +355,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move error E0507 on copyable array`() = checkByText("""
         fn copy(arr: &[i32; 4]) -> [i32; 4] {
             *arr
@@ -553,6 +557,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
 
     /** Issue [#4307](https://github.com/intellij-rust/intellij-rust/issues/4307) */
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move error copy slice`() = checkByText("""
         fn main() {
             let v: Vec<i32> = vec![1, 2, 3];
@@ -633,6 +638,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move struct expr with base`() = checkByText("""
         struct S { x: i32, y: i32 }
 
@@ -644,6 +650,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move struct expr with base paren`() = checkByText("""
         struct S { x: i32, y: i32 }
 
@@ -655,6 +662,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move generic struct expr with base`() = checkByText("""
         struct S<T> { x: T, y: T }
 
@@ -677,6 +685,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move self struct expr with base`() = checkByText("""
         struct S { x: i32, y: i32 }
 
@@ -688,6 +697,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move self struct expr with complex base`() = checkByText("""
         struct A<T> { x: T }
         struct B<T> { a: A<T>, aa: i32 }
@@ -767,6 +777,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move when Copy is implemented for struct named as a primitive type`() = checkByText("""
         struct f64;
         impl Copy for f64 {}

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntentionTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.ide.intentions
 
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.macros.MacroExpansionScope
 
 class ConvertClosureToFunctionIntentionTest : RsIntentionTestBase(ConvertClosureToFunctionIntention::class) {
 
@@ -47,6 +49,7 @@ class ConvertClosureToFunctionIntentionTest : RsIntentionTestBase(ConvertClosure
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test intention adds return type to function when closure doesnt have one`() = doAvailableTest("""
         fn main() {
             let foo = |x: i32/*caret*/| x + 1;

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -6,13 +6,11 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
-import org.rust.MockAdditionalCfgOptions
-import org.rust.ProjectDescriptor
-import org.rust.RsTestBase
-import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.*
 import org.rust.ide.refactoring.extractFunction.ExtractFunctionUi
 import org.rust.ide.refactoring.extractFunction.RsExtractFunctionConfig
 import org.rust.ide.refactoring.extractFunction.withMockExtractFunctionUi
+import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsExtractFunctionTest : RsTestBase() {
     fun `test extract a function without parameters and a return value`() = doTest("""
@@ -826,6 +824,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test extract a function with passing primitive`() = doTest("""
         fn foo() {
             let i = 1;
@@ -1777,6 +1776,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test extract println! argument expression`() = doTest("""
         fn main() {
             println!("{}", <selection>1 + 2</selection>);
@@ -1792,6 +1792,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test extract vec! argument expression`() = doTest("""
         fn main() {
             vec![<selection>1 + 2</selection>];

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceConstantTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceConstantTest.kt
@@ -6,16 +6,19 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.refactoring.introduceConstant.ExtractConstantUi
 import org.rust.ide.refactoring.introduceConstant.InsertionCandidate
 import org.rust.ide.refactoring.introduceConstant.withMockExtractConstantChooser
+import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsExpr
 
 class RsIntroduceConstantTest : RsTestBase() {
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test insertion binary expression`() = doTest("""
         fn foo() {
             let x = /*caret*/5 + 5;
@@ -148,6 +151,7 @@ class RsIntroduceConstantTest : RsTestBase() {
     """, replaceAll = true)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test expression containing a constant`() = doTest("""
         const C: i32 = 1;
 

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
@@ -6,11 +6,9 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
-import org.rust.CheckTestmarkHit
-import org.rust.ProjectDescriptor
-import org.rust.RsTestBase
-import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.*
 import org.rust.ide.refactoring.introduceVariable.IntroduceVariableTestmarks
+import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsExpr
 
 
@@ -86,6 +84,7 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test replace occurrences forward`() = doTest("""
         fn hello() {
             foo(5 + /*caret*/10);
@@ -100,6 +99,7 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
     """, replaceAll = true)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test replace occurrences backward`() = doTest("""
         fn main() {
             let a = 1;
@@ -116,6 +116,7 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
     """, replaceAll = true)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test replace occurrences backward for expr stmt`() = doTest("""
         fn main() {
             let a = 1;
@@ -132,6 +133,7 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
     """, replaceAll = true)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test replace occurrences backward for returned expr`() = doTest("""
         fn main() {
             let _ = {

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.ide.refactoring.generate
 
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.macros.MacroExpansionScope
 
 class GenerateGetterActionTest : RsGenerateBaseTest() {
     override val generateId: String = "Rust.GenerateGetter"
@@ -219,6 +221,7 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test tuple copy`() = doTest("""
         struct S {
             a: (u32, u32)
@@ -411,6 +414,7 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test type alias 2`() = doTest("""
         type Alias = (u32, u32);
         struct S {

--- a/src/test/kotlin/org/rust/ide/template/postfix/IterPostFixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/IterPostFixTemplateTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.ide.template.postfix
 
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.macros.MacroExpansionScope
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 abstract class IterPostFixTemplateTestBase(private val key: String) :
@@ -18,6 +20,7 @@ abstract class IterPostFixTemplateTestBase(private val key: String) :
         """
     )
 
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iterable expr`() = doTest("""
         fn main(){
             let v = vec![1, 2, 3];

--- a/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.ide.template.postfix
 
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.macros.MacroExpansionScope
 
 class LetPostfixTemplateTest : RsPostfixTemplateTest(LetPostfixTemplate(RsPostfixTemplateProvider())) {
     fun `test not expr 1`() = doTestNotApplicable("""
@@ -44,6 +46,7 @@ class LetPostfixTemplateTest : RsPostfixTemplateTest(LetPostfixTemplate(RsPostfi
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test par expr`() = doTest("""
         fn foo() {
             (1 + 2).let/*caret*/;

--- a/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
@@ -5,10 +5,13 @@
 
 package org.rust.ide.template.postfix
 
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.macros.MacroExpansionScope
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+@ExpandMacros(MacroExpansionScope.ALL, "std")
 class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate(RsPostfixTemplateProvider())) {
     fun `test string`() = doTest("""
        fn main() {
@@ -175,7 +178,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
     """, """
         fn main() {
             let test = 4;
-            println!("{:?}", test);/*caret*/
+            println!("{}", test);/*caret*/
         }
     """)
 
@@ -186,7 +189,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
     """, """
         fn main() {
             let test = 4;
-            println!("{:?}", test);/*caret*/
+            println!("{}", test);/*caret*/
         }
     """)
 
@@ -200,7 +203,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
         fn main() {
             let a = 123;
             let b = a - 42 * 3; // this is a comment
-            println!("{:?}", b);/*caret*/
+            println!("{}", b);/*caret*/
             let c = a + b;
         }
     """)
@@ -215,7 +218,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
         fn main() {
             let a = 123;
             let b = a - 42 * 3; // this is a comment
-            println!("{:?}", 42);/*caret*/
+            println!("{}", 42);/*caret*/
             let c = a + b;
         }
     """)
@@ -237,7 +240,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
             let a = 123;
             match E::A(22) {
                 E::A(value) => {
-                    println!("{:?}", 42);/*caret*/
+                    println!("{}", 42);/*caret*/
                     a - 42 * 3
                 } // this is a comment
                 _ => -1
@@ -258,7 +261,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
         enum E<T> { A(T), B }
 
         fn main() {
-            println!("{:?}", match E::A(22) {
+            println!("{}", match E::A(22) {
                 E::A(value) => value,
                 _ => -1
             });/*caret*/
@@ -282,7 +285,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
         fn main() {
             match E::A(22) {
                 E::A(value) => {
-                    println!("{:?}", value);/*caret*/
+                    println!("{}", value);/*caret*/
                 }
                 _ => ()
             }
@@ -304,7 +307,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
         fn main() {
             match E::A(22) {
                 E::A(value) => {
-                    println!("{:?}", value);/*caret*/
+                    println!("{}", value);/*caret*/
                     value
                 }
                 _ => -1
@@ -326,7 +329,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
 
         fn main() {
             match E::A(22) {
-                E::A(value) => println!("{:?}", value),/*caret*/
+                E::A(value) => println!("{}", value),/*caret*/
                 _ => ()
             };
         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -173,7 +173,7 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
     """)
 
     fun `test tuple of 'Copy' types is 'Copy'`() = doTest("""
-        type T = (i32, i32);
+        type T = ((), ());
                //^ Copy
     """)
 
@@ -184,7 +184,7 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
     """)
 
     fun `test array of 'Copy' type is 'Copy'`() = doTest("""
-        type T = [i32; 4];
+        type T = [(); 4];
                //^ Copy
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -567,6 +567,7 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iter take`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
@@ -603,6 +604,7 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iterator cloned`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {


### PR DESCRIPTION
I think the new macro expansion now works perfectly and I can't imagine a case where the old engine is usable. These is still an option to disable macro expansion at all.

I need to remove it because there are some hacks in type inference (hardcoded impls) that hinder type inference engine development
Some kind of "old" macro expansion is still used in our tests (until `@ExpandMacros` annotation is used) due to performance reasons. 

changelog: Remove Old Macro Expansion Engine option.
