### PR TITLE
RES: Fix resolve of macro without `macro_export` reexported as macro 2.0

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -293,7 +293,7 @@ class ModData(
     val name: String get() = path.name
     val isDeeplyEnabledByCfg: Boolean get() = isDeeplyEnabledByCfgOuter && isEnabledByCfgInner
     val parents: Sequence<ModData> get() = generateSequence(this) { it.parent }
-    private val rootModData: ModData = parent?.rootModData ?: this
+    val rootModData: ModData = parent?.rootModData ?: this
 
     // Optimization to reduce allocations
     val visibilityInSelf: Restricted = Restricted.create(this)

--- a/src/main/kotlin/org/rust/lang/core/resolve2/PathResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/PathResolution.kt
@@ -160,7 +160,12 @@ private fun CrateDefMap.doResolveNameInModule(modData: ModData, name: String, wi
  */
 private fun ModData.getFirstLegacyMacro(name: String): PerNs? {
     val def = legacyMacros[name]?.firstOrNull() ?: return null
-    val visibility = if (def is DeclMacroDefInfo && def.hasMacroExport) Visibility.Public else visibilityInSelf
+    val visibility = when {
+        // the macro was added from another crate using `#[macro_use] export crate ...`, it must be public
+        def !is DeclMacroDefInfo -> Visibility.Public
+        def.hasMacroExport -> Visibility.Public
+        else -> rootModData.visibilityInSelf
+    }
     val visItem = VisItem(def.path, visibility)
     return PerNs.macros(visItem)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -928,6 +928,21 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         } //^
     """)
 
+    fun `test legacy textual macro reexported as macro 2 (no macro_export)`() = checkByCode("""
+        mod inner {
+            macro_rules! as_is_ { ($ i:item) => { $ i } }
+            pub(crate) use as_is_ as as_is;
+        }
+
+        use inner::as_is;
+        as_is! { fn foo() {} }
+                         //X
+
+        fn main() {
+            foo();
+        } //^
+    """)
+
     fun `test macro call expanded to macro def and macro call 1`() = checkByCode("""
         macro_rules! as_is { ($($ t:tt)*) => { $($ t)* }; }
         as_is! {


### PR DESCRIPTION
Fixes #8651

changelog: Fix resolve of reexported macro in some cases
