### PR TITLE
Improve function documentation stub generation

### DIFF
--- a/src/main/resources/intentionDescriptions/GenerateDocStubIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/GenerateDocStubIntention/after.rs.template
@@ -1,17 +1,14 @@
 ///
 ///
-/// # Arguments
+/// # Safety
 ///
-/// * `param1`:
-/// * `param2`:
 ///
-/// returns: &str
 ///
 /// # Examples
 ///
 /// ```
 ///
 /// ```
-fn foo(param1: &str, param2: u8) -> &str {
-    return "bar"
+unsafe fn foo(param1: &str, param2: u8) -> &str {
+    "bar"
 }


### PR DESCRIPTION
The old version was not very idiomatic, containing the arguments and the return type. The new version is taken directly from examples in `std`, having some space for a general description and an examples section. If the function is unsafe, it also adds a safety section.

changelog: Make function documentation stub more idiomatic