### PR TITLE
RUN: Emulate terminal for implicit run configurations by default on the nightly version of the plugin

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
@@ -55,7 +55,7 @@ class CargoTestCommandRunner : AsyncProgramRunner<RunnerSettings>() {
 
         private fun buildTests(environment: ExecutionEnvironment, state: CargoRunStateBase, cmdHasNoRun: Boolean): Promise<Int?> {
             val buildProcessHandler = run {
-                val buildCmd = state.commandLine.copy(withSudo = false).run {
+                val buildCmd = state.commandLine.copy(emulateTerminal = false, withSudo = false).run {
                     if (cmdHasNoRun) this else prependArgument("--no-run")
                 }
                 val buildConfig = CargoCommandConfiguration.CleanConfiguration.Ok(buildCmd, state.config.toolchain)

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -51,7 +51,7 @@ fun RunManager.createCargoCommandRunConfiguration(cargoCommandLine: CargoCommand
         CargoCommandConfigurationType.getInstance().factory
     )
     val configuration = runnerAndConfigurationSettings.configuration as CargoCommandConfiguration
-    configuration.setFromCmd(cargoCommandLine)
+    configuration.setFromCmd(cargoCommandLine.copy(emulateTerminal = configuration.emulateTerminal))
     return runnerAndConfigurationSettings
 }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskRunner.kt
@@ -140,6 +140,7 @@ class CargoBuildTaskRunner : ProjectTaskRunner() {
             val settings = runManager.createCargoCommandRunConfiguration(commandLine)
             val environment = ExecutionEnvironment(executor, runner, settings, project)
             val configuration = settings.configuration as? CargoCommandConfiguration ?: return@mapNotNull null
+            configuration.emulateTerminal = false
             val buildableElement = CargoBuildConfiguration(configuration, environment)
             ProjectModelBuildTaskImpl(buildableElement, false)
         }

--- a/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
@@ -17,6 +17,7 @@ import org.rust.RsBundle
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration.Companion.emulateTerminalDefault
 import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.runconfig.createCargoCommandRunConfiguration
 import org.rust.cargo.runconfig.wasmpack.WasmPackCommandConfiguration
@@ -79,7 +80,7 @@ data class CargoCommandLine(
     val environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT,
     val requiredFeatures: Boolean = true,
     val allFeatures: Boolean = false,
-    val emulateTerminal: Boolean = false,
+    val emulateTerminal: Boolean = emulateTerminalDefault,
     val withSudo: Boolean = false
 ) : RsCommandLineBase() {
 


### PR DESCRIPTION
Implicit run configurations are used in:
- `Run Anything` for cargo and wasm-pack
- Launch a target from Cargo Tool Window
- `Run Cargo Expand` intention
- `Build` button if Build Tool Window is disabled (except for `Test` command)
- Installing `cargo-expand`, `evcxr_repl`, `wasm-pack` or `grcov` via plugin's notification

You can turn it on / off in `Experimental features` - `org.rust.cargo.emulate.terminal`

changelog: Fix emulating terminal in output console in some cases
