### PR TITLE
COMP: fix method completion filtering by trait bounds with autoderef

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -381,15 +381,15 @@ private fun filterMethodCompletionVariantsByTraitBounds(
     // Don't filter partially unknown types
     if (receiver.containsTyOfClass(TyUnknown::class.java)) return processor
 
-    val cache = mutableMapOf<TraitImplSource, Boolean>()
+    val cache = mutableMapOf<Pair<TraitImplSource, Int>, Boolean>()
     return createProcessor(processor.name) {
         // If not a method (actually a field) or a trait method - just process it
         if (it !is MethodResolveVariant) return@createProcessor processor(it)
         // Filter methods by trait bounds (try to select all obligations for each impl)
         // We're caching evaluation results here because we can often complete methods
         // in the same impl and always have the same receiver type
-        val canEvaluate = cache.getOrPut(it.source) {
-            lookup.ctx.canEvaluateBounds(it.source, receiver)
+        val canEvaluate = cache.getOrPut(it.source to it.derefCount) {
+            lookup.ctx.canEvaluateBounds(it.source, it.selfTy)
         }
         if (canEvaluate) return@createProcessor processor(it)
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -49,6 +49,28 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         fn main() { S.foo()/*caret*/ }
     """)
 
+    fun `test unsatisfied bound filtered 3`() = doSingleCompletion("""
+        trait Bound1 {}
+        trait Bound2 {}
+        trait Trait1 { fn foo(&self) {} }
+        trait Trait2 { fn bar(&self) {} }
+        impl<T: Bound1> Trait1 for T {}
+        impl<T: Bound2> Trait2 for T {}
+        struct S;
+        impl Bound1 for S {}
+        fn foo(a: &S) { a./*caret*/ }
+    """, """
+        trait Bound1 {}
+        trait Bound2 {}
+        trait Trait1 { fn foo(&self) {} }
+        trait Trait2 { fn bar(&self) {} }
+        impl<T: Bound1> Trait1 for T {}
+        impl<T: Bound2> Trait2 for T {}
+        struct S;
+        impl Bound1 for S {}
+        fn foo(a: &S) { a.foo()/*caret*/ }
+    """)
+
     fun `test unsatisfied bound not filtered for unknown type`() = doSingleCompletion("""
         trait Bound {}
         trait Trait { fn foo(&self) {} }


### PR DESCRIPTION
```rust
trait Bound1 {}
trait Bound2 {}
trait Trait1 { fn foo(&self) {} }
trait Trait2 { fn bar(&self) {} }
impl<T: Bound1> Trait1 for T {}
impl<T: Bound2> Trait2 for T {}
struct S;
impl Bound1 for S {}
fn foo(a: &S) { a./*caret*/ } // `foo` must be in the completion list
```

changelog: Complete more methods when autoderef occurs
