### PR TITLE
PERF&MACRO: use stubs for expansions of macro calls inside `impl`s

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -926,7 +926,6 @@ private fun expandMacroToMemoryFile(call: RsPossibleMacroCall, storeRangeMap: Bo
     val result = FunctionLikeMacroExpander.forCrate(crate).expandMacro(
         def,
         call,
-        RsPsiFactory(call.project, markGenerated = false),
         storeRangeMap,
         useCache = true
     ).map { expansion ->

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFileInternals.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFileInternals.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.google.common.annotations.VisibleForTesting
+import com.intellij.psi.impl.source.PsiFileImpl
+import com.intellij.psi.stubs.PsiFileStub
+import org.rust.openapiext.isUnitTestMode
+import java.lang.reflect.Method
+
+object RsPsiFileInternals {
+    @VisibleForTesting
+    val setStubTreeMethod: Method? = try {
+        PsiFileImpl::class.java
+            .getDeclaredMethod("setStubTree", PsiFileStub::class.java)
+            .apply { isAccessible = true }
+    } catch (e: Throwable) {
+        if (isUnitTestMode) throw e else null
+    }
+
+    fun setStubTree(file: RsFile, stub: PsiFileStub<*>): Boolean {
+        return if (setStubTreeMethod != null) {
+            setStubTreeMethod.invoke(file, stub)
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -370,7 +370,8 @@ class DefCollector(
         val callData = RsMacroCallDataWithHash(RsMacroCallData(call.body, defMap.metaData.env), call.bodyHash)
         val mixHash = defData.mixHash(callData) ?: return null
         val (expandedFile, expansion) =
-            macroExpanderShared.createExpansionStub(project, macroExpander, defData, callData) ?: (null to null)
+            macroExpanderShared.createExpansionStub(project, macroExpander, defData.data, callData.data, mixHash).ok()
+                ?: (null to null)
         return ExpansionOutput(call, def, expandedFile, expansion, mixHash)
     }
 

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -119,7 +119,6 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
         val expansionResult = expander.expandMacro(
             RsMacroDataWithHash(def, null),
             call,
-            RsPsiFactory(project, markGenerated = false),
             storeRangeMap = true,
             useCache = false
         )

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsBuiltinMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsBuiltinMacroExpansionTest.kt
@@ -8,7 +8,6 @@ package org.rust.lang.core.macros.decl
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.macros.builtin.BuiltinMacroExpander
 import org.rust.lang.core.psi.RsMacroCall
-import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsPossibleMacroCall
 import org.rust.lang.core.resolve2.resolveToMacroWithoutPsi
@@ -24,7 +23,6 @@ class RsBuiltinMacroExpansionTest : RsMacroExpansionTestBase() {
         val expansionResult = expander.expandMacro(
             RsMacroDataWithHash(def, null),
             call,
-            RsPsiFactory(project, markGenerated = false),
             storeRangeMap = true,
             useCache = false
         )

--- a/src/test/kotlin/org/rust/lang/core/psi/RsPsiFileInternalsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsPsiFileInternalsTest.kt
@@ -1,0 +1,14 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import org.rust.RsTestBase
+
+class RsPsiFileInternalsTest: RsTestBase() {
+    fun `test setStubTree`() {
+        assertNotNull(RsPsiFileInternals.setStubTreeMethod)
+    }
+}


### PR DESCRIPTION
Depends on #9188

This actually fixes a performance regression introduced in #8647. In that PR we started to expand macro calls inside impl blocks (`impl Foo { bar!(); }`) to temporary in-memory files `LightVirtualFile` (like we do with local macro calls). A side-effect of in-memory files usage is the fact that PSI constructed from such in-memory files does not use stubs. As a result, we waste CPU parsing the content of expansions and waste memory for full AST of such expansions. This could be not a big problem if macro calls inside impls are rarely used, but they're actually used in stdlib, in impls for primitive files :)

In this PR I found a way to specify a stub for a PsiFile. However, this way involves reflection usage. The stub is extracted from the macro expansion cache, as in the case of a top-level macro.

changelog: Slightly speed up name resolution
