### PR TITLE
TY&RES: take into account impls for macro types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -319,7 +319,7 @@ class ImplLookup(
             }
             if (result) return true
         }
-        return processor(TyFingerprint.TYPE_PARAMETER_FINGERPRINT)
+        return processor(TyFingerprint.TYPE_PARAMETER_OR_MACRO_FINGERPRINT)
     }
 
     private fun canCombineTypes(

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -29,7 +29,7 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
     companion object {
         /** return impls for generic type `impl<T> Trait for T {}` */
         fun findFreeImpls(project: Project, processor: RsProcessor<RsCachedImplItem>): Boolean {
-            return findPotentialImpls(project, TyFingerprint.TYPE_PARAMETER_FINGERPRINT, processor)
+            return findPotentialImpls(project, TyFingerprint.TYPE_PARAMETER_OR_MACRO_FINGERPRINT, processor)
         }
 
         /**

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -74,7 +74,7 @@ class RsFileStub(
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 226
+        private const val STUB_VERSION = 227
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION

--- a/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt
@@ -22,7 +22,7 @@ data class TyFingerprint constructor(
 ) {
     companion object {
 
-        val TYPE_PARAMETER_FINGERPRINT = TyFingerprint("#T")
+        val TYPE_PARAMETER_OR_MACRO_FINGERPRINT = TyFingerprint("#T")
         private val ANY_INTEGER_FINGERPRINT = TyFingerprint("{integer}")
         private val ANY_FLOAT_FINGERPRINT = TyFingerprint("{float}")
 
@@ -36,7 +36,7 @@ data class TyFingerprint constructor(
                     RsBaseTypeKind.Underscore -> return emptyList()
                     is RsBaseTypeKind.Path -> when (val name = kind.path.referenceName) {
                         null -> return emptyList()
-                        in typeParameters -> TYPE_PARAMETER_FINGERPRINT
+                        in typeParameters -> TYPE_PARAMETER_OR_MACRO_FINGERPRINT
                         in TyInteger.NAMES -> return listOf(TyFingerprint(name), ANY_INTEGER_FINGERPRINT)
                         in TyFloat.NAMES -> return listOf(TyFingerprint(name), ANY_FLOAT_FINGERPRINT)
                         else -> TyFingerprint(name)
@@ -60,6 +60,7 @@ data class TyFingerprint constructor(
                 } else {
                     return emptyList()
                 }
+                is RsMacroType -> TYPE_PARAMETER_OR_MACRO_FINGERPRINT
                 else -> return emptyList()
             }
             return listOf(fingerprint)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -864,4 +864,19 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             str::trim();
         }      //^
     """)
+
+    fun `test impl for a macro type`() = checkByCode("""
+        struct S;
+        macro_rules! foo {
+            () => { S };
+        }
+
+        impl foo!() {
+            fn bar(self) {}
+        }    //X
+
+        fn main() {
+            S.bar();
+        }   //^
+    """)
 }


### PR DESCRIPTION
Fixes #8947, fixes #8945

Such methods now will be resolved:

```rust
struct S;
macro_rules! foo {
    () => { S };
}

impl foo!() {
    fn bar(self) {}
}    //X

fn main() {
    S.bar();
}   //^
```

changelog: take into account impls for macro types. For example, `impl foo!() { fn bar(&self) {} }`
