### PR TITLE
ANN: allow leading | in nested or patterns

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -197,17 +197,6 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     private fun checkOrPat(holder: RsAnnotationHolder, orPat: RsOrPat) {
         val parent = orPat.context
 
-        if (parent is RsPat) {
-            val firstChild = orPat.firstChild
-            if (firstChild?.elementType == RsElementTypes.OR) {
-                holder.createErrorAnnotation(
-                    firstChild,
-                    "a leading `|` is only allowed in a top-level pattern",
-                    RemoveElementFix(firstChild)
-                )
-            }
-        }
-
         if (parent !is RsCondition && parent !is RsMatchArm) {
             OR_PATTERNS.check(holder, orPat, "or-patterns syntax")
         }


### PR DESCRIPTION
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

Fixes #9001

Nested or-patterns were [stabilized](https://github.com/rust-lang/rust/pull/79278) in Rust 1.53. The final design allows leading vertical bar `|` in nested or-patterns, just like toplevel or-patterns. This was previously an explicit error, also implemented in the plugin.

This PR reverts the deprecated error on nested patterns.

changelog: allow leading | in nested or-patterns