### PR TITLE
MACRO: check that the plugin can expand proc macros with given rustc

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
@@ -117,6 +117,7 @@ abstract class RsToolchainBase(val location: Path) {
     }
 
     companion object {
+        // TODO get rid of `RustcCompatibilityChecker.MIN_SUPPORTED_TOOLCHAIN` after bump
         val MIN_SUPPORTED_TOOLCHAIN = "1.41.0".parseSemVer()
 
         /** Environment variable to unlock unstable features of rustc and cargo.

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/BuildMessages.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/BuildMessages.kt
@@ -8,7 +8,7 @@ package org.rust.cargo.toolchain.impl
 import org.rust.cargo.project.workspace.PackageId
 
 class BuildMessages(
-    private val messages: Map<PackageId, List<CompilerMessage>>,
+    val messages: Map<PackageId, List<CompilerMessage>>,
     val isSuccessful: Boolean
 ) {
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -469,15 +469,7 @@ object CargoMetadata {
     }
 
     private fun getProcMacroArtifact(buildMessages: List<CompilerMessage>): CargoWorkspaceData.ProcMacroArtifact? {
-        val procMacroArtifacts = buildMessages
-            .filterIsInstance<CompilerArtifactMessage>()
-            .filter {
-                it.target.kind.contains("proc-macro") && it.target.crate_types.contains("proc-macro")
-            }
-
-        val procMacroArtifactPath = procMacroArtifacts
-            .flatMap { it.filenames }
-            .find { file -> DYNAMIC_LIBRARY_EXTENSIONS.any { file.endsWith(it) } }
+        val procMacroArtifactPath = findProcMacroArtifact(buildMessages)
 
         return procMacroArtifactPath?.let {
             val originPath = Path.of(procMacroArtifactPath)
@@ -493,6 +485,19 @@ object CargoMetadata {
 
             CargoWorkspaceData.ProcMacroArtifact(path, hash)
         }
+    }
+
+    fun findProcMacroArtifact(buildMessages: List<CompilerMessage>): String? {
+        val procMacroArtifacts = buildMessages
+            .filterIsInstance<CompilerArtifactMessage>()
+            .filter {
+                it.target.kind.contains("proc-macro") && it.target.crate_types.contains("proc-macro")
+            }
+
+        val procMacroArtifactPath = procMacroArtifacts
+            .flatMap { it.filenames }
+            .find { file -> DYNAMIC_LIBRARY_EXTENSIONS.any { file.endsWith(it) } }
+        return procMacroArtifactPath
     }
 
     /**

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -257,7 +257,7 @@ class Cargo(
         return Ok(CargoConfig(buildTarget, env))
     }
 
-    private fun fetchBuildScriptsInfo(
+    fun fetchBuildScriptsInfo(
         owner: Project,
         projectDirectory: Path,
         listener: ProcessListener?

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -918,8 +918,9 @@ private fun expandMacroOld(call: RsMacroCall): MacroExpansionCachedResult {
 private fun expandMacroToMemoryFile(call: RsPossibleMacroCall, storeRangeMap: Boolean): MacroExpansionCachedResult {
     val def = call.resolveToMacroWithoutPsiWithErr()
         .unwrapOrElse { return memExpansionResult(call, Err(it.toExpansionError())) }
-    val project = call.project
-    val result = FunctionLikeMacroExpander.new(project).expandMacro(
+    val crate = call.containingCrate ?: return memExpansionResult(call, Err(GetMacroExpansionError.Unresolved))
+    val project = crate.project
+    val result = FunctionLikeMacroExpander.new(crate).expandMacro(
         def,
         call,
         RsPsiFactory(project, markGenerated = false),

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
@@ -77,6 +77,8 @@ sealed class GetMacroExpansionError {
             ProcMacroExpansionError.ExecutableNotFound -> "`${RsPathManager.INTELLIJ_RUST_NATIVE_HELPER}` executable is not found; " +
                 "(maybe it's not provided for your platform by IntelliJ-Rust)"
             ProcMacroExpansionError.ProcMacroExpansionIsDisabled -> "procedural macro expansion is not enabled"
+            ProcMacroExpansionError.UnsupportedRustcVersion -> "IntelliJ Rust can't expand procedural macros using " +
+                "your Rust toolchain version"
         }
         ModDataNotFound -> "can't find ModData for containing mod of the macro call"
         NoMacroIndex -> "can't find macro index of the macro call"

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
@@ -89,6 +89,7 @@ sealed class ProcMacroExpansionError : MacroExpansionError() {
     object CantRunExpander : ProcMacroExpansionError()
     object ExecutableNotFound : ProcMacroExpansionError()
     object ProcMacroExpansionIsDisabled : ProcMacroExpansionError()
+    object UnsupportedRustcVersion : ProcMacroExpansionError()
 
     override fun toString(): String = "${ProcMacroExpansionError::class.simpleName}.${javaClass.simpleName}"
 }
@@ -109,6 +110,7 @@ fun DataOutput.writeMacroExpansionError(err: MacroExpansionError) {
         ProcMacroExpansionError.ProcMacroExpansionIsDisabled -> 8
         BuiltinMacroExpansionError -> 9
         DeclMacroExpansionError.TooLargeExpansion -> 10
+        ProcMacroExpansionError.UnsupportedRustcVersion -> 11
     }
     writeByte(ordinal)
 
@@ -142,6 +144,7 @@ fun DataInput.readMacroExpansionError(): MacroExpansionError = when (val ordinal
     8 -> ProcMacroExpansionError.ProcMacroExpansionIsDisabled
     9 -> BuiltinMacroExpansionError
     10 -> DeclMacroExpansionError.TooLargeExpansion
+    11 -> ProcMacroExpansionError.UnsupportedRustcVersion
     else -> throw IOException("Unknown expansion error code $ordinal")
 }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/RustcCompatibilityChecker.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/RustcCompatibilityChecker.kt
@@ -1,0 +1,265 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.proc
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.util.io.delete
+import com.intellij.util.io.write
+import org.intellij.lang.annotations.Language
+import org.rust.cargo.project.model.RustcInfo
+import org.rust.cargo.toolchain.RsToolchainBase
+import org.rust.cargo.toolchain.impl.CargoMetadata
+import org.rust.cargo.toolchain.impl.RustcVersion
+import org.rust.cargo.toolchain.tools.cargo
+import org.rust.cargo.util.parseSemVer
+import org.rust.lang.core.macros.errors.ProcMacroExpansionError
+import org.rust.lang.core.macros.tt.TokenTree
+import org.rust.lang.core.macros.tt.parseSubtree
+import org.rust.lang.core.parser.createRustPsiBuilder
+import org.rust.openapiext.RsPathManager
+import org.rust.openapiext.StdOutputCollectingProcessListener
+import org.rust.stdext.RsResult
+import org.rust.stdext.RsResult.Err
+import org.rust.stdext.RsResult.Ok
+import org.rust.stdext.andThen
+import org.rust.stdext.randomLowercaseAlphabetic
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Checks that a given Rust Compiler is supported by our proc macro expander
+ */
+@Service
+class RustcCompatibilityChecker : Disposable {
+    // Guarded by self object monitor (@Synchronized)
+    private val cache: MutableMap<CachingKey, CompletableFuture<RsResult<Unit, IncompatibilityCause>>> = hashMapOf()
+
+    // Guarded by self object monitor (@Synchronized)
+    private val progressIndicators: MutableList<ProgressIndicator> = mutableListOf()
+
+    @Synchronized // The method should be fast enough
+    fun isRustcCompatibleWithProcMacroExpander(
+        project: Project,
+        toolchain: RsToolchainBase,
+        rustcInfo: RustcInfo,
+        rustcVersion: RustcVersion,
+    ): CompletableFuture<RsResult<Unit, IncompatibilityCause>> {
+        if (!ProcMacroApplicationService.isEnabled()) {
+            return CompletableFuture.completedFuture(Ok(Unit))
+        }
+        if (rustcVersion.semver < MIN_SUPPORTED_TOOLCHAIN) {
+            return CompletableFuture.completedFuture(Err(IncompatibilityCause.TooOldRustCompiler))
+        }
+
+        return cache.getOrPut(CachingKey(toolchain.location, rustcInfo.rustupActiveToolchain, rustcVersion)) {
+            val future = CompletableFuture<RsResult<Unit, IncompatibilityCause>>()
+            val task = object : Task.Backgroundable(project, "Checking Rustc compatibility with proc macro expander", false) {
+                override fun run(indicator: ProgressIndicator) {
+                    val result = try {
+                        checkRustcCompatibleWithProcMacroExpander(project, toolchain, rustcInfo, rustcVersion)
+                    } catch (t: Throwable) {
+                        future.completeExceptionally(t)
+                        throw t
+                    } finally {
+                        onTaskFinish(indicator)
+                    }
+                    future.complete(result)
+                }
+            }
+            val progressIndicator = EmptyProgressIndicator(ModalityState.any())
+            progressIndicators += progressIndicator
+            ProgressManager.getInstance().runProcessWithProgressAsynchronously(task, progressIndicator)
+            future
+        }
+    }
+
+    @Synchronized
+    private fun onTaskFinish(indicator: ProgressIndicator) {
+        progressIndicators.remove(indicator)
+    }
+
+    @Synchronized
+    override fun dispose() {
+        for (indicator in progressIndicators) {
+            indicator.cancel()
+        }
+        for (future in cache.values) {
+            future.cancel(true)
+        }
+        cache.clear()
+    }
+
+    private fun checkRustcCompatibleWithProcMacroExpander(
+        project: Project,
+        toolchain: RsToolchainBase,
+        rustcInfo: RustcInfo,
+        version: RustcVersion,
+    ): RsResult<Unit, IncompatibilityCause> {
+        val start = System.currentTimeMillis()
+
+        val root = RsPathManager.tempPluginDirInSystem()
+            .resolve("proc-macros-compat-check")
+            .resolve(randomLowercaseAlphabetic(16))
+
+        try {
+            try {
+                makeTempProcMacroProject(root, rustcInfo)
+            } catch (e: IOException) {
+                LOG.error("Failed to create a temp proc macro project at $root", e)
+                return Ok(Unit)
+            }
+
+            val outputCollector = StdOutputCollectingProcessListener()
+
+            val buildMessages = toolchain.cargo()
+                .fetchBuildScriptsInfo(project, root, outputCollector)
+            val procMacroArtifactPath = CargoMetadata.findProcMacroArtifact(buildMessages.messages.values.flatten())
+
+            if (procMacroArtifactPath == null) {
+                LOG.warn(
+                    "Failed to compile the reference proc macro project.\n" +
+                        "Toolchain: ${toolchain.location},\n" +
+                        "Rustup toolchain: ${rustcInfo.rustupActiveToolchain},\n" +
+                        "Rustc version: $version,\n" +
+                        "Process stdout: ${outputCollector.stdout}" +
+                        "Process stderr: ${outputCollector.stderr}"
+                )
+                return Err(IncompatibilityCause.ProcMacroCrateCompilationError)
+            }
+
+            val expander = ProcMacroExpander(project, toolchain, timeout = 20_000)
+
+            fun expand(
+                macroName: String,
+                macroCallBody: TokenTree.Subtree,
+                env: Map<String, String> = emptyMap()
+            ): RsResult<Unit, IncompatibilityCause> {
+                return expander.expandMacroAsTtWithErr(
+                    macroCallBody,
+                    null,
+                    macroName,
+                    procMacroArtifactPath,
+                    env
+                ).map {}.mapErr { IncompatibilityCause.ExpansionError(macroName, it) }
+            }
+
+            val input = project.createRustPsiBuilder("input (.) :: 123").parseSubtree().subtree
+
+            val result = expand("test_macro", input)
+                .andThen { expand("function_like_read_env_var", input, mapOf("FOO_ENV_VAR" to "val")) }
+
+            val elapsed = System.currentTimeMillis() - start
+            LOG.info("Finished proc macro compatibility check in $elapsed ms. Result: $result")
+            return result
+        } finally {
+            try {
+                root.delete()
+            } catch (ignored: IOException) {
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun makeTempProcMacroProject(root: Path, rustcInfo: RustcInfo) {
+        val src = root.resolve("src")
+        Files.createDirectories(src)
+
+        val rustupActiveToolchain = rustcInfo.rustupActiveToolchain
+        if (rustupActiveToolchain != null) {
+            root.resolve("rust-toolchain.toml").write(
+                """
+                [toolchain]
+                channel = "$rustupActiveToolchain"
+            """.trimIndent()
+            )
+        }
+
+        @Language("TOML")
+        val cargoToml = """
+            [package]
+            name = "test-proc-macro"
+            version = "0.1.0"
+            edition = "2018"
+
+            [lib]
+            proc-macro = true
+            path = "src/lib.rs"
+
+            # A binary target is needed in order to make Cargo compile our proc macro as a shared library
+            [[bin]]
+            path = "src/main.rs"
+            name = "placeholder"
+
+            [dependencies]
+        """.trimIndent()
+        root.resolve("Cargo.toml").write(cargoToml)
+
+        @Language("Rust")
+        val procMacroSrc = """
+            extern crate proc_macro;
+
+            use proc_macro::TokenStream;
+
+            #[proc_macro]
+            pub fn test_macro(input: TokenStream) -> TokenStream {
+                // Try doing something non-trivial and use more proc_macro API
+                let tts = input.into_iter().collect::<Vec<_>>();
+                tts.iter().enumerate().map(|(i, tt)| {
+                    let mut tt2 = tt.clone();
+                    tt2.set_span(tts[tts.len() - 1 - i].span());
+                    tt2
+                }).collect::<TokenStream>()
+            }
+
+            #[proc_macro]
+            pub fn function_like_read_env_var(input: TokenStream) -> TokenStream {
+                use std::fmt::Write;
+                let v = std::env::var("FOO_ENV_VAR").unwrap();
+                let mut s = String::new();
+                write!(&mut s, "\"{}\"", v);
+                return s.parse().unwrap();
+            }
+        """.trimIndent()
+        src.resolve("lib.rs").write(procMacroSrc)
+        src.resolve("main.rs").write("fn main() {}")
+    }
+
+    private data class CachingKey(
+        val toolchainLocation: Path,
+        val rustupActiveToolchain: String?,
+        val rustcVersion: RustcVersion
+    )
+
+    sealed class IncompatibilityCause {
+        object TooOldRustCompiler : IncompatibilityCause()
+        object ProcMacroCrateCompilationError : IncompatibilityCause()
+        data class ExpansionError(
+            val macroName: String,
+            val error: ProcMacroExpansionError
+        ) : IncompatibilityCause()
+    }
+
+    companion object {
+        private val LOG = logger<RustcCompatibilityChecker>()
+
+        // TODO use `RsToolchainBase.MIN_SUPPORTED_TOOLCHAIN` after its bumping
+        private val MIN_SUPPORTED_TOOLCHAIN = "1.47.0".parseSemVer()
+
+        @JvmStatic
+        fun getInstance(): RustcCompatibilityChecker = service()
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -17,6 +17,7 @@ import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.macros.decl.MACRO_DOLLAR_CRATE_IDENTIFIER
+import org.rust.lang.core.macros.errors.MacroExpansionError
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.body
 import org.rust.lang.core.resolve.Namespace
@@ -39,6 +40,7 @@ private val EXPAND_MACROS_IN_PARALLEL: RegistryValue = Registry.get("org.rust.re
 /** Resolves all imports and expands macros (new items are added to [defMap]) using fixed point iteration algorithm */
 class DefCollector(
     private val project: Project,
+    private val macroExpander: MacroExpander<RsMacroData, MacroExpansionError>,
     private val defMap: CrateDefMap,
     private val context: CollectorContext,
     private val pool: ExecutorService?,
@@ -58,8 +60,6 @@ class DefCollector(
 
     private val macroCallsToExpand: MutableList<MacroCallInfo> = context.macroCalls
 
-    /** Created once as optimization */
-    private val macroExpander = FunctionLikeMacroExpander.new(project)
     private val macroExpanderShared: MacroExpansionSharedCache = MacroExpansionSharedCache.getInstance()
 
     private val macroMixHashToOrder: MutableMap<HashCode /* mix hash */, Int> = THashMap()

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
@@ -15,6 +15,7 @@ import org.rust.cargo.util.AutoInjectedCrates.CORE
 import org.rust.cargo.util.AutoInjectedCrates.STD
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.macros.FunctionLikeMacroExpander
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.isEnabledByCfgSelf
 import org.rust.lang.core.psi.shouldIndexFile
@@ -40,7 +41,7 @@ fun buildDefMap(
     val context = CollectorContext(crate, project)
     val defMap = buildDefMapContainingExplicitItems(context, allDependenciesDefMaps, isNormalCrate)
         ?: return null
-    DefCollector(project, defMap, context, pool, indicator).collect()
+    DefCollector(project, FunctionLikeMacroExpander.new(crate), defMap, context, pool, indicator).collect()
     testAssert({ !isNormalCrate || !isCrateChanged(crate, defMap) }, {
         "DefMap $defMap should be up-to-date just after built"
     })

--- a/src/main/kotlin/org/rust/lang/core/resolve2/HangingModData.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/HangingModData.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.resolve2
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.Key
+import org.rust.lang.core.macros.FunctionLikeMacroExpander
 import org.rust.lang.core.macros.decl.MACRO_DOLLAR_CRATE_IDENTIFIER
 import org.rust.lang.core.macros.decl.MACRO_DOLLAR_CRATE_IDENTIFIER_REGEX
 import org.rust.lang.core.macros.findMacroCallExpandedFromNonRecursive
@@ -108,7 +109,7 @@ private fun createHangingModData(scope: RsItemsOwner, contextInfo: RsModInfo): M
     collectScope(scope, hangingModData, modCollectorContext, dollarCrateHelper = dollarCrateHelper)
 
     val indicator = ProgressManager.getGlobalProgressIndicator() ?: EmptyProgressIndicator()
-    DefCollector(project, defMap, collectorContext, pool = null, indicator).collect()
+    DefCollector(project, FunctionLikeMacroExpander.new(crate), defMap, collectorContext, pool = null, indicator).collect()
     return hangingModData
 }
 

--- a/src/main/kotlin/org/rust/openapiext/StdOutputCollectingProcessListener.kt
+++ b/src/main/kotlin/org/rust/openapiext/StdOutputCollectingProcessListener.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.openapiext
+
+import com.intellij.execution.process.ProcessAdapter
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessOutputType
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.text.StringUtil
+
+class StdOutputCollectingProcessListener : ProcessAdapter() {
+    private val stdoutBuffer: StringBuilder = StringBuilder()
+    private val stderrBuffer: StringBuilder = StringBuilder()
+    private var storedLength: Int = 0
+
+    val stdout: CharSequence get() = stdoutBuffer
+    val stderr: CharSequence get() = stderrBuffer
+
+    @Synchronized
+    override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+        val output = when (outputType) {
+            ProcessOutputType.STDOUT -> stdoutBuffer
+            ProcessOutputType.STDERR -> stderrBuffer
+            else -> return
+        }
+
+        if (storedLength > 16384) return
+
+        val text = event.text
+        if (StringUtil.isEmptyOrSpaces(text)) return
+        storedLength += text.length
+
+        output.append(text)
+    }
+}

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -86,6 +86,13 @@ notification.no.toolchain.configured=No Rust toolchain configured
 notification.run.tests.as.root.windows=Running tests with Administrator privileges is not yet supported
 notification.run.tests.as.root.unix=Running tests with root privileges is not yet supported
 
+notification.proc.macro.expander.incompatible.heading=IntelliJ Rust can''t expand procedural macros using Rust <b>{0}</b>.
+notification.proc.macro.expander.incompatible.old={0} The Rust compiler is too old. Consider upgrading your toolchain to more recent version
+notification.proc.macro.expander.incompatible.compilation={0} Can't compile the reference proc macro to perform the check. See logs for more details
+notification.proc.macro.expander.incompatible.run={0} Error occurred during `{1}` process creation. See logs for more details
+notification.proc.macro.expander.incompatible.no.executable=IntelliJ Rust can't expand procedural macros: `{0}` executable is not found. Maybe it is not provided for your platform/operating system by IntelliJ Rust
+notification.proc.macro.expander.incompatible.too.recent={0} It looks like the version is too recent. Consider downgrading your Rust toolchain to a previous version or try to update IntelliJ Rust plugin
+
 refactoring.change.signature.error.cfg.disabled.parameters=Cannot change signature of function with cfg-disabled parameters
 refactoring.change.signature.name.conflict=The name {0} conflicts with an existing item in {1}
 refactoring.change.signature.name=Change Signature

--- a/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
@@ -19,6 +19,7 @@ import org.rust.stdext.singleOrFilter
 /**
  * A test for detecting proc macro attributes on items. See [ProcMacroAttribute]
  */
+@MinRustcVersion("1.46.0")
 @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
 @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
 class ProcMacroAttributeTest : RsTestBase() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -617,6 +617,7 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
         fn main() {}
     """)
 
+    @MinRustcVersion("1.46.0")
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
     @ProjectDescriptor(WithProcMacroAndDependencyRustProjectDescriptor::class)
     fun `test hardcoded not a macro on proc macro definition`() = stubOnlyResolve("""


### PR DESCRIPTION
We expand procedural macros using unstable `proc_macro` library API. Sometimes that API changes in more recent rust compilers, hence the plugin lose ability to expand proc macros with these new Rust compilers. In this case, a user can't figure out that something is wrong with their toolchain, they just see that every proc macro is failed to expand for unknown reason. Such situation can also be the cause of issues like #8125, where massive failures in proc macro expansion cause weird OS behavior.

In this PR we check that the plugin is able to expand the "reference" proc macro (bundled with the plugin) compiler with a user's Rust toolchain before trying to expand any proc macro. If we figuring out that we can't expand proc macros, we don't make further attempts and we're showing an error message to the user.

### The message when we can't expand the reference proc macro:

![Screenshot from 2022-06-12 17-18-49](https://user-images.githubusercontent.com/3221931/173238725-82e96527-4b24-4acc-ad7f-293f0b2299fc.png)

### The message when the rustc is known to be too old for macro expansion (older 1.47.0):

![Screenshot from 2022-06-12 17-20-01](https://user-images.githubusercontent.com/3221931/173238730-fa53f11a-a85e-499e-9b79-fb17ed979bc1.png)

### The message when we can't even compile the reference proc macro (I don't know how to get it in practice):

![Screenshot from 2022-06-12 17-21-28](https://user-images.githubusercontent.com/3221931/173238733-eaf85948-e39d-4b40-a318-a4efa95545d7.png)


changelog: Check that the plugin can expand proc macros with given user's rustc version. Show a message if can't
