### PR TITLE
CARGO: watch changes in cargo config and rust toolchain files

### DIFF
--- a/src/222/main/kotlin/org/rust/cargo/project/model/impl/CargoSettingsFilesService.kt
+++ b/src/222/main/kotlin/org/rust/cargo/project/model/impl/CargoSettingsFilesService.kt
@@ -46,6 +46,10 @@ class CargoSettingsFilesService(private val project: Project) {
         if (rootPath != null) {
             out["$rootPath/${CargoConstants.MANIFEST_FILE}"] = SettingFileType.CONFIG
             out["$rootPath/${CargoConstants.LOCK_FILE}"] = SettingFileType.CONFIG
+            out["$rootPath/${CargoConstants.TOOLCHAIN_FILE}"] = SettingFileType.CONFIG
+            out["$rootPath/${CargoConstants.TOOLCHAIN_TOML_FILE}"] = SettingFileType.CONFIG
+            out["$rootPath/.cargo/${CargoConstants.CONFIG_FILE}"] = SettingFileType.CONFIG
+            out["$rootPath/.cargo/${CargoConstants.CONFIG_TOML_FILE}"] = SettingFileType.CONFIG
         }
 
         for (pkg in workspace?.packages.orEmpty().filter { it.origin == PackageOrigin.WORKSPACE }) {

--- a/src/222/test/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAwareTest.kt
+++ b/src/222/test/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAwareTest.kt
@@ -47,6 +47,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 [workspace]
                 members = [ "subproject" ]
             """)
+            configs()
             allTargets()
 
             dir("subproject") {
@@ -64,6 +65,10 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
         // Configs
         testProject.checkFileModification("Cargo.toml", triggered = true)
         testProject.checkFileModification("Cargo.lock", triggered = true)
+        testProject.checkFileModification("rust-toolchain", triggered = true)
+        testProject.checkFileModification("rust-toolchain.toml", triggered = true)
+        testProject.checkFileModification(".cargo/config", triggered = true)
+        testProject.checkFileModification(".cargo/config.toml", triggered = true)
         testProject.checkFileModification("subproject/Cargo.toml", triggered = true)
         // Implicit crate roots
         // TODO: it should trigger project model reloading if build script evaluation is enabled
@@ -98,6 +103,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 [workspace]
                 members = [ "subproject" ]
             """)
+            configs()
             allTargets()
 
             dir("subproject") {
@@ -115,6 +121,10 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
         // Configs
         testProject.checkFileDeletion("Cargo.toml", triggered = true)
         testProject.checkFileDeletion("Cargo.lock", triggered = true)
+        testProject.checkFileDeletion("rust-toolchain", triggered = true)
+        testProject.checkFileDeletion("rust-toolchain.toml", triggered = true)
+        testProject.checkFileDeletion(".cargo/config", triggered = true)
+        testProject.checkFileDeletion(".cargo/config.toml", triggered = true)
         testProject.checkFileDeletion("subproject/Cargo.toml", triggered = true)
         // Implicit crate roots
         testProject.checkFileDeletion("build.rs", triggered = true)
@@ -159,6 +169,11 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
         }.create()
         assertNotificationAware(event = "initial project creation")
 
+        // Configs
+        testProject.checkFileCreation("rust-toolchain", triggered = true)
+        testProject.checkFileCreation("rust-toolchain.toml", triggered = true)
+        testProject.checkFileCreation(".cargo/config", triggered = true)
+        testProject.checkFileCreation(".cargo/config.toml", triggered = true)
         // Implicit crate roots
         testProject.checkFileCreation("build.rs", triggered = true)
         testProject.checkFileCreation("src/main.rs", triggered = true)
@@ -351,6 +366,25 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
         }
         rust("build.rs", """
             fn main() {}
+        """)
+    }
+
+    private fun FileTreeBuilder.configs() {
+        dir(".cargo") {
+            // Note, cargo reads only `config` file if both `config` and `config.toml` exist in `.config` dir.
+            // But it's OK for tests to have both of them
+            toml("config", "")
+            toml("config.toml", "")
+        }
+        // Note, cargo reads only `rust-toolchain` file if both `rust-toolchain` and `rust-toolchain.toml` exist.
+        // But it's OK for tests to have both of them
+        toml("rust-toolchain", """
+            [toolchain]
+            channel = "nightly"
+        """)
+        toml("rust-toolchain.toml", """
+            [toolchain]
+            channel = "nightly"
         """)
     }
 

--- a/src/main/kotlin/org/rust/cargo/CargoConstants.kt
+++ b/src/main/kotlin/org/rust/cargo/CargoConstants.kt
@@ -11,6 +11,17 @@ object CargoConstants {
     const val XARGO_MANIFEST_FILE = "Xargo.toml"
     const val LOCK_FILE = "Cargo.lock"
 
+    // From https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure:
+    //  Cargo also reads config files without the .toml extension, such as .cargo/config.
+    //  Support for the .toml extension was added in version 1.39 and is the preferred form.
+    //  If both files exist, Cargo will use the file without the extension.
+    const val CONFIG_FILE = "config"
+    const val CONFIG_TOML_FILE = "config.toml"
+
+    // https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+    const val TOOLCHAIN_FILE = "rust-toolchain"
+    const val TOOLCHAIN_TOML_FILE = "rust-toolchain.toml"
+
     const val RUST_BACKTRACE_ENV_VAR = "RUST_BACKTRACE"
 
     object ProjectLayout {


### PR DESCRIPTION
Now the plugin watches changes in [Cargo config](https://doc.rust-lang.org/cargo/reference/config.html) and [rust-toolchain](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) files and updates/suggests updating the project model in the same way as it already does with `Cargo.toml`

Note, this change works only with new project model auto import (can be enabled via `org.rust.cargo.new.auto.import` registry key) which is available since 2022.2 major IDE release

See #8114
Part of #6424

changelog: Update or suggest updating the project model on changes in [Cargo config](https://doc.rust-lang.org/cargo/reference/config.html) and [rust-toolchain](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) files using new project model auto import
