### PR TITLE
INSP: Add redundant_semicolons inspection and fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -33,6 +33,7 @@ enum class RsLint(
     NonShorthandFieldPatterns("non_shorthand_field_patterns"),
     UnusedQualifications("unused_qualifications", listOf("unused")),
     UnusedMustUse("unused_must_use", listOf("unused")),
+    RedundantSemicolons("redundant_semicolons", listOf("unused")),
     // errors
     UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
     // CLippy lints

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspection.kt
@@ -1,0 +1,69 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.RsBundle
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.lang.core.psi.RsBlock
+import org.rust.lang.core.psi.RsEmptyStmt
+import org.rust.lang.core.psi.RsStmt
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.RsItemElement
+import org.rust.lang.core.psi.ext.endOffsetInParent
+
+private class FixRedundantSemicolons(start: PsiElement, end: PsiElement = start)
+    : LocalQuickFixAndIntentionActionOnPsiElement(start, end) {
+
+    override fun getFamilyName() = RsBundle.message("inspection.RedundantSemicolons.fix.name")
+    override fun getText() = familyName
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        val parent = startElement.parent as? RsBlock ?: return
+        parent.deleteChildRange(startElement, endElement)
+    }
+}
+
+/** Analogue of https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#redundant-semicolons */
+class RsRedundantSemicolonsInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.RedundantSemicolons
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+        override fun visitBlock(block: RsBlock) {
+            super.visitBlock(block)
+
+            fun tryRegisterProblemAndClearSeq(stmts: MutableList<RsStmt>) {
+                if (stmts.isEmpty()) return
+                val highlighting = RsLintHighlightingType.UNUSED_SYMBOL
+                if (stmts.size == 1) {
+                    val description = RsBundle.message("inspection.RedundantSemicolons.description.single")
+                    val fixes = listOf(FixRedundantSemicolons(stmts.first()))
+                    holder.registerLintProblem(stmts.first(), description, highlighting, fixes)
+                } else {
+                    val description = RsBundle.message("inspection.RedundantSemicolons.description.multiple")
+                    val range = TextRange.create(stmts.first().startOffsetInParent, stmts.last().endOffsetInParent)
+                    val fixes = listOf(FixRedundantSemicolons(stmts.first(), stmts.last()))
+                    holder.registerLintProblem(block, description, range, highlighting, fixes)
+                }
+                stmts.clear()
+            }
+
+            val seq = mutableListOf<RsStmt>()
+            for (element in block.children) {
+                when (element) {
+                    is RsEmptyStmt -> seq += element
+                    is RsItemElement, is RsStmt -> tryRegisterProblemAndClearSeq(seq)
+                }
+            }
+            tryRegisterProblemAndClearSeq(seq)
+        }
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -550,6 +550,11 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsDoubleMustUseInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Redundant semicolons"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsRedundantSemicolonsInspection"/>
+
         <localInspection language="Rust" groupName="Rust"
                          displayName="Assert Equal"
                          enabledByDefault="true" level="WEAK WARNING"

--- a/src/main/resources/inspectionDescriptions/RsRedundantSemicolons.html
+++ b/src/main/resources/inspectionDescriptions/RsRedundantSemicolons.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<body>
+Detects unnecessary trailing semicolons.
+
+Corresponds to the <a href="https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#redundant-semicolons">redundant_semicolons</a>
+lint.
+</body>
+</html>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -246,5 +246,9 @@ inspection.UnusedMustUse.FixAddLetUnderscore.name=Add `let _ =`
 inspection.UnusedMustUse.FixAddUnwrap.name=Add `.unwrap()`
 inspection.UnusedMustUse.FixAddExpect.family.name=Add `.expect("")`
 
+inspection.RedundantSemicolons.description.single=Unnecessary trailing semicolon
+inspection.RedundantSemicolons.description.multiple=Unnecessary trailing semicolons
+inspection.RedundantSemicolons.fix.name=Remove unnecessary trailing semicolons
+
 inspection.DoubleMustUse.description=This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`
 inspection.DoubleMustUse.FixRemoveMustUseAttr.name=Remove `#[must_use]` from the function

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspectionTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsRedundantSemicolonsInspectionTest : RsInspectionsTestBase(RsRedundantSemicolonsInspection::class) {
+    fun `test single redundant semicolon`() = checkByText("""
+        fn main() {
+            struct A;
+            struct B;/*warning descr="Unnecessary trailing semicolon"*/;/*warning**/
+        }
+    """)
+
+    fun `test single redundant semicolon after assign statement`() = checkByText("""
+        fn main() {
+            let _a = 1 + 1;/*warning descr="Unnecessary trailing semicolon"*/;/*warning**/
+        }
+    """)
+
+    fun `test multiple redundant semicolons on one line`() = checkByText("""
+        fn main() {
+            struct A;/*warning descr="Unnecessary trailing semicolons"*/; ;/*warning**/
+            {/*warning descr="Unnecessary trailing semicolons"*/;;;/*warning**/}
+        }
+    """)
+
+    fun `test multiple redundant semicolon on many lines`() = checkByText("""
+        fn main() {
+            struct A;/*warning descr="Unnecessary trailing semicolons"*/;
+
+            ;
+
+            ;/*warning**/
+
+            {/*warning descr="Unnecessary trailing semicolons"*/;
+            ;
+            ;/*warning**/}
+        }
+    """)
+
+    fun `test allow redundant_semicolons`() = checkByText("""
+        #[allow(redundant_semicolons)]
+        fn main() {
+            struct A;;
+        }
+    """)
+
+    fun `test allow unused`() = checkByText("""
+        #[allow(unused)]
+        fn main() {
+            struct A;;
+        }
+    """)
+
+    fun `test single fix`() = checkFixByText("Remove unnecessary trailing semicolons", """
+        fn main() {
+            struct A;/*warning descr="Unnecessary trailing semicolon"*//*caret*/;/*warning**/
+        }
+    """, """
+        fn main() {
+            struct A;/*caret*/
+        }
+    """)
+
+    fun `test multiple fix`() = checkFixByText("Remove unnecessary trailing semicolons", """
+        fn main() {
+            struct A;/*warning descr="Unnecessary trailing semicolons"*/;
+            ;/*caret*/
+            ;/*warning**/
+        }
+    """, """
+        fn main() {
+            struct A;/*caret*/
+        }
+    """)
+
+    fun `test multiple semicolons after item statements fix`() = checkFixByText("Remove unnecessary trailing semicolons", """
+        fn main() {
+            struct A {}/*warning descr="Unnecessary trailing semicolon"*//*caret*/;/*warning**/
+            struct B {}/*warning descr="Unnecessary trailing semicolon"*/;/*warning**/
+        }
+    """, """
+        fn main() {
+            struct A {}/*caret*/
+            struct B {};
+        }
+    """)
+
+    fun `test suppression quick fix for main fn`() = checkFixByText("Suppress `redundant_semicolons` for fn main", """
+        fn main() {
+            struct A;/*warning descr="Unnecessary trailing semicolon"*//*caret*/;/*warning**/
+        }
+    """, """
+        #[allow(redundant_semicolons)]
+        fn main() {
+            struct A;;
+        }
+    """)
+}


### PR DESCRIPTION
Based on https://github.com/rust-lang/rust/blob/673d0db5e/compiler/rustc_lint/src/redundant_semicolon.rs

Part of #5888 (_"Compiler lints support"_)

changelog: Add [redundant_semicolons](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#redundant-semicolons) inspection and quick-fix for it