### PR TITLE
CARGO: Use `--keep-going` when building and evaluating buildscripts

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -361,7 +361,8 @@ private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext, rustcInfo: R
         val (projectDescriptionData, status) = cargo.fullProjectDescription(
             childContext.project,
             projectDirectory,
-            cargoConfig.buildTarget ?: rustcInfo?.version?.host
+            cargoConfig.buildTarget ?: rustcInfo?.version?.host,
+            rustcInfo?.version,
         ) {
             when (it) {
                 CargoCallType.METADATA -> SyncProcessAdapter(childContext)

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -281,8 +281,11 @@ open class WithProcMacros(
             setExperimentalFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS, true, disposable)
             val testProcMacroProjectPath = Path.of("testData/$TEST_PROC_MACROS")
             fullyRefreshDirectoryInUnitTests(LocalFileSystem.getInstance().findFileByNioFile(testProcMacroProjectPath)!!)
-            val (testProcMacroProject, _) = toolchain!!.cargo().fullProjectDescription(project, testProcMacroProjectPath)
-                .unwrapOrThrow()
+            val (testProcMacroProject, _) = toolchain!!.cargo().fullProjectDescription(
+                project,
+                testProcMacroProjectPath,
+                rustcVersion = rustcInfo?.version,
+            ).unwrapOrThrow()
             procMacroPackage = testProcMacroProject.packages.find { it.name == TEST_PROC_MACROS }!!
                 .copy(origin = PackageOrigin.DEPENDENCY)
             procMacroPackage


### PR DESCRIPTION
Since Rust 1.62 Cargo has an unstable option [`--keep-going`](https://github.com/rust-lang/cargo/issues/10496).

By default, cargo stops the build immediately if one rustc instance or buildscript instance fails, even if it would be possible to compile other crates that does not depends on the error crate.

The option `--keep-going` instructs cargo to continue building even if the compilation of some crate fails or the evaluation of some buildscript fails. This behavior is exactly what we need in the case of buildscript evaluation - as an IDE, we need to compile&evaluate as much as possible.
