### PR TITLE
CARGO: support new Cargo features syntax from 1.60.0

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -410,11 +410,16 @@ object CargoMetadata {
 
         val features = features.toMutableMap()
 
-        // Optional dependencies are features implicitly
+        // Backcompat Cargo 1.59.0: optional dependencies are features implicitly.
+        // Since 1.60.0 these implicit features are returned from cargo as usual
+        val allFeatureDependencies = features.values.flatten().toSet()
         for (dependency in dependencies) {
             val featureName = dependency.rename ?: dependency.name
             if (dependency.optional && featureName !in features) {
-                features[featureName] = emptyList()
+                val depFeatureName = "dep:$featureName"
+                if (depFeatureName !in allFeatureDependencies) {
+                    features[featureName] = listOf(depFeatureName)
+                }
             }
         }
 

--- a/src/test/kotlin/org/rust/common.kt
+++ b/src/test/kotlin/org/rust/common.kt
@@ -30,6 +30,7 @@ import org.rust.cargo.project.model.impl.CargoProjectImpl
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.FeatureName
 import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageFeature
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.RsPossibleMacroCall
@@ -177,6 +178,12 @@ fun CargoProjectsService.singleWorkspace(): CargoWorkspace = singleProject().wor
 
 fun CargoProjectsService.singlePackage(name: String): CargoWorkspace.Package =
     singleWorkspace().packages.singleOrNull { it.name == name } ?: error("Package with name `$name` does not exists")
+
+fun CargoProjectsService.enableCargoFeature(packageName: String, featureName: FeatureName) =
+    modifyFeatures(singleProject(), setOf(PackageFeature(singlePackage(packageName), featureName)), FeatureState.Enabled)
+
+fun CargoProjectsService.disableCargoFeature(packageName: String, featureName: FeatureName) =
+    modifyFeatures(singleProject(), setOf(PackageFeature(singlePackage(packageName), featureName)), FeatureState.Disabled)
 
 fun CargoWorkspace.Package.checkFeatureEnabled(featureName: FeatureName) =
     checkFeatureState(featureName, FeatureState.Enabled)

--- a/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFeatureDependencyReferenceProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFeatureDependencyReferenceProvider.kt
@@ -39,15 +39,17 @@ private class CargoTomlFeatureDependencyReference(element: TomlLiteral) : PsiPol
         val element = element
         val literalValue = (element.kind as? TomlLiteralKind.String)?.value ?: return ResolveResult.EMPTY_ARRAY
         return if ("/" in literalValue) {
-            val (depName, featureName) = literalValue.split("/", limit = 2)
+            val (firstSegment, featureName) = literalValue.split("/", limit = 2)
                 .takeIf { it.size == 2 }
                 ?: return ResolveResult.EMPTY_ARRAY
+            val depName = firstSegment.removeSuffix("?")
 
             val depToml = findDependencyTomlFile(element, depName) ?: return ResolveResult.EMPTY_ARRAY
             depToml.resolveFeature(featureName)
         } else {
+            val depOnly = literalValue.startsWith("dep:")
             val tomlFile = element.containingFile as? TomlFile ?: return ResolveResult.EMPTY_ARRAY
-            tomlFile.resolveFeature(literalValue)
+            tomlFile.resolveFeature(literalValue.removePrefix("dep:"), depOnly)
         }
     }
 

--- a/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlNameResolution.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlNameResolution.kt
@@ -16,51 +16,67 @@ import org.toml.lang.psi.*
 import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
 
-fun TomlFile.resolveFeature(featureName: String): Array<ResolveResult> =
-    allFeatures()
+fun TomlFile.resolveFeature(featureName: String, depOnly: Boolean = false): Array<ResolveResult> =
+    allFeatures(depOnly)
         .filter { it.text == featureName }
         .map { PsiElementResolveResult(it) }
         .toList()
         .toTypedArray()
 
-fun TomlFile.allFeatures(): Sequence<TomlKeySegment> = childrenOfType<TomlTable>()
-    .asSequence()
-    .flatMap { table ->
-        val header = table.header
-        when {
-            // [features]
-            header.isFeatureListHeader -> {
-                table.entries.asSequence().mapNotNull { it.key.segments.singleOrNull() }
-            }
+fun TomlFile.allFeatures(depOnly: Boolean = false): Sequence<TomlKeySegment> {
+    val explicitFeatures = hashSetOf<String>()
+    return childrenOfType<TomlTable>()
+        .asSequence()
+        .flatMap { table ->
+            val header = table.header
+            when {
+                // [features]
+                header.isFeatureListHeader && !depOnly -> {
+                    table.entries
+                        .asSequence()
+                        .mapNotNull { it.key.segments.singleOrNull() }
+                        .map { key ->
+                            key.name?.let { explicitFeatures += it }
+                            key
+                        }
+                }
 
-            // # Optional dependencies are features too:
-            // [dependencies]
-            // bar = { version = "*", optional = true }
-            header.isDependencyListHeader -> {
-                table.entries
-                    .asSequence()
-                    .filter {
-                        (it.value as? TomlInlineTable)?.getValueWithKey("optional")?.asBoolean() == true
+                // # Optional dependencies are features too:
+                // [dependencies]
+                // bar = { version = "*", optional = true }
+                header.isDependencyListHeader -> {
+                    table.entries
+                        .asSequence()
+                        .filter {
+                            (it.value as? TomlInlineTable)?.getValueWithKey("optional")?.asBoolean() == true
+                        }
+                        .mapNotNull { it.key.segments.singleOrNull() }
+                        .filter { it.name !in explicitFeatures }
+                }
+
+                // [dependencies.bar]
+                // version = "*"
+                // optional = true
+                header.isSpecificDependencyTableHeader -> {
+                    if (table.getValueWithKey("optional")?.asBoolean() == true) {
+                        val lastKey = header.key?.segments?.last()
+                        if (lastKey != null && lastKey.name !in explicitFeatures) {
+                            sequenceOf(lastKey)
+                        } else {
+                            emptySequence()
+                        }
+                    } else {
+                        emptySequence()
                     }
-                    .mapNotNull { it.key.segments.singleOrNull() }
-            }
+                }
 
-            // [dependencies.bar]
-            // version = "*"
-            // optional = true
-            header.isSpecificDependencyTableHeader -> {
-                if (table.getValueWithKey("optional")?.asBoolean() == true) {
-                    val lastKey = header.key?.segments?.last()
-                    if (lastKey != null) sequenceOf(lastKey) else emptySequence()
-                } else {
+                else -> {
                     emptySequence()
                 }
             }
-            else -> {
-                emptySequence()
-            }
         }
-    }
+        .constrainOnce()
+}
 
 private fun TomlValue.asBoolean(): Boolean? =
     ((this as? TomlLiteral)?.kind as? TomlLiteralKind.Boolean)?.value

--- a/toml/src/test/kotlin/org/rust/toml/CargoFeatureLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoFeatureLineMarkerProviderTest.kt
@@ -14,7 +14,6 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.FeatureName
 import org.rust.cargo.project.workspace.FeatureState
 import org.rust.cargo.project.workspace.PackageOrigin
-import org.rust.fileTree
 import org.rust.ide.lineMarkers.RsLineMarkerProviderTestBase
 import org.rust.ide.lineMarkers.invokeNavigationHandler
 import org.rust.singleProject
@@ -56,6 +55,24 @@ class CargoFeatureLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         [dependencies]
         foo = { path = "foo", optional = true } # - Toggle feature `foo`
     """)
+
+    // TODO the line marker should not be shown for the dependency
+    @MockCargoFeatures("foo")
+    fun `test optional dependency is not a feature`() = expect<Throwable> {
+    doTest("foo", """
+        [package]
+        name = "intellij-rust-test"
+        version = "0.1.0"
+        authors = []
+
+        [features]
+        foo = ["dep:foo"] # - Toggle feature `foo`
+
+        [dependencies.foo]
+        path = "foo"
+        optional = true
+    """)
+    }
 
     private fun doTest(featureName: FeatureName, @Language("Toml") source: String) {
         doTestByFileTree("Cargo.toml") {


### PR DESCRIPTION
Support cargo feature values inference for [new features syntax](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#new-syntax-for-cargo-features).

Unfortunately, this implementation already has a known bug - #9476.

You can refresh knowledge about Cargo Features in [Cargo Book](https://doc.rust-lang.org/cargo/reference/features.html) and in [the CLion blog post](https://blog.jetbrains.com/clion/2020/10/intellij-rust-new-functionality-for-cargo-features/) about our support of cargo features.

### Examples of the new syntax:

In this (simple old-fashion) case, there is an implicit feature `foo` of the optional dependency `foo`:

```toml
[dependencies]
foo = { path = "./foo", optional = true }
```

In this (again old-fashion) case, there is an explicit feature `feature_foo` that depends on implicit feature `foo` of the optional dependency `foo`:

```toml
[features]
feature_foo = ["foo"]

[dependencies]
foo = { path = "./foo", optional = true }
```

In this case, there is an explicit feature `feature_foo` that depends directly on the optional dependency `foo`. There isn't an implicit feature `foo` anymore!

```toml
[features]
feature_foo = ["dep:foo"] # Note `dep:`!

[dependencies]
foo = { path = "./foo", optional = true }
```

Since `foo` is not a feature now, it can't be referred as `#[cfg(feature = "foo")]` and can't be referred/enabled anyhow except using `dep:foo` syntax in the same `Cargo.toml` file.