### PR TITLE
COMP: Fix raw identifier in `use` cannot be complete

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -268,18 +268,19 @@ open class RsDefaultInsertHandler : InsertHandler<LookupElement> {
         item: LookupElement
     ) {
         val document = context.document
-        val startOffset = context.startOffset
-        val curUseItem = context.getElementOfType<RsUseItem>()
+
         if (element is RsNameIdentifierOwner && !RsNamesValidator.isIdentifier(scopeName) && scopeName !in CAN_NOT_BE_ESCAPED) {
-            document.insertString(startOffset, RS_RAW_PREFIX)
+            document.insertString(context.startOffset, RS_RAW_PREFIX)
+            context.commitDocument() // Fixed PSI element escape
         }
 
         if (element is RsGenericDeclaration) {
             addGenericTypeCompletion(element, document, context)
         }
 
-        when (element) {
+        val curUseItem = context.getElementOfType<RsUseItem>()
 
+        when (element) {
             is RsMod -> {
                 when (scopeName) {
                     "self",

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -1431,4 +1431,26 @@ class RsCompletionTest : RsCompletionTestBase() {
 
         fn foo<T: /*caret*/>() {}
     """)
+
+    fun `test complete the raw identifier in use`() = checkCompletion("break", """
+        mod foo {
+            pub fn r#break() {}
+        }
+
+        fn main() {
+            use self::foo::b/*caret*/
+
+            r#break();
+        }
+    """, """
+        mod foo {
+            pub fn r#break() {}
+        }
+
+        fn main() {
+            use self::foo::r#break;/*caret*/
+
+            r#break();
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #9031

```rust
use self::foo::break
```

The original content of the above error caused the PSI element to escape from `USE_ITEM`

changelog: Fix raw identifier in `use declarations` not complete