### PR TITLE
RES: Fix resolve of macros when other item with same name is in scope

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -30,7 +30,6 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.*
 import org.rust.lang.core.resolve.ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS
 import org.rust.lang.core.resolve.ref.ResolveCacheDependency
-import org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl
 import org.rust.lang.core.resolve.ref.RsResolveCache
 import org.rust.lang.core.resolve2.RsModInfoBase.*
 import org.rust.openapiext.toPsiFile
@@ -589,7 +588,8 @@ private fun MacroDefInfo.legacyMacroToPsi(containingScope: RsItemsOwner, info: R
             val defIndex = info.getMacroIndex(it, crate) ?: return@singleOrNull false
             MacroIndex.equals(defIndex, macroIndex)
         }
-        is ProcMacroDefInfo, is DeclMacro2DefInfo -> items.named[path.name]?.firstOrNull()
+        is ProcMacroDefInfo -> items.named[path.name]?.firstOrNull { it is RsFunction }
+        is DeclMacro2DefInfo -> items.named[path.name]?.firstOrNull { it is RsMacro2 }
     }
     // Note that we can return null, e.g. if old macro engine is enabled and macro definition is itself expanded
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -578,6 +578,19 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                 //X
     """)
 
+    fun `test macro 2 (import by macro_use)`() = stubOnlyResolve("""
+    //- main.rs
+        #[macro_use]
+        extern crate test_package;
+        fn main() {
+            foo!();
+        } //^ lib.rs
+    //- lib.rs
+        mod foo {}
+        pub macro foo() {}
+                //X
+    """)
+
     fun `test macro 2 (unresolved in textual scope)`() = stubOnlyResolve("""
     //- lib.rs
         pub macro foo() {}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -77,6 +77,18 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
         //^ dep-proc-macro/lib.rs
     """)
 
+    fun `test resolve bang proc macro from macro call (other item with same name)`() = stubOnlyResolve("""
+    //- dep-proc-macro/lib.rs
+        mod example_proc_macro {}
+        #[proc_macro]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+    //- lib.rs
+        #[macro_use]
+        extern crate dep_proc_macro;
+        example_proc_macro!();
+        //^ dep-proc-macro/lib.rs
+    """)
+
     fun `test resolve attr proc macro in use item`() = stubOnlyResolve("""
     //- dep-proc-macro/lib.rs
         #[proc_macro_attribute]


### PR DESCRIPTION
Fixes #8804

changelog: Fix resolve of procedural macro when there is other item with same name in scope
