### PR TITLE
Do not unconditionally succeed RUSTC_WRAPPER when run by build scripts

### DIFF
--- a/native-helper/src/rustc_wrapper.rs
+++ b/native-helper/src/rustc_wrapper.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
-use std::process::{Command, Stdio};
 use std::io;
+use std::process::{Command, Stdio};
 
 pub struct ExitCode(pub Option<i32>);
 
@@ -8,6 +8,12 @@ pub fn run_rustc_skipping_cargo_checking(
     rustc_executable: OsString,
     args: Vec<OsString>,
 ) -> io::Result<ExitCode> {
+    // `CARGO_CFG_TARGET_ARCH` is only set by cargo when executing build scripts
+    // We don't want to exit out checks unconditionally with success if a build
+    // script tries to invoke checks themselves
+    // See https://github.com/rust-lang/rust-analyzer/issues/12973 for context
+    let is_invoked_by_build_script = std::env::var_os("CARGO_CFG_TARGET_ARCH").is_some();
+
     let is_cargo_check = args.iter().any(|arg| {
         let arg = arg.to_string_lossy();
         // `cargo check` invokes `rustc` with `--emit=metadata` argument.
@@ -20,7 +26,7 @@ pub fn run_rustc_skipping_cargo_checking(
         //            The default output filename is CRATE_NAME.rmeta.
         arg.starts_with("--emit=") && arg.contains("metadata") && !arg.contains("link")
     });
-    if is_cargo_check {
+    if !is_invoked_by_build_script && is_cargo_check {
         return Ok(ExitCode(Some(0)));
     }
     run_rustc(rustc_executable, args)


### PR DESCRIPTION
Fixes #9198, fixes #9227.

Based on https://github.com/rust-lang/rust-analyzer/pull/13010 and discussion in https://github.com/rust-lang/rust-analyzer/issues/12973.

intellij-rust-native-helper in `RUSTC_WRAPPER` role unconditionally succeeds `cargo check` invocations tripping up build scripts using `cargo check` to probe for successful compilations. To prevent this from happening the `RUSTC_WRAPPER` now checks if it's run from a build script by looking for the `CARGO_CFG_TARGET_ARCH` env var that cargo sets only when running build scripts.

changelog: Fix broken `anyhow` compilation when `org.rust.cargo.evaluate.build.scripts` [experimental feature](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features) is enabled