### PR TITLE
INSP: Add path_statements warning and fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -35,6 +35,7 @@ enum class RsLint(
     UnusedMustUse("unused_must_use", listOf("unused")),
     RedundantSemicolons("redundant_semicolons", listOf("unused")),
     UnusedLabels("unused_labels", listOf("unused")),
+    PathStatements("path_statements", listOf("unused")),
     // errors
     UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
     // CLippy lints

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsPathStatementsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsPathStatementsInspection.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.psi.PsiElement
+import org.rust.RsBundle
+import org.rust.ide.fixes.RemoveElementFix
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.lang.core.psi.RsExprStmt
+import org.rust.lang.core.psi.RsPathExpr
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.isTailStmt
+
+// TODO: Future improvements: https://github.com/intellij-rust/intellij-rust/issues/9555
+/** Analogue of https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#path-statements */
+class RsPathStatementsInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.PathStatements
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+        override fun visitExprStmt(exprStmt: RsExprStmt) {
+            super.visitExprStmt(exprStmt)
+
+            val expr = exprStmt.expr
+            if (expr is RsPathExpr && !exprStmt.isTailStmt) {
+                val highlighting = RsLintHighlightingType.WEAK_WARNING
+                val description = RsBundle.message("inspection.PathStatementsInspection.description.no.effect")
+                val fixes = listOf(RemoveElementFix(exprStmt))
+                holder.registerLintProblem(exprStmt, description, highlighting, fixes)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsPathStatementsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsPathStatementsInspection.kt
@@ -15,6 +15,7 @@ import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.isTailStmt
 
 // TODO: Future improvements: https://github.com/intellij-rust/intellij-rust/issues/9555
+//  The inspection is currently disabled by default.
 /** Analogue of https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#path-statements */
 class RsPathStatementsInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.PathStatements

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -562,6 +562,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsRedundantSemicolonsInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Path statements"
+                         enabledByDefault="true" level="WEAK WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsPathStatementsInspection"/>
+
         <localInspection language="Rust" groupName="Rust"
                          displayName="Assert Equal"
                          enabledByDefault="true" level="WEAK WARNING"

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -564,7 +564,7 @@
 
         <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Path statements"
-                         enabledByDefault="true" level="WEAK WARNING"
+                         enabledByDefault="false" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsPathStatementsInspection"/>
 
         <localInspection language="Rust" groupName="Rust"

--- a/src/main/resources/inspectionDescriptions/RsPathStatements.html
+++ b/src/main/resources/inspectionDescriptions/RsPathStatements.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<body>
+Detects path statements with no effect. It is usually a mistake to have a statement that has no effect.
+
+Corresponds to the <a href="https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#path-statements">path_statements</a>
+Rust lint.
+</body>
+</html>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -275,4 +275,6 @@ inspection.DoubleMustUse.FixRemoveMustUseAttr.name=Remove `#[must_use]` from the
 
 inspection.UnusedLabels.description=Unused label
 
+inspection.PathStatementsInspection.description.no.effect=Path statement with no effect
+
 rust.code.vision.usage.hint={0,choice, 0#no usages|1#1 usage|2#{0,number} usages}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsPathStatementsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsPathStatementsInspectionTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsPathStatementsInspectionTest : RsInspectionsTestBase(RsPathStatementsInspection::class) {
+    fun `test path statement with no effect`() = checkByText("""
+        fn main() {
+            let n = 0;
+            /*weak_warning descr="Path statement with no effect"*/n;/*weak_warning**/
+        }
+    """, checkWeakWarn = true)
+
+    fun `test path statement with no effect in block`() = checkByText("""
+        fn main() {
+            let n = 0;
+            let _m = {
+                /*weak_warning descr="Path statement with no effect"*/n;/*weak_warning**/
+                n
+            };
+        }
+    """, checkWeakWarn = true)
+
+    fun `test allow redundant_semicolons`() = checkByText("""
+        #[allow(path_statements)]
+        fn main() {
+            let n = 0;
+            n;
+        }
+    """, checkWeakWarn = true)
+
+    fun `test fix by removing statement`() = checkFixByText("Remove `n;`", """
+        fn main() {
+            let n = 0;
+            /*caret*//*weak_warning descr="Path statement with no effect"*/n;/*weak_warning**/
+        }
+    """, """
+        fn main() {
+            let n = 0;
+        /*caret*/}
+    """, checkWeakWarn = true)
+}


### PR DESCRIPTION
Based on https://github.com/rust-lang/rust/blob/1f12ac872/compiler/rustc_lint/src/unused.rs#L328-L377

Part of #5888 (_"Compiler lints support"_)

The inspection is disabled by default because of #9555.