### PR TITLE
CARGO: invoke `cargo metadata` only for current platform

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -353,6 +353,7 @@ private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext, rustcInfo: R
         val (projectDescriptionData, status) = cargo.fullProjectDescription(
             childContext.project,
             projectDirectory,
+            cargoConfig.buildTarget ?: rustcInfo?.version?.host
         ) {
             when (it) {
                 CargoCallType.METADATA -> SyncProcessAdapter(childContext)
@@ -417,11 +418,12 @@ private fun fetchStdlib(context: CargoSyncTask.SyncContext, cargoProject: CargoP
             }
         }
 
+        val cargoConfig = cargoProject.rawWorkspace?.cargoConfig ?: CargoConfig.DEFAULT
         val rustup = childContext.toolchain.rustup(workingDirectory)
         if (rustup == null) {
             val explicitPath = childContext.project.rustSettings.explicitPathToStdlib
                 ?: childContext.toolchain.rustc().getStdlibFromSysroot(workingDirectory)?.path
-            val lib = explicitPath?.let { StandardLibrary.fromPath(childContext.project, it, rustcInfo) }
+            val lib = explicitPath?.let { StandardLibrary.fromPath(childContext.project, it, rustcInfo, cargoConfig) }
             return@runWithChildProgress when {
                 explicitPath == null -> TaskResult.Err("no explicit stdlib or rustup found")
                 lib == null -> TaskResult.Err("invalid standard library: $explicitPath")
@@ -429,15 +431,19 @@ private fun fetchStdlib(context: CargoSyncTask.SyncContext, cargoProject: CargoP
             }
         }
 
-        rustup.fetchStdlib(childContext, rustcInfo)
+        rustup.fetchStdlib(childContext, rustcInfo, cargoConfig)
     }
 }
 
 
-private fun Rustup.fetchStdlib(context: CargoSyncTask.SyncContext, rustcInfo: RustcInfo?): TaskResult<StandardLibrary> {
+private fun Rustup.fetchStdlib(
+    context: CargoSyncTask.SyncContext,
+    rustcInfo: RustcInfo?,
+    cargoConfig: CargoConfig
+): TaskResult<StandardLibrary> {
     return when (val download = UnitTestRustcCacheService.cached(rustcInfo?.version) { downloadStdlib() }) {
         is DownloadResult.Ok -> {
-            val lib = StandardLibrary.fromFile(context.project, download.value, rustcInfo, listener = SyncProcessAdapter(context))
+            val lib = StandardLibrary.fromFile(context.project, download.value, rustcInfo, cargoConfig, listener = SyncProcessAdapter(context))
             if (lib == null) {
                 TaskResult.Err("Corrupted standard library: ${download.value.presentableUrl}")
             } else {

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -395,7 +395,6 @@ private class WorkspaceImpl(
     }
 
     override fun withDisabledFeatures(userDisabledFeatures: UserDisabledFeatures): CargoWorkspace {
-        checkFeaturesInference()
         val featuresState = inferFeatureState(userDisabledFeatures).associateByPackageRoot()
 
         return WorkspaceImpl(

--- a/src/test/kotlin/org/rust/cargo/project/model/CargoPackagesTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/CargoPackagesTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model
+
+import com.intellij.openapi.util.SystemInfo
+import org.rust.FileTreeBuilder
+import org.rust.MinRustcVersion
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.singleProject
+import org.rust.workspaceOrFail
+
+class CargoPackagesTest : RsWithToolchainTestBase() {
+
+    fun `test target specific dependencies`() {
+        buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "sandbox"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                common_package = { path = "common_package" }
+
+                [target.'cfg(unix)'.dependencies]
+                unix_package = { path = "unix_package" }
+
+                [target.'cfg(windows)'.dependencies]
+                windows_package = { path = "windows_package" }
+            """)
+
+            dir("src") {
+                rust("lib.rs", "")
+            }
+
+            dependencyPackage("common_package")
+            dependencyPackage("unix_package")
+            dependencyPackage("windows_package")
+        }
+
+        val workspace = project.cargoProjects.singleProject().workspaceOrFail()
+
+        workspace.checkPackage("common_package", shouldExist = true)
+        workspace.checkPackage("unix_package", shouldExist = SystemInfo.isUnix)
+        workspace.checkPackage("windows_package", shouldExist = SystemInfo.isWindows)
+    }
+
+    @MinRustcVersion("1.53.0")
+    fun `test target specific dependencies with build target`() {
+        buildProject {
+            dir(".cargo") {
+                toml("config.toml", """
+                    [build]
+                    target = "x86_64-pc-windows-msvc"
+                """)
+            }
+            toml("Cargo.toml", """
+                [package]
+                name = "sandbox"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                common_package = { path = "common_package" }
+
+                [target.'cfg(unix)'.dependencies]
+                unix_package = { path = "unix_package" }
+
+                [target.'cfg(windows)'.dependencies]
+                windows_package = { path = "windows_package" }
+            """)
+
+            dir("src") {
+                rust("lib.rs", "")
+            }
+
+            dependencyPackage("common_package")
+            dependencyPackage("unix_package")
+            dependencyPackage("windows_package")
+        }
+
+        val workspace = project.cargoProjects.singleProject().workspaceOrFail()
+
+        workspace.checkPackage("common_package", shouldExist = true)
+        workspace.checkPackage("unix_package", shouldExist = false)
+        workspace.checkPackage("windows_package", shouldExist = true)
+    }
+
+    private fun FileTreeBuilder.dependencyPackage(name: String) {
+        dir(name) {
+            toml("Cargo.toml", """
+                [package]
+                name = "$name"
+                version = "0.1.0"
+                authors = []
+            """)
+            dir("src") {
+                rust("lib.rs", "")
+            }
+        }
+    }
+
+    private fun CargoWorkspace.checkPackage(name: String, shouldExist: Boolean) {
+        val pkg = packages.find { it.name == name }
+        if (shouldExist) {
+            assertNotNull("Can't find `$name` in workspace", pkg)
+        } else {
+            assertNull("Workspace shouldn't contain `$name` package", pkg)
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/cargo/project/model/CargoStdlibPackagesTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/CargoStdlibPackagesTest.kt
@@ -36,6 +36,11 @@ class CargoStdlibPackagesTest : RsWithToolchainTestBase() {
         assertEquals(PackageOrigin.STDLIB_DEPENDENCY, hashbrownPkg.origin)
         hashbrownPkg.checkFeature("rustc-dep-of-std", FeatureState.Enabled)
         hashbrownPkg.checkFeature("default", FeatureState.Disabled)
+
+        for (pkgName in TARGET_SPECIFIC_DEPENDENCIES) {
+            val pkg = workspace.packages.find { it.name == pkgName }
+            assertNull("$pkgName shouldn't be in stdlib dependencies because it's target-specific", pkg)
+        }
     }
 
     fun `test recover corrupted stdlib dependency directory`() {
@@ -79,5 +84,8 @@ class CargoStdlibPackagesTest : RsWithToolchainTestBase() {
 
     companion object {
         private const val HASHBROWN = "hashbrown"
+
+        // Some stdlib dependencies for non default (from IDE point of view) build targets
+        private val TARGET_SPECIFIC_DEPENDENCIES = listOf("wasi", "hermit-abi", "dlmalloc", "fortanix-sgx-abi")
     }
 }


### PR DESCRIPTION
`cargo metadata` gathers (including downloading) info about dependencies for all targets. As a result, the plugin always took into account all dependencies including [platform-specific](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies) ones before these changes.
Now, the plugin passes proper build target via `--filter-platform` flag to get dependencies only for the given platform.
It should reduce the time of some operations (like indexing) since the plugin will process less code now.

These changes affect almost all users since it makes plugin analyze fewer dependencies even for stdlib (although in the case of stdlib the effect is not significant)


| Before | After |
| - | - |
| <img width="358" alt="Screen Shot 2022-06-21 at 09 12 53" src="https://user-images.githubusercontent.com/2539310/174728945-e893152f-6a2a-48fd-8010-e92810a68a68.png"> | <img width="351" alt="Screen Shot 2022-06-21 at 09 12 22" src="https://user-images.githubusercontent.com/2539310/174728977-0f01776f-f6c2-4b57-99ae-4236bb15bea6.png"> |


Fixes #7185
Closes #8440

changelog: Take into account build target during collection information about the project model and don't download and analyze [platform-specific](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies) dependencies not suitable for the current platform
