### PR TITLE
PERF: re-revert #9021 speed up `getIncludingMod` usages

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -77,9 +77,7 @@ class RsFile(
     val crate: Crate? get() = cachedData.crate
     override val crateRoot: RsMod? get() = cachedData.crateRoot
     val isDeeplyEnabledByCfg: Boolean get() = cachedData.isDeeplyEnabledByCfg
-    // TODO a hotfix for https://github.com/intellij-rust/intellij-rust/issues/9110
-    val isIncludedByIncludeMacro: Boolean get() = true
-//    val isIncludedByIncludeMacro: Boolean get() = cachedData.isIncludedByIncludeMacro
+    val isIncludedByIncludeMacro: Boolean get() = cachedData.isIncludedByIncludeMacro
 
     /** Used for in-memory macro expansions */
     @Volatile


### PR DESCRIPTION
#9021 has been reverted in #9169 because of #9110. Now it can be enabled again because we got rid of recursion in `RsFile.getCachedData()` in #9171

changelog: Enable again [the optimization](https://github.com/intellij-rust/intellij-rust/pull/9021) reverted in the previous release. Slightly speed up name resolution