### PR TITLE
PERF: Don't increment rust structure mod tracker on change in macro call

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -43,8 +43,8 @@ abstract class RsMacroCallImplMixin : RsStubbedElementImpl<RsMacroCallStub>,
 
     override fun incModificationCount(element: PsiElement): Boolean {
         modificationTracker.incModificationCount()
-        // global tracker will be incremented if top level
-        return !isTopLevelExpansion
+        val isStructureModification = ancestors.any { it is RsMacroCall && it.macroName == "include" }
+        return !isStructureModification // Note: RsMacroCall is a special case for RsPsiManagerImpl
     }
 }
 

--- a/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
@@ -158,7 +158,7 @@ class RsRustStructureModificationTrackerTest : RsTestBase() {
     """, "a")
 
     @ExpandMacros
-    fun `test macro call (new engine)`() = checkModCount(INC, """
+    fun `test macro call (new engine)`() = checkModCount(NOT_INC, """
         foo! { /*caret*/ }
     """, "a")
 


### PR DESCRIPTION
We started to increment the rust structure modification tracker on changes in macro call bodies since #8647, but this seems to be not actually needed.

changelog: Invalidate less caches after changes in macro call bodies. This speeds up completion&highlighting performance when typing in macro invocations.