### PR TITLE
DBG: Fix `Ref`/`RefMut` GDB pretty-printers on Rust 1.62

### DIFF
--- a/prettyPrinters/gdb_providers.py
+++ b/prettyPrinters/gdb_providers.py
@@ -255,7 +255,7 @@ class StdRefProvider:
         # type: (Value) -> None
         # BACKCOMPAT: Rust 1.62.0. Drop `else`-branch
         value = valobj["value"]
-        if value["pointer"]:
+        if value.type.code == gdb.TYPE_CODE_STRUCT and value["pointer"]:
             # Since Rust 1.63.0, `Ref` and `RefMut` use `value: NonNull<T>` instead of `value: &T`
             # https://github.com/rust-lang/rust/commit/d369045aed63ac8b9de1ed71679fac9bb4b0340a
             # https://github.com/rust-lang/rust/commit/2b8041f5746bdbd7c9f6ccf077544e1c77e927c0


### PR DESCRIPTION
Fixes the issue described in https://github.com/intellij-rust/intellij-rust/pull/9203#issuecomment-1220719461, concerning Rust version 1.62 or earlier.

In contrast to LLDB, GDB's pretty-printing API does not allow access to non-existing child members.