### PR TITLE
DOC: add line marker and test run configuration provider for doctests

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoBenchRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoBenchRunConfigurationProducer.kt
@@ -7,12 +7,21 @@ package org.rust.cargo.runconfig.test
 
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.isBench
 import org.rust.lang.core.psi.ext.processExpandedItemsExceptImplsAndUses
 
 class CargoBenchRunConfigurationProducer : CargoTestRunConfigurationProducerBase() {
     override val commandName: String = "bench"
+
+    init {
+        registerConfigProvider { elements, climbUp -> createConfigFor<RsModDeclItem>(elements, climbUp) }
+        registerConfigProvider { elements, climbUp -> createConfigFor<RsFunction>(elements, climbUp) }
+        registerConfigProvider { elements, climbUp -> createConfigFor<RsMod>(elements, climbUp) }
+        registerConfigProvider { elements, climbUp -> createConfigForMultipleFiles(elements, climbUp) }
+        registerDirectoryConfigProvider { dir -> createConfigForDirectory(dir) }
+    }
 
     override fun isSuitable(element: PsiElement): Boolean =
         when (element) {

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestEventsConverter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestEventsConverter.kt
@@ -290,10 +290,10 @@ class CargoTestEventsConverter(
                 .addAttribute("nodeId", suite)
 
         private fun createTestStartedMessage(test: NodeId): ServiceMessageBuilder {
-            // target_name::name1::name2 (line i) -> target_name::name1::name2#(i - 1)
+            // target_name::name1::name2 (line i) -> target_name::name1::name2# i
             val name = test.replace(LINE_NUMBER_RE) {
                 val line = it.groups["line"]?.value ?: error("Failed to find `line` capturing group")
-                "#${line.toInt() - 1}"
+                "#${line.toInt()}"
             }
             return ServiceMessageBuilder.testStarted(test.name)
                 .addAttribute("nodeId", test)

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestLocator.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestLocator.kt
@@ -82,6 +82,11 @@ object CargoTestLocator : SMTestLocator {
     fun getTestUrl(function: RsQualifiedNamedElement): String =
         getTestUrl(function.qualifiedName ?: "")
 
+    fun getTestUrl(ctx: DocTestContext): String {
+        val owner = ctx.owner.qualifiedName ?: ""
+        return getTestUrl("$owner#${ctx.lineNumber}")
+    }
+
     private fun toQualifiedName(path: String): Pair<String, Int?> {
         val targetName = path.substringBefore(NAME_SEPARATOR).substringBeforeLast("-")
         if (NAME_SEPARATOR !in path) return targetName to null

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestLocator.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestLocator.kt
@@ -68,7 +68,7 @@ object CargoTestLocator : SMTestLocator {
         if (lineNum != null) {
             object : PsiLocation<PsiElement>(project, element) {
                 override fun getOpenFileDescriptor(): OpenFileDescriptor? =
-                    virtualFile?.let { OpenFileDescriptor(project, it, lineNum, 0) }
+                    virtualFile?.let { OpenFileDescriptor(project, it, lineNum - 1, 0) }
             }
         } else {
             PsiLocation.fromPsiElement(element)

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt
@@ -7,6 +7,7 @@ package org.rust.cargo.runconfig.test
 
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.workspace.CargoWorkspace
@@ -15,6 +16,8 @@ import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.doc.psi.RsDocCodeFence
+import org.rust.openapiext.isUnitTestMode
 import org.rust.openapiext.pathAsPath
 
 class CargoTestRunConfigurationProducer : CargoTestRunConfigurationProducerBase() {
@@ -23,6 +26,7 @@ class CargoTestRunConfigurationProducer : CargoTestRunConfigurationProducerBase(
     init {
         registerDirectoryConfigProvider { dir -> createConfigForCargoProject(dir) }
         registerDirectoryConfigProvider { dir -> createConfigForCargoPackage(dir) }
+        registerConfigProvider { elements, climbUp -> createConfigForDocTest(elements, climbUp) }
     }
 
     override fun isSuitable(element: PsiElement): Boolean =
@@ -44,6 +48,28 @@ class CargoTestRunConfigurationProducer : CargoTestRunConfigurationProducerBase(
         val cargoPackage = dir.findCargoPackage() ?: return null
         if (dirPath != cargoPackage.rootDirectory || cargoPackage.origin != PackageOrigin.WORKSPACE) return null
         return CargoPackageTestConfig(commandName, dir, cargoPackage)
+    }
+
+    private fun createConfigForDocTest(
+        elements: List<PsiElement>,
+        climbUp: Boolean
+    ): TestConfig? {
+        val (codeFence, ctx) = elements
+            .mapNotNull {
+                val originalElement = findElement<RsDocCodeFence>(it, climbUp) ?: return@mapNotNull null
+                if (originalElement.containingCargoTarget == null) return@mapNotNull null
+
+                val ctx = originalElement.getDoctestCtx() ?: return@mapNotNull null
+                originalElement to ctx
+            }
+            .singleOrNull()
+            ?: return null
+        val target = codeFence.containingCargoTarget ?: return null
+        val ownerPath = ctx.owner.crateRelativePath.configPath() ?: return null
+
+        return DocTestConfig(
+            commandName, ownerPath, target, codeFence, ctx
+        )
     }
 
     companion object {
@@ -82,4 +108,88 @@ private class CargoPackageTestConfig(
 
     override fun cargoCommandLine(): CargoCommandLine =
         CargoCommandLine.forPackage(cargoPackage, commandName)
+}
+
+class DocTestContext(val owner: RsQualifiedNamedElement, val lineNumber: Int, val isIgnored: Boolean)
+
+// If we encounter one of these attributes, it's probably a doctest.
+// If we encounter something else, it's probably a code block written in some other language.
+// https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html
+private val KNOWN_DOCTEST_ATTRIBUTES = setOf(
+    "compile_fail",
+    "ignore",
+    "rust",
+    "should_panic",
+    "no_run",
+    "edition2015",
+    "edition2018",
+    "edition2021"
+)
+
+fun RsDocCodeFence.getDoctestCtx(): DocTestContext? {
+    val owner = containingDoc.owner as? RsQualifiedNamedElement ?: return null
+
+    val containingFile = originalElement.containingFile
+    val project = containingFile.project
+    val psiDocumentManager = PsiDocumentManager.getInstance(project)
+    val document = psiDocumentManager.getDocument(containingFile) ?: return null
+    val textOffset = originalElement.startOffset
+
+    // Cargo uses 1-based line numbers
+    val lineNumber = document.getLineNumber(textOffset) + 1
+
+    var text = lang?.text?.trim().orEmpty()
+    // Ignore test line marker comments in tests
+    if (isUnitTestMode && "// -" in text) {
+        text = text.substring(0, text.indexOf("// -")).trim()
+    }
+
+    val tags = text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+    if (tags.isNotEmpty() && !KNOWN_DOCTEST_ATTRIBUTES.contains(tags.first())) return null
+
+    val isIgnored = tags.contains("ignore")
+    return DocTestContext(owner, lineNumber, isIgnored)
+}
+
+private class DocTestConfig(
+    override val commandName: String,
+    private val ownerPath: String,
+    val target: CargoWorkspace.Target,
+    override val sourceElement: RsDocCodeFence,
+    val ctx: DocTestContext
+) : TestConfig {
+    override val isIgnored: Boolean = ctx.isIgnored
+
+    // `cargo test` exact matching doesn't work with the escaped spaces, see below
+    override val exact: Boolean = false
+    override val isDoctest: Boolean = true
+
+    override val path: String
+        get() = buildString {
+            // `cargo test` uses a regex for matching the test names.
+            // doctests contain spaces in their name (e.g. `foo::bar (line X)`).
+            // To make test lookup work, we need to escape spaces in the test path.
+            if (ownerPath.isNotEmpty()) {
+                append("${ownerPath}\\ ")
+            }
+            append("(line\\ ${ctx.lineNumber})")
+        }
+
+    override val targets: List<CargoWorkspace.Target>
+        get() = listOf(target)
+
+    override val configurationName: String
+        get() = buildString {
+            append("Doctest of ")
+            if (ownerPath.isNotEmpty()) {
+                append(ownerPath)
+            }
+            else {
+                // The owner is a crate root library module
+                val name = ctx.owner.containingCargoPackage?.name ?: ctx.owner.containingFile.name
+                append(name)
+            }
+            append(" at line ")
+            append(ctx.lineNumber)
+        }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt
@@ -16,6 +16,7 @@ import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.ide.injected.DoctestInfo
 import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.doc.psi.RsDocCodeFence
 import org.rust.openapiext.isUnitTestMode
@@ -25,9 +26,14 @@ class CargoTestRunConfigurationProducer : CargoTestRunConfigurationProducerBase(
     override val commandName: String = "test"
 
     init {
+        registerConfigProvider { elements, climbUp -> createConfigFor<RsModDeclItem>(elements, climbUp) }
+        registerConfigProvider { elements, climbUp -> createConfigForDocTest(elements, climbUp) }
+        registerConfigProvider { elements, climbUp -> createConfigFor<RsFunction>(elements, climbUp) }
+        registerConfigProvider { elements, climbUp -> createConfigFor<RsMod>(elements, climbUp) }
+        registerConfigProvider { elements, climbUp -> createConfigForMultipleFiles(elements, climbUp) }
+        registerDirectoryConfigProvider { dir -> createConfigForDirectory(dir) }
         registerDirectoryConfigProvider { dir -> createConfigForCargoProject(dir) }
         registerDirectoryConfigProvider { dir -> createConfigForCargoPackage(dir) }
-        registerConfigProvider { elements, climbUp -> createConfigForDocTest(elements, climbUp) }
     }
 
     override fun isSuitable(element: PsiElement): Boolean =

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducerBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducerBase.kt
@@ -63,7 +63,7 @@ abstract class CargoTestRunConfigurationProducerBase : CargoRunConfigurationProd
         return true
     }
 
-    private fun registerConfigProvider(provider: TestConfigProvider) {
+    protected fun registerConfigProvider(provider: TestConfigProvider) {
         testConfigProviders.add(provider)
     }
 
@@ -137,7 +137,7 @@ abstract class CargoTestRunConfigurationProducerBase : CargoRunConfigurationProd
         )
     }
 
-    private inline fun <reified T : PsiElement> findElement(base: PsiElement, climbUp: Boolean): T? {
+    protected inline fun <reified T : PsiElement> findElement(base: PsiElement, climbUp: Boolean): T? {
         if (base is T) return base
         if (!climbUp) return null
         return base.ancestorOrSelf()
@@ -190,9 +190,10 @@ interface TestConfig {
     val sourceElement: PsiElement
     val originalElement: PsiElement get() = sourceElement
     val isIgnored: Boolean get() = false
+    val isDoctest: Boolean get() = false
 
     fun cargoCommandLine(): CargoCommandLine {
-        var commandLine = CargoCommandLine.forTargets(targets, commandName, listOf(path))
+        var commandLine = CargoCommandLine.forTargets(targets, commandName, listOf(path), isDoctest = isDoctest)
         if (exact) {
             commandLine = commandLine.withPositionalArgument("--exact")
         }

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducerBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducerBase.kt
@@ -34,14 +34,6 @@ abstract class CargoTestRunConfigurationProducerBase : CargoRunConfigurationProd
     protected abstract val commandName: String
     private val testConfigProviders: MutableList<TestConfigProvider> = mutableListOf()
 
-    init {
-        registerConfigProvider { elements, climbUp -> createConfigFor<RsModDeclItem>(elements, climbUp) }
-        registerConfigProvider { elements, climbUp -> createConfigFor<RsFunction>(elements, climbUp) }
-        registerConfigProvider { elements, climbUp -> createConfigFor<RsMod>(elements, climbUp) }
-        registerConfigProvider { elements, climbUp -> createConfigForMultipleFiles(elements, climbUp) }
-        registerDirectoryConfigProvider { dir -> createConfigForDirectory(dir) }
-    }
-
     override fun isConfigurationFromContext(
         configuration: CargoCommandConfiguration,
         context: ConfigurationContext
@@ -88,7 +80,7 @@ abstract class CargoTestRunConfigurationProducerBase : CargoRunConfigurationProd
         return elements?.let { findTestConfig(it) }
     }
 
-    private fun createConfigForDirectory(dir: PsiDirectory): TestConfig? {
+    protected fun createConfigForDirectory(dir: PsiDirectory): TestConfig? {
         val filesConfig = createConfigForMultipleFiles(dir.targets, climbUp = false) ?: return null
 
         val sourceRoot = dir.sourceRoot ?: return null
@@ -98,7 +90,7 @@ abstract class CargoTestRunConfigurationProducerBase : CargoRunConfigurationProd
         return DirectoryTestConfig(commandName, filesConfig.targets, dir)
     }
 
-    private fun createConfigForMultipleFiles(elements: List<PsiElement>, climbUp: Boolean): TestConfig? {
+    protected fun createConfigForMultipleFiles(elements: List<PsiElement>, climbUp: Boolean): TestConfig? {
         val modConfigs = elements.mapNotNull { createConfigFor<RsMod>(listOf(it), climbUp) }
 
         if (modConfigs.size == 1) {
@@ -115,7 +107,7 @@ abstract class CargoTestRunConfigurationProducerBase : CargoRunConfigurationProd
         return MultipleFileTestConfig(commandName, targets, modConfigs.first().sourceElement)
     }
 
-    private inline fun <reified T : RsQualifiedNamedElement> createConfigFor(
+    protected inline fun <reified T : RsQualifiedNamedElement> createConfigFor(
         elements: List<PsiElement>,
         climbUp: Boolean
     ): TestConfig? {
@@ -145,7 +137,7 @@ abstract class CargoTestRunConfigurationProducerBase : CargoRunConfigurationProd
 
     protected abstract fun isSuitable(element: PsiElement): Boolean
 
-    private fun isIgnoredTest(element: PsiElement): Boolean =
+    protected fun isIgnoredTest(element: PsiElement): Boolean =
         element is RsFunction && element.findOuterAttr("ignore") != null
 
     companion object {
@@ -228,7 +220,7 @@ private class MultipleFileTestConfig(
         get() = "${commandName.capitalize()} multiple selected files"
 }
 
-private class SingleItemTestConfig(
+ class SingleItemTestConfig(
     override val commandName: String,
     override val path: String,
     val target: CargoWorkspace.Target,

--- a/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
@@ -114,7 +114,8 @@ data class CargoCommandLine(
             targets: List<CargoWorkspace.Target>,
             command: String,
             additionalArguments: List<String> = emptyList(),
-            usePackageOption: Boolean = true
+            usePackageOption: Boolean = true,
+            isDoctest: Boolean = false
         ): CargoCommandLine {
             val pkgs = targets.map { it.pkg }
             // Make sure the selection does not span more than one package.
@@ -128,7 +129,13 @@ data class CargoCommandLine(
                     CargoWorkspace.TargetKind.ExampleBin, is CargoWorkspace.TargetKind.ExampleLib ->
                         listOf("--example", target.name)
                     CargoWorkspace.TargetKind.Bench -> listOf("--bench", target.name)
-                    is CargoWorkspace.TargetKind.Lib -> listOf("--lib")
+                    is CargoWorkspace.TargetKind.Lib -> {
+                        if (isDoctest) {
+                            listOf("--doc")
+                        } else {
+                            listOf("--lib")
+                        }
+                    }
                     CargoWorkspace.TargetKind.CustomBuild,
                     CargoWorkspace.TargetKind.Unknown -> emptyList()
                 }

--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -239,7 +239,7 @@ class DoctestInfo private constructor(
             return DoctestInfo(docIndent, fenceIndent, contents, codeFence.text)
         }
 
-        private fun hasUnbalancedCodeFencesBefore(context: RsDocCodeFence): Boolean {
+        fun hasUnbalancedCodeFencesBefore(context: RsDocCodeFence): Boolean {
             val containingDoc = context.containingDoc
             val docOwner = containingDoc.owner ?: return false
             for (docElement in docOwner.docElements()) {

--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -46,8 +46,9 @@ private val RUST_LANG_ALIASES = listOf(
     "no_run",
     "test_harness",
 //    "compile_fail", // don't highlight code that is expected to contain errors
+    "edition2015",
     "edition2018",
-    "edition2015"
+    "edition2021"
 )
 
 class RsDoctestLanguageInjector : MultiHostInjector {

--- a/src/main/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributor.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributor.kt
@@ -35,8 +35,6 @@ class CargoTestRunLineMarkerContributor : RunLineMarkerContributor() {
                 val parent = element.parent as? RsDocCodeFenceStartEnd ?: return null
                 val fence = parent.parent as? RsDocCodeFence ?: return null
                 if (fence.start != parent) return null
-                // Ignore invalid fences
-                if (fence.end == null) return null
                 fence
             }
             IDENTIFIER -> {

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
@@ -16,6 +16,7 @@ import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.findCargoProject
+import org.rust.lang.doc.psi.RsDocCodeFence
 import org.rust.openapiext.toPsiDirectory
 
 class TestRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
@@ -350,5 +351,57 @@ class TestRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
             file("src/struct.rs", "#[test] fn test_foo() { /*caret*/assert!(true); }").open()
         }
         checkOnTopLevel<RsFunction>()
+    }
+
+    fun `test doctest`() {
+        testProject {
+            lib("foo", "src/lib.rs", """
+                /// Documentation
+                /// ```/*caret*/
+                /// let a = 5;
+                /// ```
+                fn foo() {}
+            """.trimIndent()).open()
+        }
+        checkOnTopLevel<RsDocCodeFence>()
+    }
+
+    fun `test ignored doctest`() {
+        testProject {
+            lib("foo", "src/lib.rs", """
+                /// Documentation
+                /// ```ignore/*caret*/
+                /// let a = 5;
+                /// ```
+                fn foo() {}
+            """.trimIndent()).open()
+        }
+        checkOnTopLevel<RsDocCodeFence>()
+    }
+
+    fun `test module top-level doctest`() {
+        testProject {
+            lib("foo", "src/lib.rs", """
+                mod bar {
+                    //! Documentation
+                    //! ```/*caret*/
+                    //! let a = 5;
+                    //! ```
+                }
+            """.trimIndent()).open()
+        }
+        checkOnTopLevel<RsDocCodeFence>()
+    }
+
+    fun `test library top-level doctest`() {
+        testProject {
+            lib("foo", "src/lib.rs", """
+                //! Documentation
+                //! ```/*caret*/
+                //! let a = 5;
+                //! ```
+            """.trimIndent()).open()
+        }
+        checkOnTopLevel<RsDocCodeFence>()
     }
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -218,10 +218,10 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         /// Some documentation.
         /// ```                 // - Doctest of foo (line 2)
         /// let a = 5;
-        ///
+        //
         /// ```
         /// let b = 5;
-        /// ```                 // - Doctest of foo (line 7)
+        /// ```
         fn foo() {}
     """.trimIndent())
 

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -148,7 +148,7 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
 
     fun `test function doctest`() = doTestByText("""
         /// Some documentation.
-        /// ```                 // - Doctest of foo at line 2
+        /// ```                 // - Doctest of foo (line 2)
         /// let a = 5;
         /// ```
         fn foo() {}
@@ -156,7 +156,7 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
 
     fun `test module doctest`() = doTestByText("""
         /// Some documentation.
-        /// ```                 // - Doctest of foo at line 2
+        /// ```                 // - Doctest of foo (line 2)
         /// let a = 5;
         /// ```
         mod foo {}
@@ -164,11 +164,11 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
 
     fun `test multiple doctests`() = doTestByText("""
         /// Some documentation.
-        /// ```                 // - Doctest of foo at line 2
+        /// ```                 // - Doctest of foo (line 2)
         /// let a = 5;
         /// ```
         ///
-        /// ```                 // - Doctest of foo at line 6
+        /// ```                 // - Doctest of foo (line 6)
         /// let a = 5;
         /// ```
         fn foo() {}
@@ -177,7 +177,7 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
     fun `test function in module doctest`() = doTestByText("""
         mod foo {
             /// Some documentation.
-            /// ```                 // - Doctest of foo::bar at line 3
+            /// ```                 // - Doctest of foo::bar (line 3)
             /// let a = 5;
             /// ```
             fn bar() {}
@@ -186,7 +186,7 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
 
     fun `test top-level doctest`() = doTestByText("""
         //! Some documentation.
-        //! ```                 // - Doctest of test-package at line 2
+        //! ```                 // - Doctest of test-package (line 2)
         //! let a = 5;
         //! ```
     """.trimIndent())
@@ -201,9 +201,27 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
 
     fun `test code block with rust`() = doTestByText("""
         /// Some documentation.
-        /// ```rust             // - Doctest of foo at line 2
+        /// ```rust             // - Doctest of foo (line 2)
         /// let a = 5;
         /// ```
+        fn foo() {}
+    """.trimIndent())
+
+    fun `test unterminated doctest`() = doTestByText("""
+        /// Some documentation.
+        /// ```                 // - Doctest of foo (line 2)
+        /// let a = 5;
+        fn foo() {}
+    """.trimIndent())
+
+    fun `test doctest with unterminated predecessor`() = doTestByText("""
+        /// Some documentation.
+        /// ```                 // - Doctest of foo (line 2)
+        /// let a = 5;
+        ///
+        /// ```
+        /// let b = 5;
+        /// ```                 // - Doctest of foo (line 7)
         fn foo() {}
     """.trimIndent())
 

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -146,6 +146,67 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         fn no_icon() { assert(true) }
     """)
 
+    fun `test function doctest`() = doTestByText("""
+        /// Some documentation.
+        /// ```                 // - Doctest of foo at line 2
+        /// let a = 5;
+        /// ```
+        fn foo() {}
+    """.trimIndent())
+
+    fun `test module doctest`() = doTestByText("""
+        /// Some documentation.
+        /// ```                 // - Doctest of foo at line 2
+        /// let a = 5;
+        /// ```
+        mod foo {}
+    """.trimIndent())
+
+    fun `test multiple doctests`() = doTestByText("""
+        /// Some documentation.
+        /// ```                 // - Doctest of foo at line 2
+        /// let a = 5;
+        /// ```
+        ///
+        /// ```                 // - Doctest of foo at line 6
+        /// let a = 5;
+        /// ```
+        fn foo() {}
+    """.trimIndent())
+
+    fun `test function in module doctest`() = doTestByText("""
+        mod foo {
+            /// Some documentation.
+            /// ```                 // - Doctest of foo::bar at line 3
+            /// let a = 5;
+            /// ```
+            fn bar() {}
+        }
+    """.trimIndent())
+
+    fun `test top-level doctest`() = doTestByText("""
+        //! Some documentation.
+        //! ```                 // - Doctest of test-package at line 2
+        //! let a = 5;
+        //! ```
+    """.trimIndent())
+
+    fun `test code block with other language`() = doTestByText("""
+        /// Some documentation.
+        /// ```python
+        /// a = 5
+        /// ```
+        fn foo() {}
+    """.trimIndent())
+
+    fun `test code block with rust`() = doTestByText("""
+        /// Some documentation.
+        /// ```rust             // - Doctest of foo at line 2
+        /// let a = 5;
+        /// ```
+        fn foo() {}
+    """.trimIndent())
+
     private inline fun <reified E : RsElement> checkElement(@Language("Rust") code: String, callback: (E) -> Unit) {
         val element = PsiFileFactory.getInstance(project)
             .createFileFromText("main.rs", RsFileType, code)

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/doctest.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/doctest.xml
@@ -1,0 +1,19 @@
+<configurations>
+  <configuration name="Doctest of foo at line 2" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="test --package test-package --doc &quot;foo\ (line\ 2)&quot;" />
+    <option name="workingDirectory" value="file:///my-crate" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</configurations>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/doctest.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/doctest.xml
@@ -1,5 +1,5 @@
 <configurations>
-  <configuration name="Doctest of foo at line 2" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+  <configuration name="Doctest of foo (line 2)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="command" value="test --package test-package --doc &quot;foo\ (line\ 2)&quot;" />
     <option name="workingDirectory" value="file:///my-crate" />
     <option name="channel" value="DEFAULT" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_doctest.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_doctest.xml
@@ -1,5 +1,5 @@
 <configurations>
-  <configuration name="Doctest of foo at line 2" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+  <configuration name="Doctest of foo (line 2)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="command" value="test --package test-package --doc &quot;foo\ (line\ 2)&quot; -- --ignored" />
     <option name="workingDirectory" value="file:///my-crate" />
     <option name="channel" value="DEFAULT" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_doctest.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_doctest.xml
@@ -1,0 +1,19 @@
+<configurations>
+  <configuration name="Doctest of foo at line 2" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="test --package test-package --doc &quot;foo\ (line\ 2)&quot; -- --ignored" />
+    <option name="workingDirectory" value="file:///my-crate" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</configurations>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/library_top-level_doctest.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/library_top-level_doctest.xml
@@ -1,5 +1,5 @@
 <configurations>
-  <configuration name="Doctest of test-package at line 2" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+  <configuration name="Doctest of test-package (line 2)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="command" value="test --package test-package --doc &quot;(line\ 2)&quot;" />
     <option name="workingDirectory" value="file:///my-crate" />
     <option name="channel" value="DEFAULT" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/library_top-level_doctest.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/library_top-level_doctest.xml
@@ -1,0 +1,19 @@
+<configurations>
+  <configuration name="Doctest of test-package at line 2" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="test --package test-package --doc &quot;(line\ 2)&quot;" />
+    <option name="workingDirectory" value="file:///my-crate" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</configurations>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/module_top-level_doctest.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/module_top-level_doctest.xml
@@ -1,0 +1,19 @@
+<configurations>
+  <configuration name="Doctest of bar at line 3" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="test --package test-package --doc &quot;bar\ (line\ 3)&quot;" />
+    <option name="workingDirectory" value="file:///my-crate" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</configurations>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/module_top-level_doctest.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/module_top-level_doctest.xml
@@ -1,5 +1,5 @@
 <configurations>
-  <configuration name="Doctest of bar at line 3" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+  <configuration name="Doctest of bar (line 3)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="command" value="test --package test-package --doc &quot;bar\ (line\ 3)&quot;" />
     <option name="workingDirectory" value="file:///my-crate" />
     <option name="channel" value="DEFAULT" />


### PR DESCRIPTION
This PR adds line markers and run configurations for doctests. The `isDoctest` parameter is a bit of a hack, but I wasn't sure how to solve it more elegantly. I would like to change the `kind` of the passed target e.g. to `Unknown`, so that no other flag like `--lib` or `--bin` is passed to `cargo test`, since it must contain only `--doc`.

Tests work fine, but in the IDE it behaves in a strange way. If I click on the test gutter of a doctest, it creates and runs the test correctly. But then if I add a normal `#[test]` function to the same file and execute that, from that moment on the gutters on the doctests go crazy and behave like if they were the main function or something like that, they offer me to profile them etc. Any idea what might be causing that? :) Maybe the test locator URL?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/9098

changelog: You can now create test run configurations from doctests.