### PR TITLE
TOML: suppress completion in Cargo.toml based on JSON scheme

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixture.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixture.kt
@@ -6,12 +6,12 @@
 package org.rust.lang.core.completion
 
 import com.intellij.codeInsight.lookup.LookupElement
-import com.intellij.openapi.vfs.VirtualFileFilter
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.impl.PsiManagerEx
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import org.rust.*
 
-class RsCompletionTestFixture(
+open class RsCompletionTestFixture(
     fixture: CodeInsightTestFixture,
     private val defaultFileName: String = "main.rs"
 ) : RsCompletionTestFixtureBase<String>(fixture) {
@@ -51,7 +51,7 @@ class RsCompletionTestFixture(
         doContainsCompletion(variants.toSet(), render)
     }
 
-    private fun checkAstNotLoaded(fileFilter: VirtualFileFilter) {
+    protected open fun checkAstNotLoaded(fileFilter: (VirtualFile) -> Boolean) {
         PsiManagerEx.getInstanceEx(project).setAssertOnFileLoadingFilter(fileFilter, testRootDisposable)
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/jsonSchema/CargoTomlJsonSchemaProviderFactory.kt
+++ b/toml/src/main/kotlin/org/rust/toml/jsonSchema/CargoTomlJsonSchemaProviderFactory.kt
@@ -22,15 +22,16 @@ class CargoTomlJsonSchemaProviderFactory : JsonSchemaProviderFactory, DumbAware 
 // It's a temporarily hack not to use remote scheme for Cargo.toml from https://json.schemastore.org/cargo.json
 // by providing own empty embedded scheme (embedded schemes have more priority than remote ones)
 // because it suggests unexpected completion variants like `{}`
-private class CargoTomlJsonSchemaFileProvider : JsonSchemaFileProvider {
+class CargoTomlJsonSchemaFileProvider : JsonSchemaFileProvider {
     override fun isAvailable(file: VirtualFile): Boolean = file.name == "Cargo.toml"
     override fun getName(): String = "Cargo.toml schema"
     override fun getSchemaType(): SchemaType = SchemaType.embeddedSchema
     override fun isUserVisible(): Boolean = false
     override fun getSchemaFile(): VirtualFile? {
-        return JsonSchemaProviderFactory.getResourceFile(
-            CargoTomlJsonSchemaFileProvider::class.java,
-            "/jsonSchema/cargo.toml-schema.json"
-        )
+        return JsonSchemaProviderFactory.getResourceFile(CargoTomlJsonSchemaFileProvider::class.java, SCHEMA_PATH)
+    }
+
+    companion object {
+        const val SCHEMA_PATH: String = "/jsonSchema/cargo.toml-schema.json"
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/jsonSchema/CargoTomlJsonSchemaProviderFactory.kt
+++ b/toml/src/main/kotlin/org/rust/toml/jsonSchema/CargoTomlJsonSchemaProviderFactory.kt
@@ -1,0 +1,36 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.jsonSchema
+
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.jsonSchema.extension.JsonSchemaFileProvider
+import com.jetbrains.jsonSchema.extension.JsonSchemaProviderFactory
+import com.jetbrains.jsonSchema.extension.SchemaType
+
+class CargoTomlJsonSchemaProviderFactory : JsonSchemaProviderFactory, DumbAware {
+    override fun getProviders(project: Project): List<JsonSchemaFileProvider> {
+        return listOf(CargoTomlJsonSchemaFileProvider())
+    }
+}
+
+// Provides empty json schema for Cargo.toml files
+// It's a temporarily hack not to use remote scheme for Cargo.toml from https://json.schemastore.org/cargo.json
+// by providing own empty embedded scheme (embedded schemes have more priority than remote ones)
+// because it suggests unexpected completion variants like `{}`
+private class CargoTomlJsonSchemaFileProvider : JsonSchemaFileProvider {
+    override fun isAvailable(file: VirtualFile): Boolean = file.name == "Cargo.toml"
+    override fun getName(): String = "Cargo.toml schema"
+    override fun getSchemaType(): SchemaType = SchemaType.embeddedSchema
+    override fun isUserVisible(): Boolean = false
+    override fun getSchemaFile(): VirtualFile? {
+        return JsonSchemaProviderFactory.getResourceFile(
+            CargoTomlJsonSchemaFileProvider::class.java,
+            "/jsonSchema/cargo.toml-schema.json"
+        )
+    }
+}

--- a/toml/src/main/resources/org.rust.toml.xml
+++ b/toml/src/main/resources/org.rust.toml.xml
@@ -78,6 +78,10 @@
         <vfs.asyncListener implementation="org.rust.toml.crates.local.CratesLocalIndexVfsListener"/>
     </extensions>
 
+    <extensions defaultExtensionNs="JavaScript">
+        <JsonSchema.ProviderFactory implementation="org.rust.toml.jsonSchema.CargoTomlJsonSchemaProviderFactory"/>
+    </extensions>
+
     <projectListeners>
         <listener class="org.rust.toml.crates.local.CratesLocalIndexWaker"
                   topic="org.rust.cargo.project.model.CargoProjectsService$CargoProjectsListener" />


### PR DESCRIPTION
TOML plugin has a feature to provide completion/documentation based on the corresponding JSON scheme. Previously, it didn't affect any completion because there weren't such schemes. But now there is https://json.schemastore.org/cargo.json and the feature started to affect us. As a result, some unexpected completion variants appear in the suggestion list

These changes provide our own scheme for Cargo.toml to use it instead of remote https://json.schemastore.org/cargo.json. It's empty for now that leads to no completion variants based on JSON scheme completion (including unexpected ones). It's supposed to be replaced with an actual scheme when completion is fixed

Fixes #9116

changelog: Don't suggest unexpected/duplicate completion variants in Cargo.toml
