### PR TITLE
GRD: make 2022.2 platform default for development

### DIFF
--- a/gradle-222.properties
+++ b/gradle-222.properties
@@ -1,11 +1,11 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-222.3244-EAP-CANDIDATE-SNAPSHOT
-clionVersion=CL-222.3244-EAP-CANDIDATE-SNAPSHOT
+ideaVersion=IU-222.3345-EAP-CANDIDATE-SNAPSHOT
+clionVersion=CL-222.3345-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=222.3244.4
+nativeDebugPluginVersion=222.3345.16
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPluginVersion=222-SNAPSHOT
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
 # Supported platforms: 221, 222
-platformVersion=221
+platformVersion=222
 # Supported IDEs: idea, clion
 baseIDE=idea
 


### PR DESCRIPTION
Update 2022.2 dependencies. Since the latest platform EAP reached beta state, let's make 222 platform default for development

changelog: Make 2022.2 platform default for development
