### PR TITLE
CARGO: show error msg in Sync tool window if project dir does not exist

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -118,6 +118,14 @@ class CargoSyncTask(
                     createContext = { it },
                     action = { childProgress ->
                         if (!cargoProject.workingDirectory.exists()) {
+                            childProgress.message(
+                                "Project directory does not exist",
+                                "Project directory `${cargoProject.workingDirectory}` does not exist.\n" +
+                                    "Consider detaching the project `${cargoProject.presentableName}` " +
+                                    "from the Cargo tool window",
+                                MessageEvent.Kind.ERROR,
+                                null
+                            )
                             val stdlibStatus = CargoProject.UpdateStatus.UpdateFailed("Project directory does not exist")
                             CargoProjectWithStdlib(cargoProject.copy(stdlibStatus = stdlibStatus), null)
                         } else {

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
@@ -13,10 +13,12 @@ import com.intellij.testFramework.fixtures.BuildViewTestFixture
 import org.rust.WithExperimentalFeatures
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.toolwindow.CargoToolWindow
 import org.rust.fileTree
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.launchAction
+import java.nio.file.Path
 
 class SyncToolWindowTest : RsWithToolchainTestBase() {
 
@@ -31,6 +33,16 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
     override fun tearDown() {
         buildViewTestFixture.tearDown()
         super.tearDown()
+    }
+
+    fun `test non-existing project`() {
+        project.cargoProjects.attachCargoProject(Path.of("/non-existing-project/Cargo.toml"))
+        checkSyncViewTree("""
+            -
+             -failed
+              -Sync non-existing-project project
+               Project directory does not exist
+        """)
     }
 
     fun `test single project`() {


### PR DESCRIPTION
Fixes #6765

changelog: Show error message in Sync tool window if project directory does not exist
