### PR TITLE
REF&MACRO: fix macro metavar renaming

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -90,6 +90,10 @@ class RsPsiFactory(
         createFromText<RsLifetimeParameter>("fn foo<$text>(_: &$text u8) {}")?.quoteIdentifier
             ?: error("Failed to create quote identifier: `$text`")
 
+    fun createMetavarIdentifier(text: String): PsiElement =
+        createFromText<RsMetaVarIdentifier>("macro m { ($ $text) => () }")
+            ?: error("Failed to create metavar identifier: `$text`")
+
     fun createExpression(text: String): RsExpr =
         tryCreateExpression(text)
             ?: error("Failed to create expression from text: `$text`")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroBinding.kt
@@ -9,11 +9,17 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.SearchScope
 import org.rust.lang.core.psi.RsMacroBinding
+import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsPsiImplUtil.localOrMacroSearchScope
 
 abstract class RsMacroBindingImplMixin(node: ASTNode) : RsNamedElementImpl(node), RsMacroBinding {
 
     override fun getNameIdentifier(): PsiElement? = metaVarIdentifier
+
+    override fun setName(name: String): PsiElement? {
+        nameIdentifier?.replace(RsPsiFactory(project).createMetavarIdentifier(name))
+        return this
+    }
 
     override fun getUseScope(): SearchScope {
         val owner = contextStrict<RsMacroDefinitionBase>() ?: error("Macro binding outside of a macro")

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
@@ -12,8 +12,7 @@ import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.PsiPolyVariantReferenceBase
 import com.intellij.psi.ResolveResult
 import org.rust.ide.refactoring.isValidRustVariableIdentifier
-import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
-import org.rust.lang.core.psi.RsElementTypes.QUOTE_IDENTIFIER
+import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.escapeIdentifierIfNeeded
 import org.rust.lang.core.psi.ext.RsElement
@@ -67,6 +66,7 @@ abstract class RsReferenceBase<T : RsReferenceElementBase>(
 
                 }
                 QUOTE_IDENTIFIER -> factory.createQuoteIdentifier(newName)
+                META_VAR_IDENTIFIER -> factory.createMetavarIdentifier(newName)
                 else -> error("Unsupported identifier type for `$newName` (${identifier.elementType})")
             }
             identifier.replace(newId)

--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.refactoring
 
 import com.intellij.refactoring.BaseRefactoringProcessor
+import com.intellij.testFramework.PsiTestUtil
 import org.intellij.lang.annotations.Language
 import org.rust.EmptyDescriptor
 import org.rust.ProjectDescriptor
@@ -664,6 +665,12 @@ class RenameTest : RsTestBase() {
         }
     """)
 
+    fun `test rename macro metavar`() = doTest("b", """
+        macro_rules! foo { ($ i/*caret*/:item) => { $ i }; }
+    """, """
+        macro_rules! foo { ($ b:item) => { $ b }; }
+    """)
+
     private fun doTest(
         newName: String,
         @Language("Rust") before: String,
@@ -673,6 +680,7 @@ class RenameTest : RsTestBase() {
         val element = myFixture.elementAtCaret
         myFixture.renameElement(element, newName, true, true)
         myFixture.checkResult(after)
+        PsiTestUtil.checkPsiStructureWithCommit(myFixture.file, PsiTestUtil::checkPsiMatchesTextIgnoringNonCode)
     }
 
     private fun doTestWithConflicts(


### PR DESCRIPTION
Fixes #8880

changelog: Support rename refactoring for macro metavariables