### PR TITLE
UI: migrate Kotlin UI DSL to second version

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsBreakOnPanicConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsBreakOnPanicConfigurableUi.kt
@@ -6,7 +6,7 @@
 package org.rust.debugger.settings
 
 import com.intellij.ui.components.JBCheckBox
-import com.intellij.ui.layout.LayoutBuilder
+import com.intellij.ui.dsl.builder.Panel
 import org.rust.debugger.RsDebuggerBundle
 
 class RsBreakOnPanicConfigurableUi : RsDebuggerUiComponent() {
@@ -24,9 +24,9 @@ class RsBreakOnPanicConfigurableUi : RsDebuggerUiComponent() {
         settings.breakOnPanic = breakOnPanicCheckBox.isSelected
     }
 
-    override fun buildUi(builder: LayoutBuilder) {
-        with(builder) {
-            row { breakOnPanicCheckBox() }
+    override fun buildUi(panel: Panel) {
+        with(panel) {
+            row { cell(breakOnPanicCheckBox) }
         }
     }
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerDataViewConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerDataViewConfigurableUi.kt
@@ -7,9 +7,8 @@ package org.rust.debugger.settings
 
 import com.intellij.openapi.options.ConfigurableUi
 import com.intellij.openapi.ui.ComboBox
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.PlatformUtils
-import com.intellij.util.ui.UIUtil.ComponentStyle.SMALL
 import org.rust.debugger.GDBRenderers
 import org.rust.debugger.LLDBRenderers
 import org.rust.debugger.RsDebuggerBundle
@@ -39,14 +38,13 @@ class RsDebuggerDataViewConfigurableUi : ConfigurableUi<RsDebuggerSettings> {
     }
 
     override fun getComponent(): JComponent = panel {
-        row(RsDebuggerBundle.message("settings.rust.debugger.data.view.lldb.renderers.label")) { lldbRenderers() }
+        row(RsDebuggerBundle.message("settings.rust.debugger.data.view.lldb.renderers.label")) { cell(lldbRenderers) }
         // GDB support is available only in CLion for now
         if (PlatformUtils.isCLion()) {
-            row(RsDebuggerBundle.message("settings.rust.debugger.data.view.gdb.renderers.label")) { gdbRenderers() }
+            row(RsDebuggerBundle.message("settings.rust.debugger.data.view.gdb.renderers.label")) { cell(gdbRenderers) }
         }
         row {
-            label(RsDebuggerBundle.message("settings.rust.debugger.data.view.change.renderers.comment"), style = SMALL)
-                .withLargeLeftGap()
+            comment(RsDebuggerBundle.message("settings.rust.debugger.data.view.change.renderers.comment"))
         }
     }
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerGeneralSettingsConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerGeneralSettingsConfigurableUi.kt
@@ -7,7 +7,7 @@ package org.rust.debugger.settings
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.options.ConfigurableUi
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import org.rust.debugger.RsDebuggerToolchainService
 import org.rust.debugger.RsDebuggerToolchainService.LLDBStatus
 import javax.swing.JComponent

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerToolchainConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerToolchainConfigurableUi.kt
@@ -7,10 +7,11 @@ package org.rust.debugger.settings
 
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.Link
-import com.intellij.ui.layout.LayoutBuilder
+import com.intellij.ui.dsl.builder.Panel
 import org.rust.debugger.RsDebuggerBundle
 import org.rust.debugger.RsDebuggerToolchainService
 import org.rust.debugger.RsDebuggerToolchainService.LLDBStatus
+import org.rust.openapiext.fullWidthCell
 import org.rust.openapiext.pathToDirectoryTextField
 import javax.swing.AbstractButton
 import javax.swing.JComponent
@@ -51,13 +52,13 @@ class RsDebuggerToolchainConfigurableUi : RsDebuggerUiComponent() {
         settings.downloadAutomatically = downloadAutomaticallyCheckBox.isSelected
     }
 
-    override fun buildUi(builder: LayoutBuilder) {
+    override fun buildUi(panel: Panel) {
         lldbPathField.text = RsDebuggerSettings.getInstance().lldbPath.orEmpty()
         update()
-        with(builder) {
-            row(RsDebuggerBundle.message("settings.rust.debugger.toolchain.lldb.path.label")) { lldbPathField() }
-            row("") { downloadLink() }
-            row { downloadAutomaticallyCheckBox() }
+        with(panel) {
+            row(RsDebuggerBundle.message("settings.rust.debugger.toolchain.lldb.path.label")) { fullWidthCell(lldbPathField) }
+            row("") { cell(downloadLink) }
+            row { cell(downloadAutomaticallyCheckBox) }
         }
     }
 

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerUiComponent.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerUiComponent.kt
@@ -7,12 +7,12 @@ package org.rust.debugger.settings
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.options.ConfigurableUi
-import com.intellij.ui.layout.LayoutBuilder
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.panel
 import javax.swing.JComponent
 
 abstract class RsDebuggerUiComponent: ConfigurableUi<RsDebuggerSettings>, Disposable {
-    abstract fun buildUi(builder: LayoutBuilder)
+    abstract fun buildUi(panel: Panel)
 
     override fun getComponent(): JComponent {
         return panel {

--- a/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
@@ -7,43 +7,34 @@ package org.rust.cargo.project.configurable
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.panel
 import org.rust.RsBundle
 import org.rust.cargo.project.model.isNewProjectModelImportEnabled
 
-// TODO: move this configurable to `Preferences | Build, Execution, Deployment | Build Tools` when
-//  new project model reloading is enabled by default
 class CargoConfigurable(project: Project) : RsConfigurableBase(project, RsBundle.message("settings.rust.cargo.name")) {
     override fun createPanel(): DialogPanel = panel {
         row {
-            checkBox(
-                RsBundle.message("settings.rust.cargo.show.first.error.label"),
-                state::autoShowErrorsInEditor
-            )
+            checkBox(RsBundle.message("settings.rust.cargo.show.first.error.label"))
+                .bindSelected(state::autoShowErrorsInEditor)
         }
         // Project model updates is controlled with `Preferences | Build, Execution, Deployment | Build Tools` settings
         // in case of new approach
         if (!isNewProjectModelImportEnabled) {
             row {
-                checkBox(
-                    RsBundle.message("settings.rust.cargo.auto.update.project.label"),
-                    state::autoUpdateEnabled
-                )
+                checkBox(RsBundle.message("settings.rust.cargo.auto.update.project.label"))
+                    .bindSelected(state::autoUpdateEnabled)
             }
         }
         row {
-            checkBox(
-                RsBundle.message("settings.rust.cargo.compile.all.targets.label"),
-                state::compileAllTargets,
-                comment = RsBundle.message("settings.rust.cargo.compile.all.targets.comment")
-            )
+            checkBox(RsBundle.message("settings.rust.cargo.compile.all.targets.label"))
+                .comment(RsBundle.message("settings.rust.cargo.compile.all.targets.comment"))
+                .bindSelected(state::compileAllTargets)
         }
         row {
-            checkBox(
-                RsBundle.message("settings.rust.cargo.offline.mode.label"),
-                state::useOffline,
-                comment = RsBundle.message("settings.rust.cargo.offline.mode.comment")
-            )
+            checkBox(RsBundle.message("settings.rust.cargo.offline.mode.label"),)
+                .comment(RsBundle.message("settings.rust.cargo.offline.mode.comment"))
+                .bindSelected(state::useOffline)
         }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsExternalLinterConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsExternalLinterConfigurable.kt
@@ -8,40 +8,36 @@ package org.rust.cargo.project.configurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.EnumComboBoxModel
-import com.intellij.ui.layout.CCFlags
-import com.intellij.ui.layout.panel
-import com.intellij.ui.layout.toBinding
+import com.intellij.ui.dsl.builder.*
 import org.rust.RsBundle
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.toolchain.ExternalLinter
 import org.rust.cargo.util.CargoCommandCompletionProvider
 import org.rust.cargo.util.RsCommandLineEditor
+import org.rust.openapiext.fullWidthCell
 
 class RsExternalLinterConfigurable(project: Project) : RsConfigurableBase(project, RsBundle.message("settings.rust.external.linters.name")) {
     override fun createPanel(): DialogPanel = panel {
         row(RsBundle.message("settings.rust.external.linters.tool.label")) {
-            comboBox(
-                EnumComboBoxModel(ExternalLinter::class.java),
-                state::externalLinter,
-            ).comment(RsBundle.message("settings.rust.external.linters.tool.comment"))
+            comboBox(EnumComboBoxModel(ExternalLinter::class.java))
+                .comment(RsBundle.message("settings.rust.external.linters.tool.comment"))
+                .bindItem(state::externalLinter.toNullableProperty())
         }
 
         row(RsBundle.message("settings.rust.external.linters.additional.arguments.label")) {
-            RsCommandLineEditor(project, CargoCommandCompletionProvider(project.cargoProjects, "check ") { null })(CCFlags.growX)
+            fullWidthCell(RsCommandLineEditor(project, CargoCommandCompletionProvider(project.cargoProjects, "check ") { null }))
                 .comment(RsBundle.message("settings.rust.external.linters.additional.arguments.comment"))
-                .withBinding(
+                .bind(
                     componentGet = { it.text },
                     componentSet = { component, value -> component.text = value },
-                    modelBinding = state::externalLinterArguments.toBinding()
+                    prop = state::externalLinterArguments.toMutableProperty()
                 )
         }
 
         row {
-            checkBox(
-                RsBundle.message("settings.rust.external.linters.on.the.fly.label"),
-                state::runExternalLinterOnTheFly,
-                comment = RsBundle.message("settings.rust.external.linters.on.the.fly.comment")
-            )
+            checkBox(RsBundle.message("settings.rust.external.linters.on.the.fly.label"))
+                .comment(RsBundle.message("settings.rust.external.linters.on.the.fly.comment"))
+                .bindSelected(state::runExternalLinterOnTheFly)
         }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -12,7 +12,10 @@ import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.EnumComboBoxModel
 import com.intellij.ui.SimpleListCellRenderer
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.bindItem
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.toNullableProperty
 import org.rust.RsBundle
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.RustProjectSettingsService.MacroExpansionEngine
@@ -32,18 +35,21 @@ class RsProjectConfigurable(
     override fun createPanel(): DialogPanel = panel {
         rustProjectSettings.attachTo(this)
         row(RsBundle.message("settings.rust.toolchain.expand.macros.label")) {
-            comboBox(
-                object : EnumComboBoxModel<MacroExpansionEngine>(MacroExpansionEngine::class.java) {
-                    override fun createEnumSet(en: Class<MacroExpansionEngine>): EnumSet<MacroExpansionEngine> {
-                        return EnumSet.of(MacroExpansionEngine.DISABLED, MacroExpansionEngine.NEW)
-                    }
-                },
-                state::macroExpansionEngine,
-                createExpansionEngineListRenderer()
-            ).comment(RsBundle.message("settings.rust.toolchain.expand.macros.comment"))
+            comboBox(createMacroExpansionEngineModel(), createExpansionEngineListRenderer())
+                .comment(RsBundle.message("settings.rust.toolchain.expand.macros.comment"))
+                .bindItem(state::macroExpansionEngine.toNullableProperty())
         }
         row {
-            checkBox(RsBundle.message("settings.rust.toolchain.inject.rust.in.doc.comments.checkbox"), state::doctestInjectionEnabled)
+            checkBox(RsBundle.message("settings.rust.toolchain.inject.rust.in.doc.comments.checkbox"))
+                .bindSelected(state::doctestInjectionEnabled)
+        }
+    }
+
+    private fun createMacroExpansionEngineModel(): EnumComboBoxModel<MacroExpansionEngine> {
+        return object : EnumComboBoxModel<MacroExpansionEngine>(MacroExpansionEngine::class.java) {
+            override fun createEnumSet(en: Class<MacroExpansionEngine>): EnumSet<MacroExpansionEngine> {
+                return EnumSet.of(MacroExpansionEngine.DISABLED, MacroExpansionEngine.NEW)
+            }
         }
     }
 

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
@@ -12,11 +12,14 @@ import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.RawCommandLineEditor
 import com.intellij.ui.components.Label
-import com.intellij.ui.layout.panel
-import com.intellij.ui.layout.toBinding
+import com.intellij.ui.dsl.builder.BottomGap
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.toMutableProperty
 import org.rust.RsBundle
 import org.rust.cargo.project.settings.rustfmtSettings
 import org.rust.cargo.toolchain.RustChannel
+import org.rust.openapiext.fullWidthCell
 
 class RustfmtConfigurable(project: Project) : BoundConfigurable(RsBundle.message("settings.rust.rustfmt.name")) {
     private val settings = project.rustfmtSettings
@@ -33,36 +36,38 @@ class RustfmtConfigurable(project: Project) : BoundConfigurable(RsBundle.message
     private val environmentVariables = EnvironmentVariablesComponent()
 
     override fun createPanel(): DialogPanel = panel {
-        blockRow {
+        group(indent = false) {
             row(RsBundle.message("settings.rust.rustfmt.additional.arguments.label")) {
-                additionalArguments(pushX, growX)
+                fullWidthCell(additionalArguments)
+                    .resizableColumn()
                     .comment(RsBundle.message("settings.rust.rustfmt.additional.arguments.comment"))
-                    .withBinding(
+                    .bind(
                         componentGet = { it.text },
                         componentSet = { component, value -> component.text = value },
-                        modelBinding = settings.state::additionalArguments.toBinding()
+                        prop = settings.state::additionalArguments.toMutableProperty()
                     )
 
                 channelLabel.labelFor = channel
-                channelLabel()
-                channel().withBinding(
-                    componentGet = { it.item },
-                    componentSet = { component, value -> component.item = value },
-                    modelBinding = settings.state::channel.toBinding()
-                )
+                cell(channelLabel)
+                cell(channel)
+                    .bind(
+                        componentGet = { it.item },
+                        componentSet = { component, value -> component.item = value },
+                        prop = settings.state::channel.toMutableProperty()
+                    )
             }
 
             row(environmentVariables.label) {
-                environmentVariables(growX)
-                    .withBinding(
+                fullWidthCell(environmentVariables)
+                    .bind(
                         componentGet = { it.envs },
                         componentSet = { component, value -> component.envs = value },
-                        modelBinding = settings.state::envs.toBinding()
+                        prop = settings.state::envs.toMutableProperty()
                     )
             }
-        }
+        }.bottomGap(BottomGap.MEDIUM) // TODO: do we really need it?
 
-        row { checkBox(RsBundle.message("settings.rust.rustfmt.builtin.formatter.label"), settings.state::useRustfmt) }
-        row { checkBox(RsBundle.message("settings.rust.rustfmt.run.on.save.label"), settings.state::runRustfmtOnSave) }
+        row { checkBox(RsBundle.message("settings.rust.rustfmt.builtin.formatter.label")).bindSelected(settings.state::useRustfmt) }
+        row { checkBox(RsBundle.message("settings.rust.rustfmt.run.on.save.label")).bindSelected(settings.state::runRustfmtOnSave) }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
@@ -17,7 +17,7 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.Key
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.Link
-import com.intellij.ui.layout.LayoutBuilder
+import com.intellij.ui.dsl.builder.Panel
 import org.rust.RsBundle
 import org.rust.cargo.project.RsToolchainPathChoosingComboBox
 import org.rust.cargo.project.settings.RustProjectSettingsService
@@ -28,13 +28,11 @@ import org.rust.cargo.toolchain.tools.Rustup
 import org.rust.cargo.toolchain.tools.rustc
 import org.rust.cargo.toolchain.tools.rustup
 import org.rust.openapiext.UiDebouncer
+import org.rust.openapiext.fullWidthCell
 import org.rust.openapiext.pathToDirectoryTextField
-import java.awt.BorderLayout
 import java.nio.file.Path
 import java.nio.file.Paths
-import javax.swing.JComponent
 import javax.swing.JLabel
-import javax.swing.JPanel
 
 class RustProjectSettingsPanel(
     private val cargoProjectDir: Path = Paths.get("."),
@@ -95,7 +93,7 @@ class RustProjectSettingsPanel(
             update()
         }
 
-    fun attachTo(layout: LayoutBuilder) = with(layout) {
+    fun attachTo(panel: Panel) = with(panel) {
         data = Data(
             toolchain = ProjectManager.getInstance().defaultProject
                 // Don't use `Project.toolchain` or `Project.rustSettings` here because
@@ -108,10 +106,18 @@ class RustProjectSettingsPanel(
             explicitPathToStdlib = null
         )
 
-        row(RsBundle.message("settings.rust.toolchain.location.label")) { wrapComponent(pathToToolchainComboBox)(growX, pushX) }
-        row(RsBundle.message("settings.rust.toolchain.version.label")) { toolchainVersion() }
-        row(RsBundle.message("settings.rust.toolchain.standard.library.label")) { wrapComponent(pathToStdlibField)(growX, pushX) }
-        row("") { downloadStdlibLink() }
+        row(RsBundle.message("settings.rust.toolchain.location.label")) {
+            fullWidthCell(pathToToolchainComboBox)
+        }
+        row(RsBundle.message("settings.rust.toolchain.version.label")) {
+            cell(toolchainVersion)
+        }
+        row(RsBundle.message("settings.rust.toolchain.standard.library.label")) {
+            fullWidthCell(pathToStdlibField)
+        }
+        row {
+            cell(downloadStdlibLink)
+        }
 
         pathToToolchainComboBox.addToolchainsAsync {
             RsToolchainFlavor.getApplicableFlavors().flatMap { it.suggestHomePaths() }.distinct()
@@ -171,8 +177,3 @@ private fun isStdlibLocationCompatible(toolchainLocation: String, stdlibLocation
 }
 
 private fun String.blankToNull(): String? = ifBlank { null }
-
-private fun wrapComponent(component: JComponent): JComponent =
-    JPanel(BorderLayout()).apply {
-        add(component, BorderLayout.NORTH)
-    }

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfigurable.kt
@@ -8,34 +8,43 @@ package org.rust.cargo.runconfig.target
 import com.intellij.execution.target.getRuntimeType
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.ui.DialogPanel
-import com.intellij.ui.layout.panel
-import com.intellij.ui.layout.titledRow
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.dsl.builder.Cell
+import com.intellij.ui.dsl.builder.Row
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import org.rust.RsBundle
 
 class RsLanguageRuntimeConfigurable(val config: RsLanguageRuntimeConfiguration) :
     BoundConfigurable(config.displayName, config.getRuntimeType().helpTopic) {
 
     override fun createPanel(): DialogPanel = panel {
-        titledRow()
-
         row(RsBundle.message("run.target.rustc.executable.path.label")) {
-            textField(config::rustcPath)
+            fullWidthTextField()
+                .bindText(config::rustcPath)
         }
         row(RsBundle.message("run.target.rustc.executable.version.label")) {
-            textField(config::rustcVersion).enabled(false)
+            fullWidthTextField()
+                .enabled(false)
+                .bindText(config::rustcVersion)
         }
-
         row(RsBundle.message("run.target.cargo.executable.path.label")) {
-            textField(config::cargoPath)
+            fullWidthTextField()
+                .bindText(config::cargoPath)
         }
         row(RsBundle.message("run.target.cargo.executable.version.label")) {
-            textField(config::cargoVersion).enabled(false)
+            fullWidthTextField()
+                .enabled(false)
+                .bindText(config::cargoVersion)
         }
-
         row(RsBundle.message("run.target.build.arguments.label")) {
-            textField(config::localBuildArgs)
+            fullWidthTextField()
                 .comment(RsBundle.message("run.target.build.arguments.comment"))
                 .apply { component.emptyText.text = "e.g. --target=x86_64-unknown-linux-gnu" }
+                .bindText(config::localBuildArgs)
         }
     }
+
+    private fun Row.fullWidthTextField(): Cell<JBTextField> = textField().horizontalAlign(HorizontalAlign.FILL)
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -15,17 +15,14 @@ import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
-import com.intellij.openapi.util.NlsContexts.Label
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.components.CheckBox
 import com.intellij.ui.components.Label
-import com.intellij.ui.layout.CCFlags
-import com.intellij.ui.layout.LayoutBuilder
-import com.intellij.ui.layout.Row
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.RowLayout
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.text.nullize
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
@@ -39,6 +36,7 @@ import org.rust.cargo.toolchain.tools.isRustupAvailable
 import org.rust.cargo.util.CargoCommandCompletionProvider
 import org.rust.cargo.util.RsCommandLineEditor
 import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.fullWidthCell
 import org.rust.openapiext.isFeatureEnabled
 import org.rust.openapiext.pathTextField
 import javax.swing.JCheckBox
@@ -163,35 +161,38 @@ class CargoCommandConfigurationEditor(project: Project)
     }
 
     override fun createEditor(): JComponent = panel {
-        labeledRow("&Command:", command) {
-            command(CCFlags.pushX, CCFlags.growX)
+        row("&Command:") {
+            fullWidthCell(command)
+                .resizableColumn()
             channelLabel.labelFor = channel
-            channelLabel()
-            channel()
+            cell(channelLabel)
+            cell(channel)
         }
 
-        row { requiredFeatures() }
-        row { allFeatures() }
-        row { emulateTerminal() }
-        row { withSudo() }
-        row { buildOnRemoteTarget() }
+        row { cell(requiredFeatures) }
+        row { cell(allFeatures) }
+        row { cell(emulateTerminal) }
+        row { cell(withSudo) }
+        row { cell(buildOnRemoteTarget) }
 
         row(environmentVariables.label) {
-            environmentVariables(growX)
+            fullWidthCell(environmentVariables)
         }
         row(workingDirectory.label) {
-            workingDirectory(growX)
+            fullWidthCell(workingDirectory)
+                .resizableColumn()
             if (project.cargoProjects.allProjects.size > 1) {
-                cargoProject(growX)
+                cell(cargoProject)
             }
         }
         row {
-            cell(isFullWidth = true) {
-                isRedirectInput()
-                redirectInput()
-            }
+            layout(RowLayout.LABEL_ALIGNED)
+            cell(isRedirectInput)
+            fullWidthCell(redirectInput)
         }
-        labeledRow("Back&trace:", backtraceMode) { backtraceMode() }
+        row("Back&trace:") {
+            cell(backtraceMode)
+        }
     }.also { panel = it }
 
     private fun hideUnsupportedFieldsIfNeeded() {
@@ -199,12 +200,5 @@ class CargoCommandConfigurationEditor(project: Project)
         val localTarget = DataManager.getInstance().getDataContext(panel)
             .getData(SingleConfigurationConfigurable.RUN_ON_TARGET_NAME_KEY) == null
         buildOnRemoteTarget.isVisible = !localTarget
-    }
-
-    @Suppress("UnstableApiUsage")
-    private fun LayoutBuilder.labeledRow(@Label labelText: String, component: JComponent, init: Row.() -> Unit) {
-        val label = Label(labelText)
-        label.labelFor = component
-        row(label) { init() }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/WasmPackCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/WasmPackCommandConfigurationEditor.kt
@@ -6,11 +6,12 @@
 package org.rust.cargo.runconfig.ui
 
 import com.intellij.openapi.project.Project
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.runconfig.wasmpack.WasmPackCommandConfiguration
 import org.rust.cargo.runconfig.wasmpack.util.WasmPackCommandCompletionProvider
 import org.rust.cargo.util.RsCommandLineEditor
+import org.rust.openapiext.fullWidthCell
 import javax.swing.JComponent
 
 class WasmPackCommandConfigurationEditor(project: Project)
@@ -22,11 +23,11 @@ class WasmPackCommandConfigurationEditor(project: Project)
 
     override fun createEditor(): JComponent = panel {
         row("Command:") {
-            command(growX, pushX)
+            fullWidthCell(command)
         }
 
         row(workingDirectory.label) {
-            workingDirectory(growX)
+            fullWidthCell(workingDirectory)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/actions/ui/CargoNewCrateDialog.kt
+++ b/src/main/kotlin/org/rust/ide/actions/ui/CargoNewCrateDialog.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import org.jetbrains.annotations.TestOnly
 import org.rust.ide.newProject.RsPackageNameValidator
 import org.rust.openapiext.isUnitTestMode
@@ -65,8 +65,8 @@ class CargoNewCrateDialog(project: Project, private val root: VirtualFile) : Dia
     }
 
     override fun createCenterPanel(): JComponent = panel {
-        row("Name") { name() }
-        row("Type") { typeCombobox() }
+        row("Name") { cell(name) }
+        row("Type") { cell(typeCombobox) }
     }
 
     override fun getPreferredFocusedComponent(): JComponent = name

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AttachFileToModuleFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AttachFileToModuleFix.kt
@@ -15,8 +15,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.components.dialog
-import com.intellij.ui.layout.CCFlags
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.containers.addIfNotNull
 import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.project.model.cargoProjects
@@ -30,6 +29,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.rustFile
 import org.rust.openapiext.isUnitTestMode
 import org.rust.openapiext.pathAsPath
+import org.rust.openapiext.fullWidthCell
 import org.rust.openapiext.toPsiFile
 
 /**
@@ -128,7 +128,7 @@ private fun selectModule(file: RsFile, availableModules: List<RsFile>): RsFile? 
     }
 
     val dialog = dialog("Select a Module", panel {
-        row { box(CCFlags.growX) }
+        row { fullWidthCell(box) }
     }, focusedComponent = box)
 
     return if (dialog.showAndGet()) {

--- a/src/main/kotlin/org/rust/ide/module/CargoConfigurationWizardStep.kt
+++ b/src/main/kotlin/org/rust/ide/module/CargoConfigurationWizardStep.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.util.Disposer
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import org.rust.cargo.CargoConstants
 import org.rust.cargo.project.model.cargoProjects

--- a/src/main/kotlin/org/rust/ide/newProject/RsProjectGeneratorPeer.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsProjectGeneratorPeer.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.platform.GeneratorPeerImpl
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import org.rust.ide.newProject.ui.RsNewProjectPanel
 import javax.swing.JComponent
 

--- a/src/main/kotlin/org/rust/ide/newProject/ui/AddUserTemplateDialog.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ui/AddUserTemplateDialog.kt
@@ -7,18 +7,17 @@ package org.rust.ide.newProject.ui
 
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import org.rust.RsBundle
 import org.rust.ide.newProject.state.RsUserTemplate
 import org.rust.ide.newProject.state.RsUserTemplatesState
 import org.rust.openapiext.addTextChangeListener
-import java.awt.Dimension
+import org.rust.openapiext.fullWidthCell
 import javax.swing.JComponent
 import javax.swing.event.DocumentEvent
 
 class AddUserTemplateDialog : DialogWrapper(null) {
     private val repoUrlField: JBTextField = JBTextField().apply {
-        preferredSize = Dimension(400, 0)
         addTextChangeListener(::suggestName)
     }
 
@@ -34,10 +33,11 @@ class AddUserTemplateDialog : DialogWrapper(null) {
 
     override fun createCenterPanel(): JComponent = panel {
         row(RsBundle.message("dialog.create.project.custom.add.template.url")) {
-            repoUrlField(comment = RsBundle.message("dialog.create.project.custom.add.template.url.description"))
+            fullWidthCell(repoUrlField)
+                .comment(RsBundle.message("dialog.create.project.custom.add.template.url.description"))
         }
         row(RsBundle.message("dialog.create.project.custom.add.template.name")) {
-            nameField()
+            fullWidthCell(nameField)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
@@ -20,7 +20,9 @@ import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.Link
-import com.intellij.ui.layout.LayoutBuilder
+import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.TopGap
+import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.ui.JBUI
 import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
 import org.rust.cargo.toolchain.tools.Cargo
@@ -32,6 +34,7 @@ import org.rust.ide.newProject.RsProjectTemplate
 import org.rust.ide.newProject.state.RsUserTemplatesState
 import org.rust.ide.notifications.showBalloon
 import org.rust.openapiext.UiDebouncer
+import org.rust.openapiext.fullWidthCell
 import org.rust.stdext.unwrapOrThrow
 import javax.swing.DefaultListModel
 import javax.swing.JList
@@ -142,14 +145,19 @@ class RsNewProjectPanel(
 
     val data: ConfigurationData get() = ConfigurationData(rustProjectSettings.data, selectedTemplate)
 
-    fun attachTo(layout: LayoutBuilder) = with(layout) {
+    fun attachTo(panel: Panel) = with(panel) {
         rustProjectSettings.attachTo(this)
 
         if (showProjectTypeSelection) {
-            titledRow("Project Template") {
-                subRowIndent = 0
-                row { templateToolbar.createPanel()(growX) }
-                row { downloadCargoGenerateLink() }
+            separator("Project Template")
+                .topGap(TopGap.MEDIUM)
+            row {
+                resizableRow()
+                fullWidthCell(templateToolbar.createPanel())
+                    .verticalAlign(VerticalAlign.FILL)
+            }
+            row {
+                cell(downloadCargoGenerateLink)
             }
         }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/ui.kt
@@ -11,12 +11,12 @@ import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.refactoring.ui.MethodSignatureComponent
 import com.intellij.refactoring.ui.NameSuggestionsField
 import com.intellij.ui.components.dialog
-import com.intellij.ui.layout.CCFlags
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import org.jetbrains.annotations.TestOnly
 import org.rust.ide.refactoring.isValidRustVariableIdentifier
 import org.rust.lang.RsFileType
+import org.rust.openapiext.fullWidthCell
 import org.rust.openapiext.isUnitTestMode
 
 private var MOCK: ExtractFunctionUi? = null
@@ -76,10 +76,10 @@ private class DialogExtractFunctionUi(
         }
 
         val panel = panel {
-            row("Name:") { functionNameField(CCFlags.grow) }
-            row("Visibility:") { visibilityBox() }
-            row("Parameters:") { parameterPanel() }
-            row("Signature:") { signatureComponent(CCFlags.grow) }
+            row("Name:") { fullWidthCell(functionNameField) }
+            row("Visibility:") { cell(visibilityBox) }
+            row("Parameters:") { fullWidthCell(parameterPanel) }
+            row("Signature:") { fullWidthCell(signatureComponent) }
         }
 
         val extractDialog = dialog(

--- a/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/ui.kt
@@ -9,10 +9,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
 import org.jetbrains.annotations.TestOnly
 import org.rust.RsBundle
 import org.rust.ide.refactoring.isValidRustVariableIdentifier
+import org.rust.openapiext.fullWidthCell
 import org.rust.openapiext.isUnitTestMode
 import javax.swing.JComponent
 
@@ -57,7 +58,9 @@ private class ExtractFieldsDialog(project: Project) : DialogWrapper(project, fal
     }
 
     override fun createCenterPanel(): JComponent =
-        panel { row { input().focused() } }
+        panel {
+            row { fullWidthCell(input).focused() }
+        }
 
     override fun selectStructName(project: Project): String? =
         if (showAndGet()) input.text else null

--- a/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitHandler.kt
@@ -18,7 +18,9 @@ import com.intellij.refactoring.RefactoringBundle
 import com.intellij.refactoring.ui.RefactoringDialog
 import com.intellij.refactoring.util.CommonRefactoringUtil
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.BottomGap
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.ui.JBUI
 import org.jetbrains.annotations.TestOnly
 import org.rust.RsBundle
@@ -32,6 +34,7 @@ import org.rust.lang.core.psi.ext.RsTraitOrImpl
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.childrenOfType
 import org.rust.openapiext.addTextChangeListener
+import org.rust.openapiext.fullWidthCell
 import org.rust.openapiext.isUnitTestMode
 import javax.swing.JComponent
 import javax.swing.JTextField
@@ -79,17 +82,20 @@ class RsExtractTraitDialog(
     }
 
     override fun createCenterPanel(): JComponent = panel {
-        blockRow {
-            cell(isFullWidth = true) {
-                label("Trait name:")
-            }
-            traitNameField().focused()
+        row {
+            label("Trait name:")
         }
         row {
+            fullWidthCell(traitNameField).focused()
+        }.bottomGap(BottomGap.MEDIUM)
+
+        row {
+            resizableRow()
             val members = RsMemberSelectionPanel("Members to form trait", memberInfos)
             members.minimumSize = JBUI.size(0, 200)
             members.table.addMemberInfoChangeListener { validateButtons() }
-            members()
+            fullWidthCell(members)
+                .verticalAlign(VerticalAlign.FILL)
         }
     }
 

--- a/src/main/kotlin/org/rust/openapiext/ui.kt
+++ b/src/main/kotlin/org/rust/openapiext/ui.kt
@@ -19,12 +19,13 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.NlsContexts.DialogTitle
 import com.intellij.ui.DocumentAdapter
-import com.intellij.ui.components.Label
-import com.intellij.ui.layout.Row
-import com.intellij.ui.layout.RowBuilder
+import com.intellij.ui.dsl.builder.Cell
+import com.intellij.ui.dsl.builder.Row
+import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.util.Alarm
 import org.rust.lang.RsFileType
 import org.rust.lang.core.psi.ext.RsElement
+import javax.swing.JComponent
 import javax.swing.JTextField
 import javax.swing.event.DocumentEvent
 
@@ -105,20 +106,14 @@ fun JTextField.addTextChangeListener(listener: (DocumentEvent) -> Unit) {
     )
 }
 
-fun RowBuilder.row(
-    labelText: String,
-    toolTip: String,
-    separated: Boolean = false,
-    init: Row.() -> Unit
-): Row {
-    val label = Label(labelText)
-    label.toolTipText = toolTip.trimIndent()
-    return row(label, separated, init)
-}
-
 fun selectElement(element: RsElement, editor: Editor) {
     val start = element.textRange.startOffset
     editor.caretModel.moveToOffset(start)
     editor.scrollingModel.scrollToCaret(ScrollType.RELATIVE)
     editor.selectionModel.setSelection(start, element.textRange.endOffset)
+}
+
+fun <T : JComponent> Row.fullWidthCell(component: T): Cell<T> {
+    return cell(component)
+        .horizontalAlign(HorizontalAlign.FILL)
 }

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -203,7 +203,7 @@ settings.rust.inlay.parameter.hints.only.smart=Only smart hints
 settings.rust.rustfmt.additional.arguments.comment=Additional arguments to pass to <b>rustfmt</b> or <b>cargo fmt</b> command
 settings.rust.rustfmt.additional.arguments.label=Additional arguments:
 settings.rust.rustfmt.builtin.formatter.label=Use rustfmt instead of the built-in formatter
-settings.rust.rustfmt.channel.label=Channel
+settings.rust.rustfmt.channel.label=Channel:
 settings.rust.rustfmt.name=Rustfmt
 settings.rust.rustfmt.run.on.save.label=Run rustfmt on Save
 


### PR DESCRIPTION
These changes replace all usages of Kotlin UI DSL v1 to v2 since the first version is deprecated

More precisely, it refactors:
- Cargo command editor in Cargo Command run configuration dialog
- Wasm pack command editor in Wasm pack run configuration dialog
- Cargo settings (`Preferences | Build, Execution, Deployment | Build Tools | Cargo` / `Preferences | Languages & Frameworks | Rust | Cargo`)
- Rustfmt settings (`Preferences | Languages & Frameworks | Rust | Rustfmt`)
- External linter settings (`Preferences | Languages & Frameworks | Rust | External Linters`)
- Rust settings (`Preferences | Languages & Frameworks | Rust`)
- New Rust project dialog (both versions in IDEA and minor IDEs like CLion)
- `Add custom template` dialog invoked from new Rust project UI
- Rust section in `Preferences | Build, Execution, Deployment | Debugger` settings. Note, in IDEA the settings have additional fields
- Debugger renderers settings (`Preferences | Build, Execution, Deployment | Debugger | Data Views | Rust`)
- `Rust Configuration` settings in new run target UI
- `File | New | Rust Crate` dialog
- Dialog of `Attach to module` quick-fix
- Dialog of `Extract function` refactoring
- Dialog of `Extract struct fields` refactoring
- Dialog of `Extract trait` refactoring
- Dialog of `Move` refactoring (invoked for top level items like structs, functions, etc.)


It's not supposed these changes make significant changes in UI from user point of view, but some minor differences (gaps in the first place) may appear.
The most significant difference was introduced in `New Rust project` panel, but I don't know how to avoid it

| Before | After |
| - | - | 
| <img width="912" alt="Screen Shot 2022-07-16 at 13 58 14" src="https://user-images.githubusercontent.com/2539310/179352249-bbe39c83-950b-45a7-a4bf-f9bbc7f111f0.png"> | <img width="912" alt="Screen Shot 2022-07-16 at 14 03 30" src="https://user-images.githubusercontent.com/2539310/179352261-6b32fe10-92d9-47cc-a0f0-2a54425f4af5.png"> |

changelog: Migrate usages of [Kotlin UI DSL version 1](https://plugins.jetbrains.com/docs/intellij/kotlin-ui-dsl-version-1.html) to [the second version]()