### PR TITLE
CARGO: don't override content entries

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -28,9 +28,7 @@ import org.rust.cargo.project.workspace.PackageFeature
 import org.rust.cargo.toolchain.RsToolchainBase
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.cargo.toolchain.tools.isRustupAvailable
-import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.notifications.showBalloon
-import org.rust.openapiext.isFeatureEnabled
 import org.rust.openapiext.pathAsPath
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
@@ -189,15 +187,37 @@ private fun discoverToolchain(project: Project) {
     }
 }
 
-fun ContentEntry.setup(contentRoot: VirtualFile) {
+fun ContentEntry.setup(contentRoot: VirtualFile) = ContentEntryWrapper(this).setup(contentRoot)
+
+fun ContentEntryWrapper.setup(contentRoot: VirtualFile) {
     val makeVfsUrl = { dirName: String -> contentRoot.findChild(dirName)?.url }
     CargoConstants.ProjectLayout.sources.mapNotNull(makeVfsUrl).forEach {
-        addSourceFolder(it, /* test = */ false)
+        addSourceFolder(it, isTestSource = false)
     }
     CargoConstants.ProjectLayout.tests.mapNotNull(makeVfsUrl).forEach {
-        addSourceFolder(it, /* test = */ true)
+        addSourceFolder(it, isTestSource = true)
     }
     makeVfsUrl(CargoConstants.ProjectLayout.target)?.let(::addExcludeFolder)
+}
+
+class ContentEntryWrapper(private val contentEntry: ContentEntry) {
+    private val knownFolders: Set<String> = contentEntry.knownFolders()
+
+    fun addExcludeFolder(url: String) {
+        if (url in knownFolders) return
+        contentEntry.addExcludeFolder(url)
+    }
+
+    fun addSourceFolder(url: String, isTestSource: Boolean) {
+        if (url in knownFolders) return
+        contentEntry.addSourceFolder(url, isTestSource)
+    }
+
+    private fun ContentEntry.knownFolders(): Set<String> {
+        val knownRoots = sourceFolders.mapTo(hashSetOf()) { it.url }
+        knownRoots += excludeFolderUrls
+        return knownRoots
+    }
 }
 
 val isNewProjectModelImportEnabled: Boolean

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -20,7 +20,6 @@ import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ex.ProjectEx
-import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.ProjectFileIndex
@@ -28,7 +27,6 @@ import com.intellij.openapi.roots.ex.ProjectRootManagerEx
 import com.intellij.openapi.startup.StartupManager
 import com.intellij.openapi.util.EmptyRunnable
 import com.intellij.openapi.util.UserDataHolderBase
-import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -626,12 +624,12 @@ private fun setupProjectRoots(project: Project, cargoProjects: List<CargoProject
             ProjectRootManagerEx.getInstanceEx(project).mergeRootsChangesDuring {
                 for (cargoProject in cargoProjects) {
                     cargoProject.workspaceRootDir?.setupContentRoots(project) { contentRoot ->
-                        addExcludeFolder(FileUtil.join(contentRoot.url, CargoConstants.ProjectLayout.target))
+                        addExcludeFolder("${contentRoot.url}/${CargoConstants.ProjectLayout.target}")
                     }
 
                     if ((cargoProject as? CargoProjectImpl)?.doesProjectLooksLikeRustc() == true) {
                         cargoProject.workspaceRootDir?.setupContentRoots(project) { contentRoot ->
-                            addExcludeFolder(FileUtil.join(contentRoot.url, "build"))
+                            addExcludeFolder("${contentRoot.url}/build")
                         }
                     }
 
@@ -640,7 +638,7 @@ private fun setupProjectRoots(project: Project, cargoProjects: List<CargoProject
                         .filter { it.origin == PackageOrigin.WORKSPACE }
 
                     for (pkg in workspacePackages) {
-                        pkg.contentRoot?.setupContentRoots(project, ContentEntry::setup)
+                        pkg.contentRoot?.setupContentRoots(project, ContentEntryWrapper::setup)
                     }
                 }
             }
@@ -648,13 +646,14 @@ private fun setupProjectRoots(project: Project, cargoProjects: List<CargoProject
     }
 }
 
-private fun VirtualFile.setupContentRoots(project: Project, setup: ContentEntry.(VirtualFile) -> Unit) {
+private fun VirtualFile.setupContentRoots(project: Project, setup: ContentEntryWrapper.(VirtualFile) -> Unit) {
     val packageModule = ModuleUtilCore.findModuleForFile(this, project) ?: return
     setupContentRoots(packageModule, setup)
 }
 
-private fun VirtualFile.setupContentRoots(packageModule: Module, setup: ContentEntry.(VirtualFile) -> Unit) {
+private fun VirtualFile.setupContentRoots(packageModule: Module, setup: ContentEntryWrapper.(VirtualFile) -> Unit) {
     ModuleRootModificationUtil.updateModel(packageModule) { rootModel ->
-        rootModel.contentEntries.singleOrNull()?.setup(this)
+        val contentEntry = rootModel.contentEntries.singleOrNull() ?: return@updateModel
+        ContentEntryWrapper(contentEntry).setup(this)
     }
 }


### PR DESCRIPTION
Previously, if some directory from default project layout (for example, `examples`) was marked as excluded, the plugin marked them as source directory after each project model reloading.
After these changes all already added folders (source and excluded ones) won't be overridden

Fixes https://youtrack.jetbrains.com/issue/CPP-29807

changelog: Don't override folder settings on project model reloading if the folder is manually marked as excluded or as source folder
