### PR TITLE
Fix deadlock in MacroExpansionFileSystem

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
@@ -275,7 +275,6 @@ class MacroExpansionFileSystem : NewVirtualFileSystem() {
             timestamp = max(currentTimestamp(), timestamp + 1)
         }
 
-        @Synchronized
         fun delete() {
             parent?.removeChild(name, bump = true)
         }


### PR DESCRIPTION
The bug was introduced in #8977 by adding `@Synchronized` to `FSItem.name`, but actually the bug has been triggered only by #8986 because of bumping `ProcMacroExpander.EXPANDER_VERSION` (see #9088)

<details>
  <summary>Deadlocked threads dump</summary>
  
  ```
  "Indexing" prio=0 tid=0x0 nid=0x0 blocked
     java.lang.Thread.State: BLOCKED
 on org.rust.lang.core.macros.MacroExpansionFileSystem$FSItem$FSFile@453d9c44 owned by "Indexing" Id=32
	at org.rust.lang.core.macros.MacroExpansionFileSystem$FSItem$FSFile.getName(MacroExpansionFileSystem.kt:381)
	at org.rust.lang.core.macros.MacroExpansionFileSystem$FSItem$FSDir.findChild(MacroExpansionFileSystem.kt:314)
	at org.rust.lang.core.macros.MacroExpansionFileSystem.convert(MacroExpansionFileSystem.kt:166)
	at org.rust.lang.core.macros.MacroExpansionFileSystem.contentsToByteArray(MacroExpansionFileSystem.kt:212)
	at com.intellij.openapi.vfs.newvfs.persistent.PersistentFSImpl.contentsToByteArray(PersistentFSImpl.java:609)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualFileImpl.contentsToByteArray(VirtualFileImpl.java:126)
	at com.intellij.util.indexing.contentQueue.CachedFileContent.getBytes(CachedFileContent.java:28)
	at com.intellij.util.indexing.contentQueue.CurrentProjectHintedCachedFileContentLoader.lambda$loadContent$0(CurrentProjectHintedCachedFileContentLoader.java:31)
	at com.intellij.util.indexing.contentQueue.CurrentProjectHintedCachedFileContentLoader$$Lambda$3210/0x0000000101d9fc40.compute(Unknown Source)
	at com.intellij.openapi.project.ProjectLocator.computeWithPreferredProject(ProjectLocator.java:60)
	at com.intellij.util.indexing.contentQueue.CurrentProjectHintedCachedFileContentLoader.loadContent(CurrentProjectHintedCachedFileContentLoader.java:31)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.loadNextContent(IndexUpdateRunner.java:351)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.indexOneFileOfJob(IndexUpdateRunner.java:239)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.lambda$indexJobsFairly$3(IndexUpdateRunner.java:213)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner$$Lambda$3202/0x0000000101d9d440.run(Unknown Source)
	at com.intellij.openapi.progress.impl.ProgressSuspender.executeNonSuspendableSection(ProgressSuspender.java:83)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.indexJobsFairly(IndexUpdateRunner.java:216)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.lambda$doIndexFiles$2(IndexUpdateRunner.java:150)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner$$Lambda$3199/0x0000000101d9cc40.run(Unknown Source)
	at com.intellij.util.concurrency.BoundedTaskExecutor.doRun(BoundedTaskExecutor.java:241)
	at com.intellij.util.concurrency.BoundedTaskExecutor.access$200(BoundedTaskExecutor.java:31)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.execute(BoundedTaskExecutor.java:214)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1$$Lambda$611/0x0000000100792440.run(Unknown Source)
	at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:212)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:203)
	at java.base@11.0.15/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base@11.0.15/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base@11.0.15/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	at java.base@11.0.15/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	at java.base@11.0.15/java.security.AccessController.doPrivileged(Native Method)
	at java.base@11.0.15/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	at java.base@11.0.15/java.lang.Thread.run(Thread.java:829)

"Indexing" prio=0 tid=0x0 nid=0x0 blocked
     java.lang.Thread.State: BLOCKED
 on org.rust.lang.core.macros.MacroExpansionFileSystem$FSItem$FSDir@56f6f450 owned by "Indexing" Id=51
	at org.rust.lang.core.macros.MacroExpansionFileSystem$FSItem$FSDir.removeChild(MacroExpansionFileSystem.kt)
	at org.rust.lang.core.macros.MacroExpansionFileSystem$FSItem.delete(MacroExpansionFileSystem.kt:280)
	at org.rust.lang.core.macros.MacroExpansionFileSystem.contentsToByteArray(MacroExpansionFileSystem.kt:221)
	at com.intellij.openapi.vfs.newvfs.persistent.PersistentFSImpl.contentsToByteArray(PersistentFSImpl.java:609)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualFileImpl.contentsToByteArray(VirtualFileImpl.java:126)
	at com.intellij.util.indexing.contentQueue.CachedFileContent.getBytes(CachedFileContent.java:28)
	at com.intellij.util.indexing.contentQueue.CurrentProjectHintedCachedFileContentLoader.lambda$loadContent$0(CurrentProjectHintedCachedFileContentLoader.java:31)
	at com.intellij.util.indexing.contentQueue.CurrentProjectHintedCachedFileContentLoader$$Lambda$3210/0x0000000101d9fc40.compute(Unknown Source)
	at com.intellij.openapi.project.ProjectLocator.computeWithPreferredProject(ProjectLocator.java:60)
	at com.intellij.util.indexing.contentQueue.CurrentProjectHintedCachedFileContentLoader.loadContent(CurrentProjectHintedCachedFileContentLoader.java:31)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.loadNextContent(IndexUpdateRunner.java:351)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.indexOneFileOfJob(IndexUpdateRunner.java:239)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.lambda$indexJobsFairly$3(IndexUpdateRunner.java:213)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner$$Lambda$3202/0x0000000101d9d440.run(Unknown Source)
	at com.intellij.openapi.progress.impl.ProgressSuspender.executeNonSuspendableSection(ProgressSuspender.java:83)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.indexJobsFairly(IndexUpdateRunner.java:216)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner.lambda$doIndexFiles$2(IndexUpdateRunner.java:150)
	at com.intellij.util.indexing.contentQueue.IndexUpdateRunner$$Lambda$3199/0x0000000101d9cc40.run(Unknown Source)
	at com.intellij.util.concurrency.BoundedTaskExecutor.doRun(BoundedTaskExecutor.java:241)
	at com.intellij.util.concurrency.BoundedTaskExecutor.access$200(BoundedTaskExecutor.java:31)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.execute(BoundedTaskExecutor.java:214)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1$$Lambda$611/0x0000000100792440.run(Unknown Source)
	at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:212)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:203)
	at java.base@11.0.15/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base@11.0.15/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base@11.0.15/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	at java.base@11.0.15/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	at java.base@11.0.15/java.security.AccessController.doPrivileged(Native Method)
	at java.base@11.0.15/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	at java.base@11.0.15/java.lang.Thread.run(Thread.java:829)
  ```
</details>

Fixes #9084

changelog: Fix possible deadlock during indexing