### PR TITLE
MACRO: Use `rust-analyzer-proc-macro-srv` from toolchain if available

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -28,9 +28,7 @@ import org.rust.cargo.project.workspace.PackageFeature
 import org.rust.cargo.toolchain.RsToolchainBase
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.cargo.toolchain.tools.isRustupAvailable
-import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.notifications.showBalloon
-import org.rust.openapiext.isFeatureEnabled
 import org.rust.openapiext.pathAsPath
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
@@ -116,6 +114,7 @@ interface CargoProject : UserDataHolderEx {
     val workspace: CargoWorkspace?
 
     val rustcInfo: RustcInfo?
+    val procMacroExpanderPath: Path?
 
     val workspaceStatus: UpdateStatus
     val stdlibStatus: UpdateStatus

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -48,6 +48,7 @@ import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsChangedEvent
 import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsListener
 import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.toolwindow.CargoToolWindow.Companion.initializeToolWindow
 import org.rust.cargo.project.workspace.*
 import org.rust.cargo.runconfig.command.workingDirectory
@@ -56,6 +57,7 @@ import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.ide.notifications.showBalloon
 import org.rust.lang.RsFileType
 import org.rust.lang.core.macros.macroExpansionManager
+import org.rust.lang.core.macros.proc.ProcMacroServerPool
 import org.rust.openapiext.TaskResult
 import org.rust.openapiext.isUnitTestMode
 import org.rust.openapiext.modules
@@ -501,6 +503,11 @@ data class CargoProjectImpl(
     override val rustcInfoStatus: UpdateStatus = UpdateStatus.NeedsUpdate
 ) : UserDataHolderBase(), CargoProject {
     override val project get() = projectService.project
+
+    override val procMacroExpanderPath: Path? = rustcInfo?.sysroot?.let { sysroot ->
+        val toolchain = project.toolchain ?: return@let null
+        ProcMacroServerPool.findExpanderExecutablePath(toolchain, sysroot)
+    }
 
     override val workspace: CargoWorkspace? by lazy(LazyThreadSafetyMode.PUBLICATION) {
         val rawWorkspace = rawWorkspace ?: return@lazy null

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
@@ -42,7 +42,7 @@ abstract class RsToolchainBase(val location: Path) {
 
     abstract fun expandUserHome(remotePath: String): String
 
-    protected abstract fun getExecutableName(toolName: String): String
+    abstract fun getExecutableName(toolName: String): String
 
     // for executables from toolchain
     abstract fun pathToExecutable(toolName: String): Path

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
@@ -25,6 +25,7 @@ import org.rust.ide.refactoring.RsInlineUsageViewDescriptor
 import org.rust.ide.refactoring.freshenName
 import org.rust.ide.refactoring.inlineValue.replaceWithAddingParentheses
 import org.rust.lang.core.dfa.ExitPoint
+import org.rust.lang.core.macros.setContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.RsReference
@@ -161,6 +162,7 @@ class RsInlineFunctionProcessor(
 
     private fun preprocessFunction(originalFunction: RsFunction): RsFunction {
         val function = originalFunction.copy() as RsFunction
+        (originalFunction.context as? RsElement?)?.let { function.setContext(it) }
         replaceSelfParameter(function)
         replaceReturnWithTailExpr(function)
         return function
@@ -410,6 +412,7 @@ private class InlineSingleUsage(
         }
 
         val function = originalFunction.copy() as RsFunction
+        (originalFunction.context as? RsElement?)?.let { function.setContext(it) }
         expandStructLiteralFieldsShorthand(function)
         renameParametersIfNecessary(function, getFreshName)
         renameTopLevelDeclarationsIfNecessary(function, getFreshName)

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -5,7 +5,7 @@
 
 package org.rust.lang.core.macros
 
-import com.intellij.openapi.project.Project
+import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.macros.builtin.BuiltinMacroExpander
 import org.rust.lang.core.macros.decl.DeclMacroExpander
 import org.rust.lang.core.macros.errors.MacroExpansionError
@@ -34,10 +34,10 @@ class FunctionLikeMacroExpander(
     }
 
     companion object {
-        fun new(project: Project): FunctionLikeMacroExpander = FunctionLikeMacroExpander(
-            DeclMacroExpander(project),
-            ProcMacroExpander(project),
-            BuiltinMacroExpander(project)
+        fun forCrate(crate: Crate): FunctionLikeMacroExpander = FunctionLikeMacroExpander(
+            DeclMacroExpander(crate.project),
+            ProcMacroExpander.forCrate(crate),
+            BuiltinMacroExpander(crate.project)
         )
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -922,11 +922,11 @@ private fun expandMacroOld(call: RsMacroCall): MacroExpansionCachedResult {
 private fun expandMacroToMemoryFile(call: RsPossibleMacroCall, storeRangeMap: Boolean): MacroExpansionCachedResult {
     val def = call.resolveToMacroWithoutPsiWithErr()
         .unwrapOrElse { return memExpansionResult(call, Err(it.toExpansionError())) }
-    val project = call.project
-    val result = FunctionLikeMacroExpander.new(project).expandMacro(
+    val crate = call.containingCrate ?: return memExpansionResult(call, Err(GetMacroExpansionError.Unresolved))
+    val result = FunctionLikeMacroExpander.forCrate(crate).expandMacro(
         def,
         call,
-        RsPsiFactory(project, markGenerated = false),
+        RsPsiFactory(call.project, markGenerated = false),
         storeRangeMap,
         useCache = true
     ).map { expansion ->

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -42,7 +42,7 @@ class DefCollector(
     private val defMap: CrateDefMap,
     private val context: CollectorContext,
     private val pool: ExecutorService?,
-    private val indicator: ProgressIndicator,
+    private val indicator: ProgressIndicator
 ) {
 
     /**
@@ -58,8 +58,7 @@ class DefCollector(
 
     private val macroCallsToExpand: MutableList<MacroCallInfo> = context.macroCalls
 
-    /** Created once as optimization */
-    private val macroExpander = FunctionLikeMacroExpander.new(project)
+    private val macroExpander = FunctionLikeMacroExpander.forCrate(context.crate)
     private val macroExpanderShared: MacroExpansionSharedCache = MacroExpansionSharedCache.getInstance()
 
     private val macroMixHashToOrder: MutableMap<HashCode /* mix hash */, Int> = THashMap()


### PR DESCRIPTION
Fixes #9172
Fixes #9159

You can read the full story [here](https://fasterthanli.me/articles/proc-macro-support-in-rust-analyzer-for-nightly-rustc-versions). Long story short, since 01.08.2022 there is a binary `$sysroot/libexec/rust-analyzer-proc-macro-srv` shipped within `rustc` rustup component in the nightly channel. This binary can be used as a drop-in replacement for our own `intellij-rust-native-helper` in the case of macro expansion. Of course it is always compatible with rustc version it shipped with, so now macro expansion will work fine on every nightly version.

In this PR I use `rust-analyzer-proc-macro-srv` instead of `intellij-rust-native-helper` if it is available (exist). This likely obsoletes #8930.
Note that `intellij-rust-native-helper` is still used as a rustc wrapper on all toolchains and as a proc macro expander on stable toolchains