### PR TITLE
DBG: Add summary pretty-printers for range types

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -224,7 +224,8 @@ class RsDebugProcessConfigurationHelper(
             "^(core::([a-z_]+::)+)Ref<.+>$",
             "^(core::([a-z_]+::)+)RefMut<.+>$",
             "^(core::([a-z_]+::)+)RefCell<.+>$",
-            "^core::num::([a-z_]+::)*NonZero.+$"
+            "^core::num::([a-z_]+::)*NonZero.+$",
+            "^core::ops::range::Range(From|Inclusive|To|ToInclusive)?<.+>$"
         )
     }
 }

--- a/prettyPrinters/gdb_lookup.py
+++ b/prettyPrinters/gdb_lookup.py
@@ -99,4 +99,15 @@ def lookup(valobj):
     if rust_type == RustType.STD_NONZERO_NUMBER:
         return StdNonZeroNumberProvider(valobj)
 
+    if rust_type == RustType.STD_RANGE:
+        return StdRangeProvider(valobj)
+    if rust_type == RustType.STD_RANGE_FROM:
+        return StdRangeFromProvider(valobj)
+    if rust_type == RustType.STD_RANGE_INCLUSIVE:
+        return StdRangeInclusiveProvider(valobj)
+    if rust_type == RustType.STD_RANGE_TO:
+        return StdRangeToProvider(valobj)
+    if rust_type == RustType.STD_RANGE_TO_INCLUSIVE:
+        return StdRangeToInclusiveProvider(valobj)
+
     return None

--- a/prettyPrinters/gdb_providers.py
+++ b/prettyPrinters/gdb_providers.py
@@ -300,6 +300,53 @@ class StdNonZeroNumberProvider:
         return self.value
 
 
+class StdRangeProvider:
+    def __init__(self, valobj):
+        # type: (Value) -> None
+        self.start = int(valobj["start"])
+        self.end = int(valobj["end"])
+
+    def to_string(self):
+        return "{}..{}".format(self.start, self.end)
+
+
+class StdRangeFromProvider:
+    def __init__(self, valobj):
+        # type: (Value) -> None
+        self.start = int(valobj["start"])
+
+    def to_string(self):
+        return "{}..".format(self.start)
+
+
+class StdRangeInclusiveProvider:
+    def __init__(self, valobj):
+        # type: (Value) -> None
+        self.start = int(valobj["start"])
+        self.end = int(valobj["end"])
+
+    def to_string(self):
+        return "{}..={}".format(self.start, self.end)
+
+
+class StdRangeToProvider:
+    def __init__(self, valobj):
+        # type: (Value) -> None
+        self.end = int(valobj["end"])
+
+    def to_string(self):
+        return "..{}".format(self.end)
+
+
+class StdRangeToInclusiveProvider:
+    def __init__(self, valobj):
+        # type: (Value) -> None
+        self.end = int(valobj["end"])
+
+    def to_string(self):
+        return "..={}".format(self.end)
+
+
 # Yields children (in a provider's sense of the word) for a BTreeMap.
 def children_of_btree_map(map):
     # Yields each key/value pair in the node and in any child nodes.

--- a/prettyPrinters/lldb_lookup.py
+++ b/prettyPrinters/lldb_lookup.py
@@ -69,6 +69,17 @@ def summary_lookup(valobj, dict):
     if rust_type == RustType.STD_NONZERO_NUMBER:
         return StdNonZeroNumberSummaryProvider(valobj, dict)
 
+    if rust_type == RustType.STD_RANGE:
+        return StdRangeSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_RANGE_FROM:
+        return StdRangeFromSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_RANGE_INCLUSIVE:
+        return StdRangeInclusiveSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_RANGE_TO:
+        return StdRangeToSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_RANGE_TO_INCLUSIVE:
+        return StdRangeToInclusiveSummaryProvider(valobj, dict)
+
     return ""
 
 

--- a/prettyPrinters/lldb_providers.py
+++ b/prettyPrinters/lldb_providers.py
@@ -678,3 +678,30 @@ def StdNonZeroNumberSummaryProvider(valobj, _dict):
     field = objtype.GetFieldAtIndex(0)
     element = valobj.GetChildMemberWithName(field.name)
     return element.GetValue()
+
+
+def StdRangeSummaryProvider(valobj, _dict):
+    # type: (SBValue, dict) -> str
+    return "{}..{}".format(valobj.GetChildMemberWithName("start").GetValueAsSigned(),
+                           valobj.GetChildMemberWithName("end").GetValueAsSigned())
+
+
+def StdRangeFromSummaryProvider(valobj, _dict):
+    # type: (SBValue, dict) -> str
+    return "{}..".format(valobj.GetChildMemberWithName("start").GetValueAsSigned())
+
+
+def StdRangeInclusiveSummaryProvider(valobj, _dict):
+    # type: (SBValue, dict) -> str
+    return "{}..={}".format(valobj.GetChildMemberWithName("start").GetValueAsSigned(),
+                            valobj.GetChildMemberWithName("end").GetValueAsSigned())
+
+
+def StdRangeToSummaryProvider(valobj, _dict):
+    # type: (SBValue, dict) -> str
+    return "..{}".format(valobj.GetChildMemberWithName("end").GetValueAsSigned())
+
+
+def StdRangeToInclusiveSummaryProvider(valobj, _dict):
+    # type: (SBValue, dict) -> str
+    return "..={}".format(valobj.GetChildMemberWithName("end").GetValueAsSigned())

--- a/prettyPrinters/rust_types.py
+++ b/prettyPrinters/rust_types.py
@@ -40,6 +40,11 @@ class RustType(object):
     STD_REF_MUT = "StdRefMut"
     STD_REF_CELL = "StdRefCell"
     STD_NONZERO_NUMBER = "StdNonZeroNumber"
+    STD_RANGE = "StdRange"
+    STD_RANGE_FROM = "StdRangeFrom"
+    STD_RANGE_INCLUSIVE = "StdRangeInclusive"
+    STD_RANGE_TO = "StdRangeTo"
+    STD_RANGE_TO_INCLUSIVE = "StdRangeToInclusive"
 
 
 # Should be synchronized with `RsDebugProcessConfigurationHelper.RUST_STD_TYPES`
@@ -70,6 +75,11 @@ STD_REF_REGEX = re.compile(r"^(core::([a-z_]+::)+)Ref<.+>$")
 STD_REF_MUT_REGEX = re.compile(r"^(core::([a-z_]+::)+)RefMut<.+>$")
 STD_REF_CELL_REGEX = re.compile(r"^(core::([a-z_]+::)+)RefCell<.+>$")
 STD_NONZERO_NUMBER_REGEX = re.compile(r"^core::num::([a-z_]+::)*NonZero.+$")
+STD_RANGE_REGEX = re.compile(r"^core::ops::range::Range<.+>$")
+STD_RANGE_FROM_REGEX = re.compile(r"^core::ops::range::RangeFrom<.+>$")
+STD_RANGE_INCLUSIVE_REGEX = re.compile(r"^core::ops::range::RangeInclusive<.+>$")
+STD_RANGE_TO_REGEX = re.compile(r"^core::ops::range::RangeTo<.+>$")
+STD_RANGE_TO_INCLUSIVE_REGEX = re.compile(r"^core::ops::range::RangeToInclusive<.+>$")
 
 TUPLE_ITEM_REGEX = re.compile(r"__\d+$")
 
@@ -101,7 +111,12 @@ STD_TYPE_TO_REGEX = {
     RustType.STD_REF_MUT: STD_REF_MUT_REGEX,
     RustType.STD_REF_CELL: STD_REF_CELL_REGEX,
     RustType.STD_CELL: STD_CELL_REGEX,
-    RustType.STD_NONZERO_NUMBER: STD_NONZERO_NUMBER_REGEX
+    RustType.STD_NONZERO_NUMBER: STD_NONZERO_NUMBER_REGEX,
+    RustType.STD_RANGE: STD_RANGE_REGEX,
+    RustType.STD_RANGE_FROM: STD_RANGE_FROM_REGEX,
+    RustType.STD_RANGE_INCLUSIVE: STD_RANGE_INCLUSIVE_REGEX,
+    RustType.STD_RANGE_TO: STD_RANGE_TO_REGEX,
+    RustType.STD_RANGE_TO_INCLUSIVE: STD_RANGE_TO_INCLUSIVE_REGEX,
 }
 
 

--- a/pretty_printers_tests/tests/range.rs
+++ b/pretty_printers_tests/tests/range.rs
@@ -1,0 +1,48 @@
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+
+// lldb-command:print range
+// lldbr-check:[...]range = 1..12 [...]
+// lldbg-check:[...]$0 = 1..12 [...]
+
+// lldb-command:print range_from
+// lldbr-check:[...]range_from = 9.. [...]
+// lldbg-check:[...]$1 = 9.. [...]
+
+// lldb-command:print range_inclusive
+// lldbr-check:[...]range_inclusive = 32..=80 [...]
+// lldbg-check:[...]$2 = 32..=80 [...]
+
+// lldb-command:print range_to
+// lldbr-check:[...]range_to = ..42 [...]
+// lldbg-check:[...]$3 = ..42 [...]
+
+// lldb-command:print range_to_inclusive
+// lldbr-check:[...]range_to_inclusive = ..=120 [...]
+// lldbg-check:[...]$4 = ..=120 [...]
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+
+// gdb-command:print range
+// gdb-check:[...]$1 = 1..12
+// gdb-command:print range_from
+// gdb-check:[...]$2 = 9..
+// gdb-command:print range_inclusive
+// gdb-check:[...]$3 = 32..=80
+// gdb-command:print range_to
+// gdb-check:[...]$4 = ..42
+// gdb-command:print range_to_inclusive
+// gdb-check:[...]$5 = ..=120
+
+
+fn main() {
+    let range = 1..12;
+    let range_from = 9..;
+    let range_inclusive = 32..=80;
+    let range_to = ..42;
+    let range_to_inclusive = ..=120;
+    print!(""); // #break
+}


### PR DESCRIPTION
Add summary pretty-printers for range types:
* `core::ops::range::Range`
* `core::ops::range::RangeFrom`
* `core::ops::range::RangeInclusive`
* `core::ops::range::RangeTo`
* `core::ops::range::RangeToInclusive`

Fixes #7760.

![image](https://user-images.githubusercontent.com/4854600/185944267-d8f1596c-93e6-4c5a-ba38-6f40c596bb59.png)


changelog: Provide debugger pretty-printers to render range types (e.g. `core::ops::range::Range`)