### PR TITLE
Fix auto-import grouping with existing unnamed import

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -181,7 +181,7 @@ private val RsUseItem.importingNames: Set<String>?
         val path = pathAsList ?: return null
         val groupedNames = useSpeck?.useGroup?.useSpeckList?.asSequence()?.map { it.text }?.toSet()
         val lastName = path.lastOrNull()
-        val alias = useSpeck?.alias?.identifier?.text
+        val alias = useSpeck?.alias?.nameIdentifier?.text
         return when {
             groupedNames != null -> groupedNames
             lastName != null && alias != null -> setOf("$lastName as $alias")

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -2968,6 +2968,30 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    fun `test correctly transform unnamed import to use group`() = checkAutoImportFixByTextWithoutHighlighting("""
+        use crate::inner::Trait as _;
+
+        mod inner {
+            pub trait Trait {}
+            pub fn func() {}
+        }
+
+        fn main() {
+            /*caret*/func();
+        }
+    """, """
+        use crate::inner::{func, Trait as _};
+
+        mod inner {
+            pub trait Trait {}
+            pub fn func() {}
+        }
+
+        fn main() {
+            func();
+        }
+    """)
+
     fun `test import inside included file`() = checkAutoImportFixByFileTree("""
         //- foo.rs
         fn func() {


### PR DESCRIPTION
Fixes #6850

changelog: Fix that auto-import may corrupt existing unnamed import