### PR TITLE
PERF: reduce memory usage by `TraitImplSource` instances

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -56,6 +56,9 @@ class RsCachedImplItem(
         membersMap
     }
 
+    // Reduces heap memory usage by reducing number on `TraitImplSource.ExplicitImpl` instances
+    val explicitImpl: TraitImplSource.ExplicitImpl = TraitImplSource.ExplicitImpl(this)
+
     companion object {
         fun forImpl(impl: RsImplItem): RsCachedImplItem {
             return (impl as RsImplItemImplMixin).cachedImplItem.value

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -292,7 +292,7 @@ class RsInferenceContext(
             val fnName = (variant.element as? RsFunction)?.name
             val impl = lookup.select(resolveTypeVarsIfPossible(traitRef)).ok()?.impl as? RsImplItem ?: continue
             val fn = impl.expandedMembers.functions.find { it.name == fnName } ?: continue
-            val source = TraitImplSource.ExplicitImpl(RsCachedImplItem.forImpl(impl))
+            val source = RsCachedImplItem.forImpl(impl).explicitImpl
             val result = ResolvedPath.AssocItem(fn, source)
             result.subst = variant.subst // TODO remap subst
             resolvedPaths[path] = listOf(result)
@@ -302,7 +302,7 @@ class RsInferenceContext(
             val variant = info.resolveVariants.firstOrNull() ?: continue
             val impl = lookup.select(resolveTypeVarsIfPossible(traitRef)).ok()?.impl as? RsImplItem ?: continue
             val fn = impl.expandedMembers.functions.find { it.name == variant.name } ?: continue
-            val source = TraitImplSource.ExplicitImpl(RsCachedImplItem.forImpl(impl))
+            val source = RsCachedImplItem.forImpl(impl).explicitImpl
             // TODO remap subst
             resolvedMethods[call] = info.copy(resolveVariants = listOf(variant.copy(element = fn, source = source)))
         }


### PR DESCRIPTION
`TraitImplSource` instances are extensively cached, so they bloat old generation heap space a lot