### PR TITLE
PERF: stop using `RsModuleIndex` in `RsFile.doGetCachedData`

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoPackageIndex.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoPackageIndex.kt
@@ -13,6 +13,7 @@ import com.intellij.util.indexing.LightDirectoryIndex
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.cargo.project.workspace.CargoWorkspace.Package
+import org.rust.cargo.project.workspace.additionalRoots
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.checkWriteAccessAllowed
 import java.util.*
@@ -41,6 +42,9 @@ class CargoPackageIndex(
                     val info = Optional.of(pkg)
                     index.putInfo(pkg.contentRoot, info)
                     index.putInfo(pkg.outDir, info)
+                    for (additionalRoot in pkg.additionalRoots()) {
+                        index.putInfo(additionalRoot, info)
+                    }
                     for (target in pkg.targets) {
                         index.putInfo(target.crateRoot?.parent, info)
                     }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -22,10 +22,7 @@ import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.macros.MacroExpansionFileSystem.FSItem
 import org.rust.lang.core.macros.MacroExpansionFileSystem.TrustedRequestor
 import org.rust.lang.core.psi.RsPsiManager
-import org.rust.lang.core.resolve2.CrateDefMap
-import org.rust.lang.core.resolve2.DefCollector
-import org.rust.lang.core.resolve2.MacroIndex
-import org.rust.lang.core.resolve2.updateDefMapForAllCrates
+import org.rust.lang.core.resolve2.*
 import org.rust.openapiext.*
 import org.rust.stdext.HashCode
 import org.rust.stdext.mapToSet
@@ -59,6 +56,7 @@ class MacroExpansionTask(
 ) : Task.Backgroundable(project, "Expanding Rust macros", /* canBeCancelled = */ false),
     RsTask {
     private val expansionFileSystem: MacroExpansionFileSystem = MacroExpansionFileSystem.getInstance()
+    private val defMapService = project.defMapService
 
     override fun run(indicator: ProgressIndicator) {
         indicator.checkCanceled()
@@ -69,7 +67,7 @@ class MacroExpansionTask(
 
         val allDefMaps = try {
             indicator.text = "Preparing resolve data"
-            updateDefMapForAllCrates(project, subTaskIndicator)
+            defMapService.updateDefMapForAllCratesWithWriteActionPriority(subTaskIndicator)
         } catch (e: ProcessCanceledException) {
             throw e
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1892,6 +1892,7 @@ object NameResolutionTestmarks {
     object ModRsFile : Testmark()
     object SelfRelatedTypeSpecialCase : Testmark()
     object SkipAssocTypeFromImpl : Testmark()
+    object UpdateDefMapsForAllCratesWhenFindingModData : Testmark()
 }
 
 private data class ImplicitStdlibCrate(val name: String, val crateRoot: RsFile)

--- a/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
+++ b/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
@@ -272,7 +272,7 @@ class RsFindUsagesTest : RsTestBase() {
     fun `test usage in child mod with path attribute`() = doTestByFileTree("""
     //- main.rs
         mod foo;
-    //- foo/main.rs
+    //- foo/mod.rs
         struct Foo;
              //^
         #[path = "../bar.rs"]
@@ -284,7 +284,7 @@ class RsFindUsagesTest : RsTestBase() {
     fun `test usage in included file`() = doTestByFileTree("""
     //- main.rs
         mod foo;
-    //- foo/main.rs
+    //- foo/mod.rs
         struct Foo;
              //^
         include!("../bar.rs");

--- a/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.psi
 
 import com.intellij.openapi.application.runWriteAction
-import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDocumentManager
@@ -17,6 +16,7 @@ import org.rust.fileTreeFromText
 import org.rust.lang.core.psi.RsRustStructureModificationTrackerTest.TestAction.INC
 import org.rust.lang.core.psi.RsRustStructureModificationTrackerTest.TestAction.NOT_INC
 import org.rust.lang.core.psi.ext.childOfType
+import org.rust.lang.core.resolve2.defMapService
 import org.rust.lang.core.resolve2.updateDefMapForAllCrates
 import org.rust.openapiext.runWriteCommandAction
 
@@ -34,7 +34,7 @@ class RsRustStructureModificationTrackerTest : RsTestBase() {
 
     private fun checkModCount(op: TestAction, depsOp: TestAction = NOT_INC, action: () -> Unit) {
         PsiDocumentManager.getInstance(project).commitAllDocuments()
-        updateDefMapForAllCrates(project, EmptyProgressIndicator(), multithread = false)
+        project.defMapService.updateDefMapForAllCrates(multithread = false)
         val modTracker = project.rustStructureModificationTracker
         val modTrackerInDeps = project.rustPsiManager.rustStructureModificationTrackerInDependencies
         val oldCount = modTracker.modificationCount

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.resolve
 
 import org.rust.CheckTestmarkHit
+import org.rust.MockAdditionalCfgOptions
 
 class RsStubOnlyResolveTest : RsResolveTestBase() {
     fun `test child mod`() = stubOnlyResolve("""
@@ -195,6 +196,27 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn quux() {}
     //- sub/mod.rs
         fn foo() {
+            crate::quux();
+       }         //^ main.rs
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test resolve in cfg disabled mod`() = stubOnlyResolve("""
+    //- main.rs
+        #[cfg(intellij_rust)]
+        #[path = "cfg_enabled/mod.rs"]
+        mod foo;
+        #[cfg(not(intellij_rust))]
+        #[path = "cfg_disabled/mod.rs"]
+        mod foo;
+
+        fn quux() {}
+    //- cfg_enabled/mod.rs
+        fn bar() {
+            crate::quux();
+       }
+    //- cfg_disabled/mod.rs
+        fn baz() {
             crate::quux();
        }         //^ main.rs
     """)


### PR DESCRIPTION
Slightly speeds up name resolution. This is also a proper fix for #9110. 

changelog: Slightly speed up name resolution