### PR TITLE
Fix `Undo` (Ctrl+Z) action after typing in a macro call

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/macros/RsUndoAfterTypingInMacroTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsUndoAfterTypingInMacroTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.psi.PsiDocumentManager
+import org.rust.ExpandMacros
+import org.rust.RsTestBase
+
+@ExpandMacros(MacroExpansionScope.WORKSPACE)
+class RsUndoAfterTypingInMacroTest : RsTestBase() {
+    fun `test typing in a macro can be undone with single undo action invocation`() {
+        val code = """
+            macro_rules! foo {
+                ($ i:item) => {$ i};
+            }
+            foo! {
+                fn foo() {
+                    /*caret*/
+                }
+            }
+        """.trimIndent()
+        InlineFile(code).withCaret()
+
+        for (c in "bar") {
+            myFixture.type(c)
+            PsiDocumentManager.getInstance(project).commitAllDocuments()
+        }
+
+        val undo = ActionManager.getInstance().getAction("\$Undo")
+            ?: error("Cannot find `undo` action")
+        myFixture.testAction(undo)
+        myFixture.checkResult(replaceCaretMarker(code))
+    }
+}


### PR DESCRIPTION
The bug was introduced in #8977.
It turned out that undo merger stopped working when typing in a macro.
That is, if you type, say, `foo` outside a macro call and invoke `Undo` action, the entire `foo` is undone.
But if you type it in a macro call, then it undoes only the last typed symbol - `o`, so `fo` remains in the document

changelog: Should not be mention in the changelog if released with #8977