### PR TITLE
IDE: normalize suggested struct names in JSON import conversion

### DIFF
--- a/src/test/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteTest.kt
@@ -1020,6 +1020,34 @@ class RsConvertJsonToStructCopyPasteTest : RsTestBase() {
         }
     """, """{"foo": {"b": 1, "c": 2}, "b": true}""")
 
+    fun `test suggest name kebab case field`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct FooBar {
+            pub field: i64,
+        }
+
+        struct Root {
+            pub foo_bar: FooBar,
+        }
+    """, """{"foo-bar": {"field": 1}}""")
+
+    fun `test suggest name invalid field name`() = doCopyPasteTest("""
+        //- lib.rs
+        /*caret*/
+    """, """
+        //- lib.rs
+        struct _1 {
+            pub field: i64,
+        }
+
+        struct Root {
+            pub _1: _1,
+        }
+    """, """{"1_": {"field": 1}}""")
+
     override fun setUp() {
         super.setUp()
         CONVERT_JSON_ON_PASTE.setValue(true, testRootDisposable)


### PR DESCRIPTION
@dima74 I'm not sure if it's better to try to normalize even invalid names like `1x` or `<>!` or if we should just ignore these for suggesting the struct names. Maybe the latter? Currently this PR tries to normalize them.

Fixes: https://github.com/intellij-rust/intellij-rust/pull/8705#issuecomment-1172186187