### PR TITLE
PERF: speed up `containingCrate` and similar properties

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -44,7 +44,21 @@ interface RsExpandedElement : RsElement {
 }
 
 fun RsExpandedElement.setContext(context: RsElement) {
+    (containingFile as? RsFile)?.setRsFileContext(context, lazy = true)
+    setExpandedElementContext(context)
+}
+
+/** Internal. Use [setContext] */
+fun RsExpandedElement.setExpandedElementContext(context: RsElement) {
     putUserData(RS_EXPANSION_CONTEXT, context)
+}
+
+/** Internal. Use [setContext] */
+fun RsFile.setRsFileContext(context: RsElement, lazy: Boolean) {
+    val contextContainingFile = context.containingRsFileSkippingCodeFragments
+    if (contextContainingFile != null) {
+        inheritCachedDataFrom(contextContainingFile, lazy)
+    }
 }
 
 /**
@@ -355,5 +369,4 @@ fun PsiElement.findNavigationTargetIfMacroExpansion(): PsiElement? {
     return element.findElementExpandedFrom() ?: findMacroCallExpandedFrom()?.path
 }
 
-private val RS_EXPANSION_CONTEXT = Key.create<RsElement>("org.rust.lang.core.psi.CODE_FRAGMENT_FILE")
-
+private val RS_EXPANSION_CONTEXT = Key.create<RsElement>("org.rust.lang.core.psi.RS_EXPANSION_CONTEXT")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -235,7 +235,7 @@ fun PsiElement.stubChildOfElementType(elementType: IElementType): PsiElement? {
 }
 
 /**
- * Same as [PsiElement.getContainingFile], but return a "fake" file. See [org.rust.lang.core.macros.RsExpandedElement].
+ * Similar to [PsiElement.getContainingFile], but return a "fake" file. See [org.rust.lang.core.macros.RsExpandedElement].
  */
 val PsiElement.contextualFile: PsiFile
     get() {
@@ -245,6 +245,20 @@ val PsiElement.contextualFile: PsiFile
         } else {
             file
         }
+    }
+
+/**
+ * Similar to [PsiElement.getContainingFile], but return a "fake" file if real file is
+ * [com.intellij.psi.impl.source.DummyHolder] or [org.rust.lang.core.psi.RsCodeFragment].
+ */
+val PsiElement.containingRsFileSkippingCodeFragments: RsFile?
+    get() {
+        var containingFile = containingFile.originalFile
+        /** Unwrap possible [com.intellij.psi.impl.source.DummyHolder]s and [org.rust.lang.core.psi.RsCodeFragment]s */
+        while (containingFile !is RsFile) {
+            containingFile = containingFile.context?.containingFile?.originalFile ?: break
+        }
+        return containingFile as? RsFile
     }
 
 /** Finds first sibling that is neither comment, nor whitespace before given element */

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -38,10 +38,10 @@ interface RsElement : PsiElement {
 }
 
 val RsElement.cargoProject: CargoProject?
-    get() = (contextualFile.originalFile as? RsFile)?.cargoProject
+    get() = containingRsFileSkippingCodeFragments?.cargoProject
 
 val RsElement.cargoWorkspace: CargoWorkspace?
-    get() = (contextualFile.originalFile as? RsFile)?.cargoWorkspace
+    get() = containingRsFileSkippingCodeFragments?.cargoWorkspace
 
 fun PsiFileSystemItem.findCargoProject(): CargoProject? {
     if (this is RsFile) return this.cargoProject
@@ -59,7 +59,7 @@ val RsElement.containingCargoTarget: CargoWorkspace.Target?
     get() = containingCrate?.cargoTarget
 
 val RsElement.containingCrate: Crate?
-    get() = (contextualFile.originalFile as? RsFile)?.crate
+    get() = containingRsFileSkippingCodeFragments?.crate
 
 val RsElement.containingCargoPackage: CargoWorkspace.Package? get() = containingCargoTarget?.pkg
 
@@ -100,7 +100,7 @@ abstract class RsElementImpl(node: ASTNode) : ASTWrapperPsiElement(node), RsElem
             ?: error("Element outside of module: $text")
 
     final override val crateRoot: RsMod?
-        get() = (contextualFile as? RsElement)?.crateRoot
+        get() = containingRsFileSkippingCodeFragments?.crateRoot
 
     override fun getNavigationElement(): PsiElement {
         return findNavigationTargetIfMacroExpansion() ?: super.getNavigationElement()
@@ -118,7 +118,7 @@ abstract class RsStubbedElementImpl<StubT : StubElement<*>> : StubBasedPsiElemen
             ?: error("Element outside of module: $text")
 
     final override val crateRoot: RsMod?
-        get() = (contextualFile as? RsElement)?.crateRoot
+        get() = containingRsFileSkippingCodeFragments?.crateRoot
 
     override fun getNavigationElement(): PsiElement {
         return findNavigationTargetIfMacroExpansion() ?: super.getNavigationElement()

--- a/src/main/kotlin/org/rust/lang/doc/psi/impl/Psi.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/impl/Psi.kt
@@ -30,7 +30,7 @@ abstract class RsDocElementImpl(type: IElementType) : CompositePsiElement(type),
             ?: error("Element outside of module: $text")
 
     final override val crateRoot: RsMod?
-        get() = (contextualFile as? RsElement)?.crateRoot
+        get() = containingRsFileSkippingCodeFragments?.crateRoot
 
     override val containingDoc: RsDocComment
         get() = ancestorStrict()


### PR DESCRIPTION
Now `RsElement.containingCrate` uses `containingFile` which is much faster than `contextualFile` it used previously. Each `RsFile` (even a macro expansion) now has a correct `CachedData` (with a `Crate`, `isDeeplyEnabledByCfg`, etc.)

changelog: Slightly speed up name resolution