### PR TITLE
Refactor `ImplLookup.assembleCandidates`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/Kind.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Kind.kt
@@ -14,6 +14,7 @@ const val HAS_RE_EARLY_BOUND_MASK: TypeFlags = 8
 const val HAS_CT_INFER_MASK: TypeFlags = 16
 const val HAS_CT_PARAMETER_MASK: TypeFlags = 32
 const val HAS_CT_UNEVALUATED_MASK: TypeFlags = 64
+const val HAS_TY_OPAQUE_MASK: TypeFlags = 128
 
 /**
  * An entity in the Rust type system, which can be one of several kinds (only types, lifetimes and constants for now).

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Expectation.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Expectation.kt
@@ -81,7 +81,7 @@ sealed class Expectation {
          * which still is useful, because it informs integer literals and the like
          */
         fun rvalueHint(ty: Ty): Expectation {
-            return when (ty.structTail()) {
+            return when (ty.structTail() ?: ty) {
                 is TyUnknown -> NoExpectation
                 is TySlice, is TyTraitObject, is TyStr -> ExpectRvalueLikeUnsized(ty)
                 else -> ExpectHasType(ty)

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -155,16 +155,16 @@ tailrec fun Ty.stripReferences(): Ty =
         else -> this
     }
 
-fun Ty.structTail(): Ty {
+fun Ty.structTail(): Ty? {
     val ancestors = mutableSetOf(this)
 
-    tailrec fun structTailInner(ty: Ty): Ty {
+    fun structTailInner(ty: Ty): Ty? {
         return when (ty) {
             is TyAdt -> {
                 val item = ty.item as? RsStructItem ?: return ty
                 val typeRef = item.fields.lastOrNull()?.typeReference
-                val fieldTy = typeRef?.type?.substitute(typeParameterValues) ?: return ty
-                if (!ancestors.add(fieldTy)) return ty
+                val fieldTy = typeRef?.type?.substitute(ty.typeParameterValues) ?: return null
+                if (!ancestors.add(fieldTy)) return null
                 structTailInner(fieldTy)
             }
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyAnon.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyAnon.kt
@@ -10,6 +10,7 @@ import org.rust.lang.core.psi.RsTraitType
 import org.rust.lang.core.psi.ext.flattenHierarchy
 import org.rust.lang.core.psi.ext.isImpl
 import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.HAS_TY_OPAQUE_MASK
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.mergeElementFlags
@@ -20,7 +21,7 @@ import org.rust.lang.core.types.mergeElementFlags
 data class TyAnon(
     val definition: RsTraitType?,
     val traits: List<BoundElement<RsTraitItem>>
-) : Ty(mergeElementFlags(traits)) {
+) : Ty(mergeElementFlags(traits) or HAS_TY_OPAQUE_MASK) {
 
     init {
         require(definition == null || definition.isImpl) {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
@@ -19,7 +19,6 @@ import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.mergeElementFlags
 import org.rust.lang.core.types.regions.ReUnknown
 import org.rust.lang.core.types.regions.Region
-import org.rust.stdext.zipValues
 
 /**
  * A "trait object" type should not be confused with a trait.
@@ -74,11 +73,7 @@ class TyTraitObject(
         for (i in traits.indices) {
             val be1 = traits[i]
             val be2 = other.traits[i]
-            if (be1.element != be2.element) return false
-
-            if (!be1.subst.zipTypeValues(be2.subst).all { it.first.isEquivalentTo(it.second) }) return false
-            if (be1.subst.constSubst != be2.subst.constSubst) return false
-            if (!zipValues(be1.assoc, be2.assoc).all { it.first.isEquivalentTo(it.second) }) return false
+            if (!be1.isEquivalentTo(be2)) return false
         }
 
         return true

--- a/src/main/kotlin/org/rust/openapiext/Testmark.kt
+++ b/src/main/kotlin/org/rust/openapiext/Testmark.kt
@@ -103,6 +103,11 @@ fun Testmark.hitOnFalse(b: Boolean): Boolean {
     return b
 }
 
+fun Testmark.hitOnTrue(b: Boolean): Boolean {
+    if (b) hit()
+    return b
+}
+
 interface TestmarkPred {
     @TestOnly
     fun <T> checkHit(f: () -> T): T

--- a/src/main/kotlin/org/rust/stdext/Collections.kt
+++ b/src/main/kotlin/org/rust/stdext/Collections.kt
@@ -214,3 +214,16 @@ private class WithNextIterator<T : Any>(private val iterator: Iterator<T>) : Ite
         return WithNextValue(next, nextNext)
     }
 }
+
+/**
+ * Removes an element from the list.
+ * The removed element is replaced by the last element of the list.
+ * Like [MutableList.removeAt], but `O(1)` at the cost of not preserving the list order
+ */
+fun <T> MutableList<T>.swapRemoveAt(index: Int) {
+    if (index == lastIndex) {
+        removeLast()
+    } else {
+        set(index, removeLast())
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -346,7 +346,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         }
     """)
 
-    @CheckTestmarkHit(TypeInferenceMarks.TraitSelectionSpecialization::class)
+    @CheckTestmarkHit(TypeInferenceMarks.WinnowSpecialization::class)
     fun `test specialization simple`() = checkByCode("""
         trait Tr { fn foo(&self); }
         struct S;


### PR DESCRIPTION
It should now look more like the Rustc version.
This PR also changes `?T: Sized` trait selection (now it follows Rustc version), so it should become compatible with #8866.