### PR TITLE
PERF: speed up prelude processing using new resolve

### DIFF
--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
@@ -14,10 +14,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.block
 import org.rust.lang.core.psi.ext.childOfType
 import org.rust.lang.core.psi.ext.expandedTailExpr
-import org.rust.lang.core.resolve.TYPES_N_VALUES_N_MACROS
-import org.rust.lang.core.resolve.createProcessor
-import org.rust.lang.core.resolve.findPrelude
-import org.rust.lang.core.resolve.processNestedScopesUpwards
+import org.rust.lang.core.resolve.*
 import org.rust.openapiext.toPsiFile
 
 class RsConsoleCodeFragmentContext(codeFragment: RsReplCodeFragment?) {
@@ -47,7 +44,7 @@ class RsConsoleCodeFragmentContext(codeFragment: RsReplCodeFragment?) {
             preludeItemsNames += it.name
             false
         }
-        processNestedScopesUpwards(prelude, TYPES_N_VALUES_N_MACROS, processor)
+        processItemDeclarations(prelude, TYPES_N_VALUES_N_MACROS, processor, ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS)
         itemsNames += preludeItemsNames
         hasAddedNamesFromPrelude = true
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -63,7 +63,15 @@ fun processItemDeclarations(
     ipm: ItemProcessingMode
 ): Boolean {
     processItemDeclarations2(scope, ns, originalProcessor, ipm)?.let { return it }
+    return processItemDeclarations1(scope, ns, originalProcessor, ipm)
+}
 
+fun processItemDeclarations1(
+    scope: RsItemsOwner,
+    ns: Set<Namespace>,
+    originalProcessor: RsResolveProcessor,
+    ipm: ItemProcessingMode
+): Boolean {
     val withPrivateImports = ipm != ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS
 
     val directlyDeclaredNames = HashMap<String, Set<Namespace>>()


### PR DESCRIPTION
Reduces `getModInfo` and `ModData.toRsMod()` calls. 

changelog: Slightly speed up name resolution
