### PR TITLE
COMP: Fix redundant macro completion in mod item name

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsMacroCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsMacroCompletionProvider.kt
@@ -19,6 +19,7 @@ import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.psi.RsElementTypes.COLONCOLON
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.core.psi.RsModItem
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.unescapedText
 import org.rust.lang.core.psiElement
@@ -45,6 +46,7 @@ object RsMacroCompletionProvider : RsCompletionProvider() {
         val position = parameters.position
         val rsElement = position.ancestorStrict<RsElement>() ?: return
         val mod = rsElement.ancestorOrSelf<RsMod>()
+        if (mod is RsModItem && mod.identifier == position) return
 
         val leftSiblings = position.leftSiblings
             .filter { it !is PsiWhiteSpace && it !is PsiComment && it !is PsiErrorElement }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -642,6 +642,11 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test macro don't suggests as mod name`() = checkNoCompletion("""
+        macro_rules! foo_bar { () => () }
+        mod foo/*caret*/ {}
+    """)
+
     fun `test complete macro2`() = doSingleCompletion("""
         macro foo() {}
         fn main() {


### PR DESCRIPTION
Fixes #7780

changelog: Fix redundant macro completion in mod item name