### PR TITLE
INSP: add inspection understanding of #[derivative(...)]

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -386,6 +386,10 @@ class QueryAttributes<out T: RsMetaItemPsiOrStub>(
     val deriveAttributes: Sequence<T>
         get() = attrsByName("derive")
 
+    // #[derivative(Clone)], #[derive(Copy(bound = ""), Clone(bound = ""))]
+    val derivativeAttributes: Sequence<T>
+        get() = attrsByName("derivative")
+
     // #[repr(u16)], #[repr(C, packed)], #[repr(simd)], #[repr(align(8))]
     val reprAttributes: Sequence<T>
         get() = attrsByName("repr")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
@@ -13,8 +13,14 @@ import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsMetaItemArgs
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.resolve.KNOWN_DERIVABLE_TRAITS
+import org.rust.lang.core.resolve.KnownItems
 import org.rust.lang.core.stubs.RsMetaItemStub
 import org.rust.lang.core.stubs.common.RsMetaItemPsiOrStub
+
+data class RsDerivativeTraitItem(
+    val trait: RsTraitItem,
+    val args: RsMetaItemArgs?
+)
 
 /**
  * Returns identifier name if path inside meta item consists only of this identifier.
@@ -37,6 +43,9 @@ val RsMetaItem.id: String?
 /** Works only for [KNOWN_DERIVABLE_TRAITS] */
 fun RsMetaItem.resolveToDerivedTrait(): RsTraitItem? =
     path?.reference?.multiResolve()?.filterIsInstance<RsTraitItem>()?.singleOrNull()
+
+fun RsMetaItem.resolveToDerivativeTrait(knownItems: KnownItems): RsDerivativeTraitItem? =
+    path?.identifier?.let { KNOWN_DERIVABLE_TRAITS[id]?.findTrait(knownItems) }?.let { RsDerivativeTraitItem(it, metaItemArgs) }
 
 val RsMetaItem.owner: RsDocAndAttributeOwner?
     get() = ancestorStrict<RsAttr>()?.owner

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1065,7 +1065,7 @@ class RsInferenceContext(
     fun canEvaluateBounds(source: TraitImplSource, selfTy: Ty): Boolean {
         return when (source) {
             is TraitImplSource.ExplicitImpl -> canEvaluateBounds(source.value, selfTy)
-            is TraitImplSource.Derived, is TraitImplSource.Builtin -> {
+            is TraitImplSource.Derived, is TraitImplSource.DerivedDerivative, is TraitImplSource.Builtin -> {
                 if (source.value.typeParameters.isNotEmpty()) return true
                 lookup.canSelect(TraitRef(selfTy, BoundElement(source.value as RsTraitItem)))
             }
@@ -1124,7 +1124,7 @@ class RsInferenceContext(
             bound?.trait?.subst?.substituteInValues(subst) ?: emptySubstitution
         }
 
-        is TraitImplSource.Derived -> emptySubstitution
+        is TraitImplSource.Derived, is TraitImplSource.DerivedDerivative -> emptySubstitution
 
         is TraitImplSource.Object -> when (selfTy) {
             is TyAnon -> selfTy.getTraitBoundsTransitively()

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerDerivativeTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerDerivativeTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.borrowck
+
+import org.rust.ExpandMacros
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.RsBorrowCheckerInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.lang.core.macros.MacroExpansionScope
+
+class RsBorrowCheckerDerivativeTest : RsInspectionsTestBase(RsBorrowCheckerInspection::class) {
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no move error on derivative copy`() = checkByText("""
+        use derivative::Derivative;
+
+        #[derive(Derivative)]
+        #[derivative(Clone, Copy)]
+        struct S(i32);
+
+        fn mov(s: &S) -> S {
+            *s
+        }
+    """, checkWarn = false)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test move error on derivative copy with non-movable generic`() = checkByText("""
+        use derivative::Derivative;
+
+        struct Foo;
+
+        #[derive(Derivative)]
+        #[derivative(Clone, Copy)]
+        struct S<T>(T);
+
+        fn mov(s: &S<Foo>) -> S {
+            <error descr="Cannot move">*s</error>
+        }
+    """, checkWarn = false)
+
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no move error on derivative copy when bound is explicitly specified as empty`() = checkByText("""
+        use derivative::Derivative;
+
+        struct Foo;
+
+        #[derive(Derivative)]
+        #[derivative(Clone(bound = ""), Copy(bound = ""))]
+        struct S<T>(PhantomData<T>);
+
+        fn mov(s: &S<Foo>) -> S {
+            *s
+        }
+    """, checkWarn = false)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test move error on derivative copy when bound is explicitly specified as typical and unfulfilled`() = checkByText("""
+        use derivative::Derivative;
+
+        struct Foo;
+
+        #[derive(Derivative)]
+        #[derivative(Clone(bound = "T: Clone"), Copy(bound = "T: Copy"))]
+        struct S<T>(PhantomData<T>);
+
+        fn mov(s: &S<Foo>) -> S {
+            <error descr="Cannot move">*s</error>
+        }
+    """, checkWarn = false)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test move error on derivative copy when bound is explicitly specified as typical and unfulfilled (alt)`() = checkByText("""
+        use derivative::Derivative;
+
+        #[derive(Debug)]
+        struct Foo;
+
+        #[derive(Derivative)]
+        #[derivative(Clone(bound = "T: Clone"), Copy(bound = "T: Copy"))]
+        struct S<T>(PhantomData<T>);
+
+        fn mov(s: &S<Foo>) -> S {
+            <error descr="Cannot move">*s</error>
+        }
+    """, checkWarn = false)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no move error on derivative copy when bound is explicitly specified as typical and fulfilled`() = checkByText("""
+        use derivative::Derivative;
+
+        #[derive(Clone, Copy)]
+        struct Foo;
+
+        #[derive(Derivative)]
+        #[derivative(Clone(bound = "T: Clone"), Copy(bound = "T: Copy"))]
+        struct S<T>(PhantomData<T>);
+
+        fn mov(s: &S<Foo>) -> S {
+            *s
+        }
+    """, checkWarn = false)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test move error on derivative copy when bound is explicitly specified as atypical and unfulfilled`() = checkByText("""
+        use derivative::Derivative;
+
+        #[derive(Clone, Copy)]
+        struct Foo;
+
+        #[derive(Derivative)]
+        #[derivative(Clone(bound = "T: Debug"), Copy(bound = "T: Debug"))]
+        struct S<T>(PhantomData<T>);
+
+        fn mov(s: &S<Foo>) -> S {
+            <error descr="Cannot move">*s</error>
+        }
+    """, checkWarn = false)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no move error on derivative copy when bound is explicitly specified as atypical and fulfilled`() = checkByText("""
+        use derivative::Derivative;
+
+        #[derive(Debug)]
+        struct Foo;
+
+        #[derive(Derivative)]
+        #[derivative(Clone(bound = "T: Debug"), Copy(bound = "T: Debug"))]
+        struct S<T>(PhantomData<T>);
+
+        fn mov(s: &S<Foo>) -> S {
+            *s
+        }
+    """, checkWarn = false)
+}


### PR DESCRIPTION
[derivative](https://crates.io/crates/derivative) is a very popular crate which provides enhanced automatic derivations of builtins like `Clone, Copy, Debug, PartialEq, Eq`, etc. In particular it allows you to explicitly specify the bounds, which I use a lot in my projects because I have generic types with phantom parameters, where I don't want the parameter to affect with the bounds.

IntelliJ can now infer when a value implements traits from `#[derivative(...)]`, even if proc-macro support is turned off. For example, if the value implements `#[derivative(Clone, Copy)]`, IntelliJ will not report move errors, just like how if the value implements `#[derive(Clone, Copy)]`. Similarly IntelliJ knows when a type implements any of the other `derivative` types.

IntelliJ can also infer a limited set of custom bounds. specified like so: `#[derivative(Trait(bounds = "<my custom bounds>")]`. e.g. with

```rust
#[derive(Derivative)]
#[derivative(Clone(bounds = ""), Copy(bounds = "")]
struct S<T>(PhantomData<T>);
```

IntelliJ will not report move errors even if `T` does not implement `Clone` or `Copy`. With

```rust
#[derive(Derivative)]
#[derivative(Clone(bounds = "T: Debug"), Copy(bounds = "T: Debug")]
struct S<T>(PhantomData<T>);
```

IntelliJ will report move errors if `T` does not implement *Debug*. Only a limited syntax of custom bounds are supported, any bounds outside of this syntax are ignored.

I added test cases to verify that inspections with Clone and Copy work, and I tested it on a local project with RunIDEA.

## Possible Issues

Note that the analysis doesn't actually check for derive(Derivative) or if derivative::Derivative is even in scope, it simply checks for the #[derivative(...)] annotation.

Moreover, I'm not sure if proc macros conflict with this, since they may also infer derivative. I have tested with proc macros and there are no issues, although I believe this is because a) they aren't smart enough to infer `derivative` yet and b) currently IntelliJ simply ignores duplicate trait impls.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

changelog:

IntelliJ can now infer when a value implements traits from `#[derivative(...)]`, even if proc-macro support is turned off. For example, if the value implements `#[derivative(Clone, Copy)]`, IntelliJ will not report move errors, just like how if the value implements `#[derive(Clone, Copy)]`. Similarly IntelliJ knows when a type implements any of the other `derivative` types.

IntelliJ can also infer a limited set of custom bounds. specified like so: `#[derivative(Trait(bounds = "<my custom bounds>")]`. e.g. with

```rust
#[derive(Derivative)]
#[derivative(Clone(bounds = ""), Copy(bounds = "")]
struct S<T>(PhantomData<T>);
```

IntelliJ will not report move errors even if `T` does not implement `Clone` or `Copy`. With

```rust
#[derive(Derivative)]
#[derivative(Clone(bounds = "T: Debug"), Copy(bounds = "T: Debug")]
struct S<T>(PhantomData<T>);
```

IntelliJ will report move errors if `T` does not implement *Debug*. Only a limited syntax of custom bounds are supported, any bounds outside of this syntax are ignored.
