### PR TITLE
PERF: introduce dependencies modification tracker

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -292,10 +292,16 @@ private val CACHED_DATA_MACROS_KEY: Key<CachedValue<CachedData>> = Key.create("C
  */
 @Suppress("KDocUnresolvedReference")
 val RsElement.isValidProjectMember: Boolean
+    get() = isValidProjectMemberAndContainingCrate.first
+
+val RsElement.isValidProjectMemberAndContainingCrate: Pair<Boolean, Crate?>
     get() {
         val file = contextualFile
-        if (file !is RsFile) return true
-        return existsAfterExpansion && file.isDeeplyEnabledByCfg && file.crateRoot != null
+        if (file !is RsFile) return true to null
+        if (!existsAfterExpansion || !file.isDeeplyEnabledByCfg) return false to null
+        val crate = file.crate ?: return false to null
+
+        return true to crate
     }
 
 /** Usually used to filter out test/bench non-workspace crates */

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.CachedValueImpl
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.presentation.getPresentation
 import org.rust.lang.core.macros.RsExpandedElement
@@ -79,7 +80,13 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 
     val cachedImplItem: CachedValue<RsCachedImplItem> = CachedValueImpl {
-        CachedValueProvider.Result(RsCachedImplItem(this), project.rustStructureModificationTracker)
+        val cachedImpl = RsCachedImplItem(this)
+        val modTracker = if (cachedImpl.containingCrate?.origin == PackageOrigin.WORKSPACE) {
+            project.rustStructureModificationTracker
+        } else {
+            project.rustPsiManager.rustStructureModificationTrackerInDependencies
+        }
+        CachedValueProvider.Result(cachedImpl, modTracker)
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -12,11 +12,13 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.util.CachedValueImpl
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsElementTypes.DEFAULT
 import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.psi.rustPsiManager
 import org.rust.lang.core.psi.rustStructureModificationTracker
 import org.rust.lang.core.resolve.RsCachedTypeAlias
 import org.rust.lang.core.stubs.RsTypeAliasStub
@@ -54,6 +56,12 @@ abstract class RsTypeAliasImplMixin : RsStubbedNamedElementImpl<RsTypeAliasStub>
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 
     val cachedImplItem: CachedValue<RsCachedTypeAlias> = CachedValueImpl {
-        CachedValueProvider.Result(RsCachedTypeAlias(this), project.rustStructureModificationTracker)
+        val cachedTypeAlias = RsCachedTypeAlias(this)
+        val modTracker = if (cachedTypeAlias.containingCrate?.origin == PackageOrigin.WORKSPACE) {
+            project.rustStructureModificationTracker
+        } else {
+            project.rustPsiManager.rustStructureModificationTrackerInDependencies
+        }
+        CachedValueProvider.Result(cachedTypeAlias, modTracker)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -8,11 +8,12 @@ package org.rust.lang.core.resolve
 import com.intellij.util.SmartList
 import com.intellij.util.recursionSafeLazy
 import gnu.trove.THashMap
+import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTraitRef
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.psi.isValidProjectMember
+import org.rust.lang.core.psi.isValidProjectMemberAndContainingCrate
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.infer.constGenerics
@@ -30,8 +31,16 @@ class RsCachedImplItem(
     val impl: RsImplItem
 ) {
     private val traitRef: RsTraitRef? = impl.traitRef
-    val isValid: Boolean = impl.isValidProjectMember && !impl.isReservationImpl
+    val containingCrate: Crate?
+    val isValid: Boolean
     val isNegativeImpl: Boolean = impl.isNegativeImpl
+
+    init {
+        val (isValid, crate) = impl.isValidProjectMemberAndContainingCrate
+        this.containingCrate = crate
+        this.isValid = isValid && !impl.isReservationImpl
+    }
+
     val isInherent: Boolean get() = traitRef == null
 
     val implementedTrait: BoundElement<RsTraitItem>? by recursionSafeLazy { traitRef?.resolveToBoundTrait() }

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedTypeAlias.kt
@@ -10,7 +10,7 @@ import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.RsTypeAliasImplMixin
 import org.rust.lang.core.psi.ext.owner
-import org.rust.lang.core.psi.isValidProjectMember
+import org.rust.lang.core.psi.isValidProjectMemberAndContainingCrate
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.infer.constGenerics
 import org.rust.lang.core.types.infer.generics
@@ -27,14 +27,16 @@ class RsCachedTypeAlias(
 ) {
     val name: String? = alias.name
 
-    val isFreeAndValid: Boolean by lazy(PUBLICATION) {
-        name != null
-            && alias.owner is RsAbstractableOwner.Free
-            && alias.isValidProjectMember
-    }
+    val isFreeAndValid: Boolean
 
-    val containingCrate: Crate? by lazy(PUBLICATION) {
-        alias.containingCrate
+    val containingCrate: Crate?
+
+    init {
+        val (isValid, crate) = alias.isValidProjectMemberAndContainingCrate
+        this.containingCrate = crate
+        this.isFreeAndValid = isValid
+            && name != null
+            && alias.owner is RsAbstractableOwner.Free
     }
 
     val typeAndGenerics: Triple<Ty, List<TyTypeParameter>, List<CtConstParameter>> by lazy(PUBLICATION) {


### PR DESCRIPTION
Introduce a separate modification tracker for changes in external dependencies. Now any changes in workspace rust files does not increment that modification tracker, hence does not invalidate any caches that depend on that tracker. 