### PR TITLE
TYPE: change folded regions to look more like unfolded ones

### DIFF
--- a/src/test/resources/org/rust/ide/folding/fixtures/crates.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/crates.rs
@@ -1,11 +1,40 @@
-<fold text='/* crates */'>#[macro_use]
-extern crate lazy_static;
+extern crate <fold text='...'>stdfoo;
+extern crate stdbar</fold>;
+
+type F = ();
+
+extern crate
+extern crate
+
+type G = ();
+
+<fold text=''>#[cfg_attr(unix, allow(dead_code))]
+#[macro_use]
+</fold>extern crate <fold text='...'>lazy_static;
 extern crate bitflags;
 extern crate dbus_macros;
 #[cfg(not(test))]
 extern crate getopts;
 #[macro_use]
-extern crate log;
-extern crate env_logger;
+extern crate log</fold>;
+
+
+type T = ();
+
+<fold text='/* ... */'><fold text=''>/// Reg doc</fold>
+
+// Reg comment
+#[cfg(unix)]
+
+<fold text='/* ... */'>/// Reg doc</fold>
+#[macro_use]
+</fold>extern crate <fold text='...'>env_logger;
 extern crate rustc_serialize;
-extern crate json_macro;</fold>
+extern crate json_macro</fold>;
+
+const _: () =();
+
+extern crate<fold text='...'>
+foobar;
+extern crate
+barbarbar</fold>;

--- a/src/test/resources/org/rust/ide/folding/fixtures/mods.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/mods.rs
@@ -1,14 +1,52 @@
-<fold text='/* mods */'>#[macro_use]
-mod macros;
+mod <fold text='...'>stdfoo;
+mod stdbar</fold>;
+
+type F = ();
+
+mod
+mod
+
+type G = ();
+
+<fold text=''>#[cfg_attr(unix, allow(dead_code))]
+#[macro_use]
+</fold>mod <fold text='...'>macros;
 mod convert;
 mod callbacks;
+#[macro_use]
+// Keys comment
+<fold text='/* ... */'>/// Keys doc</fold>
 mod keys;
-mod lua;
-mod registry;
+
+<fold text='/* ... */'>/// Lua doc</fold>
+mod lua</fold>;
+
+type T = ();
+
+<fold text='/* ... */'><fold text=''>/// Reg doc</fold>
+// Reg comment
+#[cfg(unix)]
+<fold text='/* ... */'>/// Reg doc</fold>
+</fold>mod <fold text='...'>registry;
 mod commands;
+
+<fold text='/* ... */'>/// Ipc doc</fold>
+
+// Ipc comment
+#[cfg(unix)]
+
+
+<fold text='/* ... */'>/// Ipc doc</fold>
 mod ipc;
 mod layout;
 mod render;
 mod wayland;
 mod modes;
-mod awesome;</fold>
+mod awesome</fold>;
+
+const _: () =();
+
+mod<fold text='...'>
+foobar;
+mod
+barbarbar</fold>;

--- a/src/test/resources/org/rust/ide/folding/fixtures/uses.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/uses.rs
@@ -1,6 +1,45 @@
-<fold text='/* uses */'>use std::env;
+use <fold text='...'>std;
+use alloc</fold>;
+
+type F = ();
+
+use
+type S = ();
+use
+
+type G = ();
+
+<fold text=''>#[cfg_attr(unix, allow(dead_code))]
+#[macro_use]
+</fold>use <fold text='...'>std::env;
 use std::fs::File;
 use std::path::Path;
 
 use getopts::Options;
-use log::LogLevel;</fold>
+use log::LogLevel</fold>;
+
+type T = ();
+
+<fold text='/* ... */'><fold text=''>/// Foo doc</fold>
+// Foo
+<fold text='/* ... */'>/// Foo doc</fold>
+</fold>use <fold text='...'>std::result::Result;
+// Bar
+
+#[macro_use]
+<fold text='/* ... */'>/// Doc bar</fold>
+use std::error::Error</fold>;
+
+const _: () =();
+
+use<fold text='...'>::
+foobar;
+use
+barbarbar</fold>;
+
+const _: () =();
+
+use<fold text='...'>
+foobar;
+use
+barbarbar</fold>;

--- a/src/test/resources/org/rust/ide/folding/fixtures/where.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/where.rs
@@ -1,8 +1,20 @@
+fn bar() where <fold text='{...}'>{}</fold>
+
 fn foo<X, Y><fold text='(...)'>(x: X, y: Y)</fold> -> ()
-<fold text='/* where */'>where
+where <fold text='...'>
     X: Clone,
     Y: Clone,</fold>
 <fold text='{...}'>{
 
 }</fold>
 
+fn foobar<X, Y><fold text='(...)'>(x: X, y: Y)</fold> -> ()
+where<fold text='...'>
+    X: Clone,
+    Y: Clone,</fold>
+<fold text='{...}'>{
+
+}</fold>
+
+fn foobar<X, Y><fold text='(...)'>(x: X, y: Y)</fold> -> ()
+where


### PR DESCRIPTION
Closes #8982

Examples of displayed foldings (pipes denote boundaries of replacement strings):
```
|/* uses */|   -->  uses |...|;
|/* mod */|    -->  mod |...|;
|/* crates */| -->  extern crate |...|;
fn f() |/* where */| {}   -->   fn f() where |...| {}
```

This should make folded code blocks more distinct from folded block comments (even though the latter
are almost never used in the wild).

Unfortunately, this means that folding cannot be invoked on unfolded tokens (i.e. `use`, `mod`, `where`,
`extern crate` and `;` in the examples above). This can be mildly confusing, but at the moment I have no
better solution.

This feature has a precedent in Kotlin, which also folds imports in a way which leaves `import ...` with `import` being an unfolded keyword. Kotlin also doesn't have a solution to the issue that folding cannot be invoked on the leading `import` token in the first import line of an import block. I believe this should not be a significant issue in practice, since `use`, `extern crate` and `mod` blocks are most likely to be folded automatically, or not at all. The folding can also be invoked on any other part of a `use` block, and on subsequent `use` items.

Alternatively, we could go the way of PyCharm, which folds a block of imports into `import ...`, where the whole string is a replacement text. This way, there are no unexpected unfoldable points, but the folded block itself is slightly less visually parseable, since the leading keywords are not highlighted. 

An extra source of complexity is attributes and doc comments on `use` items. These precede the leading `use` keyword, and thus must be folded separately. When present, they give a hacky solution to the issue above, since the start of `use` keyword also becomes a folding point. Unfortunately, since the `FoldingDescriptor` API forbids empty text ranges, I cannot always insert a dummy fold point at the start of the `use` keyword regardless of preceding attributes.

I have also changed the folding of `where`-clauses. This has the same issues as above (the keyword is not a fold point), but it also looks much better with a proper highlighted leading keyword.

changelog: changed the rendering of folded blocks for `use`, `mod`, `extern crate` and `where` blocks.