### PR TITLE
TY&RES: consider methods in impls for a ref when receiver is not a ref

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
@@ -91,7 +91,7 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
             ?.firstOrNull { impl ->
                 val cachedImpl = RsCachedImplItem.forImpl(impl)
                 val (_, generics, constGenerics) = cachedImpl.typeAndGenerics ?: return@firstOrNull false
-                cachedImpl.isInherent && cachedImpl.isValid
+                cachedImpl.isInherent && cachedImpl.isValid && !cachedImpl.isNegativeImpl
                     && generics.isEmpty() && constGenerics.isEmpty()  // TODO: Support generics
                     && cachedImpl.typeAndGenerics == cachedTraitImpl.typeAndGenerics
             }

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
@@ -130,7 +130,7 @@ private fun findSiblingImplItem(struct: RsStructItem): RsImplItem? {
         ?.firstOrNull { impl ->
             val cachedImpl = RsCachedImplItem.forImpl(impl)
             val (type, generics, constGenerics) = cachedImpl.typeAndGenerics ?: return@firstOrNull false
-            cachedImpl.isInherent && cachedImpl.isValid
+            cachedImpl.isInherent && cachedImpl.isValid && !cachedImpl.isNegativeImpl
                 && generics.isEmpty() && constGenerics.isEmpty()  // TODO: Support generics
                 && type.isEquivalentTo(struct.declaredType)
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -218,6 +218,8 @@ class ImplLookup(
         } else {
             Cache.new()
         }
+    private val implIndexCache: Cache<TyFingerprint, List<RsCachedImplItem>> = Cache.new()
+    private val typeAliasIndexCache: Cache<TyFingerprint, List<RsCachedTypeAlias>> = Cache.new()
     private val fnTraits = listOfNotNull(items.Fn, items.FnMut, items.FnOnce)
     private val fnOnceOutput: RsTypeAlias? by lazy(NONE) {
         val trait = items.FnOnce ?: return@lazy null
@@ -275,11 +277,10 @@ class ImplLookup(
                 ty.getTraitBoundsTransitively()
                     .distinctBy { it.element }
                     .mapTo(implsAndTraits) { TraitImplSource.Object(it.element) }
-                RsImplIndex.findFreeImpls(project) {
+                findBlanketImpls().forEach {
                     if (!it.isNegativeImpl) {
                         implsAndTraits += it.explicitImpl
                     }
-                    false
                 }
             }
             is TyProjection -> {
@@ -320,9 +321,10 @@ class ImplLookup(
     }
 
     private fun findExplicitImplsWithoutAliases(selfTy: Ty, tyf: TyFingerprint, processor: RsProcessor<RsCachedImplItem>): Boolean {
-        return RsImplIndex.findPotentialImpls(project, tyf) { cachedImpl ->
-            if (cachedImpl.isNegativeImpl) return@findPotentialImpls false
-            val (type, generics, constGenerics) = cachedImpl.typeAndGenerics ?: return@findPotentialImpls false
+        val impls = implIndexCache.getOrPut(tyf) { RsImplIndex.findPotentialImpls(project, tyf) }
+        return impls.any { cachedImpl ->
+            if (cachedImpl.isNegativeImpl) return@any false
+            val (type, generics, constGenerics) = cachedImpl.typeAndGenerics ?: return@any false
             val isAppropriateImpl = canCombineTypes(selfTy, type, generics, constGenerics) &&
                 // Check that trait is resolved if it's not an inherent impl; checking it after types because
                 // we assume that unresolved trait is a rare case
@@ -336,8 +338,11 @@ class ImplLookup(
         if (fingerprint != null) {
             val set = mutableSetOf(fingerprint)
             if (processor(fingerprint)) return true
-            val result = RsTypeAliasIndex.findPotentialAliases(project, fingerprint) {
-                val name = it.name ?: return@findPotentialAliases false
+            val aliases = typeAliasIndexCache.getOrPut(fingerprint) {
+                RsTypeAliasIndex.findPotentialAliases(project, fingerprint)
+            }
+            val result = aliases.any {
+                val name = it.name ?: return@any false
                 val aliasFingerprint = TyFingerprint(name)
                 val isAppropriateAlias = set.add(aliasFingerprint) && run {
                     val (declaredType, generics, constGenerics) = it.typeAndGenerics
@@ -364,6 +369,13 @@ class ImplLookup(
         return ctx.probe {
             val (normTy2, _) = ctx.normalizeAssociatedTypesIn(ty2.substitute(subst))
             ctx.combineTypes(normTy2, ty1).isOk
+        }
+    }
+
+    /** return impls for a generic type `impl<T> Trait for T {}` */
+    private fun findBlanketImpls(): List<RsCachedImplItem> {
+        return implIndexCache.getOrPut(TyFingerprint.TYPE_PARAMETER_OR_MACRO_FINGERPRINT) {
+            RsImplIndex.findPotentialImpls(project, TyFingerprint.TYPE_PARAMETER_OR_MACRO_FINGERPRINT)
         }
     }
 
@@ -747,7 +759,8 @@ class ImplLookup(
     }
 
     private fun assembleImplCandidatesWithoutAliases(ref: TraitRef, tyf: TyFingerprint, processor: RsProcessor<SelectionCandidate>): Boolean {
-        return RsImplIndex.findPotentialImpls(project, tyf) {
+        val impls = implIndexCache.getOrPut(tyf) { RsImplIndex.findPotentialImpls(project, tyf) }
+        return impls.any {
             val candidate = it.trySelectCandidate(ref)
             candidate != null && processor(candidate)
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -30,7 +30,8 @@ class RsCachedImplItem(
     val impl: RsImplItem
 ) {
     private val traitRef: RsTraitRef? = impl.traitRef
-    val isValid: Boolean = impl.isValidProjectMember && !impl.isReservationImpl && !impl.isNegativeImpl
+    val isValid: Boolean = impl.isValidProjectMember && !impl.isReservationImpl
+    val isNegativeImpl: Boolean = impl.isNegativeImpl
     val isInherent: Boolean get() = traitRef == null
 
     val implementedTrait: BoundElement<RsTraitItem>? by recursionSafeLazy { traitRef?.resolveToBoundTrait() }

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
@@ -16,7 +16,6 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.search.RsWithMacrosProjectScope
 import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.resolve.RsCachedTypeAlias
-import org.rust.lang.core.resolve.RsProcessor
 import org.rust.lang.core.resolve2.isNewResolveEnabled
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsTypeAliasStub
@@ -32,8 +31,7 @@ class RsTypeAliasIndex : AbstractStubIndex<TyFingerprint, RsTypeAlias>() {
         fun findPotentialAliases(
             project: Project,
             tyf: TyFingerprint,
-            processor: RsProcessor<RsCachedTypeAlias>
-        ): Boolean {
+        ): List<RsCachedTypeAlias> {
             // Note that `getElements` is intentionally used with intermediate collection instead of
             // `StubIndex.processElements` in order to simplify profiling
             val aliases = getElements(KEY, tyf, project, RsWithMacrosProjectScope(project))
@@ -62,11 +60,11 @@ class RsTypeAliasIndex : AbstractStubIndex<TyFingerprint, RsTypeAlias>() {
                         stdlibAliases + workspaceAliases
                     }
                     stdlibAliases.size <= threshold -> stdlibAliases
-                    else -> return false
+                    else -> return emptyList()
                 }
             }
 
-            return filteredAliases.any { processor(it) }
+            return filteredAliases
         }
 
         fun index(stub: RsTypeAliasStub, sink: IndexSink) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1120,7 +1120,12 @@ private fun List<RsPolybound>?.toPredicates(selfTy: Ty): Sequence<PsiPredicate> 
                     it.polyboundList.toPredicates(projectionTy)
                 }
             }
-        sequenceOf(PsiPredicate.Bound(Predicate.Trait(TraitRef(selfTy, boundTrait)))) + assocTypeBounds
+        val constness = if (bound.hasConst) {
+            BoundConstness.ConstIfConst
+        } else {
+            BoundConstness.NotConst
+        }
+        sequenceOf(PsiPredicate.Bound(Predicate.Trait(TraitRef(selfTy, boundTrait), constness))) + assocTypeBounds
     }
 
 private sealed class PsiPredicate {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -316,4 +316,26 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
             a.foo()/*caret*/
         }
     """)
+
+    fun `test filter by a bound unsatisfied because of a negative impl`() = doSingleCompletion("""
+        auto trait Sync {}
+        struct S<T> { value: T }
+        impl<T: Sync> S<T> { fn foo1(&self) {} }
+        impl<T> S<T> { fn foo2(&self) {} }
+        struct S0;
+        impl !Sync for S0 {}
+        fn main1(v: S<S0>) {
+            v.fo/*caret*/
+        }
+    """, """
+        auto trait Sync {}
+        struct S<T> { value: T }
+        impl<T: Sync> S<T> { fn foo1(&self) {} }
+        impl<T> S<T> { fn foo2(&self) {} }
+        struct S0;
+        impl !Sync for S0 {}
+        fn main1(v: S<S0>) {
+            v.foo2()/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
@@ -247,4 +247,13 @@ class RsTypeAwareCompletionTest : RsCompletionTestBase() {
             a./*caret*/;
         }
     """)
+
+    fun `test no completion for a method with ref self in ref impl`() = checkNoCompletion("""
+        struct S;
+        impl<'a> Foo for &'a S {}
+        trait Foo { fn foo(&self) {} }
+        fn main() {
+            S.fo/*caret*/;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -605,4 +605,20 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             //^
         }
     """)
+
+    fun `test trait bound satisfied for struct with negative impl`() = checkByCode("""
+        auto trait Sync {}
+        trait Tr1 { fn some_fn(&self) {} }
+        trait Tr2 { fn some_fn(&self) {} }
+                     //X
+        struct S<T> { value: T }
+        impl<T: Sync> Tr1 for S<T> {}
+        impl<T> Tr2 for S<T> {}
+        struct S0;
+        impl !Sync for S0 {}
+        fn main1(v: S<S0>) {
+            v.some_fn();
+            //^
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -879,4 +879,48 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             S.bar();
         }   //^
     """)
+
+    fun `test method in impl for reference`() = checkByCode("""
+        trait Foo { fn foo(self); }
+        struct S;
+        impl<'a> Foo for &'a S {
+            fn foo(self) { }
+        }    //X
+        fn bar(s: S) {
+            s.foo();
+        }   //^
+    """)
+
+    fun `test method in impl for mut reference`() = checkByCode("""
+        trait Foo { fn foo(self); }
+        struct S;
+        impl<'a> Foo for &'a mut S {
+            fn foo(self) { }
+        }    //X
+        fn bar(mut s: S) {
+            s.foo();
+        }   //^
+    """)
+
+    fun `test method in impl for reference with mut ref receiver`() = checkByCode("""
+        trait Foo { fn foo(self); }
+        struct S;
+        impl<'a> Foo for &'a S {
+            fn foo(self) { }
+        }    //X
+        fn bar(s: &mut S) {
+            s.foo();
+        }   //^
+    """)
+
+    fun `test method in impl for mut reference with ref receiver`() = checkByCode("""
+        trait Foo { fn foo(self); }
+        struct S;
+        impl<'a> Foo for &'a mut S {
+            fn foo(self) { }
+        }    //X
+        fn bar(s: &S) {
+            s.foo();
+        }   //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -292,6 +292,19 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
                //^ !Unsize<S<[i32]>>
     """)
 
+    fun `test a type is automatically Sync`() = doTest("""
+        struct S;
+        type T = S;
+               //^ Sync
+    """)
+
+    fun `test a type is not Sync if a negative impl present`() = doTest("""
+        struct S;
+        impl !Sync for S {}
+        type T = S;
+               //^ !Sync
+    """)
+
     private fun checkPrimitiveTypes(traitName: String) {
         val allIntegers = TyInteger.VALUES.toTypedArray()
         val allFloats = TyFloat.VALUES.toTypedArray()
@@ -308,6 +321,7 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
             #[lang = "sized"]  pub trait Sized {}
             #[lang = "copy"]   pub trait Copy {}
             #[lang = "unsize"] pub trait Unsize<T: ?Sized> {}
+            #[lang = "sync"]   pub unsafe auto trait Sync {}
 
             $code
         """

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -1007,4 +1007,13 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             } //^ i32
         }
     """)
+
+    fun `test Option clone method`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            let a = Some(String::new());
+            let b = a.clone();
+            b;
+        } //^ Option<String>
+    """)
 }


### PR DESCRIPTION
Fixes #8084

```rust
trait Foo { fn foo(self); }
struct S;
impl<'a> Foo for &'a S {
    fn foo(self) { }
}    //X
fn bar(s: S) {
    s.foo();
}   //^
```

changelog: Consider methods in impls for a reference (`&Foo`) when the receiver is not a reference type
