### PR TITLE
MACRO: Fix macro expansion error messages in several cases

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
@@ -25,10 +25,12 @@ val PsiElement.isEnabledByCfg: Boolean get() = isEnabledByCfgInner(null)
  * ```
  */
 val PsiElement.existsAfterExpansion: Boolean
-    get() {
-        val status = getCodeStatus(null)
-        return status == RsCodeStatus.CODE || status == RsCodeStatus.CFG_UNKNOWN
-    }
+    get() = existsAfterExpansion(null)
+
+fun PsiElement.existsAfterExpansion(crate: Crate?): Boolean {
+    val status = getCodeStatus(crate)
+    return status == RsCodeStatus.CODE || status == RsCodeStatus.CFG_UNKNOWN
+}
 
 fun PsiElement.isEnabledByCfg(crate: Crate): Boolean = isEnabledByCfgInner(crate)
 

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -372,12 +372,14 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
         )
         val depProcMacro2 = externalPackage("$contentRoot/dep-proc-macro-2", "lib.rs", "dep-proc-macro-2", libKind = LibKind.PROC_MACRO,
             procMacroArtifact = testProcMacroArtifact2)
+        val depProcMacro3 = externalPackage("$contentRoot/dep-proc-macro-unsuccessfully-compiled", "lib.rs", "dep-proc-unsuccessfully-compiled", libKind = LibKind.PROC_MACRO,
+            procMacroArtifact = null)
         val cyclicDepLibDevDep = externalPackage("$contentRoot/cyclic-dep-lib-dev-dep", "lib.rs", "cyclic-dep-lib-dev-dep")
 
         val packages = listOf(
             testPackage, depLib, depLibNew, depLib2, depLibWithCyclicDep, depLibToBeRenamed,
             noSrcLib, noSourceLib, transLib, transLib2, transCommonLib, rawIdentifierLib, depProcMacro, depProcMacro2,
-            cyclicDepLibDevDep
+            depProcMacro3, cyclicDepLibDevDep
         )
 
         return CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(packages, mapOf(
@@ -389,6 +391,7 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
                 dep(noSourceLib.id),
                 dep(depProcMacro.id),
                 dep(depProcMacro2.id),
+                dep(depProcMacro3.id),
                 dep(rawIdentifierLib.id),
             ),
             depLib.id to setOf(

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionErrorTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionErrorTestBase.kt
@@ -5,9 +5,9 @@
 
 package org.rust.lang.core.macros
 
-import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
+import org.rust.fileTreeFromText
 import org.rust.lang.core.macros.errors.GetMacroExpansionError
 import org.rust.lang.core.psi.ext.RsPossibleMacroCall
 import org.rust.lang.core.psi.ext.descendantsOfType
@@ -24,6 +24,21 @@ abstract class RsMacroExpansionErrorTestBase : RsTestBase() {
 
     protected fun checkError(code: String, errorClass: Class<*>) {
         InlineFile(code)
+        doCheck(errorClass)
+    }
+
+    protected inline fun <reified T : GetMacroExpansionError> checkErrorByTree(
+        @Language("Rust") code: String
+    ) {
+        checkError(code, T::class.java)
+    }
+
+    protected fun checkErrorByTree(code: String, errorClass: Class<*>) {
+        fileTreeFromText(code).createAndOpenFileWithCaretMarker()
+        doCheck(errorClass)
+    }
+
+    private fun doCheck(errorClass: Class<*>) {
         val markers = findElementsWithDataAndOffsetInEditor<RsPossibleMacroCall>()
         val (macro, expectedErrorMessage) = if (markers.isEmpty()) {
             myFixture.file
@@ -43,7 +58,7 @@ abstract class RsMacroExpansionErrorTestBase : RsTestBase() {
         check(errorClass.isInstance(err)) { "Expected error $errorClass, got $err" }
 
         if (expectedErrorMessage != null) {
-            TestCase.assertEquals(expectedErrorMessage, err.toUserViewableMessage())
+            assertEquals(expectedErrorMessage, err.toUserViewableMessage())
         }
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionErrorTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionErrorTestBase.kt
@@ -1,0 +1,49 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import junit.framework.TestCase
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.lang.core.macros.errors.GetMacroExpansionError
+import org.rust.lang.core.psi.ext.RsPossibleMacroCall
+import org.rust.lang.core.psi.ext.descendantsOfType
+import org.rust.lang.core.psi.ext.expansionResult
+import org.rust.lang.core.psi.ext.isMacroCall
+import org.rust.stdext.RsResult
+
+abstract class RsMacroExpansionErrorTestBase : RsTestBase() {
+    protected inline fun <reified T : GetMacroExpansionError> checkError(
+        @Language("Rust") code: String
+    ) {
+        checkError(code, T::class.java)
+    }
+
+    protected fun checkError(code: String, errorClass: Class<*>) {
+        InlineFile(code)
+        val markers = findElementsWithDataAndOffsetInEditor<RsPossibleMacroCall>()
+        val (macro, expectedErrorMessage) = if (markers.isEmpty()) {
+            myFixture.file
+                .descendantsOfType<RsPossibleMacroCall>()
+                .single { it.isMacroCall } to null
+        } else {
+            val (macro, message, _) = markers.single()
+            check(macro.isMacroCall)
+            macro to message
+        }
+
+        val err = when (val result = macro.expansionResult) {
+            is RsResult.Err -> result.err
+            is RsResult.Ok -> error("Expected a macro expansion error, got a successfully expanded macro")
+        }
+
+        check(errorClass.isInstance(err)) { "Expected error $errorClass, got $err" }
+
+        if (expectedErrorMessage != null) {
+            TestCase.assertEquals(expectedErrorMessage, err.toUserViewableMessage())
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
@@ -5,18 +5,12 @@
 
 package org.rust.lang.core.macros.proc
 
-import junit.framework.TestCase
-import org.intellij.lang.annotations.Language
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
 import org.rust.lang.core.macros.MacroExpansionScope
+import org.rust.lang.core.macros.RsMacroExpansionErrorTestBase
 import org.rust.lang.core.macros.errors.GetMacroExpansionError
-import org.rust.lang.core.psi.ext.RsPossibleMacroCall
-import org.rust.lang.core.psi.ext.descendantsOfType
-import org.rust.lang.core.psi.ext.expansionResult
-import org.rust.lang.core.psi.ext.isMacroCall
-import org.rust.stdext.RsResult
 
 /**
  * A test for [org.rust.lang.core.macros.errors.GetMacroExpansionError.toUserViewableMessage]
@@ -27,7 +21,7 @@ import org.rust.stdext.RsResult
 @ExpandMacros(MacroExpansionScope.WORKSPACE)
 @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
 @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
-class RsProcMacroErrorTest : RsTestBase() {
+class RsProcMacroErrorTest : RsMacroExpansionErrorTestBase() {
     @WithExperimentalFeatures()
     fun `test macro expansion is disabled`() = checkError<GetMacroExpansionError.ExpansionError>("""
         use test_proc_macros::attr_as_is;
@@ -76,35 +70,4 @@ class RsProcMacroErrorTest : RsTestBase() {
         #[function_like_as_is]
         fn foo() {} //^ `FUNCTION_LIKE` proc macro can't be called as `ATTRIBUTE`
     """)
-
-    private inline fun <reified T : GetMacroExpansionError> checkError(
-        @Language("Rust") code: String
-    ) {
-        checkError(code, T::class.java)
-    }
-
-    private fun checkError(code: String, errorClass: Class<*>) {
-        InlineFile(code)
-        val markers = findElementsWithDataAndOffsetInEditor<RsPossibleMacroCall>()
-        val (macro, expectedErrorMessage) = if (markers.isEmpty()) {
-            myFixture.file
-                .descendantsOfType<RsPossibleMacroCall>()
-                .single { it.isMacroCall } to null
-        } else {
-            val (macro, message, _) = markers.single()
-            check(macro.isMacroCall)
-            macro to message
-        }
-
-        val err = when (val result = macro.expansionResult) {
-            is RsResult.Err -> result.err
-            is RsResult.Ok -> error("Expected a macro expansion error, got a successfully expanded macro")
-        }
-
-        check(errorClass.isInstance(err)) { "Expected error $errorClass, got $err" }
-
-        if (expectedErrorMessage != null) {
-            TestCase.assertEquals(expectedErrorMessage, err.toUserViewableMessage())
-        }
-    }
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
@@ -31,6 +31,45 @@ class RsProcMacroErrorTest : RsMacroExpansionErrorTestBase() {
         fn foo() {}
     """)
 
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @WithExperimentalFeatures()
+    fun `test macro expansion is disabled with unsuccessfully compiled proc macro crate`() = checkErrorByTree<GetMacroExpansionError.ExpansionError>("""
+    //- dep-proc-macro-unsuccessfully-compiled/lib.rs
+        extern crate proc_macro;
+        use proc_macro::TokenStream;
+
+        #[proc_macro_attribute]
+        pub fn attr_as_is(_attr: TokenStream, item: TokenStream) -> TokenStream {
+           item
+        }
+        compile_error!("The crate with the macro is not compiled successfully");
+    //- main.rs
+        use dep_proc_macro_unsuccessfully_compiled::attr_as_is;
+
+        #[attr_as_is]
+        //^ procedural macro expansion is not enabled
+        fn foo() {}
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test unsuccessfully compiled proc macro crate`() = checkErrorByTree<GetMacroExpansionError.NoProcMacroArtifact>("""
+    //- dep-proc-macro-unsuccessfully-compiled/lib.rs
+        extern crate proc_macro;
+        use proc_macro::TokenStream;
+
+        #[proc_macro_attribute]
+        pub fn attr_as_is(_attr: TokenStream, item: TokenStream) -> TokenStream {
+           item
+        }
+        compile_error!("The crate with the macro is not compiled successfully");
+    //- main.rs
+        use dep_proc_macro_unsuccessfully_compiled::attr_as_is;
+
+        #[attr_as_is]
+        //^ the procedural macro is not compiled successfully
+        fn foo() {}
+    """)
+
     fun `test unresolved function-like macro`() = checkError<GetMacroExpansionError.Unresolved>("""
         unresolved_macro! {}
     """)


### PR DESCRIPTION
1. Show message "the macro call is conditionally disabled with a `#[cfg()]` attribute" in the case of cfg-disabled macro call that refers to a declarative macro. Previously there was some other unrelated error message. For example "procedural macro expansion is not enabled" if  `org.rust.cargo.evaluate.build.scripts` and/or `org.rust.macros.proc` experimental features are disabled.
```rust
macro_rules! foo {
    () => { fn foo() {} }
}
#[cfg(not(intellij_rust))]
foo! {}
```
2. Show message "the procedural macro is not compiled successfully" when `org.rust.cargo.evaluate.build.scripts` and/or `org.rust.macros.proc` experimental features are disabled. Previously the error was "the procedural macro is not compiled successfully"

Also add tests for these cases.

changelog: Fix error messages about unsuccessful macro expansion in the case when procedural macro expansion is not enabled and in the case when a declarative macro call is conditionally disabled