### PR TITLE
MACRO: fix `ProcMacroExpansionError.IOExceptionThrown` deserialization

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
@@ -135,6 +135,7 @@ fun DataInput.readMacroExpansionError(): MacroExpansionError = when (val ordinal
     1 -> DeclMacroExpansionError.DefSyntax
     2 -> ProcMacroExpansionError.ServerSideError(IOUtil.readUTF(this))
     3 -> ProcMacroExpansionError.ProcessAborted(readInt())
+    4 -> ProcMacroExpansionError.IOExceptionThrown
     5 -> ProcMacroExpansionError.Timeout(readLong())
     6 -> ProcMacroExpansionError.CantRunExpander
     7 -> ProcMacroExpansionError.ExecutableNotFound

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -17,6 +17,7 @@ import org.rust.lang.core.macros.errors.ProcMacroExpansionError.ProcMacroExpansi
 import org.rust.lang.core.macros.tt.*
 import org.rust.lang.core.parser.createRustPsiBuilder
 import org.rust.openapiext.RsPathManager.INTELLIJ_RUST_NATIVE_HELPER
+import org.rust.openapiext.isUnitTestMode
 import org.rust.stdext.RsResult
 import org.rust.stdext.RsResult.Err
 import java.io.IOException
@@ -95,7 +96,9 @@ class ProcMacroExpander(
         } catch (e: ProcessAbortedException) {
             return Err(ProcMacroExpansionError.ProcessAborted(e.exitCode))
         } catch (e: IOException) {
-            MACRO_LOG.error("Error communicating with `$INTELLIJ_RUST_NATIVE_HELPER` process", e)
+            if (!isUnitTestMode) {
+                MACRO_LOG.error("Error communicating with `$INTELLIJ_RUST_NATIVE_HELPER` process", e)
+            }
             return Err(ProcMacroExpansionError.IOExceptionThrown)
         }
         check(response is Response.ExpandMacro)

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpanderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpanderTest.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.macros.proc
 
 import com.intellij.util.ThrowableRunnable
+import com.intellij.util.io.DataOutputStream
 import com.intellij.util.io.exists
 import org.rust.*
 import org.rust.cargo.project.model.cargoProjects
@@ -13,6 +14,8 @@ import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.macros.errors.ProcMacroExpansionError
+import org.rust.lang.core.macros.errors.readMacroExpansionError
+import org.rust.lang.core.macros.errors.writeMacroExpansionError
 import org.rust.lang.core.macros.tt.TokenTree
 import org.rust.lang.core.macros.tt.parseSubtree
 import org.rust.lang.core.macros.tt.toDebugString
@@ -20,6 +23,9 @@ import org.rust.lang.core.parser.createRustPsiBuilder
 import org.rust.openapiext.RsPathManager
 import org.rust.stdext.RsResult
 import org.rust.stdext.toPath
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
 
 /**
  * A low-level test for proc macro expansion infrastructure
@@ -53,6 +59,8 @@ class RsProcMacroExpanderTest : RsTestBase() {
             checkError<ProcMacroExpansionError.ProcessAborted>(lib, "function_like_process_exit", "")
             checkError<ProcMacroExpansionError.ProcessAborted>(lib, "function_like_process_abort", "")
             checkError<ProcMacroExpansionError.ProcessAborted>(lib, "function_like_do_brace_println_and_process_exit", "")
+            checkError<ProcMacroExpansionError.IOExceptionThrown>(lib, "function_like_do_println_braces", "")
+            checkError<ProcMacroExpansionError.IOExceptionThrown>(lib, "function_like_do_println_text_in_braces", "")
             checkExpandedAsIs(lib, "function_like_as_is", "") // Insure it works after errors
         }
     }
@@ -116,9 +124,26 @@ class RsProcMacroExpanderTest : RsTestBase() {
         lib: String,
         name: String,
         macroCall: String
+    ) = checkError(T::class.java, lib, name, macroCall)
+
+    private fun ProcMacroExpander.checkError(
+        errorClass: Class<*>,
+        lib: String,
+        name: String,
+        macroCall: String
     ) {
         val result = expandMacroAsTtWithErr(project.createRustPsiBuilder(macroCall).parseSubtree().subtree, null, name, lib)
-        check(result.err() is T) { "Expected error ${T::class}, got result $result" }
+        check(errorClass.isInstance(result.err())) { "Expected error $errorClass, got result $result" }
+
+        val bytes = ByteArrayOutputStream()
+        val originError = result.err()!!
+        DataOutputStream(bytes).use {
+            it.writeMacroExpansionError(originError)
+        }
+        val restoredError = DataInputStream(ByteArrayInputStream(bytes.toByteArray())).use {
+            it.readMacroExpansionError()
+        }
+        assertEquals(originError, restoredError)
     }
 
     override fun runTestRunnable(testRunnable: ThrowableRunnable<Throwable>) {

--- a/testData/test-proc-macros/src/lib.rs
+++ b/testData/test-proc-macros/src/lib.rs
@@ -57,6 +57,18 @@ pub fn function_like_do_brace_println_and_process_exit(input: TokenStream) -> To
 }
 
 #[proc_macro]
+pub fn function_like_do_println_braces(input: TokenStream) -> TokenStream {
+    println!("{{}}");
+    input
+}
+
+#[proc_macro]
+pub fn function_like_do_println_text_in_braces(input: TokenStream) -> TokenStream {
+    println!("{{hey there}}");
+    input
+}
+
+#[proc_macro]
 pub fn function_like_reverse_spans(item: TokenStream) -> TokenStream {
     let tts = item.into_iter().collect::<Vec<_>>();
     tts.iter().enumerate().map(|(i, tt)| {


### PR DESCRIPTION
Currently, if you use `println!("{{}}")` in a proc macro, an exception will be logged (see #8939). It is (unfortunately) expected behavior and it is not touched by this PR.

But there is a bug in `ProcMacroExpansionError` serialization - if you use `println!("{{}}")` in a proc macro, it actually breaks `MacroExpansionSharedCache`, hence it breaks all macros in the project. The PR fixes this bug