### PR TITLE
Fix `attribute-info` compilation

### DIFF
--- a/.idea/runConfigurations/Generate_compiler_features.xml
+++ b/.idea/runConfigurations/Generate_compiler_features.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Generate compiler features" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="run --package attributes-info --bin attributes-info" />
+    <option name="command" value="run --manifest-path attributes-info/Cargo.toml --package attributes-info --bin attributes-info" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <option name="channel" value="NIGHTLY" />
     <option name="requiredFeatures" value="true" />

--- a/attributes-info/rust-toolchain.toml
+++ b/attributes-info/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/attributes-info/rustc_span/src/symbol.rs
+++ b/attributes-info/rustc_span/src/symbol.rs
@@ -5,15 +5,15 @@
 use std::cmp::PartialEq;
 use std::fmt;
 use std::hash::Hash;
-use std::lazy::SyncLazy;
 use std::str;
+use std::sync::LazyLock;
 
 include!(concat!(env!("OUT_DIR"), "/symbol.rs"));
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Symbol(pub u32);
 
-static INTERNER: SyncLazy<Interner> = SyncLazy::new(|| Interner::fresh());
+static INTERNER: LazyLock<Interner> = LazyLock::new(|| Interner::fresh());
 
 impl Symbol {
     const fn new(n: u32) -> Self {


### PR DESCRIPTION
These changes:
- fix `attribute-info` compilation by using `sync::LazyLock` instead of `lazy::SyncLazy`
- force using nightly toolchain (including IDE integration) via `rust-toolchain.toml`
- fix `Generate compiler features` run configuration

changelog: Fix `attribute-info` crate compilation which is used to update the compiler features
