### PR TITLE
ACT: support "type info" with field shorthand

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFix.kt
@@ -13,7 +13,6 @@ import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsVisibility
 import org.rust.lang.core.psi.ext.parentStructLiteral
-import org.rust.lang.core.psi.ext.resolveToBinding
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.regions.ReStatic
 import org.rust.lang.core.types.regions.Region
@@ -36,7 +35,7 @@ class CreateStructFieldFromConstructorFix(
     ) {
         val field = startElement as RsStructLiteralField
         val fieldName = field.identifier?.text ?: return
-        val fieldType = field.inferFieldTy() ?: return
+        val fieldType = field.type
         val struct = field.resolveToStructItem() ?: return
         val pub = struct.visibility == RsVisibility.Public
         val psiFactory = RsPsiFactory(project)
@@ -61,7 +60,7 @@ class CreateStructFieldFromConstructorFix(
     companion object {
         fun tryCreate(field: RsStructLiteralField): CreateStructFieldFromConstructorFix? {
             if (field.identifier == null) return null
-            val type = field.inferFieldTy() ?: return null
+            val type = field.type
             if (!canUse(type)) return null
             val struct = field.resolveToStructItem() ?: return null
             if (struct.tupleFields != null) return null
@@ -72,10 +71,6 @@ class CreateStructFieldFromConstructorFix(
 
         private fun RsStructLiteralField.resolveToStructItem(): RsStructItem? {
             return parentStructLiteral.path.reference?.resolve() as? RsStructItem
-        }
-
-        private fun RsStructLiteralField.inferFieldTy(): Ty? {
-            return if (colon == null) resolveToBinding()?.type else expr?.type
         }
 
         private fun canUse(ty: Ty): Boolean {

--- a/src/main/kotlin/org/rust/ide/hints/type/RsExpressionTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsExpressionTypeProvider.kt
@@ -13,10 +13,7 @@ import org.rust.ide.presentation.render
 import org.rust.lang.core.macros.findExpansionElementOrSelf
 import org.rust.lang.core.macros.findMacroCallExpandedFromNonRecursive
 import org.rust.lang.core.macros.mapRangeFromExpansionToCallBodyStrict
-import org.rust.lang.core.psi.RsExpr
-import org.rust.lang.core.psi.RsMacroCall
-import org.rust.lang.core.psi.RsPat
-import org.rust.lang.core.psi.RsPatField
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.contexts
 import org.rust.lang.core.types.ty.Ty
@@ -31,7 +28,7 @@ class RsExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
         pivot.findExpansionElementOrSelf()
             .contexts
             .takeWhile { it !is RsItemElement }
-            .filter { it is RsExpr || it is RsPat || it is RsPatField }
+            .filter { it is RsExpr || it is RsPat || it is RsPatField || it is RsStructLiteralField }
             .mapNotNull { it.wrapExpandedElements() }
             .toList()
 
@@ -45,6 +42,7 @@ class RsExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
         is RsExpr -> element.type
         is RsPat -> element.type
         is RsPatField -> element.type
+        is RsStructLiteralField -> element.type
         else -> error("Unexpected element type: $element")
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsRenameProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsRenameProcessor.kt
@@ -87,7 +87,7 @@ class RsRenameProcessor : RenamePsiElementProcessor() {
             usages.forEach {
                 val field = it.element?.ancestorOrSelf<RsStructLiteralField>(RsBlock::class.java) ?: return@forEach
                 when {
-                    field.colon == null -> {
+                    field.isShorthand -> {
                         val newPatField = psiFactory.createStructLiteralField(element.text, newName)
                         field.replace(newPatField)
                     }

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
@@ -16,6 +16,7 @@ import com.intellij.usageView.UsageViewDescriptor
 import org.rust.ide.refactoring.RsInlineUsageViewDescriptor
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.isShorthand
 import org.rust.lang.core.resolve.ref.RsReference
 
 class RsInlineValueProcessor(
@@ -41,7 +42,7 @@ class RsInlineValueProcessor(
             val reference = it.reference as? RsReference ?: return@loop
             when (val element = reference.element) {
                 is RsStructLiteralField -> {
-                    if (element.colon == null) {
+                    if (element.isShorthand) {
                         element.addAfter(factory.createColon(), element.referenceNameElement)
                     }
                     if (element.expr == null) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructLiteralField.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructLiteralField.kt
@@ -22,6 +22,23 @@ inline fun <reified T : RsElement> RsStructLiteralField.resolveToElement(): T? =
 fun RsStructLiteralField.resolveToDeclaration(): RsFieldDecl? = resolveToElement()
 fun RsStructLiteralField.resolveToBinding(): RsPatBinding? = resolveToElement()
 
+/**
+ * ```
+ * struct S {
+ *     foo: i32,
+ *     bar: i32,
+ * }
+ * fn main() {
+ *     let foo = 1;
+ *     let s = S {
+ *         foo,   // isShorthand = true
+ *         bar: 1 // isShorthand = false
+ *     };
+ * }
+ * ```
+ */
+val RsStructLiteralField.isShorthand: Boolean get() = colon == null
+
 abstract class RsStructLiteralFieldImplMixin(node: ASTNode) : RsElementImpl(node), RsStructLiteralField {
 
     override fun getReference(): RsReference = RsStructLiteralFieldReferenceImpl(this)

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructLiteralField
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.isShorthand
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processStructLiteralFieldResolveVariants
 
@@ -25,7 +26,7 @@ class RsStructLiteralFieldReferenceImpl(
         collectResolveVariants(element.referenceName) { processStructLiteralFieldResolveVariants(element, false, it) }
 
     override fun handleElementRename(newName: String): PsiElement {
-        return if (element.colon != null) {
+        return if (!element.isShorthand) {
             super.handleElementRename(newName)
         } else {
             val identifier = element.identifier ?: return element

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -90,6 +90,9 @@ val RsPatField.type: Ty
 val RsExpr.type: Ty
     get() = inference?.getExprType(this) ?: TyUnknown
 
+val RsStructLiteralField.type: Ty
+    get() = (if (isShorthand) resolveToBinding()?.type else expr?.type) ?: TyUnknown
+
 val RsExpr.adjustments: List<Adjustment>
     get() = inference?.getExprAdjustments(this) ?: emptyList()
 

--- a/src/test/kotlin/org/rust/ide/hints/type/RsExpressionTypeProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsExpressionTypeProviderTest.kt
@@ -69,10 +69,23 @@ class RsExpressionTypeProviderTest : RsTestBase() {
         }
     """, "&BoxedS<T>")
 
+    fun `test field shorthand`() = doTest("""
+        struct S {
+            foo: i32,
+        }
+        fn main() {
+            let foo = 1;
+            let _ = S {
+                /*caret*/foo
+            };
+        }
+    """, "i32, S")
+
     private fun doTest(@Language("Rust") code: String, type: String) {
         InlineFile(code).withCaret()
 
-        val element = myFixture.elementAtCaret
+        val element = myFixture.file.findElementAt(myFixture.caretOffset)
+            ?: error("No element under the caret")
 
         val provider = RsExpressionTypeProvider()
         val expressions = provider.getExpressionsAt(element)


### PR DESCRIPTION
Ctrl+shift+P
![image](https://user-images.githubusercontent.com/3221931/178010152-06d318bc-0bd7-4590-a82d-a618afd8584b.png)

changelog: Support "type info" with field shorthand syntax. You can invoke "type info" using `Ctrl`+`shift`+`P` shortcut

bors r+