### PR TITLE
DBG: Update `Ref`/`RefMut` pretty-printers to Rust 1.63 and add tests

### DIFF
--- a/prettyPrinters/lldb_providers.py
+++ b/prettyPrinters/lldb_providers.py
@@ -630,7 +630,14 @@ class StdRefSyntheticProvider:
         else:
             self.borrow = borrow.GetChildMemberWithName("borrow").GetChildMemberWithName(
                 "value").GetChildMemberWithName("value")
-            self.value = value.Dereference()
+            # BACKCOMPAT: Rust 1.62.0. Drop `else`-branch
+            if value.GetChildMemberWithName("pointer"):
+                # Since Rust 1.63.0, `Ref` and `RefMut` use `value: NonNull<T>` instead of `value: &T`
+                # https://github.com/rust-lang/rust/commit/d369045aed63ac8b9de1ed71679fac9bb4b0340a
+                # https://github.com/rust-lang/rust/commit/2b8041f5746bdbd7c9f6ccf077544e1c77e927c0
+                self.value = unwrap_unique_or_non_null(value).Dereference()
+            else:
+                self.value = value.Dereference()
 
         self.value_builder = ValueBuilder(valobj)
 

--- a/pretty_printers_tests/tests/cell.rs
+++ b/pretty_printers_tests/tests/cell.rs
@@ -1,0 +1,44 @@
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+
+// lldb-command:print cell
+// lldbr-check:[...]cell = { value = 42 }
+// lldbg-check:[...]$0 = { value = 42 }
+// lldb-command:print ref_cell1
+// lldbr-check:[...]ref_cell1 = borrow=1 { value = 42 }
+// lldbg-check:[...]$1 = borrow=1 { value = 42 }
+// lldb-command:print ref1
+// lldbr-check:[...]ref1 = borrow=1 { [...] = 42 }
+// lldbg-check:[...]$2 = borrow=1 { [...] = 42 }
+// lldb-command:print ref_mut2
+// lldbr-check:[...]ref_mut2 = borrow_mut=1 { [...] = 42 }
+// lldbg-check:[...]$3 = borrow_mut=1 { [...] = 42 }
+
+// === GDB TESTS ==================================================================================
+
+// gdb-command:run
+
+// gdb-command:print cell
+// gdb-check:[...]$1 = {value = 42}
+// gdb-command:print ref_cell1
+// gdb-check:[...]$2 = borrow=1 = {value = 42, borrow = 1}
+// gdb-command:print ref1
+// gdb-check:[...]$3 = borrow=1 = {[...] = 42, borrow = 1}
+// gdb-command:print ref_mut2
+// gdb-check:[...]$4 = borrow_mut=1 = {[...] = 42, borrow = -1}
+
+
+use std::cell::{Cell, RefCell};
+
+fn main() {
+    let cell = Cell::new(42);
+
+    let ref_cell1 = RefCell::new(42);
+    let ref1 = ref_cell1.borrow();
+
+    let ref_cell2 = RefCell::new(42);
+    let ref_mut2 = ref_cell2.borrow_mut();
+
+    print!(""); // #break
+}


### PR DESCRIPTION
Since Rust 1.63.0, `Ref` and `RefMut` use `value: NonNull<T>` instead of `value: &T`. Accidentally, we did not have the corresponding tests to catch this, so this PR also adds them.

changelog: Update debugger pretty-printers to render `Ref` and `RefMut` properly