### PR TITLE
CARGO: detect changes in build scripts and notify users about it

### DIFF
--- a/src/222/main/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAware.kt
+++ b/src/222/main/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAware.kt
@@ -47,7 +47,8 @@ class CargoExternalSystemProjectAware(
         // so we don't need to collect fresh settings file list, and we can use cached value.
         // Also, `isIgnoredSettingsFileEvent` is called from EDT so using cache should make it much faster
         val settingsFiles = CargoSettingsFilesService.getInstance(project).collectSettingsFiles(useCache = true)
-        return settingsFiles[path] == SettingFileType.IMPLICIT_TARGET
+        val settingFileType = settingsFiles[path]
+        return settingFileType == null || settingFileType == SettingFileType.IMPLICIT_TARGET
     }
 
     override fun reloadProject(context: ExternalSystemProjectReloadContext) {

--- a/src/222/test/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAwareTest.kt
+++ b/src/222/test/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAwareTest.kt
@@ -42,7 +42,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 [package]
                 name = "hello"
                 version = "0.1.0"
-                authors = []
+                edition = "2018"
 
                 [workspace]
                 members = [ "subproject" ]
@@ -55,7 +55,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                     [package]
                     name = "subproject"
                     version = "0.1.0"
-                    authors = []
+                    edition = "2018"
                 """)
                 allTargets()
             }
@@ -98,7 +98,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 [package]
                 name = "hello"
                 version = "0.1.0"
-                authors = []
+                edition = "2018"
 
                 [workspace]
                 members = [ "subproject" ]
@@ -111,7 +111,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                     [package]
                     name = "subproject"
                     version = "0.1.0"
-                    authors = []
+                    edition = "2018"
                 """)
                 allTargets()
             }
@@ -150,7 +150,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 [package]
                 name = "hello"
                 version = "0.1.0"
-                authors = []
+                edition = "2018"
 
                 [workspace]
                 members = [ "subproject" ]
@@ -162,7 +162,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                     [package]
                     name = "subproject"
                     version = "0.1.0"
-                    authors = []
+                    edition = "2018"
                 """)
                 noTargets()
             }
@@ -198,7 +198,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 [package]
                 name = "hello"
                 version = "0.1.0"
-                authors = []
+                edition = "2018"
 
                 [dependencies]
                 #foo = { path = "./foo" }
@@ -219,7 +219,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                     [package]
                     name = "foo"
                     version = "0.1.0"
-                    authors = []
+                    edition = "2018"
                 """)
 
                 dir("src") {

--- a/src/222/test/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAwareTest.kt
+++ b/src/222/test/kotlin/org/rust/cargo/project/model/impl/CargoExternalSystemProjectAwareTest.kt
@@ -15,14 +15,17 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PathUtil
 import org.rust.FileTreeBuilder
 import org.rust.TestProject
+import org.rust.WithExperimentalFeatures
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.fileTree
+import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.psi.RsPath
 import org.rustSlowTests.cargo.runconfig.waitFinished
 import java.io.IOException
 import java.util.concurrent.CountDownLatch
 
+@WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS)
 class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
 
     private val notificationAware get() = AutoImportProjectNotificationAware.getInstance(project)
@@ -45,7 +48,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 edition = "2018"
 
                 [workspace]
-                members = [ "subproject" ]
+                members = [ "subproject", "custom_build_script" ]
             """)
             configs()
             allTargets()
@@ -59,6 +62,27 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 """)
                 allTargets()
             }
+            dir("custom_build_script") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "custom_build_script"
+                    version = "0.1.0"
+                    edition = "2018"
+                    build = "build/main.rs"
+                """)
+
+                dir("build") {
+                    rust("main.rs", """
+                        mod foo;
+                        fn main() {}
+                    """)
+                    rust("foo.rs", "")
+                }
+                dir("src") {
+                    rust("main.rs", "fn main() {}")
+                }
+                rust("build.rs", "fn main() {}")
+            }
         }.create()
 
         assertNotificationAware(event = "after project creation")
@@ -70,17 +94,20 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
         testProject.checkFileModification(".cargo/config", triggered = true)
         testProject.checkFileModification(".cargo/config.toml", triggered = true)
         testProject.checkFileModification("subproject/Cargo.toml", triggered = true)
+        // Build scripts
+        testProject.checkFileModification("build.rs", triggered = true)
+        testProject.checkFileModification("subproject/build.rs", triggered = true)
+        testProject.checkFileModification("custom_build_script/build/main.rs", triggered = true)
+        // TODO: Ideally, we need to detect changes of children modules of build scripts as well
+        testProject.checkFileModification("custom_build_script/build/foo.rs", triggered = false)
+        testProject.checkFileModification("custom_build_script/build.rs", triggered = false)
         // Implicit crate roots
-        // TODO: it should trigger project model reloading if build script evaluation is enabled
-        testProject.checkFileModification("build.rs", triggered = false)
         testProject.checkFileModification("src/lib.rs", triggered = false)
         testProject.checkFileModification("src/main.rs", triggered = false)
         testProject.checkFileModification("src/bin/bin.rs", triggered = false)
         testProject.checkFileModification("examples/example.rs", triggered = false)
         testProject.checkFileModification("benches/bench.rs", triggered = false)
         testProject.checkFileModification("tests/test.rs", triggered = false)
-        // TODO: it should trigger project model reloading if build script evaluation is enabled
-        testProject.checkFileModification("subproject/build.rs", triggered = false)
         testProject.checkFileModification("subproject/src/lib.rs", triggered = false)
         testProject.checkFileModification("subproject/src/main.rs", triggered = false)
         testProject.checkFileModification("subproject/src/bin/bin.rs", triggered = false)
@@ -101,7 +128,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 edition = "2018"
 
                 [workspace]
-                members = [ "subproject" ]
+                members = [ "subproject", "custom_build_script" ]
             """)
             configs()
             allTargets()
@@ -115,6 +142,27 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 """)
                 allTargets()
             }
+            dir("custom_build_script") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "custom_build_script"
+                    version = "0.1.0"
+                    edition = "2018"
+                    build = "build/main.rs"
+                """)
+
+                dir("build") {
+                    rust("main.rs", """
+                        mod foo;
+                        fn main() {}
+                    """)
+                    rust("foo.rs", "")
+                }
+                dir("src") {
+                    rust("main.rs", "fn main() {}")
+                }
+                rust("build.rs", "fn main() {}")
+            }
         }.create()
 
         assertNotificationAware(event = "after project creation")
@@ -126,14 +174,19 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
         testProject.checkFileDeletion(".cargo/config", triggered = true)
         testProject.checkFileDeletion(".cargo/config.toml", triggered = true)
         testProject.checkFileDeletion("subproject/Cargo.toml", triggered = true)
-        // Implicit crate roots
+        // Build scripts
         testProject.checkFileDeletion("build.rs", triggered = true)
+        testProject.checkFileDeletion("subproject/build.rs", triggered = true)
+        testProject.checkFileDeletion("custom_build_script/build/main.rs", triggered = true)
+        // TODO: Ideally, we need to detect changes of children modules of build scripts as well
+        testProject.checkFileDeletion("custom_build_script/build/foo.rs", triggered = false)
+        testProject.checkFileDeletion("custom_build_script/build.rs", triggered = false)
+        // Implicit crate roots
         testProject.checkFileDeletion("src/main.rs", triggered = true)
         testProject.checkFileDeletion("src/lib.rs", triggered = true)
         testProject.checkFileDeletion("examples/example.rs", triggered = true)
         testProject.checkFileDeletion("benches/bench.rs", triggered = true)
         testProject.checkFileDeletion("tests/test.rs", triggered = true)
-        testProject.checkFileDeletion("subproject/build.rs", triggered = true)
         testProject.checkFileDeletion("subproject/src/main.rs", triggered = true)
         testProject.checkFileDeletion("subproject/src/lib.rs", triggered = true)
         testProject.checkFileDeletion("subproject/examples/example.rs", triggered = true)
@@ -153,7 +206,7 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 edition = "2018"
 
                 [workspace]
-                members = [ "subproject" ]
+                members = [ "subproject", "custom_build_script" ]
             """)
             noTargets()
 
@@ -166,6 +219,24 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
                 """)
                 noTargets()
             }
+            dir("custom_build_script") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "custom_build_script"
+                    version = "0.1.0"
+                    edition = "2018"
+                    build = "build/main.rs"
+                """)
+
+                dir("build") {
+                    rust("main.rs", """
+                        fn main() {}
+                    """)
+                }
+                dir("src") {
+                    rust("main.rs", "fn main() {}")
+                }
+            }
         }.create()
         assertNotificationAware(event = "initial project creation")
 
@@ -174,14 +245,16 @@ class CargoExternalSystemProjectAwareTest : RsWithToolchainTestBase() {
         testProject.checkFileCreation("rust-toolchain.toml", triggered = true)
         testProject.checkFileCreation(".cargo/config", triggered = true)
         testProject.checkFileCreation(".cargo/config.toml", triggered = true)
-        // Implicit crate roots
+        // Build scripts
         testProject.checkFileCreation("build.rs", triggered = true)
+        testProject.checkFileCreation("subproject/build.rs", triggered = true)
+        testProject.checkFileCreation("custom_build_script/build.rs", triggered = false)
+        // Implicit crate roots
         testProject.checkFileCreation("src/main.rs", triggered = true)
         testProject.checkFileCreation("src/lib.rs", triggered = true)
         testProject.checkFileCreation("examples/example.rs", triggered = true)
         testProject.checkFileCreation("benches/bench.rs", triggered = true)
         testProject.checkFileCreation("tests/test.rs", triggered = true)
-        testProject.checkFileCreation("subproject/build.rs", triggered = true)
         testProject.checkFileCreation("subproject/src/main.rs", triggered = true)
         testProject.checkFileCreation("subproject/src/lib.rs", triggered = true)
         testProject.checkFileCreation("subproject/examples/example.rs", triggered = true)

--- a/src/main/kotlin/org/rust/cargo/CargoConstants.kt
+++ b/src/main/kotlin/org/rust/cargo/CargoConstants.kt
@@ -22,6 +22,8 @@ object CargoConstants {
     const val TOOLCHAIN_FILE = "rust-toolchain"
     const val TOOLCHAIN_TOML_FILE = "rust-toolchain.toml"
 
+    const val BUILD_FILE = "build.rs"
+
     const val RUST_BACKTRACE_ENV_VAR = "RUST_BACKTRACE"
 
     object ProjectLayout {


### PR DESCRIPTION
Note, these changes take into account only crate root of build script target not to involve name resolution in project model updates. But such cases are quite rare - I found only 15 crates with modules in build scripts among 2000 top downloaded crates on crates.io

Part of #6424

changelog: Detect changes in build scripts and notify users about it using new project model auto import API
