### PR TITLE
Increment modification tracker in write action in `MacroExpansionTask`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -123,7 +123,6 @@ class MacroExpansionTask(
             applyBatchAndWriteAttributes(batch, filesToWriteAttributes)
         }
 
-        modificationTracker.incModificationCount()
         for (defMap in defMaps) {
             lastUpdatedMacrosAt[defMap.crate] = defMap.timestamp
         }
@@ -206,6 +205,7 @@ class MacroExpansionTask(
                     }
                 }
 
+                modificationTracker.incModificationCount()
                 true
             }
         }
@@ -233,6 +233,7 @@ class MacroExpansionTask(
                 val virtualFile = path.toVirtualFile() ?: continue
                 virtualFile.writeRangeMap(ranges)
             }
+            modificationTracker.incModificationCount()
         }
     }
 


### PR DESCRIPTION
Incrementing the modification tracker without a write action can lead to a cache incoherence, but I can't name a specific issue for now
