### PR TITLE
PERF&MACRO: edit single macro without entering the dumb mode

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
@@ -5,13 +5,13 @@
 
 package org.rust.lang.core.macros
 
-import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.RefreshQueue
 import org.jetbrains.annotations.TestOnly
 import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.macros.MacroExpansionFileSystem.FSItem
+import org.rust.openapiext.findNearestExistingFile
 
 class MacroExpansionVfsBatch(private val contentRoot: String) {
 
@@ -75,7 +75,7 @@ class MacroExpansionVfsBatch(private val contentRoot: String) {
         val root = expansionFileSystem.findFileByPath("/") ?: return
 
         for (path in pathsToMarkDirty) {
-            markDirty(findNearestExistingFile(root, path))
+            markDirty(root.findNearestExistingFile(path).first)
         }
 
         RefreshQueue.getInstance().refresh(async, true, callback, root)
@@ -84,12 +84,4 @@ class MacroExpansionVfsBatch(private val contentRoot: String) {
     private fun markDirty(file: VirtualFile) {
         VfsUtil.markDirty(false, false, file)
     }
-}
-
-private fun findNearestExistingFile(root: VirtualFile, path: String): VirtualFile {
-    var file = root
-    for (segment in StringUtil.split(path, "/")) {
-        file = file.findChild(segment) ?: break
-    }
-    return file
 }

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -149,6 +149,15 @@ fun VirtualFile.findFileByMaybeRelativePath(path: String): VirtualFile? =
     else
         findFileByRelativePath(path)
 
+fun VirtualFile.findNearestExistingFile(path: String): Pair<VirtualFile, List<String>> {
+    var file = this
+    val segments = StringUtil.split(path, "/")
+    segments.forEachIndexed { i, segment ->
+        file = file.findChild(segment) ?: return file to segments.subList(i, segments.size)
+    }
+    return file to emptyList()
+}
+
 val VirtualFile.pathAsPath: Path get() = Paths.get(path)
 
 fun VirtualFile.toPsiFile(project: Project): PsiFile? =


### PR DESCRIPTION
When creating/deleting macro expansion files, we look that if we need to create one file and delete one file, then instead we move the file that needs to be deleted to the place where we want to create a new one, and write new text there. Thanks to this, we do not go into the Dumb Mode (we always get into it when creating files on a VFS), which already helps not to clear some platform caches (seemingly). And then we don't bump the structure modification tracker again (well, if the change in the expansion happens somewhere in the body of the function, for example). It remains only not to bump it for the first time (a kind of this is implemented in #8978).

This, unfortunately, does not help with recursive macros, but it can help with procedural ones, which are usually expands in one step

This also fixes #8983 (non-recursive case) because the root problem is that entering dumb mode interrupts completion and so hides the completion popup

changelog: FIX: Show completion autopopup when typing in a macro. PERF: Don't enter Dumb Mode when typing in a (non-recursive) macros