### PR TITLE
PERF: reduce cfg evaluation in `expandedItemsCached` and cache `CfgEvaluator` for a crate

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureUsageProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureUsageProcessor.kt
@@ -125,7 +125,7 @@ private fun findNameConflicts(
         is RsAbstractableOwner.Trait -> owner.trait to owner.trait.expandedMembers
         else -> {
             val parent = function.contextStrict<RsItemsOwner>() ?: return
-            val items = parent.expandedItemsCached.named[config.name] ?: return
+            val items = parent.expandedItemsCached.getNamedElementsIfCfgEnabled(config.name) ?: return
             parent to items
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
@@ -105,7 +105,7 @@ val RsMod.childModules: List<RsMod>
         }
 
 fun RsItemsOwner.getChildModule(name: String): RsMod? =
-    expandedItemsCached.named[name]?.filterIsInstance<RsMod>()?.singleOrNull()
+    expandedItemsCached.getNamedElementsIfCfgEnabled(name)?.filterIsInstance<RsMod>()?.singleOrNull()
 
 fun commonParentMod(mod1: RsMod, mod2: RsMod): RsMod? {
     val superMods1 = mod1.superMods.asReversed()

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -586,6 +586,8 @@ private fun MacroDefInfo.legacyMacroToPsi(containingScope: RsItemsOwner, info: R
         is DeclMacroDefInfo -> items.legacyMacros.singleOrNull {
             val crate = info.project.crateGraph.findCrateById(crate) ?: return@singleOrNull false
             val defIndex = info.getMacroIndex(it, crate) ?: return@singleOrNull false
+            // Note that if macro indices are equal, the result macro is cfg-enabled
+            // since cfg-enabled and cfg-disabled macros have different macro indices
             MacroIndex.equals(defIndex, macroIndex)
         }
         is ProcMacroDefInfo -> items.named[path.name]?.firstOrNull { it is RsFunction }
@@ -693,11 +695,8 @@ private fun ModData.toRsModNullable(project: Project): List<RsMod> {
         }
 }
 
-private inline fun <reified T : RsNamedElement> RsItemsOwner.getExpandedItemsWithName(name: String): List<T> {
-    val itemsCfgEnabled = expandedItemsCached.named[name]?.filterIsInstance<T>()
-    if (itemsCfgEnabled != null && itemsCfgEnabled.isNotEmpty()) return itemsCfgEnabled
-    return expandedItemsCached.namedCfgDisabled[name]?.filterIsInstance<T>() ?: emptyList()
-}
+private inline fun <reified T : RsNamedElement> RsItemsOwner.getExpandedItemsWithName(name: String): List<T> =
+    expandedItemsCached.named[name]?.filterIsInstance<T>() ?: emptyList()
 
 /**
  * If all def maps are up-to-date, then returns correct result

--- a/src/main/kotlin/org/rust/lang/core/resolve2/util/THashMapBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/util/THashMapBase.kt
@@ -141,10 +141,10 @@ abstract class THashMapBase<K : Any, V : Any> : TObjectHash<K>(), MutableMap<K, 
     }
 
     private inner class EntryView : AbstractSet<MutableMap.MutableEntry<K, V>>() {
-        override fun iterator(): MutableIterator<Entry<K, V>> {
-            return object : THashIterator<Entry<K, V>>() {
-                override fun objectAtIndex(index: Int): Entry<K, V> {
-                    return Entry(_set[index] as K, getValueAtIndex(index)!!)
+        override fun iterator(): MutableIterator<Entry> {
+            return object : THashIterator<Entry>() {
+                override fun objectAtIndex(index: Int): THashMapBase<K, V>.Entry {
+                    return Entry(index)
                 }
             }
         }
@@ -154,8 +154,14 @@ abstract class THashMapBase<K : Any, V : Any> : TObjectHash<K>(), MutableMap<K, 
         override fun contains(element: MutableMap.MutableEntry<K, V>): Boolean = throw UnsupportedOperationException()
     }
 
-    private class Entry<K : Any, V : Any>(override val key: K, override val value: V) : MutableMap.MutableEntry<K, V> {
-        override fun setValue(newValue: V): V = throw UnsupportedOperationException()
+    private inner class Entry(private val index: Int) : MutableMap.MutableEntry<K, V> {
+        override val key: K get() = _set[index] as K
+        override val value: V get() = getValueAtIndex(index)!!
+        override fun setValue(newValue: V): V {
+            val oldValue = value
+            setValueAtIndex(index, newValue)
+            return oldValue
+        }
     }
 
     private abstract inner class THashIterator<V> : MutableIterator<V> {

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapMacroIndexConsistencyTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapMacroIndexConsistencyTest.kt
@@ -73,7 +73,7 @@ class RsDefMapMacroIndexConsistencyTest : RsTestBase() {
         val info = getModInfo(crateRoot) as RsModInfo
 
         val expandedItems = mutableListOf<RsElement>()
-        crateRoot.processExpandedItemsInternal(withMacroCalls = true) { item, _ ->
+        crateRoot.processExpandedItemsInternal(withMacroCalls = true) { item ->
             expandedItems += item
             false
         }


### PR DESCRIPTION
changelog: Slightly speed up name resolution