### PR TITLE
CARGO: enable new project model reloading in 2022.2 builds

### DIFF
--- a/src/221/main/resources-nightly/META-INF/platform-experiments.xml
+++ b/src/221/main/resources-nightly/META-INF/platform-experiments.xml
@@ -1,2 +1,0 @@
-<idea-plugin>
-</idea-plugin>

--- a/src/221/main/resources-stable/META-INF/platform-experiments.xml
+++ b/src/221/main/resources-stable/META-INF/platform-experiments.xml
@@ -1,2 +1,0 @@
-<idea-plugin>
-</idea-plugin>

--- a/src/221/main/resources/META-INF/platform-rust-core.xml
+++ b/src/221/main/resources/META-INF/platform-rust-core.xml
@@ -1,2 +1,7 @@
 <idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <projectConfigurable instance="org.rust.cargo.project.configurable.CargoConfigurable"
+                             parentId="language.rust"
+                             id="language.rust.cargo"/>
+    </extensions>
 </idea-plugin>

--- a/src/222/main/kotlin/org/rust/cargo/project/configurable/CargoPlaceholderConfigurable.kt
+++ b/src/222/main/kotlin/org/rust/cargo/project/configurable/CargoPlaceholderConfigurable.kt
@@ -1,0 +1,44 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.configurable
+
+import com.intellij.ide.DataManager
+import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.openapi.options.ex.Settings
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.gridLayout.HorizontalAlign
+import org.rust.RsBundle
+import java.awt.Component
+
+// BACKCOMPAT: 2022.2. Just drop it
+class CargoPlaceholderConfigurable : BoundConfigurable(RsBundle.message("settings.rust.cargo.name")) {
+
+    override fun createPanel(): DialogPanel {
+        var callback = { }
+
+        val panel = panel {
+            row {
+                link(RsBundle.message("settings.rust.cargo.moved.label")) { callback() }
+                    .resizableColumn()
+                    .horizontalAlign(HorizontalAlign.CENTER)
+            }.resizableRow()
+        }
+
+        callback = { openCargoSettings(panel) }
+
+        return panel
+    }
+
+    private fun openCargoSettings(component: Component) {
+        val dataContext = DataManager.getInstance().getDataContext(component)
+        val settings = Settings.KEY.getData(dataContext)
+        if (settings != null) {
+            val configurable = settings.find(CargoConfigurable::class.java)
+            settings.select(configurable)
+        }
+    }
+}

--- a/src/222/main/resources-nightly/META-INF/platform-experiments.xml
+++ b/src/222/main/resources-nightly/META-INF/platform-experiments.xml
@@ -1,8 +1,0 @@
-<idea-plugin>
-    <extensions defaultExtensionNs="com.intellij">
-        <registryKey key="org.rust.cargo.new.auto.import"
-                     defaultValue="true"
-                     description="Enable new Cargo project model reloading"
-                     restartRequired="true"/>
-    </extensions>
-</idea-plugin>

--- a/src/222/main/resources-stable/META-INF/platform-experiments.xml
+++ b/src/222/main/resources-stable/META-INF/platform-experiments.xml
@@ -1,8 +1,0 @@
-<idea-plugin>
-    <extensions defaultExtensionNs="com.intellij">
-        <registryKey key="org.rust.cargo.new.auto.import"
-                     defaultValue="false"
-                     description="Enable new Cargo project model reloading"
-                     restartRequired="true"/>
-    </extensions>
-</idea-plugin>

--- a/src/222/main/resources/META-INF/platform-rust-core.xml
+++ b/src/222/main/resources/META-INF/platform-rust-core.xml
@@ -2,5 +2,13 @@
     <extensions defaultExtensionNs="com.intellij">
         <externalIconProvider key="Cargo"
                               implementationClass="org.rust.cargo.project.model.impl.CargoExternalSystemIconProvider"/>
+
+        <projectConfigurable instance="org.rust.cargo.project.configurable.CargoConfigurable"
+                             parentId="build.tools"
+                             id="language.rust.cargo"/>
+
+        <projectConfigurable instance="org.rust.cargo.project.configurable.CargoPlaceholderConfigurable"
+                             parentId="language.rust"
+                             id="language.rust.cargoPlaceholder"/>
     </extensions>
 </idea-plugin>

--- a/src/222/main/resources/META-INF/platform-rust-core.xml
+++ b/src/222/main/resources/META-INF/platform-rust-core.xml
@@ -10,5 +10,10 @@
         <projectConfigurable instance="org.rust.cargo.project.configurable.CargoPlaceholderConfigurable"
                              parentId="language.rust"
                              id="language.rust.cargoPlaceholder"/>
+
+        <registryKey key="org.rust.cargo.new.auto.import"
+                     defaultValue="true"
+                     description="Enable new Cargo project model reloading"
+                     restartRequired="true"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -5,7 +5,6 @@
 
     <xi:include href="/META-INF/experiments.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/platform-rust-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
-    <xi:include href="/META-INF/platform-experiments.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Rust -->

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1026,10 +1026,6 @@
                              groupId="language"
                              id="language.rust"/>
 
-        <projectConfigurable instance="org.rust.cargo.project.configurable.CargoConfigurable"
-                             parentId="language.rust"
-                             id="language.rust.cargo"/>
-
         <projectConfigurable instance="org.rust.cargo.project.configurable.RsExternalLinterConfigurable"
                              parentId="language.rust"
                              id="language.rust.cargo.check"/>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -109,6 +109,7 @@ settings.rust.auto.import.title=Rust
 settings.rust.cargo.auto.update.project.label=Update project automatically when Cargo.toml changes
 settings.rust.cargo.compile.all.targets.comment=Pass the <b>--target-all</b> option to Cargo <b>build</b>/<b>check</b> command
 settings.rust.cargo.compile.all.targets.label=Compile all project targets if possible
+settings.rust.cargo.moved.label=Cargo settings were moved to 'Build, Execution, Deployment | Build Tools | Cargo'
 settings.rust.cargo.name=Cargo
 settings.rust.cargo.offline.mode.comment=Pass the <b>--offline</b> option to Cargo to avoid network requests
 settings.rust.cargo.offline.mode.label=Offline mode


### PR DESCRIPTION
These changes enable new project model reloading starting with **2022.2** major platform release.
It includes:
- detection changes in config files even if they are not saved to disk that should make project model reloading more predictable for users (see detailed explanation in #8919)
- notifying users when the project model is not up-to-date because of changes in configuration files via floating button
- taking into account changes in [Cargo config](https://doc.rust-lang.org/cargo/reference/config.html), [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) and [build scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html). Build script changes are detected only if `org.rust.cargo.evaluate.build.scripts` [experimental feature](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features) is enabled
- more granular settings for the project model auto reloading: never reload, always reload, reload only on external changes like VCS branch change (default value). The corresponding options are located in `Preferences | Build, Execution, Deployment | Build Tools`
- moving Cargo settings to `Preferences | Build, Execution, Deployment | Build Tools | Cargo` for consistency with other settings for build tools


I also added a placeholder configurable at the old Cargo settings path with a link navigating to new settings location to simplify migration for users

https://user-images.githubusercontent.com/2539310/177526479-fd7d7a54-2a73-47b1-88e5-1720844c0101.mov

Closes #6424
Fixes #5062
Fixes #8114
Fixes #8779

changelog: Introduce new approach of project model reloading and detection changes in configuration files. Now the plugin detects changes in configuration files like `Cargo.toml` even if they are not saved into disk yet, takes into account [Cargo config](https://doc.rust-lang.org/cargo/reference/config.html), [toolchain](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) and [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html) files and notifies you if the project model is not up-to-date via floating button at the top-right corner of the editor.
You can select preferable way when the project model should be reloaded automatically in `Preferences | Build, Execution, Deployment | Build Tools`. At the same time, Cargo settings were moved to `Preferences | Build, Execution, Deployment | Build Tools | Cargo`
