### PR TITLE
INSP: do not offer to remove unused patterns if they are required

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
@@ -81,7 +81,11 @@ class RsLivenessInspection : RsLintInspection() {
         if (isSimplePat) {
             when (kind) {
                 Parameter -> fixes.add(RemoveParameterFix(binding, name))
-                Variable -> fixes.add(RemoveVariableFix(binding, name))
+                Variable -> {
+                    if (binding.topLevelPattern.parent is RsLetDecl) {
+                        fixes.add(RemoveVariableFix(binding, name))
+                    }
+                }
             }
         }
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
@@ -654,6 +654,26 @@ class RsLivenessInspectionTest : RsInspectionsTestBase(RsLivenessInspection::cla
         }
     """)
 
+    fun `test do not offer to remove loop variable`() = checkFixIsUnavailable("Remove variable `a`", """
+        fn foo() {
+            for <warning>a/*caret*/</warning> in &[1, 2, 3] {}
+        }
+    """)
+
+    fun `test do not offer to remove condition variable`() = checkFixIsUnavailable("Remove variable `a`", """
+        fn foo() {
+            if let <warning>a/*caret*/</warning> = 1 {}
+        }
+    """)
+
+    fun `test do not offer to remove match arm variable`() = checkFixIsUnavailable("Remove variable `a`", """
+        fn foo() {
+            match 1 {
+                <warning>a/*caret*/</warning> => {}
+            }
+        }
+    """)
+
     fun `test function internally deny`() = checkByText("""
         fn foo() {
             #[deny(unused_variables)]


### PR DESCRIPTION
Another approach could be simply to only allow removing the variable if the parent is a `LetDecl` :thinking: I'm not sure which is more robust (maybe I missed some cases?).

Fixes: https://github.com/intellij-rust/intellij-rust/issues/8941

changelog: Do not offer to remove unused variables in places where they are required.