### PR TITLE
RES: Fix nested `include!`-ed files in different directory

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
@@ -136,6 +136,17 @@ class RsIncludeMacroResolveTest : RsResolveTestBase() {
                 //^ lib.rs
     """)
 
+    fun `test include file in included file 3`() = checkResolve("""
+    //- lib.rs
+        include!("inner/foo.rs");
+        fn foo(x: Foo) {}
+                //^ inner/bar.rs
+    //- inner/foo.rs
+        include!("bar.rs");
+    //- inner/bar.rs
+        struct Foo;
+    """)
+
     @ExpandMacros
     fun `test include macro in macro 1`() = checkResolve("""
     //- lib.rs


### PR DESCRIPTION
Fixes #8614

Related: #7156 (but that is for mod declaration in `include!`-ed file )

changelog: Fix resolve of items from nested `include!`-ed files in some cases
