### PR TITLE
RES: Fix cache invalidation after toggle "Expand macros" settings

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -566,6 +566,10 @@ private class MacroExpansionServiceImplInner(
         if (!isExpansionModeNew) {
             cleanMacrosDirectoryAndStorage()
         }
+        project.runWriteCommandAction {
+            project.defMapService.scheduleRebuildAllDefMaps()
+            project.rustPsiManager.incRustStructureModificationCount()
+        }
         processUnprocessedMacros()
     }
 


### PR DESCRIPTION
Currently when toggle ["Expand macros" option](https://github.com/intellij-rust/intellij-rust/pull/9127), we have two problems:
* `CrateDefMap`s don't rebuild
* `structureModificationTracker` doesn't increment if option was disabled but becomes enabled

---

This may lead to problems like (thanks @neonaot):
```rust
macro_rules! gen {
    () => { fn func() {} }
}
gen!();
fn main() {
    func();
}
```

* Disable "Expand macros" - `func` is unresolved (good)
* Enable "Expand macros" - `func` is still unresolved (bad)

changelog: Fix cache invalidation after toggle "Expand macros" settings
