### PR TITLE
RES: Fix propagation of `include!`-ed macros to child modules

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -407,7 +407,7 @@ class DefCollector(
         val includingRsFile = includingFile?.toPsiFile(project)?.rustFile
         if (includingRsFile != null) {
             val context = getModCollectorContextForExpandedElements(call) ?: return
-            collectScope(includingRsFile, call.containingMod, context, call.macroIndex)
+            collectScope(includingRsFile, call.containingMod, context, call.macroIndex, propagateLegacyMacros = true)
         } else if (!context.isHangingMode) {
             val filePath = parentDirectory.pathAsPath.resolve(includePath)
             defMap.missedFiles.add(filePath)

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -58,12 +58,13 @@ fun collectScope(
     context: ModCollectorContext,
     modMacroIndex: MacroIndex = modData.macroIndex,
     dollarCrateHelper: DollarCrateHelper? = null,
+    propagateLegacyMacros: Boolean = false,
 ): LegacyMacros {
     val hashCalculator = HashCalculator(modData.isEnabledByCfgInner)
         .takeIf { modData.isNormalCrate }
 
     val collector = ModCollector(modData, context, modMacroIndex, hashCalculator, dollarCrateHelper)
-    collector.collectMod(scope.getOrBuildStub() ?: return emptyMap())
+    collector.collectMod(scope.getOrBuildStub() ?: return emptyMap(), propagateLegacyMacros)
 
     if (hashCalculator != null && scope is RsFile) {
         val fileHash = hashCalculator.getFileHash()

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
@@ -218,6 +218,16 @@ class RsIncludeMacroResolveTest : RsResolveTestBase() {
         gen_use!();
     """)
 
+    fun `test macro def in included file`() = checkResolve("""
+    //- main.rs
+        include!("foo.rs");
+        mod other {
+            foo!();
+        } //^ foo.rs
+    //- foo.rs
+        macro_rules! foo { () => {} }
+    """)
+
     fun `test concat in include 1`() = checkResolve("""
         //- main.rs
             include!(concat!("foo.rs"));


### PR DESCRIPTION
Fixes #8559

changelog: Fix resolve of macros declared in `include!`-ed files in some cases
