### PR TITLE
TY&RES: fix method picking by self type when self type is arbitrary

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -755,4 +755,19 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                         //^ ...libstd/sys/windows/ext/mod.rs|...std/src/sys/windows/ext/mod.rs|...std/src/os/windows/mod.rs
         """)
     }
+
+    fun `test pick method by self type`() = checkByCode("""
+        struct S<T>(T);
+
+        trait T1 { fn foo(self: Box<Self>); }
+        trait T2 { fn foo(self: Rc<Self>); }
+
+        impl<T> T1 for S<T> { fn foo(self: Box<Self>) {} }
+                               //X
+        impl<T> T2 for S<T> { fn foo(self: Rc<Self>) {} }
+
+        fn main() {
+            Box::new(S(0i32)).foo();
+        }                    //^
+    """)
 }


### PR DESCRIPTION
Fixes method resolve in this case:

```rust
struct S<T>(T);

trait T1 { fn foo(self: Box<Self>); }
trait T2 { fn foo(self: Rc<Self>); }

impl<T> T1 for S<T> { fn foo(self: Box<Self>) {} }
                       //X
impl<T> T2 for S<T> { fn foo(self: Rc<Self>) {} }

fn main() {
    Box::new(S(0i32)).foo();
}                    //^
```

changelog: fix method picking by self type when self type is arbitrary
