### PR TITLE
INSP: configure project to run inspections from command line

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -459,9 +459,12 @@ open class CargoProjectsServiceImpl(
         // instead of `modifyProjects` for this reason
         projects.updateSync { loaded }
             .whenComplete { _, _ ->
-                invokeLater {
-                    if (project.isDisposed) return@invokeLater
-                    refreshAllProjects()
+                val disableRefresh = System.getProperty(CARGO_DISABLE_PROJECT_REFRESH_ON_CREATION, "false").toBooleanStrictOrNull()
+                if (disableRefresh != true) {
+                    invokeLater {
+                        if (project.isDisposed) return@invokeLater
+                        refreshAllProjects()
+                    }
                 }
             }
     }
@@ -487,6 +490,10 @@ open class CargoProjectsServiceImpl(
 
     override fun toString(): String =
         "CargoProjectsService(projects = $allProjects)"
+
+    companion object {
+        const val CARGO_DISABLE_PROJECT_REFRESH_ON_CREATION: String = "cargo.disable.project.refresh.on.creation"
+    }
 }
 
 data class CargoProjectImpl(

--- a/src/main/kotlin/org/rust/ide/inspections/CargoCommandLineInspectionProjectConfigurator.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/CargoCommandLineInspectionProjectConfigurator.kt
@@ -1,0 +1,105 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.ide.CommandLineInspectionProgressReporter
+import com.intellij.ide.CommandLineInspectionProjectConfigurator
+import com.intellij.ide.CommandLineInspectionProjectConfigurator.ConfiguratorContext
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.util.ProgressIndicatorUtils
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import org.rust.RsBundle
+import org.rust.cargo.CargoConstants
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.model.guessAndSetupRustProject
+import org.rust.cargo.project.model.impl.CargoProjectsServiceImpl
+import org.rust.cargo.project.settings.rustSettings
+import java.util.concurrent.CountDownLatch
+import kotlin.io.path.exists
+
+class CargoCommandLineInspectionProjectConfigurator : CommandLineInspectionProjectConfigurator {
+    override fun getName(): String = "cargo"
+    override fun getDescription(): String = RsBundle.message("cargo.commandline.description")
+
+    override fun isApplicable(context: ConfiguratorContext): Boolean {
+        // TODO: find all Cargo.toml in the project
+        return context.projectPath.resolve(CargoConstants.MANIFEST_FILE).exists()
+    }
+
+    override fun configureEnvironment(context: ConfiguratorContext) {
+        System.setProperty(CargoProjectsServiceImpl.CARGO_DISABLE_PROJECT_REFRESH_ON_CREATION, "true")
+        // See `com.intellij.openapi.externalSystem.autoimport.AutoImportProjectTracker.isDisabledAutoReload`
+        Registry.get("external.system.auto.import.disabled").setValue(true)
+    }
+
+    override fun preConfigureProject(project: Project, context: ConfiguratorContext) {
+        project.rustSettings.modify {
+            it.autoUpdateEnabled = false
+        }
+    }
+
+    override fun configureProject(project: Project, context: ConfiguratorContext) {
+        val logger = LoggerWrapper(context.logger, logger<CargoCommandLineInspectionProjectConfigurator>())
+
+        val refreshStarted = CountDownLatch(1)
+        val refreshFinished = CountDownLatch(1)
+        project.messageBus.connect().subscribe(
+            CargoProjectsService.CARGO_PROJECTS_REFRESH_TOPIC,
+            object : CargoProjectsService.CargoProjectsRefreshListener {
+                override fun onRefreshStarted() {
+                    logger.info("Cargo project model loading...")
+                    refreshStarted.countDown()
+                }
+
+                override fun onRefreshFinished(status: CargoProjectsService.CargoRefreshStatus) {
+                    logger.info("Cargo project model loading finished: $status")
+                    refreshFinished.countDown()
+                }
+            }
+        )
+
+        val cargoProjectsService = project.cargoProjects
+
+        val result = guessAndSetupRustProject(project, explicitRequest = true)
+        if (!result) {
+            if (cargoProjectsService.hasAtLeastOneValidProject) {
+                cargoProjectsService.refreshAllProjects()
+            } else {
+                logger.error("Cargo project model loading failed to start")
+                return
+            }
+        }
+
+        ProgressIndicatorUtils.awaitWithCheckCanceled(refreshStarted)
+        ProgressIndicatorUtils.awaitWithCheckCanceled(refreshFinished)
+
+        for (cargoProject in cargoProjectsService.allProjects) {
+            val status = cargoProject.mergedStatus
+            if (status is CargoProject.UpdateStatus.UpdateFailed) {
+                logger.error(status.reason)
+            }
+        }
+    }
+
+    private class LoggerWrapper(
+        private val inspectionProgressReporter: CommandLineInspectionProgressReporter,
+        private val logger: Logger
+    ) {
+        fun info(message: String) {
+            logger.info(message)
+            inspectionProgressReporter.reportMessage(1, message)
+        }
+
+        fun error(message: String) {
+            logger.error(message)
+            inspectionProgressReporter.reportError(message)
+        }
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -317,6 +317,8 @@
 
         <lang.inspectionSuppressor language="Rust"
                                    implementationClass="org.rust.ide.inspections.RsInspectionSuppressor"/>
+        <commandLineInspectionProjectConfigurator
+            implementation="org.rust.ide.inspections.CargoCommandLineInspectionProjectConfigurator"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Implicit trait objects are deprecated"

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -62,6 +62,7 @@ action.Rust.ShowSingleStepMacroExpansionAction.text=Show Expanded Macro
 action.Rust.ToggleNewResolve.text=Rust: Toggle new name resolution engine
 
 cargo=Cargo
+cargo.commandline.description=Configures Cargo projects under the given folder
 
 group.Rust.MacroExpansionActions.text=Show Macro Expansion
 group.Rust.Tools.text=Rust


### PR DESCRIPTION
Provide implementation of `CommandLineInspectionProjectConfigurator` EP to properly configure project model for cargo-based projects for running inspection from [command line](https://www.jetbrains.com/help/idea/command-line-code-inspector.html) or via [Qodana](https://www.jetbrains.com/qodana/)

changelog: properly configure cargo-based projects for running inspection from [command line](https://www.jetbrains.com/help/idea/command-line-code-inspector.html) or via [Qodana](https://www.jetbrains.com/qodana/)
