### PR TITLE
COMP: add new attribute completions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.tree.TokenSet
+import com.intellij.psi.util.parentOfType
 import com.intellij.util.ProcessingContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
@@ -84,6 +85,10 @@ object RsPsiPattern {
 
     val onTestFn: PsiElementPattern.Capture<PsiElement> = onItem(psiElement<RsFunction>()
         .withChild(psiElement<RsOuterAttr>().withText("#[test]")))
+
+    val onProcMacroFn: PsiElementPattern.Capture<PsiElement> = onFn.with("proc_macro crate") { it ->
+        it.parentOfType<RsFile>()?.crate?.kind?.isProcMacro ?: false
+    }
 
     val onStructLike: PsiElementPattern.Capture<PsiElement> = onStruct or onEnum or onEnumVariant
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsAttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsAttributeCompletionProvider.kt
@@ -25,6 +25,7 @@ import org.rust.lang.core.RsPsiPattern.onExternCrate
 import org.rust.lang.core.RsPsiPattern.onFn
 import org.rust.lang.core.RsPsiPattern.onMacro
 import org.rust.lang.core.RsPsiPattern.onMod
+import org.rust.lang.core.RsPsiPattern.onProcMacroFn
 import org.rust.lang.core.RsPsiPattern.onStatic
 import org.rust.lang.core.RsPsiPattern.onStaticMut
 import org.rust.lang.core.RsPsiPattern.onStruct
@@ -51,8 +52,9 @@ object RsAttributeCompletionProvider : RsCompletionProvider() {
         onExternCrate to "macro_use no_link",
         onMod to "no_implicit_prelude path macro_use",
         onFn to "main start test cold naked export_name link_section lang inline track_caller " +
-            "panic_handler must_use",
+            "panic_handler must_use target_feature()",
         onTestFn to "should_panic ignore",
+        onProcMacroFn to "proc_macro proc_macro_derive() proc_macro_attribute",
         onStaticMut to "thread_local",
         onExternBlock to "link_args link() linked_from",
         onExternBlockDecl to "link_name linkage",

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt
@@ -310,4 +310,30 @@ class RsAttributeCompletionTest : RsAttributeCompletionTestBase() {
         #[function_like_/*caret*/]
         fn func() {}
     """)
+
+    fun `test target_feature on function`() = doSingleAttributeCompletion("""
+        #[target_f/*caret*/]
+        fn foo() {}
+    """, """
+        #[target_feature(/*caret*/)]
+        fn foo() {}
+    """)
+
+    fun `test no target_feature on type`() = checkNoCompletion("""
+        #[target_f/*caret*/]
+        type Foo = bool;
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test proc_macro completions on function in proc-macro crate`() = checkAttributeCompletionByFileTree(
+        listOf("proc_macro", "proc_macro_derive", "proc_macro_attribute"), """
+        //- dep-proc-macro/lib.rs
+        #[proc_ma/*caret*/]
+        fn mac() {}
+    """)
+
+    fun `test no proc_macro attributes on function in non-proc-macro crate`() = checkNoCompletion("""
+        #[proc_ma/*caret*/]
+        fn mac() {}
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTestBase.kt
@@ -8,10 +8,22 @@ package org.rust.lang.core.completion
 import org.intellij.lang.annotations.Language
 
 abstract class RsAttributeCompletionTestBase : RsCompletionTestBase() {
-    protected fun doSingleAttributeCompletion(@Language("Rust") before: String, @Language("Rust") after: String) {
-        fun String.withCfgAttr(): String = replace("""(#!?)\[(.*/\*caret\*/.*)]""".toRegex(), "$1[cfg_attr(unix, $2)]")
-
+    protected fun doSingleAttributeCompletion(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String
+    ) {
         doSingleCompletion(before, after)
-        doSingleCompletion(before.withCfgAttr(), after.withCfgAttr())
+        doSingleCompletion(withCfgAttr(before), withCfgAttr(after))
+    }
+
+    protected fun checkAttributeCompletionByFileTree(
+        variants: List<String>,
+        @Language("Rust") code: String,
+    ) {
+        checkContainsCompletionByFileTree(variants, code)
+        checkContainsCompletionByFileTree(variants, withCfgAttr(code))
     }
 }
+
+private fun withCfgAttr(s: String): String =
+    s.replace("""(#!?)\[(.*/\*caret\*/.*)]""".toRegex(), "$1[cfg_attr(unix, $2)]")


### PR DESCRIPTION
This includes `target_feature`, `proc_macro`, `proc_macro_derive` and `proc_macro_attribute`. The latter three are provided only insides proc macro crates. These attributes require a function with specific signature, but imho checking the signature is too hard and too brittle for the gain. Providing these attributes in more cases also makes them slightly more discoverable, although it likely won't matter in practice.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

changelog: update completions for function attributes
