### PR TITLE
DBG: Add registry flag to enable native Rust support in MSVC LLDB

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/RsDefaultDebuggerDriverConfigurationProvider.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsDefaultDebuggerDriverConfigurationProvider.kt
@@ -6,6 +6,8 @@
 package org.rust.debugger
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.registry.Registry
 import com.jetbrains.cidr.ArchitectureType
 import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriverConfiguration
 import com.jetbrains.cidr.execution.debugger.backend.lldb.LLDBDriverConfiguration
@@ -24,10 +26,13 @@ class RsDefaultDebuggerDriverConfigurationProvider : RsDebuggerDriverConfigurati
     }
 }
 
-private open class RsLLDBDriverConfiguration(
+open class RsLLDBDriverConfiguration(
     private val isElevated: Boolean
 ) : LLDBDriverConfiguration() {
     override fun isElevated(): Boolean = isElevated
+
+    override fun useRustTypeSystem(): Boolean =
+        SystemInfo.isWindows && Registry.`is`("org.rust.debugger.lldb.rust.msvc", false)
 }
 
 private class RsCustomBinariesLLDBDriverConfiguration(

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunParameters.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunParameters.kt
@@ -11,9 +11,9 @@ import com.jetbrains.cidr.execution.Installer
 import com.jetbrains.cidr.execution.RunParameters
 import com.jetbrains.cidr.execution.TrivialInstaller
 import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriverConfiguration
-import com.jetbrains.cidr.execution.debugger.backend.lldb.LLDBDriverConfiguration
 import org.rust.cargo.project.model.CargoProject
 import org.rust.debugger.RsDebuggerDriverConfigurationProvider
+import org.rust.debugger.RsLLDBDriverConfiguration
 
 class RsDebugRunParameters(
     val project: Project,
@@ -29,8 +29,6 @@ class RsDebugRunParameters(
         for (provider in RsDebuggerDriverConfigurationProvider.EP_NAME.extensionList) {
             return provider.getDebuggerDriverConfiguration(project, isElevated) ?: continue
         }
-        return object : LLDBDriverConfiguration() {
-            override fun isElevated(): Boolean = isElevated
-        }
+        return RsLLDBDriverConfiguration(isElevated)
     }
 }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1200,6 +1200,8 @@
                      description="Show notification warning if the external linter is running longer than the set value (ms)"/>
         <registryKey key="org.rust.ide.json.paste.processor" defaultValue="false" restartRequired="false"
                      description="Enable converting JSON to Rust struct on paste"/>
+        <registryKey key="org.rust.debugger.lldb.rust.msvc" defaultValue="false" restartRequired="false"
+                     description="Enable Rust MSVC support in LLDB (Windows-only)"/>
 
         <!-- Move refactoring -->
 


### PR DESCRIPTION
Add registry flag to enable native Rust support in MSVC LLDB on Windows. The flag is disabled by default and operates as follows:
- when disabled, MSVC LLDB uses Clang-based implementation and treats Rust types and expressions as C++ types and expressions (same as it was before);
- when enabled, MSVC LLDB detects if a PDB file corresponds to Rust source code, and in that case, the new Rust-aware implementation is used to manipulate debug information, types and expressions.

This functionality is available for MSVC LLDB bundled with CLion 2022.2 since 222.2889 build. Note, the Rust-aware implementation at this point is experimental and might cause LLDB crashes in certain cases.

Part of #5632.

changelog: Add registry flag to enable native Rust support in MSVC LLDB on Windows. Note, the implementation at this point is experimental and might cause LLDB crashes in certain cases
