### PR TITLE
INSP: fix false-positive unresolved reference in explicit assoc path

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -338,6 +338,18 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         }
     """, false)
 
+    // https://github.com/intellij-rust/intellij-rust/issues/8962
+    fun `test no unresolved reference for explicit type-qualified associated member path`() = checkByText("""
+        struct S;
+        mod module {
+            pub trait Trait { fn convert(self); }
+            impl Trait for super::S { fn convert(self) {} }
+        }
+        fn main() {
+            <S as module::Trait>::convert(S);
+        }
+    """)
+
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         withIgnoreWithoutQuickFix(ignoreWithoutQuickFix) { checkByText(text) }
     }


### PR DESCRIPTION
Fixes #8962

changelog: Fix false-positive unresolved reference in explicit type-qualified associated member path like `<S as module::Trait>::convert(S)`