### PR TITLE
PERF: resolve nested paths at once

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -64,9 +64,9 @@ val RsPath.qualifier: RsPath?
         return (ctx as? RsUseSpeck)?.qualifier
     }
 
-fun RsPath.allowedNamespaces(isCompletion: Boolean = false): Set<Namespace> = when (val parent = parent) {
+fun RsPath.allowedNamespaces(isCompletion: Boolean = false, parent: PsiElement? = this.parent): Set<Namespace> = when (parent) {
     is RsPath, is RsTraitRef, is RsStructLiteral, is RsPatStruct -> TYPES
-    is RsTypeReference -> when (parent.parent) {
+    is RsTypeReference -> when (parent.stubParent) {
         is RsTypeArgumentList -> when {
             // type A = Foo<T>
             //              ~ `T` can be either type or const argument

--- a/src/main/kotlin/org/rust/lang/core/resolve/PathResolutionContext.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/PathResolutionContext.kt
@@ -1,0 +1,142 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import com.intellij.psi.PsiElement
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.lang.core.macros.decl.MACRO_DOLLAR_CRATE_IDENTIFIER
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.RsPathResolveKind.*
+import kotlin.LazyThreadSafetyMode.NONE
+
+class PathResolutionContext(
+    val context: RsElement,
+    val isCompletion: Boolean,
+    private val givenImplLookup: ImplLookup?,
+) {
+    val crateRoot: RsMod? = context.crateRoot
+    val containingMod: RsMod by lazy(NONE) {
+        context.containingMod
+    }
+    val implLookup: ImplLookup by lazy(NONE) {
+        givenImplLookup ?: ImplLookup.relativeTo(context)
+    }
+    val isAtLeastEdition2018: Boolean
+        get() {
+            val edition = crateRoot?.edition ?: CargoWorkspace.Edition.DEFAULT
+            return edition >= CargoWorkspace.Edition.EDITION_2018
+        }
+
+    fun classifyPath(path: RsPath): RsPathResolveKind {
+        val parent = path.stubParent
+        if (parent is RsMacroCall) {
+            error("Tried to use `processPathResolveVariants` for macro path. See `RsMacroPathReferenceImpl`")
+        }
+        if (parent is RsAssocTypeBinding) {
+            return AssocTypeBindingPath(parent)
+        }
+
+        val qualifier = path.qualifier
+        val typeQual = path.typeQual
+        val ns = path.allowedNamespaces(isCompletion, parent)
+
+        return when {
+            // foo::bar
+            qualifier != null ->
+                QualifiedPath(path, ns, qualifier, parent)
+
+            // `<T as Trait>::Item` or `<T>::Item`
+            typeQual != null ->
+                ExplicitTypeQualifiedPath(ns, typeQual)
+
+            else -> classifyUnqualifiedPath(path, ns)
+        }
+    }
+
+    private fun classifyUnqualifiedPath(
+        path: RsPath,
+        ns: Set<Namespace>,
+    ): RsPathResolveKind {
+        /** Path starts with `::` */
+        val hasColonColon = path.hasColonColon
+        if (!hasColonColon) {
+            // hacks around $crate macro metavar. See `expandDollarCrateVar` function docs
+            val referenceName = path.referenceName
+            if (referenceName == MACRO_DOLLAR_CRATE_IDENTIFIER) {
+                return MacroDollarCrateIdentifier(path)
+            }
+        }
+
+        val isAtLeastEdition2018 = isAtLeastEdition2018
+
+        // In 2015 edition a path is crate-relative (global) if it's inside use item,
+        // inside "visibility restriction" or if it starts with `::`
+        // ```rust, edition2015
+        // use foo::bar; // `foo` is crate-relative
+        // let a = ::foo::bar; // `foo` is also crate-relative
+        // pub(in foo::bar) fn baz() {}
+        //       //^ crate-relative path too
+        // ```
+        // Starting 2018 edition a path is crate-relative if it starts with `crate::` (handled above)
+        // or if it's inside "visibility restriction". `::`-qualified path since 2018 edition means that
+        // such path is a name of some dependency crate (that should be resolved without `extern crate`)
+        val isCrateRelative = !isAtLeastEdition2018 && (hasColonColon || path.rootPath().parent is RsUseSpeck)
+            || path.rootPath().parent is RsVisRestriction
+        // see https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html#the-crate-keyword-refers-to-the-current-crate
+        val isExternCrate = isAtLeastEdition2018 && hasColonColon
+        return when {
+            isCrateRelative -> CrateRelativePath(path, ns, hasColonColon)
+
+            isExternCrate -> ExternCratePath
+
+            else -> UnqualifiedPath(ns)
+        }
+    }
+}
+
+sealed class RsPathResolveKind {
+    /** A path consist of a single identifier, e.g. `foo` */
+    data class UnqualifiedPath(val ns: Set<Namespace>) : RsPathResolveKind()
+
+    /** `bar` in `foo::bar` or `use foo::{bar}` */
+    class QualifiedPath(
+        val path: RsPath,
+        val ns: Set<Namespace>,
+        val qualifier: RsPath,
+        val parent: PsiElement?
+    ) : RsPathResolveKind()
+
+    /** `<Foo>::bar` or `<Foo as Bar>::baz` */
+    class ExplicitTypeQualifiedPath(
+        val ns: Set<Namespace>,
+        val typeQual: RsTypeQual
+    ) : RsPathResolveKind()
+
+    /** @see MACRO_DOLLAR_CRATE_IDENTIFIER */
+    class MacroDollarCrateIdentifier(val path: RsPath) : RsPathResolveKind()
+
+    /**
+     * ```
+     * pub (in foo) struct Bar;
+     *       //^ this path is crate-relative
+     * ```
+     *
+     * Also, in 2015 edition a path is crate-relative if it starts with `::` or it is a first path
+     * segment in a `use` item.
+     */
+    class CrateRelativePath(
+        val path: RsPath,
+        val ns: Set<Namespace>,
+        val hasColonColon: Boolean,
+    ) : RsPathResolveKind()
+
+    /** A path starting with `::` since 2018 edition */
+    object ExternCratePath : RsPathResolveKind()
+
+    /** `Item` path in `dyn Iterator<Item = u8>` */
+    class AssocTypeBindingPath(val parent: RsAssocTypeBinding) : RsPathResolveKind()
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsPathResolveResult.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsPathResolveResult.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.ResolveResult
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.types.Substitution
+import org.rust.lang.core.types.emptySubstitution
+
+/**
+ * Used as a resolve result in [org.rust.lang.core.resolve.ref.RsPathReferenceImpl]
+ */
+data class RsPathResolveResult<T : RsElement>(
+    val element: T,
+    val resolvedSubst: Substitution = emptySubstitution,
+    val isVisible: Boolean,
+) : ResolveResult {
+    override fun getElement(): PsiElement = element
+
+    override fun isValidResult(): Boolean = true
+
+    inline fun mapSubst(
+        f: (Substitution) -> Substitution
+    ): RsPathResolveResult<T> {
+        if (resolvedSubst === emptySubstitution) {
+            return this
+        }
+        return RsPathResolveResult(element, f(resolvedSubst), isVisible)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
@@ -79,17 +79,3 @@ val BoundElement<RsGenericDeclaration>.positionalConstArguments: List<Const>
 
 val BoundElement<RsGenericDeclaration>.singleParamValue: Ty
     get() = element.typeParameters.singleOrNull()?.let { subst[it] } ?: TyUnknown
-
-data class BoundElementWithVisibility<T : RsElement>(
-    val inner: BoundElement<T>,
-    val isVisible: Boolean,
-) {
-    override fun toString(): String {
-        val visibility = if (isVisible) "public" else "private"
-        return "$visibility $inner"
-    }
-}
-
-fun <T : RsElement> BoundElementWithVisibility<T>.map(
-    f: (BoundElement<T>) -> BoundElement<T>
-): BoundElementWithVisibility<T> = BoundElementWithVisibility(f(inner), isVisible)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -429,8 +429,9 @@ class RsTypeInferenceWalker(
 
         val subst = instantiatePathGenerics(
             path,
-            BoundElement(element, scopeEntry.subst),
-            PathExprResolver.fromContext(ctx)
+            element,
+            scopeEntry.subst,
+            PathExprResolver.fromContext(ctx),
         ).subst
 
         val typeParameters = when {


### PR DESCRIPTION
Resolve and cache all nested paths at once, so `Foo<Foo<Foo<Foo>>>` resolution costs `O(1)` instead of `O(4)`.

This is particularly helpful in the case of `typenum` crate where there are a lot of types like this:
```rust
pub type U50 = UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B1>, B0>, B0>, B1>, B0>;
```

changelog: Speed up name resolution of large nested paths like `Foo<Foo<Foo<Foo<...>>>>`
