### PR TITLE
PERF: reduce usages of `existsAfterExpansion` in annotators

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/AnnotationSessionEx.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/AnnotationSessionEx.kt
@@ -1,0 +1,29 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.AnnotationSession
+import com.intellij.openapi.util.Key
+import com.intellij.util.containers.orNull
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.psi.RsFile
+import org.rust.openapiext.getOrPut
+import java.util.*
+
+private val CRATE_KEY = Key<Optional<Crate>>("org.rust.ide.annotator.currentCrate")
+
+fun AnnotationSession.currentCrate(): Crate? {
+    return getOrPut(CRATE_KEY) {
+        Optional.ofNullable((file as? RsFile)?.crate)
+    }.orNull()
+}
+
+fun AnnotationSession.setCurrentCrate(crate: Crate?) {
+    putUserData(CRATE_KEY, Optional.ofNullable(crate))
+}
+
+fun AnnotationHolder.currentCrate(): Crate? = currentAnnotationSession.currentCrate()

--- a/src/main/kotlin/org/rust/ide/annotator/RsAnnotationHolder.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsAnnotationHolder.kt
@@ -43,7 +43,7 @@ class RsAnnotationHolder(val holder: AnnotationHolder) {
         @InspectionMessage message: String?,
         vararg fixes: IntentionAction
     ): AnnotationBuilder? {
-        if (!element.existsAfterExpansion) return null
+        if (!element.existsAfterExpansion(currentAnnotationSession.currentCrate())) return null
         val builder = if (message == null) {
             holder.newSilentAnnotation(severity)
         } else {

--- a/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
@@ -16,11 +16,16 @@ class RsCfgDisabledCodeAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         if (holder.isBatchMode) return
 
-        if (element is RsDocAndAttributeOwner && !element.isEnabledByCfgSelf) {
+        val crate = holder.currentCrate() ?: return
+
+        if (element is RsDocAndAttributeOwner && !element.isEnabledByCfgSelfOrInAttrProcMacroBody(crate)) {
             holder.createCondDisabledAnnotation()
         }
 
-        if (element is RsAttr && element.isDisabledCfgAttrAttribute && element.owner?.isEnabledByCfgSelf == true) {
+        val isAttrDisabled = element is RsAttr
+            && element.isDisabledCfgAttrAttribute(crate)
+            && element.owner?.isEnabledByCfgSelfOrInAttrProcMacroBody(crate) == true
+        if (isAttrDisabled) {
             holder.createCondDisabledAnnotation()
         }
     }

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -34,8 +34,9 @@ class RsHighlightingAnnotator : AnnotatorBase() {
             else -> null
         } ?: return
 
-        if (!element.existsAfterExpansion) return
-        if (element.ancestors.any { it is RsAttr && it.isDisabledCfgAttrAttribute }) return
+        val crate = holder.currentCrate()
+        if (crate != null && !element.existsAfterExpansion(crate)) return
+        if (crate != null && element.ancestors.any { it is RsAttr && it.isDisabledCfgAttrAttribute(crate) }) return
 
         val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
@@ -23,6 +23,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.macros.*
+import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.RsAttrProcMacroOwner
 import org.rust.lang.core.psi.ext.RsPossibleMacroCall
@@ -93,11 +94,16 @@ class RsMacroExpansionHighlightingPass(
 
         if (macros.isEmpty()) return
 
+        val crate = (file as? RsFile)?.crate
         val annotators = createAnnotators()
+
         while (macros.isNotEmpty()) {
             val macro = macros.removeLast()
+            val annotationSession = AnnotationSession(macro.expansion.file)
+                .apply { setCurrentCrate(crate) }
+
             @Suppress("DEPRECATION")
-            val holder = AnnotationHolderImpl(AnnotationSession(macro.expansion.file), false)
+            val holder = AnnotationHolderImpl(annotationSession, false)
 
             for (element in macro.elementsForHighlighting) {
                 for (ann in annotators) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -124,7 +124,8 @@ private fun getHighlightElement(useSpeck: RsUseSpeck): PsiElement {
 private fun isApplicableForUseItem(item: RsUseItem): Boolean {
     if (!item.project.isNewResolveEnabled) return false
     if (item.visibility == RsVisibility.Public) return false
-    if (!item.isEnabledByCfg) return false
+    val crate = item.containingCrate ?: return false
+    if (!item.existsAfterExpansion(crate)) return false
     return true
 }
 

--- a/src/main/kotlin/org/rust/ide/presentation/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/Utils.kt
@@ -58,7 +58,7 @@ fun getPresentationForStructure(psi: RsElement): ItemPresentation {
     }
     val icon = psi.getIcon(Iconable.ICON_FLAG_VISIBILITY)
     val textAttributes = when {
-        psi is RsDocAndAttributeOwner && !psi.isEnabledByCfgSelf -> RsColor.CFG_DISABLED_CODE.textAttributesKey
+        psi is RsDocAndAttributeOwner && !psi.isEnabledByCfgSelfOrInAttrProcMacroBody -> RsColor.CFG_DISABLED_CODE.textAttributesKey
         psi.isExpandedFromMacro -> RsColor.GENERATED_ITEM.textAttributesKey
         else -> null
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -314,8 +314,9 @@ val RsElement.isValidProjectMemberAndContainingCrate: Pair<Boolean, Crate?>
     get() {
         val file = contextualFile
         if (file !is RsFile) return true to null
-        if (!existsAfterExpansion || !file.isDeeplyEnabledByCfg) return false to null
+        if (!file.isDeeplyEnabledByCfg) return false to null
         val crate = file.crate ?: return false to null
+        if (!existsAfterExpansion(crate)) return false to null
 
         return true to crate
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
@@ -158,11 +158,9 @@ enum class RsCodeStatus {
 }
 
 /** Returns `true` if this attribute is `#[cfg_attr()]` and it is disabled */
-val RsAttr.isDisabledCfgAttrAttribute: Boolean
-    get() {
-        val metaItem = metaItem
-        if (metaItem.name != "cfg_attr") return false
-        val condition = metaItem.metaItemArgs?.metaItemList?.firstOrNull() ?: return false
-        val crate = containingCrate ?: return false
-        return CfgEvaluator.forCrate(crate).evaluateCondition(condition) == ThreeValuedLogic.False
-    }
+fun RsAttr.isDisabledCfgAttrAttribute(crate: Crate): Boolean {
+    val metaItem = metaItem
+    if (metaItem.name != "cfg_attr") return false
+    val condition = metaItem.metaItemArgs?.metaItemList?.firstOrNull() ?: return false
+    return CfgEvaluator.forCrate(crate).evaluateCondition(condition) == ThreeValuedLogic.False
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -431,18 +431,24 @@ class QueryAttributes<out T: RsMetaItemPsiOrStub>(
  *
  * HACK: do not check on [RsFile] as [RsFile.queryAttributes] would access the PSI
  */
-val RsDocAndAttributeOwner.isEnabledByCfgSelf: Boolean
-    get() {
-        if (getCodeStatus(null) == RsCodeStatus.ATTR_PROC_MACRO_CALL) return true
-        return evaluateCfg() != ThreeValuedLogic.False
-    }
+val RsDocAndAttributeOwner.isEnabledByCfgSelfOrInAttrProcMacroBody: Boolean
+    get() = isEnabledByCfgSelfOrInAttrProcMacroBody(null)
+
+fun RsDocAndAttributeOwner.isEnabledByCfgSelfOrInAttrProcMacroBody(crate: Crate?): Boolean {
+    if (getCodeStatus(crate) == RsCodeStatus.ATTR_PROC_MACRO_CALL) return true
+    return evaluateCfg() != ThreeValuedLogic.False
+}
 
 /**
- * Returns `true` if it [isEnabledByCfgSelf] and is not under attribute procedural macro
+ * Returns `true` if it [isEnabledByCfgSelfOrInAttrProcMacroBody] and is not under attribute procedural macro
  */
 val RsDocAndAttributeOwner.existsAfterExpansionSelf: Boolean
-    get() = evaluateCfg() != ThreeValuedLogic.False &&
-        (this !is RsAttrProcMacroOwner || procMacroAttribute !is ProcMacroAttribute.Attr)
+    get() = existsAfterExpansionSelf(null)
+
+fun RsDocAndAttributeOwner.existsAfterExpansionSelf(crate: Crate?): Boolean =
+    evaluateCfg(crate) != ThreeValuedLogic.False &&
+        (this !is RsAttrProcMacroOwner ||
+            ProcMacroAttribute.getProcMacroAttribute(this, explicitCrate = crate) !is ProcMacroAttribute.Attr)
 
 fun RsDocAndAttributeOwner.isEnabledByCfgSelf(crate: Crate): Boolean =
     isEnabledByCfgSelfInner(crate)


### PR DESCRIPTION
changelog: 1. Slightly speed up highlighting 2. Speed up appearance of inlay hints