### PR TITLE
RES: Fix glob import of item with identity proc macro

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -332,7 +332,8 @@ class DefCollector(
         val (visItem, namespaces, procMacroKind) = call.originalItem
 
         /** See also [ModCollector.collectSimpleItem] */
-        call.containingMod.addVisibleItem(visItem.name, PerNs.from(visItem, namespaces))
+        val perNs = PerNs.from(visItem, namespaces)
+        update(call.containingMod, listOf(visItem.name to perNs), visItem.visibility, NAMED)
         if (procMacroKind != null) {
             call.containingMod.procMacros[visItem.name] = procMacroKind
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -631,4 +631,19 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
             dep_proc_macro::example_proc_macro!();
         }                 //^ dep-proc-macro/lib.rs
     """)
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test glob import item with identity proc macro`() = stubOnlyResolve("""
+    //- main.rs
+        mod inner {
+            #[test_proc_macros::attr_hardcoded_not_a_macro]
+            pub fn func() {}
+        }        //X
+        use inner::*;
+
+        fn main() {
+            func();
+        } //^ main.rs
+    """)
 }


### PR DESCRIPTION
Fixes #8768
Fixes #9141

changelog: Fixes resolve of items with `#[async_trait]` in some cases
