### PR TITLE
REF: Fix counting number of occurrences in inline function refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineUtils.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineUtils.kt
@@ -20,27 +20,18 @@ abstract class RsInlineDialog(
     element: RsNameIdentifierOwner,
     private val refElement: RsReference?,
     project: Project,
-    private val occurrencesNumber: Int
 ) : InlineOptionsWithSearchSettingsDialog(project, true, element) {
     private var searchInCommentsAndStrings = true
     private var searchInTextOccurrences = true
 
-    abstract fun getLabelText(occurrences: String): String
-
     fun shouldBeShown() = EditorSettingsExternalizable.getInstance().isShowInlineLocalDialog
 
-    override fun getNameLabelText(): String {
-        val occurrencesString =
-            if (occurrencesNumber < 0) {
-                ""
-            } else {
-                buildString {
-                    append("has $occurrencesNumber occurrence")
-                    if (occurrencesNumber != 1) append("s")
-                }
-            }
-        return getLabelText(occurrencesString)
-    }
+    protected fun getOccurrencesText(occurrences: Int): String =
+        when {
+            occurrences < 0 -> ""
+            occurrences == 1 -> "has 1 occurrence"
+            else -> "has $occurrences occurrences"
+        }
 
     override fun isInlineThis(): Boolean = false
 

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineValue/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineValue/ui.kt
@@ -12,8 +12,10 @@ import org.rust.ide.refactoring.RsInlineDialog
 class RsInlineValueDialog(
     private val context: InlineValueContext,
     project: Project = context.element.project,
-    occurrencesNumber: Int = initOccurrencesNumber(context.element)
-) : RsInlineDialog(context.element, context.reference, project, occurrencesNumber) {
+) : RsInlineDialog(context.element, context.reference, project) {
+
+    private val occurrencesNumber: Int = initOccurrencesNumber(context.element)
+
     init {
         init()
     }
@@ -35,9 +37,8 @@ class RsInlineValueDialog(
     override fun getBorderTitle(): String =
         RefactoringBundle.message("inline.field.border.title")
 
-    override fun getLabelText(occurrences: String): String {
-        return "${context.type.capitalize()} ${context.name} $occurrences"
-    }
+    override fun getNameLabelText(): String =
+        "${context.type.capitalize()} ${context.name} ${getOccurrencesText(occurrencesNumber)}"
 
     override fun getInlineAllText(): String {
         val text =


### PR DESCRIPTION
Implement `RsInlineFunctionDialog::ignoreOccurrence` to ignore occurrences in imports. This affects the situation when a function has single usage in another module. Please see #8563 for details

changelog: Fix ["Inline function"](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-refactorings.html#extractmethod-refactoring) refactoring dialog when function has single usage in another module
