### PR TITLE
MACRO: support liveness inspection for implicit args in `format_args`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.util.registry.Registry
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
+import org.rust.ide.annotator.format.RsFormatMacroAnnotator
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMacroCall

--- a/src/main/kotlin/org/rust/ide/annotator/format/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/format/RsFormatMacroAnnotator.kt
@@ -1,0 +1,71 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.format
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.psi.PsiElement
+import org.rust.ide.annotator.*
+import org.rust.ide.injected.isDoctestInjection
+import org.rust.lang.core.macros.MacroExpansionMode
+import org.rust.lang.core.macros.macroExpansionManager
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.ext.existsAfterExpansion
+import org.rust.openapiext.isUnitTestMode
+
+class RsFormatMacroAnnotator : AnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        val formatMacro = element as? RsMacroCall ?: return
+        if (!formatMacro.existsAfterExpansion) return
+
+        val (macroPos, macroArgs) = getFormatMacroCtx(formatMacro) ?: return
+
+        val formatStr = macroArgs
+            .getOrNull(macroPos)
+            ?.expr as? RsLitExpr
+            ?: return
+
+        val parseCtx = parseParameters(formatStr) ?: return
+
+        val errors = checkSyntaxErrors(parseCtx)
+        for (error in errors) {
+            holder.newAnnotation(HighlightSeverity.ERROR, error.error).range(error.range).create()
+        }
+
+        if (!holder.isBatchMode) {
+            highlightParametersOutside(parseCtx, holder)
+        }
+
+        // skip advanced checks and highlighting if there are syntax errors
+        if (errors.isNotEmpty()) {
+            return
+        }
+
+        if (!holder.isBatchMode) {
+            highlightParametersInside(parseCtx, holder)
+        }
+
+        val suppressTraitErrors = !isUnitTestMode &&
+            (element.project.macroExpansionManager.macroExpansionMode !is MacroExpansionMode.New
+                || element.isDoctestInjection)
+
+        val parameters = buildParameters(parseCtx)
+        val arguments = macroArgs
+            .drop(macroPos + 1)
+            .toList()
+        val ctx = FormatContext(parameters, arguments, formatMacro)
+
+        val annotations = checkParameters(ctx).toMutableList()
+        annotations += checkArguments(ctx)
+
+        for (annotation in annotations) {
+            if (suppressTraitErrors && annotation.isTraitError) continue
+
+            holder.newAnnotation(HighlightSeverity.ERROR, annotation.error).range(annotation.range).create()
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
@@ -276,7 +276,13 @@ class CFGBuilder(
             is RsVecMacroArgument -> argument.exprList.fold(pred) { acc, subExpr -> process(subExpr, acc) }
 
             is RsFormatMacroArgument -> {
-                argument.formatMacroArgList.map { it.expr }.fold(pred) { acc, subExpr -> process(subExpr, acc) }
+                val expansion = macroCall.expansion
+                @Suppress("IfThenToElvis")
+                if (expansion != null) {
+                    expansion.elements.fold(pred) { pred, element -> process(element, pred) }
+                } else {
+                    argument.formatMacroArgList.map { it.expr }.fold(pred) { acc, subExpr -> process(subExpr, acc) }
+                }
             }
 
             is RsAssertMacroArgument -> {

--- a/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
@@ -324,7 +324,14 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
             is RsVecMacroArgument -> argument.exprList.forEach(::walkExpr)
 
             is RsFormatMacroArgument -> {
-                argument.formatMacroArgList.map { it.expr }.forEach(::walkExpr)
+                val expansion = macroCall.expansion
+                if (expansion != null) {
+                    for (expandedElement in expansion.elements) {
+                        walk(expandedElement)
+                    }
+                } else {
+                    argument.formatMacroArgList.map { it.expr }.forEach(::walkExpr)
+                }
             }
             is RsAssertMacroArgument -> {
                 argument.expr?.let(::walkExpr)

--- a/src/main/kotlin/org/rust/lang/core/macros/MappedText.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MappedText.kt
@@ -31,6 +31,7 @@ class MutableMappedText private constructor(
     constructor(capacity: Int) : this(StringBuilder(capacity))
 
     val length: Int get() = sb.length
+    val text: CharSequence get() = sb
 
     fun appendUnmapped(text: CharSequence) {
         sb.append(text)

--- a/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
@@ -6,13 +6,22 @@
 package org.rust.lang.core.macros.builtin
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.macros.MacroExpander
-import org.rust.lang.core.macros.RangeMap
-import org.rust.lang.core.macros.RsBuiltinMacroData
-import org.rust.lang.core.macros.RsMacroCallData
+import org.rust.ide.annotator.format.ParameterLookup
+import org.rust.ide.annotator.format.buildParameters
+import org.rust.ide.annotator.format.checkSyntaxErrors
+import org.rust.ide.annotator.format.parseParameters
+import org.rust.lang.core.macros.*
 import org.rust.lang.core.macros.errors.BuiltinMacroExpansionError
+import org.rust.lang.core.parser.RustParser
+import org.rust.lang.core.parser.createAdaptedRustPsiBuilder
+import org.rust.lang.core.psi.RsElementTypes
+import org.rust.lang.core.psi.RsFormatMacroArgument
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
 import org.rust.stdext.RsResult
 import org.rust.stdext.RsResult.Err
+import org.rust.stdext.RsResult.Ok
 
 /**
  * A macro expander for built-in macros like `concat!()` and `stringify!()`
@@ -22,10 +31,89 @@ class BuiltinMacroExpander(val project: Project) : MacroExpander<RsBuiltinMacroD
         def: RsBuiltinMacroData,
         call: RsMacroCallData
     ): RsResult<Pair<CharSequence, RangeMap>, BuiltinMacroExpansionError> {
+        val macroBody = call.macroBody
+        if (def.name in BUILTIN_FORMAT_MACROS && macroBody is MacroCallBody.FunctionLike) {
+            val formatMacro = parseMacroBodyAsFormat(project, macroBody) ?: return Err(BuiltinMacroExpansionError)
+            val result = handleFormatMacro(def.name, macroBody.text, formatMacro) ?: return Err(BuiltinMacroExpansionError)
+            return Ok(result.text to result.ranges)
+        }
         return Err(BuiltinMacroExpansionError)
     }
 
     companion object {
-        const val EXPANDER_VERSION = 0
+        private val BUILTIN_FORMAT_MACROS: Set<String> = setOf("format_args", "format_args_nl")
+
+        const val EXPANDER_VERSION = 1
     }
+}
+
+private fun parseMacroBodyAsFormat(project: Project, macroBody: MacroCallBody.FunctionLike): RsFormatMacroArgument? {
+    val text = "(${macroBody.text})"
+
+    val (builder, _) = project
+        .createAdaptedRustPsiBuilder(text)
+        .lowerDocCommentsToAdaptedPsiBuilder(project)
+
+    val result = RustParser.FormatMacroArgument(builder, 0)
+    if (!result) return null
+
+    return builder.treeBuilt.psi as? RsFormatMacroArgument
+}
+
+private fun handleFormatMacro(macroName: String, macroText: String, format: RsFormatMacroArgument): MappedText? {
+    val formatStr = format.formatMacroArgList
+        .getOrNull(0)
+        ?.expr as? RsLitExpr
+        ?: return null
+
+    val parseCtx = parseParameters(formatStr) ?: return null
+    val errors = checkSyntaxErrors(parseCtx)
+    if (errors.isNotEmpty()) return null
+
+    val namedArguments = mutableSetOf<String>()
+    for (argument in format.formatMacroArgList) {
+        val identifier = argument.identifier
+        if (identifier != null) {
+            namedArguments.add(identifier.text)
+        }
+    }
+
+    val macroBuilder = MutableMappedText(macroText.length * 2)
+    macroBuilder.appendUnmapped("$macroName!(")
+    macroBuilder.appendMapped(macroText, 0)
+
+    var endsWithComma = format.lastChild.getPrevNonCommentSibling()?.elementType == RsElementTypes.COMMA
+
+    fun addImplicitArgument(name: String, offset: Int) {
+        // Make sure that we have ', ' at the end before we add the new argument
+        if (!endsWithComma) {
+            macroBuilder.appendUnmapped(", ")
+            endsWithComma = false
+        }
+        else if (macroBuilder.text.lastOrNull() != ' ') {
+            macroBuilder.appendUnmapped(" ")
+        }
+        macroBuilder.appendUnmapped("$name = ")
+        macroBuilder.appendMapped(name, offset)
+    }
+
+    var hasChanges = false
+    val parameters = buildParameters(parseCtx)
+    for (parameter in parameters) {
+        if (parameter.lookup is ParameterLookup.Named) {
+            if (parameter.lookup.name !in namedArguments) {
+                // Candidate for implicit argument
+                // We subtract 1 because we have added '(' to the beginning of the format so that it could be parsed
+                addImplicitArgument(parameter.lookup.name, parameter.range.startOffset - 1)
+                hasChanges = true
+            }
+        }
+    }
+
+    if (!hasChanges) {
+        return null
+    }
+
+    macroBuilder.appendUnmapped(")")
+    return macroBuilder.toMappedText()
 }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1319,13 +1319,14 @@ class RsTypeInferenceWalker(
         = (macroCall.expansion as? MacroExpansion.Expr)?.expr?.inferType() ?: TyUnknown
 
     private fun inferFormatMacro(macroCall: RsMacroCall): Ty {
+        val inferredTy = inferMacroAsExpr(macroCall)
         val name = macroCall.macroName
         return when {
             "print" in name -> TyUnit.INSTANCE
             name == "format" -> items.String.asTy()
             name == "format_args" -> items.Arguments.asTy()
             name == "unimplemented" || name == "unreachable" || name == "panic" -> TyNever
-            name == "write" || name == "writeln" -> inferMacroAsExpr(macroCall)
+            name == "write" || name == "writeln" -> inferredTy
             else -> TyUnknown
         }
     }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -196,7 +196,7 @@
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsSyntaxErrorsAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsEdition2018KeywordsAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsLiteralAnnotator"/>
-        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsFormatMacroAnnotator"/>
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.format.RsFormatMacroAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsHighlightingAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsHighlightingMutableAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsExpressionAnnotator"/>

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.annotator
 
 import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
+import org.rust.ide.annotator.format.RsFormatMacroAnnotator
 import org.rust.ide.colors.RsColor
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorToolchainTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorToolchainTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.annotator
 
 import org.rust.ExpandMacros
+import org.rust.ide.annotator.format.RsFormatMacroAnnotator
 import org.rust.ide.colors.RsColor
 
 @ExpandMacros

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
@@ -895,4 +895,22 @@ class RsLivenessInspectionTest : RsInspectionsTestBase(RsLivenessInspection::cla
         }
     """)
     }
+
+    fun `test usage in implicit format arg`() = checkByText("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args {}
+
+        fn foo(a: u32) {
+            format_args!("{a}");
+        }
+    """)
+
+    fun `test usage in implicit format arg argument unused`() = checkByText("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args {}
+
+        fn foo(<warning descr="Parameter `a` is never used">a</warning>: u32) {
+            format_args!("{a}", a = 5);
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -100,7 +100,7 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
         }
     }
 
-    private fun expandMacroOrFail(call: RsPossibleMacroCall): MacroExpansion {
+    open fun expandMacroOrFail(call: RsPossibleMacroCall): MacroExpansion {
         require(call is RsMacroCall)
         call.resolveToMacroWithoutPsi()
         val def = call.resolveToMacroWithoutPsi().ok()?.data as? RsDeclMacroData

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsBuiltinMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsBuiltinMacroExpansionTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.decl
+
+import org.rust.lang.core.macros.*
+import org.rust.lang.core.macros.builtin.BuiltinMacroExpander
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsPossibleMacroCall
+import org.rust.lang.core.resolve2.resolveToMacroWithoutPsi
+import org.rust.stdext.unwrapOrElse
+
+class RsBuiltinMacroExpansionTest : RsMacroExpansionTestBase() {
+    override fun expandMacroOrFail(call: RsPossibleMacroCall): MacroExpansion {
+        require(call is RsMacroCall)
+        val def = call.resolveToMacroWithoutPsi().ok()?.data as? RsBuiltinMacroData
+            ?: error("Failed to resolve macro `${call.path.text}`")
+
+        val expander = BuiltinMacroExpander(project)
+        val expansionResult = expander.expandMacro(
+            RsMacroDataWithHash(def, null),
+            call,
+            RsPsiFactory(project, markGenerated = false),
+            storeRangeMap = true,
+            useCache = false
+        )
+        val result = expansionResult.map {
+            it.elements.forEach { el ->
+                el.setContext(call.context as RsElement)
+                el.setExpandedFrom(call)
+            }
+            it
+        }
+
+        return result.unwrapOrElse {
+            error("Failed to expand macro `${call.path.text}`")
+        }
+    }
+
+    fun `test format_args`() = checkSingleMacro("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args {}
+
+        fn foo() {
+            let a = 1;
+            format_args!("{a}", b = 5);
+            //^
+        }
+    """, """
+        format_args!("{a}", b = 5, a = a)
+    """)
+
+    fun `test format_args_nl`() = checkSingleMacro("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args_nl {}
+
+        fn foo() {
+            let a = 1;
+            format_args_nl!("{a}", b = 5);
+            //^
+        }
+    """, """
+        format_args_nl!("{a}", b = 5, a = a)
+    """)
+
+    fun `test format_args no expansion when named parameter is present`() = doErrorTest("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args {}
+
+        fn foo() {
+            format_args!("{a}", a = 5);
+            //^
+        }
+    """)
+
+    fun `test format_args expand multiple parameters`() = checkSingleMacro("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args {}
+
+        fn foo() {
+            format_args!("{} {b} {a} {c}", 3, a = 5);
+            //^
+        }
+    """, """
+        format_args!("{} {b} {a} {c}", 3, a = 5, b = b, c = c)
+    """)
+
+    fun `test format_args trailing comma`() = checkSingleMacro("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args {}
+
+        fn foo() {
+            format_args!("{a}",);
+            //^
+        }
+    """, """
+        format_args!("{a}", a = a)
+    """)
+
+    fun `test format_args trailing comma and space`() = checkSingleMacro("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args {}
+
+        fn foo() {
+            format_args!("{a}", );
+            //^
+        }
+    """, """
+        format_args!("{a}", a = a)
+    """)
+}


### PR DESCRIPTION
This is an attempt to implement the method for supporting implicit format arguments mentioned [here](https://github.com/intellij-rust/intellij-rust/pull/8561#issuecomment-1187276428). Currently, it fixes false positives in the liveness inspection.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/8417

changelog: Remove false positive "unused variable" warnings for implicit format arguments used in macros like println.