### PR TITLE
Hotfix #9110 by reverting #9021

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -76,7 +76,9 @@ class RsFile(
     val crate: Crate? get() = cachedData.crate
     override val crateRoot: RsMod? get() = cachedData.crateRoot
     val isDeeplyEnabledByCfg: Boolean get() = cachedData.isDeeplyEnabledByCfg
-    val isIncludedByIncludeMacro: Boolean get() = cachedData.isIncludedByIncludeMacro
+    // TODO a hotfix for https://github.com/intellij-rust/intellij-rust/issues/9110
+    val isIncludedByIncludeMacro: Boolean get() = true
+//    val isIncludedByIncludeMacro: Boolean get() = cachedData.isIncludedByIncludeMacro
 
     private val cachedData: CachedData
         get() {


### PR DESCRIPTION
Fixes #9110

#9021 leads to a stack overflow through `RsExpandedElement.getContextImpl` and `RsModulesIndex.getDeclarationsFor`.
I think the proper fix is stopping using `RsModulesIndex` in `RsFile.doGetCachedData`, I'll do it later

changelog: Fix possible Stack overflow introduced in the previous release of the plugin