### PR TITLE
REF: Fix rename of item used in struct literal field shorthand

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/RsRenameProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsRenameProcessor.kt
@@ -83,15 +83,15 @@ class RsRenameProcessor : RenamePsiElementProcessor() {
         listener: RefactoringElementListener?
     ) {
         val psiFactory = RsPsiFactory(element.project)
-        if (element is RsPatBinding) {
-            usages.forEach {
-                val field = it.element?.ancestorOrSelf<RsStructLiteralField>(RsBlock::class.java) ?: return@forEach
+        if (element !is RsNamedFieldDecl) {
+            for (usage in usages) {
+                val field = usage.element?.ancestorOrSelf<RsStructLiteralField>(RsBlock::class.java) ?: continue
                 when {
                     field.isShorthand -> {
-                        val newPatField = psiFactory.createStructLiteralField(element.text, newName)
+                        val newPatField = psiFactory.createStructLiteralField(field.referenceName, newName)
                         field.replace(newPatField)
                     }
-                    field.referenceName == newName && field.expr is RsPathExpr -> {
+                    field.referenceName == newName && (field.expr as? RsPathExpr)?.path == usage.element -> {
                         field.expr?.delete()
                         field.colon?.delete()
                     }

--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -614,6 +614,34 @@ class RenameTest : RsTestBase() {
         fn foo(value: u32) -> u32 { unimplemented!() }
     """)
 
+    fun `test can't use initialization shorthand after rename 3`() = doTest("value2", """
+        struct Foo { value: u32 }
+        fn bar() -> Foo {
+            const /*caret*/value: i32 = 1;
+            Foo { value }
+        }
+    """, """
+        struct Foo { value: u32 }
+        fn bar() -> Foo {
+            const value2: i32 = 1;
+            Foo { value: value2 }
+        }
+    """)
+
+    fun `test can't use initialization shorthand after rename 4`() = doTest("value2", """
+        struct Foo<T> { value: T }
+        fn bar() -> Foo {
+            fn /*caret*/value() {}
+            Foo { value }
+        }
+    """, """
+        struct Foo<T> { value: T }
+        fn bar() -> Foo {
+            fn value2() {}
+            Foo { value: value2 }
+        }
+    """)
+
     fun `test rename variable with variable conflict`() = doTestWithConflicts("a", """
         fn test() {
             let a = 1;


### PR DESCRIPTION
Fixes #9115

changelog: Fix rename of constant used in struct literal field shorthand