### PR TITLE
Allow to exclude specific paths from auto-import

### DIFF
--- a/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt
@@ -8,12 +8,17 @@ package org.rust.ide.settings
 import com.intellij.application.options.editor.AutoImportOptionsProvider
 import com.intellij.openapi.application.ApplicationBundle
 import com.intellij.openapi.options.UiDslUnnamedConfigurable
+import com.intellij.openapi.project.Project
+import com.intellij.ui.dsl.builder.LabelPosition
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.RightGap
 import com.intellij.ui.dsl.builder.bindSelected
 import org.rust.RsBundle
+import org.rust.openapiext.fullWidthCell
 
-class RsAutoImportOptions : UiDslUnnamedConfigurable.Simple(), AutoImportOptionsProvider {
+class RsAutoImportOptions(project: Project) : UiDslUnnamedConfigurable.Simple(), AutoImportOptionsProvider {
+
+    private val excludeTable: RsPathsExcludeTable = RsPathsExcludeTable(project)
 
     override fun Panel.createContent() {
         val settings = RsCodeInsightSettings.getInstance()
@@ -35,6 +40,14 @@ class RsAutoImportOptions : UiDslUnnamedConfigurable.Simple(), AutoImportOptions
                     .bindSelected(settings::addUnambiguousImportsOnTheFly)
                     .gap(RightGap.SMALL)
                 contextHelp(ApplicationBundle.message("help.add.unambiguous.imports"))
+            }
+            row {
+                fullWidthCell(excludeTable.component)
+                    .label(RsBundle.message("settings.rust.auto.import.exclude.label"), LabelPosition.TOP)
+                    .comment(RsBundle.message("settings.rust.auto.import.exclude.comment"), maxLineLength = 100)
+                    .onApply { excludeTable.apply() }
+                    .onReset { excludeTable.reset() }
+                    .onIsModified { excludeTable.isModified() }
             }
         }
     }

--- a/src/main/kotlin/org/rust/ide/settings/RsCodeInsightSettings.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsCodeInsightSettings.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.settings
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
@@ -12,13 +13,20 @@ import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 
 @State(name = "RsCodeInsightSettings", storages = [Storage("rust.xml")])
-class RsCodeInsightSettings : PersistentStateComponent<RsCodeInsightSettings> {
+class RsCodeInsightSettings : PersistentStateComponent<RsCodeInsightSettings>, Disposable {
 
     var showImportPopup: Boolean = false
     var importOutOfScopeItems: Boolean = true
     var suggestOutOfScopeItems: Boolean = true
     var addUnambiguousImportsOnTheFly: Boolean = false
     var importOnPaste: Boolean = false
+    private var excludedPaths: Array<ExcludedPath>? = null
+
+    fun getExcludedPaths(): Array<ExcludedPath> = excludedPaths ?: DEFAULT_EXCLUDED_PATHS
+
+    fun setExcludedPaths(value: Array<ExcludedPath>) {
+        excludedPaths = if (DEFAULT_EXCLUDED_PATHS.contentEquals(value)) null else value
+    }
 
     override fun getState(): RsCodeInsightSettings = this
 
@@ -26,7 +34,32 @@ class RsCodeInsightSettings : PersistentStateComponent<RsCodeInsightSettings> {
         XmlSerializerUtil.copyBean(state, this)
     }
 
+    override fun dispose() {}
+
     companion object {
         fun getInstance(): RsCodeInsightSettings = service()
+
+        private val DEFAULT_EXCLUDED_PATHS: Array<ExcludedPath> = arrayOf(
+            // These imports interfere with `RefCell::borrow` & `RefCell::borrow_mut` and methods from
+            // them are very rarely needed (mostly inside a `HashMap` implementations).
+            // See https://github.com/intellij-rust/intellij-rust/issues/5805
+            ExcludedPath("std::borrow::Borrow", ExclusionType.Methods),
+            ExcludedPath("std::borrow::BorrowMut", ExclusionType.Methods),
+            ExcludedPath("core::borrow::Borrow", ExclusionType.Methods),
+            ExcludedPath("core::borrow::BorrowMut", ExclusionType.Methods),
+            ExcludedPath("alloc::borrow::Borrow", ExclusionType.Methods),
+            ExcludedPath("alloc::borrow::BorrowMut", ExclusionType.Methods),
+            // Functions from this module are often suggested instead of `panic!()` macro, also
+            // it is always unstable (with a stable alternative - `panic!()` macro).
+            // See https://github.com/intellij-rust/intellij-rust/issues/9157
+            ExcludedPath("core::panicking::*"),
+            // This method is often suggested in completion instead of `unreachable!()` macro, also
+            // it is always unstable (with a stable alternative - `core::hint::unreachable_unchecked`)
+            ExcludedPath("std::intrinsics::unreachable"),
+        )
     }
 }
+
+// must have default constructor and mutable fields for deserialization
+class ExcludedPath(var path: String = "", var type: ExclusionType = ExclusionType.ItemsAndMethods)
+enum class ExclusionType { ItemsAndMethods, Methods }

--- a/src/main/kotlin/org/rust/ide/settings/RsPathsExcludeTable.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsPathsExcludeTable.kt
@@ -1,0 +1,157 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.settings
+
+import com.intellij.execution.util.ListTableWithButtons
+import com.intellij.icons.AllIcons
+import com.intellij.ide.ui.laf.darcula.DarculaUIUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBoxTableRenderer
+import com.intellij.openapi.ui.ComponentValidator
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.openapi.ui.cellvalidators.ValidatingTableCellRendererWrapper
+import com.intellij.openapi.ui.cellvalidators.ValidationUtils
+import com.intellij.ui.components.fields.ExtendableTextField
+import com.intellij.ui.scale.JBUIScale
+import com.intellij.util.containers.map2Array
+import com.intellij.util.ui.ColumnInfo
+import com.intellij.util.ui.ListTableModel
+import org.rust.ide.settings.RsPathsExcludeTable.ExclusionScope
+import org.rust.ide.settings.RsPathsExcludeTable.Item
+import java.util.function.Supplier
+import javax.swing.DefaultCellEditor
+import javax.swing.JComponent
+import javax.swing.JTextField
+import javax.swing.table.DefaultTableCellRenderer
+import javax.swing.table.TableCellEditor
+import javax.swing.table.TableCellRenderer
+
+class RsPathsExcludeTable(project: Project) : ListTableWithButtons<Item>() {
+
+    private val globalSettings: RsCodeInsightSettings = RsCodeInsightSettings.getInstance()
+    private val projectSettings: RsProjectCodeInsightSettings = RsProjectCodeInsightSettings.getInstance(project)
+
+    private fun getSettingsItems(): List<Item> =
+        globalSettings.getExcludedPaths().map { Item(it.path, it.type, ExclusionScope.IDE) } +
+            projectSettings.state.excludedPaths.map { Item(it.path, it.type, ExclusionScope.Project) }
+
+    private fun getCurrentItems(): List<Item> =
+        tableView.listTableModel.items
+
+    private fun getCurrentItems(scope: ExclusionScope): Array<ExcludedPath> =
+        getCurrentItems().filter { it.scope == scope }.map2Array { ExcludedPath(it.path, it.type) }
+
+    fun isModified(): Boolean = getSettingsItems() != getCurrentItems()
+
+    fun apply() {
+        globalSettings.setExcludedPaths(getCurrentItems(ExclusionScope.IDE))
+        projectSettings.state.excludedPaths = getCurrentItems(ExclusionScope.Project)
+    }
+
+    fun reset() {
+        setValues(getSettingsItems())
+    }
+
+    override fun createListModel(): ListTableModel<*> = ListTableModel<Item>(PATH_COLUMN, TYPE_COLUMN, SCOPE_COLUMN)
+
+    override fun createElement(): Item = Item("", ExclusionType.ItemsAndMethods, ExclusionScope.IDE)
+
+    override fun isEmpty(item: Item): Boolean = item.path.isEmpty()
+
+    override fun canDeleteElement(item: Item): Boolean = true
+
+    override fun cloneElement(item: Item): Item = item.copy()
+
+    data class Item(var path: String, var type: ExclusionType, var scope: ExclusionScope)
+    enum class ExclusionScope { Project, IDE }
+}
+
+@Suppress("DialogTitleCapitalization")
+private val PATH_COLUMN: ColumnInfo<Item, String> = object : ColumnInfo<Item, String>("Item or module") {
+    override fun valueOf(item: Item): String = item.path
+
+    override fun isCellEditable(item: Item): Boolean = true
+
+    override fun setValue(item: Item, value: String) {
+        item.path = value
+    }
+
+    override fun getEditor(item: Item): TableCellEditor {
+        val cellEditor = ExtendableTextField()
+        cellEditor.putClientProperty(DarculaUIUtil.COMPACT_PROPERTY, true)
+        ComponentValidator(RsCodeInsightSettings.getInstance()).withValidator(Supplier {
+            val error = getValidationInfo(cellEditor.text, cellEditor)
+            ValidationUtils.setExtension(cellEditor, ValidationUtils.ERROR_EXTENSION, error != null)
+            error
+        }).andRegisterOnDocumentListener(cellEditor).installOn(cellEditor)
+        return DefaultCellEditor(cellEditor)
+    }
+
+    override fun getRenderer(item: Item?): TableCellRenderer {
+        val cellEditor = JTextField()
+        cellEditor.putClientProperty(DarculaUIUtil.COMPACT_PROPERTY, true)
+        @Suppress("UnstableApiUsage")
+        return ValidatingTableCellRendererWrapper(DefaultTableCellRenderer())
+            .withCellValidator { value, _, _ -> getValidationInfo(value?.toString(), null) }
+            .bindToEditorSize(cellEditor::getPreferredSize)
+    }
+
+    private fun getValidationInfo(path: String?, component: JComponent?): ValidationInfo? {
+        if (path.isNullOrEmpty() || path.matches(PATH_PATTERN)) return null
+        val errorText = "Illegal path: $path"
+        return ValidationInfo(errorText, component)
+    }
+}
+
+private val PATH_PATTERN: Regex = Regex("(\\w+::)*\\w+(::\\*)?")
+
+private val TYPE_COLUMN: ColumnInfo<Item, ExclusionType> = object : ComboboxColumnInfo<ExclusionType>(ExclusionType.values(), "Apply to") {
+
+    override fun ExclusionType.displayText(): String = when (this) {
+        ExclusionType.ItemsAndMethods -> "Everything"
+        ExclusionType.Methods -> "Methods only"
+    }
+
+    override fun valueOf(item: Item): ExclusionType = item.type
+
+    override fun setValue(item: Item, value: ExclusionType) {
+        item.type = value
+    }
+}
+
+private val SCOPE_COLUMN: ColumnInfo<Item, ExclusionScope> = object : ComboboxColumnInfo<ExclusionScope>(ExclusionScope.values(), "Scope") {
+
+    override fun valueOf(item: Item): ExclusionScope = item.scope
+
+    override fun setValue(item: Item, value: ExclusionScope) {
+        item.scope = value
+    }
+}
+
+private abstract class ComboboxColumnInfo<T : Any>(
+    private val values: Array<T>,
+    name: String,
+) : ColumnInfo<Item, T>(name) {
+
+    open fun T.displayText(): String = toString()
+
+    override fun isCellEditable(item: Item): Boolean = true
+
+    override fun getRenderer(pair: Item?): TableCellRenderer = renderer
+
+    override fun getEditor(pair: Item?): TableCellEditor = renderer
+
+    private val renderer: ComboBoxTableRenderer<T> =
+        object : ComboBoxTableRenderer<T>(values) {
+            override fun getTextFor(value: T): String = value.displayText()
+        }
+
+    override fun getMaxStringValue(): String =
+        values.map { it.displayText() }.maxByOrNull { it.length }!!
+
+    override fun getAdditionalWidth(): Int =
+        JBUIScale.scale(12) + AllIcons.General.ArrowDown.iconWidth
+}

--- a/src/main/kotlin/org/rust/ide/settings/RsProjectCodeInsightSettings.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsProjectCodeInsightSettings.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.settings
+
+import com.intellij.openapi.components.*
+import com.intellij.openapi.project.Project
+
+@State(name = "RsProjectCodeInsightSettings", storages = [Storage("rust.xml")])
+class RsProjectCodeInsightSettings : SimplePersistentStateComponent<RsProjectCodeInsightSettings.State>(State()) {
+
+    class State : BaseState() {
+        var excludedPaths: Array<ExcludedPath> by property(arrayOf(), Array<ExcludedPath>::isEmpty)
+    }
+
+    companion object {
+        fun getInstance(project: Project): RsProjectCodeInsightSettings = project.service()
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -47,6 +47,7 @@
         <!-- Code insight settings -->
 
         <applicationService serviceImplementation="org.rust.ide.settings.RsCodeInsightSettings"/>
+        <projectService serviceImplementation="org.rust.ide.settings.RsProjectCodeInsightSettings"/>
         <editorActionHandler action="EditorEnter" implementationClass="org.rust.ide.actions.RsEnterHandler"/>
 
         <applicationService serviceImplementation="org.rust.cargo.runconfig.RsRunConfigurationExtensionManager"/>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -110,6 +110,8 @@ run.target.rustc.executable.version.label=Rustc version:
 settings.rust.auto.import.on.completion=Import out-of-scope items on completion
 settings.rust.auto.import.show.popup=Show import popup
 settings.rust.auto.import.on.paste=Insert imports on paste
+settings.rust.auto.import.exclude.label=Exclude from auto-import and completion:
+settings.rust.auto.import.exclude.comment=Specify each path just as you would in a <code>use</code> declaration. Add <code>::*</code> to a path if you want to disable auto-import for all items whose paths include the given prefix. When excluding traits, specify whether you want to disable auto-import only for trait methods or for the trait name too. Note that a <code>use</code> declaration overwrites these settings.
 settings.rust.auto.import.title=Rust
 
 settings.rust.cargo.auto.update.project.label=Update project automatically when Cargo.toml changes

--- a/src/test/kotlin/org/rust/WithExcludedPaths.kt
+++ b/src/test/kotlin/org/rust/WithExcludedPaths.kt
@@ -1,0 +1,10 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class WithExcludedPath(val path: String, val onlyMethods: Boolean = false)

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -786,4 +786,23 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
             Vec::new();
         }
     """)
+
+    fun `test don't import method of Borrow trait`() = checkAutoImportFixIsUnavailable("""
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        fn main() {
+            let rc = Rc::new(RefCell::new(0));
+            let option = Some(rc);
+            option.<error>borrow/*caret*/</error>()
+        }
+    """)
+
+    fun `test import Borrow trait`() = checkAutoImportFixByTextWithoutHighlighting("""
+        fn func(_: impl /*caret*/Borrow<i32>) {}
+    """, """
+        use std::borrow::Borrow;
+
+        fn func(_: impl Borrow<i32>) {}
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
@@ -113,5 +113,10 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
             use std::os::windows/*caret*/
         """)
     }
-}
 
+    fun `test don't complete borrow method`() = checkNotContainsCompletion("borrow", """
+        fn main() {
+            0.borro/*caret*/
+        }
+    """)
+}


### PR DESCRIPTION
Fixes #5805
Fixes #8044
Fixes #8971
Fixes #9099
Fixes #9157

Added option to exclude specific paths from auto-import and completion. By default `std::borrow::Borrow`, `core::panicking` and `std::intrinsics::unreachable` are excluded

There are two types of exclusions:
* `Only methods` - used for `std::borrow::Borrow`, it will exclude methods of the trait from auto-import, but the trait itself can be imported
* `Always` - will exclude both methods (if item is trait) and item itself

![image](https://user-images.githubusercontent.com/6505554/196016392-a39023ec-d57f-4254-9747-341cd9316e8c.png)

changelog: Allow to exclude specific paths from auto-import
