### PR TITLE
Fix `java.io.IOException` during typing inside a macro call

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
@@ -134,11 +134,14 @@ class MacroExpansionFileSystem : NewVirtualFileSystem() {
         if (requestor != TrustedRequestor) {
             throw UnsupportedOperationException()
         }
+        if (file.parent == newParent) {
+            throw IOException("Cannot move file `${file.path}` to the same directory where it is already located")
+        }
         val fsItem = convert(file) ?: throw FileNotFoundException("${file.path} (No such file or directory)")
         val newParentFsDir = convert(newParent) ?: throw FileNotFoundException("${newParent.path} (No such file or directory)")
         if (newParentFsDir !is FSDir) throw IOException("${newParent.path} is not a directory")
         if (newParentFsDir.findChild(file.name) != null) {
-            throw IOException("Directory already contains a file named $file.name")
+            throw IOException("Directory already contains a file named ${file.name}")
         }
         val oldParentFsDir = fsItem.parent ?: throw IOException("Can't move root (${file.path})")
         oldParentFsDir.removeChild(fsItem.name, bump = true)

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -186,7 +186,11 @@ class MacroExpansionTask(
                         newFileParent = newFileParent.createChildDirectory(TrustedRequestor, segment)
                     }
                     RsPsiManager.withIgnoredPsiEvents(oldPsiFile) {
-                        oldFile.move(TrustedRequestor, newFileParent)
+                        if (newFileParent != oldFile.parent) {
+                            oldFile.move(TrustedRequestor, newFileParent)
+                        } else {
+                            MoveToTheSameDir.hit()
+                        }
                         oldFile.rename(TrustedRequestor, newName)
                     }
                     val doc = FileDocumentManager.getInstance().getCachedDocument(oldFile)
@@ -289,6 +293,8 @@ class MacroExpansionTask(
 
     override val runSyncInUnitTests: Boolean
         get() = true
+
+    object MoveToTheSameDir: Testmark()
 }
 
 // "<mixHash>_<order>.rs" → "<mixHash>"


### PR DESCRIPTION
Fixes #9023

changelog: Fixes possible `java.io.IOException` during typing in a macro call