### PR TITLE
PERF: speed up `getIncludingMod` usages

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -33,7 +33,9 @@ interface RsExpandedElement : RsElement {
                 val project = parent.project
                 if (!DumbService.isDumb(project)) {
                     project.macroExpansionManager.getContextOfMacroCallExpandedFrom(parent)?.let { return it }
-                    RsIncludeMacroIndex.getIncludedFrom(parent)?.let { return it.containingMod }
+                    if (parent.isIncludedByIncludeMacro) {
+                        RsIncludeMacroIndex.getIncludedFrom(parent)?.let { return it.containingMod }
+                    }
                 }
             }
             return parent
@@ -69,7 +71,11 @@ val RsExpandedElement.expandedFromSequence: Sequence<RsMacroCall>
 val PsiElement.includedFrom: RsMacroCall?
     get() {
         val containingFile = stubParent as? RsFile ?: return null
-        return RsIncludeMacroIndex.getIncludedFrom(containingFile)
+        return if (containingFile.isIncludedByIncludeMacro) {
+            RsIncludeMacroIndex.getIncludedFrom(containingFile)
+        } else {
+            null
+        }
     }
 
 val RsExpandedElement.expandedOrIncludedFrom: RsPossibleMacroCall?


### PR DESCRIPTION
Compute `getIncludingMod` only if mod declaration for the file is not found.
This is useful because mod declaration search is usually performed anyway, and including macro search may be omitted if there is a mod declaration

changelog: Slightly speed up type inference