### PR TITLE
CARGO: properly parse env variable in cargo config

### DIFF
--- a/src/main/kotlin/org/rust/cargo/CargoConfig.kt
+++ b/src/main/kotlin/org/rust/cargo/CargoConfig.kt
@@ -5,6 +5,7 @@
 
 package org.rust.cargo
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
@@ -15,10 +16,11 @@ data class CargoConfig(
     val env: Map<String, EnvValue>,
 
 ) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
     data class EnvValue(
         @JsonProperty("value")
         val value: String,
-        @JsonProperty("forced")
+        @JsonProperty("force")
         val isForced: Boolean = false,
         @JsonProperty("relative")
         val isRelative: Boolean = false

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -233,6 +233,7 @@ class Cargo(
         val tree = try {
             TOML_MAPPER.readTree(output)
         } catch (e: JacksonException) {
+            LOG.error(e)
             return Err(RsDeserializationException(e))
         }
 
@@ -247,6 +248,7 @@ class Cargo(
                 val valueParams = try {
                     TOML_MAPPER.treeToValue(field.value, CargoConfig.EnvValue::class.java)
                 } catch (e: JacksonException) {
+                    LOG.error(e)
                     return Err(RsDeserializationException(e))
                 }
                 field.key to CargoConfig.EnvValue(valueParams.value, valueParams.isForced, valueParams.isRelative)

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoConfigTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoConfigTest.kt
@@ -49,8 +49,9 @@ class CargoConfigTest : RsWithToolchainTestBase() {
                 toml("config.toml", """
                     [env]
                     foo = "42"
-                    bar = { value = "24", forced = true }
+                    bar = { value = "24", force = true }
                     baz = { value = "hello/world", relative = true }
+                    qwe = { value = "value", unknown_field = 123 }
                 """)
             }
             file("Cargo.toml", CARGO_TOML)
@@ -62,6 +63,7 @@ class CargoConfigTest : RsWithToolchainTestBase() {
         assertEquals(CargoConfig.EnvValue("42"), env["foo"])
         assertEquals(CargoConfig.EnvValue("24", isForced = true), env["bar"])
         assertEquals(CargoConfig.EnvValue("hello/world", isRelative = true), env["baz"])
+        assertEquals(CargoConfig.EnvValue("value"), env["qwe"])
     }
 
     companion object {


### PR DESCRIPTION
Previously, the plugin expected `forced` field instead of `force`.
Also, now parsing doesn't fail on unknown fields

Fixes #9212

changelog: Properly parse environment variables in [cargo config](https://doc.rust-lang.org/cargo/reference/config.html#env)
