### PR TITLE
REF: increase robustness of handling self parameters in Change Signature refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
@@ -83,6 +83,18 @@ class Parameter(
     fun parseTypeReference(): RsTypeReference? = type.item
     fun parsePat(): RsPat? = factory.tryCreatePat(patText)
 
+    fun hasValidPattern(): Boolean {
+        if (parsePat() == null) {
+            return false
+        }
+
+        if (factory.tryCreateValueParameter(patText, parseTypeReference() ?: factory.createType("()")) == null) {
+            return false
+        }
+
+        return true
+    }
+
     val pat: RsPat
         get() = parsePat() ?: factory.createPat("_")
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
@@ -354,7 +354,7 @@ private class ChangeSignatureDialog(project: Project, descriptor: SignatureDescr
         }
 
         for ((index, parameter) in config.parameters.withIndex()) {
-            if (parameter.parsePat() == null) {
+            if (!parameter.hasValidPattern()) {
                 return "Parameter $index has invalid pattern"
             }
             if (parameter.type is ParameterProperty.Empty) {

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
@@ -171,7 +171,7 @@ private fun changeParameters(factory: RsPsiFactory, function: RsFunction, config
         parametersCopy.selfParameter,
         parametersCopy.valueParameterList,
         config
-    ) { factory.createValueParameter(it.patText, it.typeReference, reference = false) }
+    ) { factory.tryCreateValueParameter(it.patText, it.typeReference, reference = false) }
 }
 
 private fun changeParametersNameAndType(parameters: List<RsValueParameter>, descriptors: List<Parameter>) {

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -463,12 +463,22 @@ class RsPsiFactory(
         reference: Boolean = true,
         lifetime: RsLifetime? = null
     ): RsValueParameter {
+        return tryCreateValueParameter(name, type, mutable, reference, lifetime)
+            ?: error("Failed to create parameter element")
+    }
+
+    fun tryCreateValueParameter(
+        name: String,
+        type: RsTypeReference,
+        mutable: Boolean = false,
+        reference: Boolean = true,
+        lifetime: RsLifetime? = null
+    ): RsValueParameter? {
         val referenceText = if (reference) "&" else ""
         val lifetimeText = if (lifetime != null) "${lifetime.text} " else ""
         val mutText = if (mutable) "mut " else ""
         return createFromText<RsFunction>("fn main($name: $referenceText$lifetimeText$mutText${type.text}){}")
-            ?.valueParameterList?.valueParameterList?.get(0)
-            ?: error("Failed to create parameter element")
+            ?.valueParameterList?.valueParameterList?.getOrNull(0)
     }
 
     fun createPatFieldFull(name: String, value: String): RsPatFieldFull =

--- a/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
@@ -1261,6 +1261,22 @@ Cannot change signature of function with cfg-disabled parameters""")
         returnTypeDisplay = foo
     }
 
+    fun `test add self parameter to function`() = doTest("""
+        fn foo/*caret*/(a: u32) {}
+
+        fn bar() {
+            foo(1);
+        }
+    """, """
+        fn foo(a: u32, ) {}
+
+        fn bar() {
+            foo(1, );
+        }
+    """) {
+        parameters.add(parameter("self", createType("u32")))
+    }
+
     private fun RsChangeFunctionSignatureConfig.swapParameters(a: Int, b: Int) {
         val param = parameters[a]
         parameters[a] = parameters[b]


### PR DESCRIPTION
This PR adds additional checks to `Change signature` refactoring to:
1) Disallow using `self`, `&self` and other invalid patterns for parameter names
2) Make sure that if the parameter cannot be created, the refactoring silently fails rather than crashes and removes all parameters.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/9147

changelog: Fix handling of `self` parameters in `Change signature` refactoring.