### PR TITLE
PERF: Index new stdlib parts `portable-simd`

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -734,7 +734,9 @@ fun CargoWorkspace.Package.additionalRoots(): List<VirtualFile> {
             CORE -> contentRoot?.parent?.let {
                 listOfNotNull(
                     it.findFileByRelativePath("stdarch/crates/core_arch"),
-                    it.findFileByRelativePath("stdarch/crates/std_detect")
+                    it.findFileByRelativePath("stdarch/crates/std_detect"),
+                    it.findFileByRelativePath("portable-simd/crates/core_simd"),
+                    it.findFileByRelativePath("portable-simd/crates/std_float"),
                 )
             } ?: emptyList()
             else -> emptyList()

--- a/src/test/kotlin/org/rust/lang/core/resolve2/TestAllStdlibFilesAreIndexed.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/TestAllStdlibFilesAreIndexed.kt
@@ -1,0 +1,36 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
+import org.rust.ProjectDescriptor
+import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.crate.crateGraph
+import org.rust.lang.core.psi.shouldIndexFile
+
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+class TestAllStdlibFilesAreIndexed : RsTestBase() {
+    fun `test all stdlib files are indexed`() {
+        InlineFile("")
+        val crateIds = project.crateGraph.topSortedCrates.mapNotNull { it.id }
+        val defMaps = project.defMapService.getOrUpdateIfNeeded(crateIds).values.filterNotNull()
+        val usedFiles = defMaps
+            .flatMap { it.fileInfos.keys }
+            .mapNotNull { PersistentFS.getInstance().findFileById(it) }
+        val notIndexedFiles = usedFiles.filter { !shouldIndexFile(project, it) }
+
+        if (notIndexedFiles.isNotEmpty()) {
+            val filePaths = notIndexedFiles.joinToString(separator = "\n") { "  ${it.path}" }
+            error(
+                "The following files are not indexed but are included to the module tree.\n" +
+                    "If the files are parts of stdlib, they must be added to `additionalRoots()`.\n" +
+                    "Files:\n" +
+                    filePaths
+            )
+        }
+    }
+}


### PR DESCRIPTION
Add new stdlib parts to index, also add a test that checks that all stdlib files are indexed. Since `portable-simd` is an unstable part of stdlib, this most likely does not affect users except in terms of performance.

Also, new stdlib parts are now visible in "External Libraries":
![image](https://user-images.githubusercontent.com/3221931/184020525-53c2b4a6-f98f-4111-b40f-3822360095fc.png)

changelog: Slightly speed up name resolution