### PR TITLE
TY&COMP: support `.await`ing `IntoFuture`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
@@ -60,9 +60,22 @@ object RsAwaitCompletionProvider : RsCompletionProvider() {
     }
 
     private fun Ty.lookupFutureOutputTy(lookup: ImplLookup): Ty {
+        val outputTy = this.lookupRawFutureOutputTy(lookup)
+        if (outputTy !is TyUnknown) return outputTy
+        return this.lookupIntoFutureOutputTy(lookup)
+    }
+
+    private fun Ty.lookupRawFutureOutputTy(lookup: ImplLookup): Ty {
         val futureTrait = lookup.items.Future ?: return TyUnknown
         val outputType = futureTrait.findAssociatedType("Output") ?: return TyUnknown
         val selection = lookup.selectProjectionStrict(TraitRef(this, futureTrait.withSubst()), outputType)
+        return selection.ok()?.value ?: TyUnknown
+    }
+
+    private fun Ty.lookupIntoFutureOutputTy(lookup: ImplLookup): Ty {
+        val intoFutureTrait = lookup.items.IntoFuture ?: return TyUnknown
+        val outputType = intoFutureTrait.findAssociatedType("Output") ?: return TyUnknown
+        val selection = lookup.selectProjectionStrict(TraitRef(this, intoFutureTrait.withSubst()), outputType)
         return selection.ok()?.value ?: TyUnknown
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -101,6 +101,7 @@ class KnownItems(
     val Try: RsTraitItem? get() = findItem("core::ops::try_trait::Try") ?: findItem("core::ops::try::Try")
     val Generator: RsTraitItem? get() = findItem("core::ops::generator::Generator")
     val Future: RsTraitItem? get() = findItem("core::future::future::Future")
+    val IntoFuture: RsTraitItem? get() = findItem("core::future::into_future::IntoFuture")
     val Octal: RsTraitItem? get() = findItem("core::fmt::Octal")
     val LowerHex: RsTraitItem? get() = findItem("core::fmt::LowerHex")
     val UpperHex: RsTraitItem? get() = findItem("core::fmt::UpperHex")

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1496,9 +1496,22 @@ class RsTypeInferenceWalker(
         ctx.writePatFieldTy(psi, ty)
 
     private fun Ty.lookupFutureOutputTy(lookup: ImplLookup): Ty {
+        val outputTy = this.lookupRawFutureOutputTy(lookup)
+        if (outputTy !is TyUnknown) return outputTy
+        return this.lookupIntoFutureOutputTy(lookup)
+    }
+
+    private fun Ty.lookupRawFutureOutputTy(lookup: ImplLookup): Ty {
         val futureTrait = lookup.items.Future ?: return TyUnknown
         val outputType = futureTrait.findAssociatedType("Output") ?: return TyUnknown
         val selection = lookup.selectProjection(TraitRef(this, futureTrait.withSubst()), outputType)
+        return selection.ok()?.register() ?: TyUnknown
+    }
+
+    private fun Ty.lookupIntoFutureOutputTy(lookup: ImplLookup): Ty {
+        val intoFutureTrait = lookup.items.IntoFuture ?: return TyUnknown
+        val outputType = intoFutureTrait.findAssociatedType("Output") ?: return TyUnknown
+        val selection = lookup.selectProjection(TraitRef(this, intoFutureTrait.withSubst()), outputType)
         return selection.ok()?.register() ?: TyUnknown
     }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
@@ -67,4 +67,28 @@ class RsAwaitCompletionTest : RsCompletionTestBase() {
             foo().await/*caret*/;
         }
     """)
+
+    fun `test postfix await 2018 (into future)`() = checkCompletion("await", """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        #[lang = "core::future::into_future::IntoFuture"]
+        trait IntoFuture { type Output; }
+        struct S;
+        impl IntoFuture for S { type Output = i32; }
+        fn foo() -> S { unimplemented!() }
+        fn main() {
+            foo()./*caret*/;
+        }
+    """, """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        #[lang = "core::future::into_future::IntoFuture"]
+        trait IntoFuture { type Output; }
+        struct S;
+        impl IntoFuture for S { type Output = i32; }
+        fn foo() -> S { unimplemented!() }
+        fn main() {
+            foo().await/*caret*/;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -724,6 +724,23 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test await postfix 2018 (into future)`() = testExpr("""
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+
+        #[lang = "core::future::into_future::IntoFuture"]
+        trait IntoFuture { type Output; }
+
+        struct S;
+        impl IntoFuture for S { type Output = i32; }
+        fn foo() -> S { unimplemented!() }
+        fn main() {
+            let x = foo().await;
+            x;
+          //^ i32
+        }
+    """)
+
     @MockEdition(Edition.EDITION_2015)
     fun `test await postfix 2015`() = testExpr("""
         struct S { await: i32 }


### PR DESCRIPTION
Prefers `Future::Output` over `IntoFuture::Output`, not sure if it's possible to have both

Fixes #9051 

changelog: support `.await`ing types that implement `IntoFuture` and resolve the output type
