### PR TITLE
Add slice pretty-printers

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -202,6 +202,8 @@ class RsDebugProcessConfigurationHelper(
         private val RUST_STD_TYPES: List<String> = listOf(
             "^(alloc::([a-z_]+::)+)String$",
             "^[&*]?(const |mut )?str\\*?$",
+            "^&(mut )?\\[.*\\]$",
+            "^(mut )?slice\\$<.+>$",
             "^(std::ffi::([a-z_]+::)+)OsString$",
             "^((&|&mut )?std::ffi::([a-z_]+::)+)OsStr( \\*)?$",
             "^(std::([a-z_]+::)+)PathBuf$",

--- a/prettyPrinters/gdb_lookup.py
+++ b/prettyPrinters/gdb_lookup.py
@@ -67,6 +67,8 @@ def lookup(valobj):
         return StdOsStringProvider(valobj)
     if rust_type == RustType.STD_STR:
         return StdStrProvider(valobj)
+    if rust_type == RustType.STD_SLICE:
+        return StdSliceProvider(valobj)
 
     if rust_type == RustType.STD_VEC:
         return StdVecProvider(valobj)

--- a/prettyPrinters/gdb_providers.py
+++ b/prettyPrinters/gdb_providers.py
@@ -152,12 +152,20 @@ class StdStrProvider:
         return "string"
 
 
-class StdVecProvider:
+class ArrayLikeProviderBase:
     def __init__(self, valobj):
         # type: (Value) -> None
         self.valobj = valobj
-        self.length = int(valobj["len"])
-        self.data_ptr = unwrap_unique_or_non_null(valobj["buf"]["ptr"])
+        self.data_ptr = self.get_data_ptr()
+        self.length = self.get_length()
+
+    def get_data_ptr(self):
+        # type: () -> Value
+        pass
+
+    def get_length(self):
+        # type: () -> int
+        pass
 
     def to_string(self):
         return "size={}".format(self.length)
@@ -169,6 +177,26 @@ class StdVecProvider:
     @staticmethod
     def display_hint():
         return "array"
+
+
+class StdSliceProvider(ArrayLikeProviderBase):
+    def get_data_ptr(self):
+        # type: () -> Value
+        return self.valobj["data_ptr"]
+
+    def get_length(self):
+        # type: () -> int
+        return int(self.valobj["length"])
+
+
+class StdVecProvider(ArrayLikeProviderBase):
+    def get_data_ptr(self):
+        # type: () -> Value
+        return unwrap_unique_or_non_null(self.valobj["buf"]["ptr"])
+
+    def get_length(self):
+        # type: () -> int
+        return int(self.valobj["len"])
 
 
 class StdVecDequeProvider:

--- a/prettyPrinters/lldb_lookup.py
+++ b/prettyPrinters/lldb_lookup.py
@@ -41,6 +41,9 @@ def summary_lookup(valobj, dict):
     if rust_type == RustType.STD_CSTR:
         return StdFFIStrSummaryProvider(valobj, dict, is_null_terminated=True)
 
+    if rust_type == RustType.STD_SLICE or rust_type == RustType.STD_MSVC_SLICE:
+        return SizeSummaryProvider(valobj, dict)
+
     if rust_type == RustType.STD_VEC:
         return SizeSummaryProvider(valobj, dict)
     if rust_type == RustType.STD_VEC_DEQUE:
@@ -89,6 +92,9 @@ def synthetic_lookup(valobj, dict):
         return synthetic_lookup(valobj.GetChildAtIndex(discriminant), dict)
     if rust_type == RustType.SINGLETON_ENUM:
         return synthetic_lookup(valobj.GetChildAtIndex(0), dict)
+
+    if rust_type == RustType.STD_SLICE or rust_type == RustType.STD_MSVC_SLICE:
+        return StdSliceSyntheticProvider(valobj, dict)
 
     if rust_type == RustType.STD_VEC:
         return StdVecSyntheticProvider(valobj, dict)

--- a/prettyPrinters/rust_types.py
+++ b/prettyPrinters/rust_types.py
@@ -19,6 +19,8 @@ class RustType(object):
     STD_OS_STRING = "StdOsString"
     STD_PATH_BUF = "StdPathBuf"
     STD_STR = "StdStr"
+    STD_SLICE = "StdSlice"
+    STD_MSVC_SLICE = "StdMsvcSlice"
     STD_OS_STR = "StdOsStr"
     STD_PATH = "StdPath"
     STD_CSTRING = "StdCString"
@@ -42,6 +44,9 @@ class RustType(object):
 STD_STRING_REGEX = re.compile(r"^(alloc::([a-z_]+::)+)String$")
 # str, mut str, const str*, mut str* (vanilla LLDB); &str, &mut str, *const str, *mut str (Rust-enabled LLDB)
 STD_STR_REGEX = re.compile(r"^[&*]?(const |mut )?str\*?$")
+STD_SLICE_REGEX = re.compile(r"^&(mut )?\[.*\]$")
+STD_MSVC_SLICE_REGEX = re.compile(r"^(mut )?slice\$<.+>$")
+
 STD_OS_STRING_REGEX = re.compile(r"^(std::ffi::([a-z_]+::)+)OsString$")
 STD_OS_STR_REGEX = re.compile(r"^((&|&mut )?std::ffi::([a-z_]+::)+)OsStr( \*)?$")
 STD_PATH_BUF_REGEX = re.compile(r"^(std::([a-z_]+::)+)PathBuf$")
@@ -73,6 +78,8 @@ STD_TYPE_TO_REGEX = {
     RustType.STD_PATH_BUF: STD_PATH_BUF_REGEX,
     RustType.STD_PATH: STD_PATH_REGEX,
     RustType.STD_STR: STD_STR_REGEX,
+    RustType.STD_SLICE: STD_SLICE_REGEX,
+    RustType.STD_MSVC_SLICE: STD_MSVC_SLICE_REGEX,
     RustType.STD_OS_STR: STD_OS_STR_REGEX,
     RustType.STD_CSTRING: STD_CSTRING_REGEX,
     RustType.STD_CSTR: STD_CSTR_REGEX,

--- a/pretty_printers_tests/tests/slice.rs
+++ b/pretty_printers_tests/tests/slice.rs
@@ -1,0 +1,26 @@
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+
+// lldb-command:print slice
+// lldbr-check:[...]slice = size=2 { [0] = 1 [1] = 2 }
+// lldbg-check:[...]$0 = size=2 { [0] = 1 [1] = 2 }
+// lldb-command:print slice_mut
+// lldbr-check:[...]slice_mut = size=2 { [0] = 1 [1] = 2 }
+// lldbg-check:[...]$1 = size=2 { [0] = 1 [1] = 2 }
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+
+// gdb-command:print slice
+// gdb-check:[...]$1 = size=2 = {1, 2}
+// gdb-command:print slice_mut
+// gdb-check:[...]$2 = size=2 = {1, 2}
+
+fn main() {
+    let slice: &[i32] = &[1, 2];
+    let slice_mut: &mut [i32] = &mut [1, 2];
+
+    print!(""); // #break
+}


### PR DESCRIPTION
Add GDB/LLDB pretty-printers to show the contents and the size of Rust slices.

Fixes #8519.

<img width="587" alt="Screenshot 2022-08-08 at 13 26 35" src="https://user-images.githubusercontent.com/4854600/183407763-b160354d-506d-4ab1-a491-a681b2afaa08.png">


changelog: Add debugger pretty-printers to show the contents and the size of Rust slices
