### PR TITLE
TY: take into account negative impls

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
@@ -91,7 +91,7 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
             ?.firstOrNull { impl ->
                 val cachedImpl = RsCachedImplItem.forImpl(impl)
                 val (_, generics, constGenerics) = cachedImpl.typeAndGenerics ?: return@firstOrNull false
-                cachedImpl.isInherent && cachedImpl.isValid
+                cachedImpl.isInherent && cachedImpl.isValid && !cachedImpl.isNegativeImpl
                     && generics.isEmpty() && constGenerics.isEmpty()  // TODO: Support generics
                     && cachedImpl.typeAndGenerics == cachedTraitImpl.typeAndGenerics
             }

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
@@ -130,7 +130,7 @@ private fun findSiblingImplItem(struct: RsStructItem): RsImplItem? {
         ?.firstOrNull { impl ->
             val cachedImpl = RsCachedImplItem.forImpl(impl)
             val (type, generics, constGenerics) = cachedImpl.typeAndGenerics ?: return@firstOrNull false
-            cachedImpl.isInherent && cachedImpl.isValid
+            cachedImpl.isInherent && cachedImpl.isValid && !cachedImpl.isNegativeImpl
                 && generics.isEmpty() && constGenerics.isEmpty()  // TODO: Support generics
                 && type.isEquivalentTo(struct.declaredType)
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -30,7 +30,8 @@ class RsCachedImplItem(
     val impl: RsImplItem
 ) {
     private val traitRef: RsTraitRef? = impl.traitRef
-    val isValid: Boolean = impl.isValidProjectMember && !impl.isReservationImpl && !impl.isNegativeImpl
+    val isValid: Boolean = impl.isValidProjectMember && !impl.isReservationImpl
+    val isNegativeImpl: Boolean = impl.isNegativeImpl
     val isInherent: Boolean get() = traitRef == null
 
     val implementedTrait: BoundElement<RsTraitItem>? by recursionSafeLazy { traitRef?.resolveToBoundTrait() }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -316,4 +316,26 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
             a.foo()/*caret*/
         }
     """)
+
+    fun `test filter by a bound unsatisfied because of a negative impl`() = doSingleCompletion("""
+        auto trait Sync {}
+        struct S<T> { value: T }
+        impl<T: Sync> S<T> { fn foo1(&self) {} }
+        impl<T> S<T> { fn foo2(&self) {} }
+        struct S0;
+        impl !Sync for S0 {}
+        fn main1(v: S<S0>) {
+            v.fo/*caret*/
+        }
+    """, """
+        auto trait Sync {}
+        struct S<T> { value: T }
+        impl<T: Sync> S<T> { fn foo1(&self) {} }
+        impl<T> S<T> { fn foo2(&self) {} }
+        struct S0;
+        impl !Sync for S0 {}
+        fn main1(v: S<S0>) {
+            v.foo2()/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -605,4 +605,20 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             //^
         }
     """)
+
+    fun `test trait bound satisfied for struct with negative impl`() = checkByCode("""
+        auto trait Sync {}
+        trait Tr1 { fn some_fn(&self) {} }
+        trait Tr2 { fn some_fn(&self) {} }
+                     //X
+        struct S<T> { value: T }
+        impl<T: Sync> Tr1 for S<T> {}
+        impl<T> Tr2 for S<T> {}
+        struct S0;
+        impl !Sync for S0 {}
+        fn main1(v: S<S0>) {
+            v.some_fn();
+            //^
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -292,6 +292,19 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
                //^ !Unsize<S<[i32]>>
     """)
 
+    fun `test a type is automatically Sync`() = doTest("""
+        struct S;
+        type T = S;
+               //^ Sync
+    """)
+
+    fun `test a type is not Sync if a negative impl present`() = doTest("""
+        struct S;
+        impl !Sync for S {}
+        type T = S;
+               //^ !Sync
+    """)
+
     private fun checkPrimitiveTypes(traitName: String) {
         val allIntegers = TyInteger.VALUES.toTypedArray()
         val allFloats = TyFloat.VALUES.toTypedArray()
@@ -308,6 +321,7 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
             #[lang = "sized"]  pub trait Sized {}
             #[lang = "copy"]   pub trait Copy {}
             #[lang = "unsize"] pub trait Unsize<T: ?Sized> {}
+            #[lang = "sync"]   pub unsafe auto trait Sync {}
 
             $code
         """


### PR DESCRIPTION
Depends on #8902

This is a first step in implementing auto traits like `Sync` or `Send`. By definition, an auto trait is automatically implemented for primitive types and for composite data types if all their constituent types implement that auto trait. Hence, the only way to "unimplement" an auto trait is using a negative impl.

changelog: Consider negative impls (e.g. `impl !Sync for T {}`) in type inference