### PR TITLE
RUN: Don't erase the file content while formatting if `#![cfg_attr(rustfmt, rustfmt_skip)]` attribute is presented

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.execution.ParametersListUtil
+import com.intellij.util.text.nullize
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.settings.rustfmtSettings
 import org.rust.cargo.project.settings.toolchain
@@ -37,12 +38,13 @@ class Rustfmt(toolchain: RsToolchainBase) : RustupComponent(NAME, toolchain) {
 
     fun reformatDocumentTextOrNull(cargoProject: CargoProject, document: Document): String? {
         val project = cargoProject.project
-        return createCommandLine(cargoProject, document)
+        val stdout = createCommandLine(cargoProject, document)
             ?.execute(project, stdIn = document.text.toByteArray())
             ?.unwrapOrElse { e ->
                 e.showRustfmtError(project)
                 if (isUnitTestMode) throw e else return null
             }?.stdout
+        return stdout.nullize()
     }
 
     fun createCommandLine(cargoProject: CargoProject, document: Document): GeneralCommandLine? {


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/8913.

TODO: Come up with a minimal reproducible example for tests

changelog: Don't erase the file content while formatting if `#![cfg_attr(rustfmt, rustfmt_skip)]` attribute is presented
