### PR TITLE
MACRO: limit maximal recursion depth to 1000

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1232,7 +1232,7 @@
         />
         <advancedSetting
             id="org.rust.macros.maximum.recursion.limit"
-            default="0"
+            default="1000"
             groupKey="advanced.setting.rust.group"
         />
     </extensions>


### PR DESCRIPTION
Since #8927 the plugin accept any recursion limit specified by `#![recursion_limit]` attribute. But we use several recursive algorithms when working with macros, hence pure unlimited `recursion_limit` may lead to a stack overflow. By this hotfix I limit the maximal recursion depth to 1000, but in the future we can get rid of such recursive algorithms and then remove the limit

changelog: Restore maximal `#![recursion_limit]` to 1000 when expanding macros. This fixes possible stack overflow