### PR TITLE
INT: Add an intention to import constants in match arms

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -46,7 +46,7 @@ class AutoImportFix(element: RsElement, private val context: Context) :
         invoke(project)
     }
 
-    private fun invoke(project: Project) {
+    fun invoke(project: Project) {
         val element = startElement as? RsElement ?: return
         val candidates = context.candidates
         if (candidates.size == 1) {
@@ -135,6 +135,13 @@ class AutoImportFix(element: RsElement, private val context: Context) :
             val importContext = ImportContext2.from(path, ImportContext2.Type.AUTO_IMPORT) ?: return null
             val candidates = ImportCandidatesCollector2.getImportCandidates(importContext, referenceName)
 
+            return Context(GENERAL_PATH, candidates)
+        }
+
+        fun findApplicableContext(pat: RsPatBinding): Context? {
+            val importContext = ImportContext2.from(pat, ImportContext2.Type.AUTO_IMPORT) ?: return null
+            val candidates = ImportCandidatesCollector2.getImportCandidates(importContext, pat.referenceName)
+            if (candidates.isEmpty()) return null
             return Context(GENERAL_PATH, candidates)
         }
 

--- a/src/main/kotlin/org/rust/ide/intentions/AddImportForPatternIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImportForPatternIntention.kt
@@ -1,0 +1,53 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.inspections.import.AutoImportFix
+import org.rust.ide.intentions.AddImportForPatternIntention.Context
+import org.rust.lang.core.psi.RsMatchArm
+import org.rust.lang.core.psi.RsPatBinding
+import org.rust.lang.core.psi.RsPatIdent
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.isAncestorOf
+
+class AddImportForPatternIntention : RsElementBaseIntentionAction<Context>() {
+
+    override fun getText(): String = "Import"
+    override fun getFamilyName(): String = "Add import for path in pattern"
+
+    override fun startInWriteAction(): Boolean = false
+
+    override fun getElementToMakeWritable(currentFile: PsiFile): PsiFile = currentFile
+
+    class Context(val pat: RsPatIdent, val context: AutoImportFix.Context)
+
+    // enum E { A, B }
+    // match e {
+    //     A => {}
+    //     B => {}
+    // }   ^ RsPatBinding
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val pat = element.ancestorOrSelf<RsPatBinding>() ?: return null
+        if (pat.bindingMode != null) return null
+        val patIdent = pat.parent as? RsPatIdent ?: return null
+        // TODO: Support other patterns (not in match arm)
+        val matchArm = patIdent.ancestorStrict<RsMatchArm>() ?: return null
+        if (!matchArm.pat.isAncestorOf(patIdent)) return null
+        if (pat.reference.multiResolve().isNotEmpty()) return null
+
+        val context = AutoImportFix.findApplicableContext(pat) ?: return null
+        return Context(patIdent, context)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        AutoImportFix(ctx.pat, ctx.context).invoke(project)
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -928,6 +928,10 @@
             <category>Rust</category>
         </intentionAction>
         <intentionAction>
+            <className>org.rust.ide.intentions.AddImportForPatternIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
             <className>org.rust.ide.intentions.SubstituteTypeAliasIntention</className>
             <category>Rust</category>
         </intentionAction>

--- a/src/main/resources/intentionDescriptions/AddImportForPatternIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/AddImportForPatternIntention/after.rs.template
@@ -1,0 +1,12 @@
+<spot>use crate::inner::C;</spot>
+
+mod inner {
+    pub const C: i32 = 0;
+}
+
+fn main() {
+    match 0 {
+        C => {}
+        _ => {}
+    }
+}

--- a/src/main/resources/intentionDescriptions/AddImportForPatternIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/AddImportForPatternIntention/before.rs.template
@@ -1,0 +1,10 @@
+mod inner {
+    pub const C: i32 = 0;
+}
+
+fn main() {
+    match 0 {
+        <spot>C</spot> => {}
+        _ => {}
+    }
+}

--- a/src/main/resources/intentionDescriptions/AddImportForPatternIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddImportForPatternIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Adds import for a path used as a pattern.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/AddImportForPatternIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImportForPatternIntentionTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.intellij.lang.annotations.Language
+import org.rust.ide.inspections.import.checkAutoImportWithMultipleChoice
+
+class AddImportForPatternIntentionTest : RsIntentionTestBase(AddImportForPatternIntention::class) {
+
+    fun `test constant`() = doAvailableTest("""
+        mod inner {
+            pub const C: i32 = 0;
+        }
+
+        fn main() {
+            match 0 {
+                /*caret*/C => {}
+                _ => {}
+            }
+        }
+    """, """
+        use crate::inner::C;
+
+        mod inner {
+            pub const C: i32 = 0;
+        }
+
+        fn main() {
+            match 0 {
+                C => {}
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test enum variant`() = doAvailableTest("""
+        enum E { A, B }
+        fn func(e: E) {
+            match e {
+                /*caret*/A => {}
+                B => {}
+            }
+        }
+    """, """
+        use crate::E::A;
+
+        enum E { A, B }
+        fn func(e: E) {
+            match e {
+                A => {}
+                B => {}
+            }
+        }
+    """)
+
+    fun `test complex pattern`() = doAvailableTest("""
+        mod inner {
+            pub const C: i32 = 0;
+        }
+
+        fn main() {
+            match (0, 0) {
+                (/*caret*/C, _) => {}
+            }
+        }
+    """, """
+        use crate::inner::C;
+
+        mod inner {
+            pub const C: i32 = 0;
+        }
+
+        fn main() {
+            match (0, 0) {
+                (C, _) => {}
+            }
+        }
+    """)
+
+    // Ideally we should filter variants by expected type
+    fun `test enum variant and constant`() = checkAutoImportVariantsByText("""
+        mod inner {
+            pub const C: i32 = 0;
+        }
+        enum E { C }
+        fn func(e: E) {
+            match e {
+                /*caret*/C => {}
+                _ => {}
+            }
+        }
+    """, listOf("crate::E::C", "crate::inner::C"))
+
+    fun `test unavailable for ref pattern`() = doUnavailableTest("""
+        mod inner {
+            pub const C: i32 = 0;
+        }
+
+        fn main() {
+            match 0 {
+                ref /*caret*/C => {}
+                _ => {}
+            }
+        }
+    """)
+
+    // Potentially intention can work in this case
+    fun `test unavailable for field binding`() = doUnavailableTest("""
+        mod inner {
+            pub const C: i32 = 0;
+        }
+
+        struct Foo { C: i32 }
+        fn func(foo: Foo) {
+            match foo {
+                Foo { /*caret*/C } => {}
+            }
+        }
+    """)
+
+    fun `test unavailable for let declaration`() = doUnavailableTest("""
+        mod inner {
+            pub const C: i32 = 0;
+        }
+
+        fn func(foo: Foo) {
+            let /*caret*/C = 1;
+        }
+    """)
+
+    fun `test unavailable for resolved path`() = doUnavailableTest("""
+        mod inner {
+            pub const C: i32 = 0;
+        }
+
+        pub const C: i32 = 0;
+        fn main() {
+            match 0 {
+                /*caret*/C => {}
+                _ => {}
+            }
+        }
+    """)
+
+    private fun checkAutoImportVariantsByText(
+        @Language("Rust") before: String,
+        expectedElements: List<String>
+    ) = checkAutoImportWithMultipleChoice(expectedElements, choice = null) {
+        InlineFile(before.trimIndent()).withCaret()
+        launchAction()
+        myFixture.checkResult(replaceCaretMarker(before.trimIndent()))
+    }
+}


### PR DESCRIPTION
Fixes #7815

Consider match arm:
```rust
match ... {
    Foo => {}
    _ => {}
}
```

Here `Foo` can be constant or enum variant if any is in scope, otherwise it will be name of variable (irrefutable pattern). Therefore we don't show unresolved reference error for `Foo`, though user actually may want `Foo` to be constant but doesn't import it yet. This PR adds `Import` intention for such cases.

<img src="https://user-images.githubusercontent.com/6505554/182730170-776b9c38-c4c3-4b00-8347-e6b4b98294b1.gif" width="50%">

changelog: Add an intention to import constants in match arms
