### PR TITLE
MACRO: try to fix up rust syntax before calling an attribute proc macro

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroCallBody.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroCallBody.kt
@@ -30,7 +30,11 @@ sealed class MacroCallBody {
      * }
      * ```
      */
-    data class Attribute(val item: MappedText, val attr: MappedText) : MacroCallBody()
+    data class Attribute(
+        val item: MappedText,
+        val attr: MappedText,
+        val fixupRustSyntaxErrors: Boolean,
+    ) : MacroCallBody()
 
     val kind: RsProcMacroKind
         get() = when (this) {

--- a/src/main/kotlin/org/rust/lang/core/macros/MappedText.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MappedText.kt
@@ -30,13 +30,15 @@ class MutableMappedText private constructor(
 ) {
     constructor(capacity: Int) : this(StringBuilder(capacity))
 
+    val length: Int get() = sb.length
+
     fun appendUnmapped(text: CharSequence) {
         sb.append(text)
     }
 
     fun appendMapped(text: CharSequence, srcOffset: Int) {
         if (text.isNotEmpty()) {
-            ranges += MappedTextRange(srcOffset, sb.length, text.length)
+            ranges.mergeAdd(MappedTextRange(srcOffset, sb.length, text.length))
             sb.append(text)
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
@@ -144,8 +144,14 @@ private fun doPrepareProcMacroCallBody(
         is ProcMacroAttribute.Attr -> {
             val attrIndex = attr.index
             val crate = explicitCrate ?: owner.containingCrate ?: return null
-            val body = doPrepareAttributeProcMacroCallBody(project, text, endOfAttrsOffset, crate, attrIndex)
-                ?: return null
+            val body = doPrepareAttributeProcMacroCallBody(
+                project,
+                text,
+                endOfAttrsOffset,
+                crate,
+                attrIndex,
+                fixupRustSyntaxErrors = owner is RsFunction
+            ) ?: return null
             PreparedProcMacroCallBody.Attribute(body, attr)
         }
         is ProcMacroAttribute.Derive -> {
@@ -221,7 +227,8 @@ fun doPrepareAttributeProcMacroCallBody(
     text: String,
     endOfAttrsOffset: Int,
     crate: Crate,
-    attrIndex: Int
+    attrIndex: Int,
+    fixupRustSyntaxErrors: Boolean,
 ): MacroCallBody.Attribute? {
     val item = createAttributeHolderPsi(project, text, endOfAttrsOffset) ?: return null
     val evaluator = CfgEvaluator.forCrate(crate)
@@ -266,7 +273,8 @@ fun doPrepareAttributeProcMacroCallBody(
     val b = theMacroCallAttr ?: return null
     return MacroCallBody.Attribute(
         sb.toMappedText(),
-        b.metaItemArgs?.let { MappedText.single(it.text, it.textOffset) } ?: MappedText.EMPTY
+        b.metaItemArgs?.let { MappedText.single(it.text, it.textOffset) } ?: MappedText.EMPTY,
+        fixupRustSyntaxErrors
     )
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -242,6 +242,7 @@ class ModCollectorBase private constructor(
             bodyStartOffsetInExpansion = item.startOffset,
             bodyEndOffsetInExpansion = item.startOffset + rawBody.length,
             originalItem,
+            fixupRustSyntaxErrors = item is RsFunctionStub
         )
         visitor.collectProcMacroCall(callLight)
     }
@@ -268,6 +269,7 @@ class ModCollectorBase private constructor(
             bodyStartOffsetInExpansion = item.startOffset,
             bodyEndOffsetInExpansion = item.startOffset + rawBody.length,
             null,
+            fixupRustSyntaxErrors = false
         )
         visitor.collectProcMacroCall(callLight)
     }
@@ -581,6 +583,7 @@ class ProcMacroCallLight(
     val bodyEndOffsetInExpansion: Int,
 
     val originalItem: SimpleItemLight?,
+    val fixupRustSyntaxErrors: Boolean,
 ) : Writeable {
 
     override fun writeTo(data: DataOutput) {
@@ -604,7 +607,8 @@ class ProcMacroCallLight(
                 body,
                 endOfAttrsOffset,
                 crate,
-                attrIndex
+                attrIndex,
+                fixupRustSyntaxErrors,
             )
         } else {
             doPrepareCustomDeriveMacroCallBody(

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroSyntaxFixupTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroSyntaxFixupTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.proc
+
+import com.intellij.openapi.util.text.StringUtil
+import org.intellij.lang.annotations.Language
+import org.rust.*
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.macros.MacroExpansionScope
+import org.rust.lang.core.psi.ext.RsPossibleMacroCall
+import org.rust.lang.core.psi.ext.descendantsOfType
+import org.rust.lang.core.psi.ext.expansion
+import org.rust.lang.core.psi.ext.isMacroCall
+
+@MinRustcVersion("1.46.0")
+@ExpandMacros(MacroExpansionScope.WORKSPACE)
+@ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+@WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
+class RsProcMacroSyntaxFixupTest : RsTestBase() {
+    fun `test add semicolon to let stmt`() = checkSyntaxFixup("""
+        fn main() {
+            let a = 123
+        }
+    """, """
+        fn main() {
+            let a = 123;
+        }
+    """)
+
+    fun `test add semicolon to expr stmt`() = checkSyntaxFixup("""
+        fn main() {
+            123
+            321;
+        }
+    """, """
+        fn main() {
+            123;
+            321;
+        }
+    """)
+
+    fun `test fix dot expr`() = checkSyntaxFixup("""
+        fn main() {
+            foo.
+        }
+    """, """
+        fn main() {
+            foo.__ij__fixup
+        }
+    """)
+
+    fun `test fix dot expr and add semicolon`() = checkSyntaxFixup("""
+        fn main() {
+            foo.
+            let _ = 1;
+        }
+    """, """
+        fn main() {
+            foo.__ij__fixup;
+            let _ = 1;
+        }
+    """)
+
+    fun `test remove expressions with errors 1`() = checkSyntaxFixup("""
+        fn main() {
+            let a = 1;
+            a + ;
+            let c = 2;
+        }
+    """, """
+        fn main() {
+            let a = 1;
+            __ij__fixup;
+            let c = 2;
+        }
+    """)
+
+    fun `test remove expressions with errors 2`() = checkSyntaxFixup("""
+        fn main() {
+            let a = 1;
+            let b = a + ;
+            let c = 2;
+        }
+    """, """
+        fn main() {
+            let a = 1;
+            let b = __ij__fixup;
+            let c = 2;
+        }
+    """)
+
+    fun `test remove expressions with errors 3`() = checkSyntaxFixup("""
+        fn main() {
+            let a = 1;
+            let b = a + (a + );
+            let c = 2;
+        }
+    """, """
+        fn main() {
+            let a = 1;
+            let b = a + (__ij__fixup);
+            let c = 2;
+        }
+    """)
+
+    private fun checkSyntaxFixup(input: String, @Language("Rust") expectedOutput: String) {
+        InlineFile("""
+            |use test_proc_macros::attr_as_is;
+            |
+            |#[attr_as_is]
+            |${input.trimIndent()}
+        """.trimMargin())
+
+        val macro = myFixture.file
+            .descendantsOfType<RsPossibleMacroCall>()
+            .single { it.isMacroCall }
+
+        val output = macro.expansion?.file?.text
+
+        if (!StringUtil.equalsIgnoreWhitespaces(expectedOutput.trimIndent(), output)) {
+            assertEquals(expectedOutput.trimIndent(), output)
+        }
+    }
+}


### PR DESCRIPTION
Follows https://github.com/rust-lang/rust-analyzer/issues/11014 discussion