### PR TITLE
TY: infer type of multi-resolved method as unknown

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -673,7 +673,7 @@ class RsTypeInferenceWalker(
             val variantsForDisplay = callee?.let { listOf(it.toMethodResolveVariant()) } ?: variants
             ctx.writeResolvedMethod(methodCall, variantsForDisplay)
 
-            callee ?: variants.firstOrNull()?.let { MethodPick.from(it) }
+            callee
         }
         if (callee == null) {
             val methodType = unknownTyFunction(argExprs.size)

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -1815,4 +1815,15 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
                   //^ u8
         }
     """)
+
+    fun `test type of multi-resolved method is unknown`() = testExpr("""
+        struct S;
+        impl S { fn foo(&self) -> i32 { 0 } }
+        impl S { fn foo(&self) -> u32 { 0 } }
+        fn main() {
+            let a = S.foo();
+            a;
+          //^ <unknown>
+        }
+    """)
 }


### PR DESCRIPTION
Previously, in the case of a multi-resolved method we picked a first variant for its type inference. That was an artifact of old days when method resolution was too imprecise and was often wrongly multi-resolved. Now infer it as `<unknown>`:

```rust
struct S;
impl S { fn foo(&self) -> i32 { 0 } }
impl S { fn foo(&self) -> u32 { 0 } }
fn main() {
    let a = S.foo();
    a;
  //^ <unknown>
}
```

changelog: Infer type of multi-resolved method as `<unknown>` (don't pick a first multi-resolved variant)
