### PR TITLE
COMP: Fix duplicate top-level completion of macro calls

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsMacroCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsMacroCompletionProvider.kt
@@ -21,7 +21,6 @@ import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.psi.RsElementTypes.COLONCOLON
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsExpressionCodeFragment
-import org.rust.lang.core.psi.RsFileBase
 import org.rust.lang.core.psi.RsModItem
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psiElement
@@ -58,7 +57,6 @@ object RsMacroCompletionProvider : RsCompletionProvider() {
         val text = leftSiblingsText + position.text + "!()"
         val fragment = RsExpressionCodeFragment(position.project, text, mod)
         fragment.putUserData(FORCE_OUT_OF_SCOPE_COMPLETION, true)
-        (mod.containingFile as? RsFileBase)?.let { fragment.originalFile = it }  // needed for paths "::dep::foo"
 
         val offset = leftSiblingsText.length + (parameters.offset - position.startOffset)
         val element = fragment.findElementAt(offset) ?: return

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -240,7 +240,7 @@ fun PsiElement.stubChildOfElementType(elementType: IElementType): PsiElement? {
 val PsiElement.contextualFile: PsiFile
     get() {
         val file = contextOrSelf<PsiFile>() ?: error("Element outside of file: $text")
-        return if (file is RsReplCodeFragment) {
+        return if (file is RsCodeFragment) {
             file.context.contextualFile
         } else {
             file

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -650,6 +650,30 @@ class RsCompletionTest : RsCompletionTestBase() {
         foo!(/*caret*/)
     """)
 
+    fun `test complete top-level unqualified macro from other module 2`() = doSingleCompletion("""
+        mod mod1 {
+            mod mod2 {
+                #[macro_export]
+                macro_rules! foo {
+                    () => {};
+                }
+            }
+            fo/*caret*/
+        }
+    """, """
+        mod mod1 {
+            use crate::foo;
+
+            mod mod2 {
+                #[macro_export]
+                macro_rules! foo {
+                    () => {};
+                }
+            }
+            foo!(/*caret*/)
+        }
+    """)
+
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test complete top-level unqualified macro from other crate`() = doSingleCompletionByFileTree("""
     //- main.rs


### PR DESCRIPTION
Fixes duplicate top-level completion of macro calls in some cases:

```rust
mod mod1 {
    mod mod2 {
        #[macro_export]
        macro_rules! foo {
            () => {};
        }
    }
    fo/*caret*/
}
```

<img src="https://user-images.githubusercontent.com/6505554/184024090-98a02a0e-027d-4fe7-9e87-7e6f142c1713.png" width="50%">

This is hotfix for #9156 so no changelog