### PR TITLE
CARGO: support common approach for project model reloading for Cargo via `ExternalSystemProjectAware`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -389,8 +389,10 @@ project(":") {
         main {
             if (channel == "nightly" || channel == "dev") {
                 resources.srcDirs("src/main/resources-nightly")
+                resources.srcDirs("src/$platformVersion/main/resources-nightly")
             } else {
                 resources.srcDirs("src/main/resources-stable")
+                resources.srcDirs("src/$platformVersion/main/resources-stable")
             }
         }
     }

--- a/src/221/main/kotlin/org/rust/cargo/project/model/impl/compatUtils.kt
+++ b/src/221/main/kotlin/org/rust/cargo/project/model/impl/compatUtils.kt
@@ -1,0 +1,12 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+
+@Suppress("UNUSED_PARAMETER")
+fun registerProjectAware(project: Project, disposable: Disposable) {}

--- a/src/221/main/resources-nightly/META-INF/platform-experiments.xml
+++ b/src/221/main/resources-nightly/META-INF/platform-experiments.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/221/main/resources-stable/META-INF/platform-experiments.xml
+++ b/src/221/main/resources-stable/META-INF/platform-experiments.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/222/main/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAware.kt
+++ b/src/222/main/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAware.kt
@@ -1,0 +1,81 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.externalSystem.autoimport.*
+import com.intellij.openapi.externalSystem.autoimport.ExternalSystemSettingsFilesModificationContext.ReloadStatus
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.util.PathUtil
+import org.rust.cargo.CargoConstants
+import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.model.CargoProjectsService.CargoRefreshStatus
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.model.impl.CargoSettingsFilesService.SettingFileType
+
+@Suppress("UnstableApiUsage")
+class CargoExternalSystemProjectAware(
+    private val project: Project
+) : ExternalSystemProjectAware {
+
+    override val projectId: ExternalSystemProjectId = ExternalSystemProjectId(CARGO_SYSTEM_ID, project.name)
+    override val settingsFiles: Set<String>
+        get() {
+            val settingsFilesService = CargoSettingsFilesService.getInstance(project)
+            // Always collect fresh settings files
+            return settingsFilesService.collectSettingsFiles(useCache = false).keys
+        }
+
+    override fun isIgnoredSettingsFileEvent(path: String, context: ExternalSystemSettingsFilesModificationContext): Boolean {
+        if (super.isIgnoredSettingsFileEvent(path, context)) return true
+        // We consider any external change of `Cargo.lock` during project reloading is made by `Cargo`
+        // and it shouldn't trigger new project reloading
+        val fileName = PathUtil.getFileName(path)
+        if (fileName == CargoConstants.LOCK_FILE &&
+            context.modificationType == ExternalSystemModificationType.EXTERNAL &&
+            (context.reloadStatus == ReloadStatus.IN_PROGRESS || context.reloadStatus == ReloadStatus.JUST_FINISHED)
+        ) return true
+
+        if (context.event != ExternalSystemSettingsFilesModificationContext.Event.UPDATE) return false
+
+        // `isIgnoredSettingsFileEvent` is called just to filter settings files already detected by `settingsFiles` call,
+        // so we don't need to collect fresh settings file list, and we can use cached value.
+        // Also, `isIgnoredSettingsFileEvent` is called from EDT so using cache should make it much faster
+        val settingsFiles = CargoSettingsFilesService.getInstance(project).collectSettingsFiles(useCache = true)
+        return settingsFiles[path] == SettingFileType.IMPLICIT_TARGET
+    }
+
+    override fun reloadProject(context: ExternalSystemProjectReloadContext) {
+        FileDocumentManager.getInstance().saveAllDocuments()
+        project.cargoProjects.refreshAllProjects()
+    }
+
+    override fun subscribe(listener: ExternalSystemProjectListener, parentDisposable: Disposable) {
+        project.messageBus.connect(parentDisposable).subscribe(
+            CargoProjectsService.CARGO_PROJECTS_REFRESH_TOPIC,
+            object : CargoProjectsService.CargoProjectsRefreshListener {
+                override fun onRefreshStarted() {
+                    listener.onProjectReloadStart()
+                }
+
+                override fun onRefreshFinished(status: CargoRefreshStatus) {
+                    val externalStatus = when (status) {
+                        CargoRefreshStatus.SUCCESS -> ExternalSystemRefreshStatus.SUCCESS
+                        CargoRefreshStatus.FAILURE -> ExternalSystemRefreshStatus.FAILURE
+                        CargoRefreshStatus.CANCEL -> ExternalSystemRefreshStatus.CANCEL
+                    }
+                    listener.onProjectReloadFinish(externalStatus)
+                }
+            }
+        )
+    }
+
+    companion object {
+        val CARGO_SYSTEM_ID: ProjectSystemId = ProjectSystemId("Cargo")
+    }
+}

--- a/src/222/main/kotlin/org/rust/cargo/project/model/impl/CargoSettingsFilesService.kt
+++ b/src/222/main/kotlin/org/rust/cargo/project/model/impl/CargoSettingsFilesService.kt
@@ -1,0 +1,93 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.CargoConstants
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.RsFileType
+
+@Service
+class CargoSettingsFilesService(private val project: Project) {
+
+    @Volatile
+    private var settingsFilesCache: Map<String, SettingFileType>? = null
+
+    fun collectSettingsFiles(useCache: Boolean): Map<String, SettingFileType> {
+        return if (useCache) {
+            settingsFilesCache ?: collectSettingsFiles()
+        } else {
+            collectSettingsFiles()
+        }
+    }
+
+    private fun collectSettingsFiles(): Map<String, SettingFileType> {
+        val result = mutableMapOf<String, SettingFileType>()
+        for (cargoProject in project.cargoProjects.allProjects) {
+            cargoProject.collectSettingsFiles(result)
+        }
+
+        settingsFilesCache = result
+
+        return result
+    }
+
+    private fun CargoProject.collectSettingsFiles(out: MutableMap<String, SettingFileType>) {
+        val rootPath = rootDir?.path
+        if (rootPath != null) {
+            out["$rootPath/${CargoConstants.MANIFEST_FILE}"] = SettingFileType.CONFIG
+            out["$rootPath/${CargoConstants.LOCK_FILE}"] = SettingFileType.CONFIG
+        }
+
+        for (pkg in workspace?.packages.orEmpty().filter { it.origin == PackageOrigin.WORKSPACE }) {
+            pkg.contentRoot?.collectSettingsFiles(out)
+        }
+    }
+
+    private fun VirtualFile.collectSettingsFiles(out: MutableMap<String, SettingFileType>) {
+        out["$path/${CargoConstants.MANIFEST_FILE}"] = SettingFileType.CONFIG
+
+        // Here we track only existing implicit target files.
+        // It's enough because `com.intellij.openapi.externalSystem.autoimport.ExternalSystemProjectAware.getSettingsFiles`
+        // will be called on new file creation by the platform, so we need to provide a list of all possible implicit target files here
+        for (targetFileName in IMPLICIT_TARGET_FILES) {
+            val path = findFileByRelativePath(targetFileName)?.path ?: continue
+            out[path] = SettingFileType.IMPLICIT_TARGET
+        }
+
+        for (targetDirName in IMPLICIT_TARGET_DIRS) {
+            val dir = findFileByRelativePath(targetDirName) ?: continue
+            for (file in VfsUtil.collectChildrenRecursively(dir)) {
+                if (file.fileType == RsFileType) {
+                    out[file.path] = SettingFileType.IMPLICIT_TARGET
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun getInstance(project: Project): CargoSettingsFilesService = project.service()
+
+        private val IMPLICIT_TARGET_FILES = listOf(
+            "build.rs", "src/main.rs", "src/lib.rs"
+        )
+
+        private val IMPLICIT_TARGET_DIRS = listOf(
+            "src/bin", "examples", "tests", "benches"
+        )
+    }
+
+    enum class SettingFileType {
+        CONFIG,
+        IMPLICIT_TARGET
+    }
+}

--- a/src/222/main/kotlin/org/rust/cargo/project/model/impl/compatUtils.kt
+++ b/src/222/main/kotlin/org/rust/cargo/project/model/impl/compatUtils.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.externalSystem.autoimport.AutoImportProjectTracker
+import com.intellij.openapi.externalSystem.autoimport.ExternalSystemProjectTracker
+import com.intellij.openapi.project.Project
+import org.rust.cargo.project.settings.RustProjectSettingsService
+import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsChangedEvent
+import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsListener
+
+fun registerProjectAware(project: Project, disposable: Disposable) {
+    val cargoProjectAware = CargoExternalSystemProjectAware(project)
+    val projectTracker = ExternalSystemProjectTracker.getInstance(project)
+    projectTracker.register(cargoProjectAware, disposable)
+    projectTracker.activate(cargoProjectAware.projectId)
+
+    project.messageBus.connect(disposable)
+        .subscribe(RustProjectSettingsService.RUST_SETTINGS_TOPIC, object : RustSettingsListener {
+            override fun rustSettingsChanged(e: RustSettingsChangedEvent) {
+                if (e.affectsCargoMetadata) {
+                    AutoImportProjectTracker.getInstance(project).markDirty(cargoProjectAware.projectId)
+                }
+            }
+        })
+}

--- a/src/222/main/resources-nightly/META-INF/platform-experiments.xml
+++ b/src/222/main/resources-nightly/META-INF/platform-experiments.xml
@@ -1,0 +1,8 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <registryKey key="org.rust.cargo.new.auto.import"
+                     defaultValue="true"
+                     description="Enable new Cargo project model reloading"
+                     restartRequired="true"/>
+    </extensions>
+</idea-plugin>

--- a/src/222/main/resources-stable/META-INF/platform-experiments.xml
+++ b/src/222/main/resources-stable/META-INF/platform-experiments.xml
@@ -1,0 +1,8 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <registryKey key="org.rust.cargo.new.auto.import"
+                     defaultValue="true"
+                     description="Enable new Cargo project model reloading"
+                     restartRequired="false"/>
+    </extensions>
+</idea-plugin>

--- a/src/222/test/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAwareTest.kt
+++ b/src/222/test/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAwareTest.kt
@@ -1,0 +1,368 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.externalSystem.autoimport.AutoImportProjectNotificationAware
+import com.intellij.openapi.externalSystem.autoimport.AutoImportProjectTracker
+import com.intellij.openapi.externalSystem.autoimport.ExternalSystemProjectId
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.PathUtil
+import org.rust.FileTreeBuilder
+import org.rust.TestProject
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.fileTree
+import org.rust.lang.core.psi.RsPath
+import org.rustSlowTests.cargo.runconfig.waitFinished
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+
+class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
+
+    private val notificationAware get() = AutoImportProjectNotificationAware.getInstance(project)
+    private val projectTracker get() = AutoImportProjectTracker.getInstance(project)
+
+    private val cargoSystemId: ExternalSystemProjectId get() = projectTracker.getActivatedProjects()
+        .first { it.systemId == CargoExternalSystemProjectAware.CARGO_SYSTEM_ID }
+
+    override fun setUp() {
+        super.setUp()
+        projectTracker.enableAutoImportInTests()
+    }
+
+    fun `test modifications`() {
+        val testProject = fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+
+                [workspace]
+                members = [ "subproject" ]
+            """)
+            allTargets()
+
+            dir("subproject") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject"
+                    version = "0.1.0"
+                    authors = []
+                """)
+                allTargets()
+            }
+        }.create()
+
+        assertNotificationAware(event = "after project creation")
+        // Configs
+        testProject.checkFileModification("Cargo.toml", triggered = true)
+        testProject.checkFileModification("Cargo.lock", triggered = true)
+        testProject.checkFileModification("subproject/Cargo.toml", triggered = true)
+        // Implicit crate roots
+        // TODO: it should trigger project model reloading if build script evaluation is enabled
+        testProject.checkFileModification("build.rs", triggered = false)
+        testProject.checkFileModification("src/lib.rs", triggered = false)
+        testProject.checkFileModification("src/main.rs", triggered = false)
+        testProject.checkFileModification("src/bin/bin.rs", triggered = false)
+        testProject.checkFileModification("examples/example.rs", triggered = false)
+        testProject.checkFileModification("benches/bench.rs", triggered = false)
+        testProject.checkFileModification("tests/test.rs", triggered = false)
+        // TODO: it should trigger project model reloading if build script evaluation is enabled
+        testProject.checkFileModification("subproject/build.rs", triggered = false)
+        testProject.checkFileModification("subproject/src/lib.rs", triggered = false)
+        testProject.checkFileModification("subproject/src/main.rs", triggered = false)
+        testProject.checkFileModification("subproject/src/bin/bin.rs", triggered = false)
+        testProject.checkFileModification("subproject/examples/example.rs", triggered = false)
+        testProject.checkFileModification("subproject/benches/bench.rs", triggered = false)
+        testProject.checkFileModification("subproject/tests/test.rs", triggered = false)
+        // Regular Rust files
+        testProject.checkFileModification("src/foo.rs", triggered = false)
+        testProject.checkFileModification("subproject/src/foo.rs", triggered = false)
+    }
+
+    fun `test files deletion`() {
+        val testProject = fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+
+                [workspace]
+                members = [ "subproject" ]
+            """)
+            allTargets()
+
+            dir("subproject") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject"
+                    version = "0.1.0"
+                    authors = []
+                """)
+                allTargets()
+            }
+        }.create()
+
+        assertNotificationAware(event = "after project creation")
+        // Configs
+        testProject.checkFileDeletion("Cargo.toml", triggered = true)
+        testProject.checkFileDeletion("Cargo.lock", triggered = true)
+        testProject.checkFileDeletion("subproject/Cargo.toml", triggered = true)
+        // Implicit crate roots
+        testProject.checkFileDeletion("build.rs", triggered = true)
+        testProject.checkFileDeletion("src/main.rs", triggered = true)
+        testProject.checkFileDeletion("src/lib.rs", triggered = true)
+        testProject.checkFileDeletion("examples/example.rs", triggered = true)
+        testProject.checkFileDeletion("benches/bench.rs", triggered = true)
+        testProject.checkFileDeletion("tests/test.rs", triggered = true)
+        testProject.checkFileDeletion("subproject/build.rs", triggered = true)
+        testProject.checkFileDeletion("subproject/src/main.rs", triggered = true)
+        testProject.checkFileDeletion("subproject/src/lib.rs", triggered = true)
+        testProject.checkFileDeletion("subproject/examples/example.rs", triggered = true)
+        testProject.checkFileDeletion("subproject/benches/bench.rs", triggered = true)
+        testProject.checkFileDeletion("subproject/tests/test.rs", triggered = true)
+        // Regular Rust files
+        testProject.checkFileDeletion("src/foo.rs", triggered = false)
+        testProject.checkFileDeletion("subproject/src/foo.rs", triggered = false)
+    }
+
+    fun `test files creation`() {
+        val testProject = fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+
+                [workspace]
+                members = [ "subproject" ]
+            """)
+            noTargets()
+
+            dir("subproject") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject"
+                    version = "0.1.0"
+                    authors = []
+                """)
+                noTargets()
+            }
+        }.create()
+        assertNotificationAware(event = "initial project creation")
+
+        // Implicit crate roots
+        testProject.checkFileCreation("build.rs", triggered = true)
+        testProject.checkFileCreation("src/main.rs", triggered = true)
+        testProject.checkFileCreation("src/lib.rs", triggered = true)
+        testProject.checkFileCreation("examples/example.rs", triggered = true)
+        testProject.checkFileCreation("benches/bench.rs", triggered = true)
+        testProject.checkFileCreation("tests/test.rs", triggered = true)
+        testProject.checkFileCreation("subproject/build.rs", triggered = true)
+        testProject.checkFileCreation("subproject/src/main.rs", triggered = true)
+        testProject.checkFileCreation("subproject/src/lib.rs", triggered = true)
+        testProject.checkFileCreation("subproject/examples/example.rs", triggered = true)
+        testProject.checkFileCreation("subproject/benches/bench.rs", triggered = true)
+        testProject.checkFileCreation("subproject/tests/test.rs", triggered = true)
+        // Regular Rust files
+        testProject.checkFileCreation("src/foo.rs", triggered = false)
+        testProject.checkFileCreation("subproject/src/foo.rs", triggered = false)
+    }
+
+    fun `test reloading`() {
+        val testProject = fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                #foo = { path = "./foo" }
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    extern crate foo;
+
+                    fn main() {
+                        foo::hello();
+                    }       //^
+                """)
+            }
+
+            dir("foo") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "foo"
+                    version = "0.1.0"
+                    authors = []
+                """)
+
+                dir("src") {
+                    rust("lib.rs", """
+                        pub fn hello() {}
+                    """)
+                }
+            }
+        }.create()
+        assertNotificationAware(event = "initial project creation")
+
+        testProject.checkReferenceIsResolved<RsPath>("src/main.rs", shouldNotResolve = true)
+
+        val cargoToml = testProject.file("Cargo.toml")
+        runWriteAction {
+            VfsUtil.saveText(cargoToml, VfsUtil.loadText(cargoToml).replace("#", ""))
+        }
+        assertNotificationAware(cargoSystemId, event = "modification in Cargo.toml")
+
+        scheduleProjectReload()
+        assertNotificationAware(event = "project reloading")
+
+        runWithInvocationEventsDispatching("Failed to resolve the reference") {
+            testProject.findElementInFile<RsPath>("src/main.rs").reference?.resolve() != null
+        }
+    }
+
+    private fun TestProject.checkFileModification(path: String, triggered: Boolean) {
+        val file = file(path)
+        val initialText = VfsUtil.loadText(file)
+        checkModification("modifying of", path, triggered,
+            apply = { VfsUtil.saveText(file, "$initialText\nsome text") },
+            revert = { VfsUtil.saveText(file, initialText) }
+        )
+    }
+
+    private fun TestProject.checkFileDeletion(path: String, triggered: Boolean) {
+        val file = file(path)
+        val initialText = VfsUtil.loadText(file)
+        checkModification("removing of ", path, triggered,
+            apply = { file.delete(file.fileSystem) },
+            revert = { createFile(root, path, initialText) }
+        )
+    }
+
+    private fun TestProject.checkFileCreation(path: String, triggered: Boolean) {
+        checkModification("creation of", path, triggered,
+            apply = { createFile(root, path) },
+            revert = {
+                val file = file(path)
+                file.delete(file.fileSystem)
+            }
+        )
+    }
+
+    private fun checkModification(
+        eventName: String,
+        path: String,
+        triggered: Boolean,
+        apply: () -> Unit,
+        revert: () -> Unit
+    ) {
+        runWriteAction {
+            apply()
+        }
+        val externalSystems = if (triggered) arrayOf(cargoSystemId) else arrayOf()
+        assertNotificationAware(*externalSystems, event = "$eventName $path")
+
+        runWriteAction {
+            revert()
+        }
+        assertNotificationAware(event = "revert $eventName $path")
+    }
+
+    private fun scheduleProjectReload() {
+        val newDisposable = Disposer.newDisposable()
+        val startLatch = CountDownLatch(1)
+        val endLatch = CountDownLatch(1)
+        project.messageBus.connect(newDisposable).subscribe(
+            CargoProjectsService.CARGO_PROJECTS_REFRESH_TOPIC,
+            object : CargoProjectsService.CargoProjectsRefreshListener {
+                override fun onRefreshStarted() {
+                    startLatch.countDown()
+                }
+
+                override fun onRefreshFinished(status: CargoProjectsService.CargoRefreshStatus) {
+                    endLatch.countDown()
+                }
+            }
+        )
+
+        try {
+            projectTracker.scheduleProjectRefresh()
+
+            if (!startLatch.waitFinished(1000)) error("Cargo project reloading hasn't started")
+            if (!endLatch.waitFinished(5000)) error("Cargo project reloading hasn't finished")
+        } finally {
+            Disposer.dispose(newDisposable)
+        }
+    }
+
+    private fun assertNotificationAware(vararg projects: ExternalSystemProjectId, event: String) {
+        val message = if (projects.isEmpty()) "Notification must be expired" else "Notification must be notified"
+        assertEquals("$message on $event", projects.toSet(), notificationAware.getProjectsWithNotification())
+    }
+
+    @Throws(IOException::class)
+    private fun createFile(root: VirtualFile, path: String, text: String = ""): VirtualFile {
+        val name = PathUtil.getFileName(path)
+        val parentPath = PathUtil.getParentPath(path)
+        var parent = root
+        if (parentPath.isNotEmpty()) {
+            parent = VfsUtil.createDirectoryIfMissing(root, parentPath) ?: error("Failed to create $parentPath directory")
+        }
+        val file = parent.createChildData(parent.fileSystem, name)
+        VfsUtil.saveText(file, text)
+        return file
+    }
+
+    private fun FileTreeBuilder.allTargets() {
+        dir("src") {
+            dir("bin") {
+                rust("bin.rs", """
+                    fn main() {}
+                """)
+            }
+            rust("lib.rs", "")
+            rust("main.rs", """
+                mod foo;
+                fn main() {}
+            """)
+            rust("foo.rs", "")
+        }
+        dir("examples") {
+            rust("example.rs", """
+                fn main() {}
+            """)
+        }
+        dir("benches") {
+            rust("bench.rs", "")
+        }
+        dir("tests") {
+            rust("test.rs", "")
+        }
+        rust("build.rs", """
+            fn main() {}
+        """)
+    }
+
+    private fun FileTreeBuilder.noTargets() {
+        dir("src") {
+            dir("bin") {
+                // `cargo metadata` fails if package doesn't contain any target at all
+                file("binary.rs")
+            }
+        }
+        dir("examples") {}
+        dir("benches") {}
+        dir("tests") {}
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
@@ -9,7 +9,10 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.layout.panel
 import org.rust.RsBundle
+import org.rust.cargo.project.model.isNewProjectModelImportEnabled
 
+// TODO: move this configurable to `Preferences | Build, Execution, Deployment | Build Tools` when
+//  new project model reloading is enabled by default
 class CargoConfigurable(project: Project) : RsConfigurableBase(project, RsBundle.message("settings.rust.cargo.name")) {
     override fun createPanel(): DialogPanel = panel {
         row {
@@ -18,11 +21,15 @@ class CargoConfigurable(project: Project) : RsConfigurableBase(project, RsBundle
                 state::autoShowErrorsInEditor
             )
         }
-        row {
-            checkBox(
-                RsBundle.message("settings.rust.cargo.auto.update.project.label"),
-                state::autoUpdateEnabled
-            )
+        // Project model updates is controlled with `Preferences | Build, Execution, Deployment | Build Tools` settings
+        // in case of new approach
+        if (!isNewProjectModelImportEnabled) {
+            row {
+                checkBox(
+                    RsBundle.message("settings.rust.cargo.auto.update.project.label"),
+                    state::autoUpdateEnabled
+                )
+            }
         }
         row {
             checkBox(

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -4,6 +4,7 @@
     <depends>com.intellij.modules.lang</depends>
 
     <xi:include href="/META-INF/experiments.xml" xpointer="xpointer(/idea-plugin/*)"/>
+    <xi:include href="/META-INF/platform-experiments.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Rust -->


### PR DESCRIPTION
These changes introduce a new approach to detect potential project model changes and notify users about it.
Previously, the plugin had only file listener that was triggered by changes in VFS and it checked if changes were "interesting"  -  any changes in config files like `Cargo.toml` and creation/deletion of implicit crate roots like `main.rs`, `lib.rs`, `build.rs`, files in `tests`, `benches` and `examples` directories. 

And it mostly works, but the implementation has some disadvantages:
- your changes should be saved to VFS, i.e. if you type something in `Cargo.toml`, the plugin won't know about it until IDE saves a new version of `Cargo.toml` with your changes. And you have to save files manually (which is quite weird in IntelliJ world) or wait when the IDE saves your change in some unpredictable moment
- any change in config files is considered as important and triggers project model update. But if you add just a new line or space, it's 100% redundant. Moreover, if you enable `org.rust.cargo.evaluate.build.scripts` enabled, each additional project model reloading may require significant time
- if you disable auto project model reloading (via `Update project automatically when Cargo.toml changes` option in `Preferences | Languages & Frameworks | Rust | Cargo` settings), users won't be notified anyhow that the current project model is not up-to-date and some analysis may not respect the latest changes
- if `cargo metadata` call (part of project model reloading) is long enough (more than 5 seconds by default) and it changes/creates `Cargo.lock` file, the project model reloading will be called again (actually, there was a case when it never stopped)

The new approach is based on the platform solution used by almost all other build systems like Gradle, Maven, CMake, etc.. And it solves problems listed above:
- it detects not only changes in the file system but also any change in opened files just after you type them
- it skips insignificant changes like the addition of new line/space. Moreover, if you type something and revert the change, the IDE will know about it and won't make redundant project model update
- if auto project model updates are disabled, the IDE shows you a floating button that you can click to manually reload project model when it's convenient for you. Also, there are more gradual settings for auto reloading - in addition to two simplest states: never reload, always reload, - IDE may reload the project model only on external changes (like VCS branch change). Actually, it's a default value

  <img src="https://user-images.githubusercontent.com/2539310/173096245-ef4e9fb8-ec7d-4a0f-9845-b5b301636a1d.png" width="500px"/>

- All changes in `Cargo.lock` happened during project reloading are considered as a already taken into account by Cargo, so it doesn't trigger project model reloading again regardless duration of the reloading process.


Note, currently these changes are **not enabled** by default (in stable plugin builds) because:
- I want to be sure that they don't break something significantly (so QA help needed)
- I want to make some other related changes. See the corresponding list in #6424

To turn it on, you need to enable `org.rust.cargo.new.auto.import` option in registry (yep, not experimental feature this time, since I still want to have a way to turn it off, but at the same time I don't expect long period when it's not enabled by default).
Also, proper implementation in our case requires some changes in the platform, so new project model reloading is available only **starting with 2022.2 major release**

https://user-images.githubusercontent.com/2539310/173095892-6df37985-d941-4001-984b-82ed2bd55dd7.mov

changelog: Implement new approach to detect changes that possibly affect project model
