### PR TITLE
Fix cargo features inference

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -144,6 +144,7 @@ object CargoMetadata {
     data class RawDependency(
         /** A `package` name (non-normalized) of the dependency */
         val name: String,
+        /** Non-null if renamed. Non-normalized (i.e. can contain "-") */
         val rename: String?,
         val kind: String?,
         val target: String?,


### PR DESCRIPTION
Fix cargo features inference in the case of a dependency duplicated with rename, where these dependencies have different required features and only one dependency is actually enabled (see example in tests).

The bug could be reproduced with `mysql_async` crate:
```toml
[dependencies]
mysql_async = "=0.30.0"
```
In this case, the `bigdecimal` dependency of `mysql_async` must not have `serde` feature (optional dependency) enabled.

changelog: Fix cargo feature state inference in several cases