### PR TITLE
INSP: Fix `Needless lifetimes` inspection in case of async fn

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -56,6 +56,7 @@ class RsNeedlessLifetimesInspection : RsLintInspection() {
  * - no output references, all input references have different LT
  * - output references, exactly one input reference with same LT
  * All lifetimes must be unnamed, 'static or defined without bounds on the level of the current item.
+ * Note: async fn syntax does not allow lifetime elision outside of & and &mut references.
  */
 private fun couldUseElision(fn: RsFunction): Boolean {
     if (hasWhereLifetimes(fn.whereClause)) return false
@@ -63,8 +64,11 @@ private fun couldUseElision(fn: RsFunction): Boolean {
     val typeParametersBounds = fn.typeParameters.flatMap { it.bounds }.map { it.bound }
     if (typeParametersBounds.any { hasNamedReferenceLifetime(it) }) return false
 
-    val (inputLifetimes, outputLifetimes) = collectLifetimesFromFnSignature(fn)
-        ?: return false
+    val (inputLifetimeCollector, outputLifetimesCollector) = collectLifetimesFromFnSignature(fn) ?: return false
+    val inputLifetimes = inputLifetimeCollector.lifetimes
+    val outputLifetimes = outputLifetimesCollector.lifetimes
+
+    if (fn.isAsync && (inputLifetimeCollector.hasLifetimeOutsideRef || outputLifetimesCollector.hasLifetimeOutsideRef)) return false
 
     // no input lifetimes? easy case!
     if (inputLifetimes.isEmpty()) return false
@@ -103,6 +107,7 @@ private fun couldUseElision(fn: RsFunction): Boolean {
 
 private class LifetimesCollector(val isForInputParams: Boolean = false) : RsRecursiveVisitor() {
     var abort: Boolean = false
+    var hasLifetimeOutsideRef: Boolean = false
     val lifetimes = mutableListOf<ReferenceLifetime>()
 
     override fun visitSelfParameter(selfParameter: RsSelfParameter) {
@@ -143,7 +148,10 @@ private class LifetimesCollector(val isForInputParams: Boolean = false) : RsRecu
         super.visitPath(path)
     }
 
-    override fun visitLifetime(lifetime: RsLifetime) = record(lifetime)
+    override fun visitLifetime(lifetime: RsLifetime) {
+        hasLifetimeOutsideRef = hasLifetimeOutsideRef || lifetime.parent !is RsRefLikeType
+        record(lifetime)
+    }
 
     override fun visitElement(element: RsElement) {
         if (abort) return
@@ -198,9 +206,9 @@ private class BodyLifetimeChecker : RsWithMacrosInspectionVisitor() {
     }
 }
 
-private fun collectLifetimesFromFnSignature(fn: RsFunction): Pair<List<ReferenceLifetime>, List<ReferenceLifetime>>? {
+private fun collectLifetimesFromFnSignature(fn: RsFunction): Pair<LifetimesCollector, LifetimesCollector>? {
     // these will collect all the lifetimes for references in arg/return types
-    val inputCollector = LifetimesCollector(true)
+    val inputCollector = LifetimesCollector(isForInputParams = true)
     val outputCollector = LifetimesCollector()
 
     // extract lifetimes in input argument types
@@ -214,7 +222,7 @@ private fun collectLifetimesFromFnSignature(fn: RsFunction): Pair<List<Reference
     fn.retType?.typeReference?.accept(outputCollector)
     if (outputCollector.abort) return null
 
-    return Pair(inputCollector.lifetimes, outputCollector.lifetimes)
+    return inputCollector to outputCollector
 }
 
 private fun allowedLifetimesFrom(lifetimeParameters: List<RsLifetimeParameter>): Set<ReferenceLifetime> {
@@ -301,5 +309,5 @@ fun RsFunction.hasMissingLifetimes(): Boolean {
     if (retType == null) return false
     if (selfParameter?.isRefLike == true) return false
     val (inputLifetimes, outputLifetimes) = collectLifetimesFromFnSignature(this) ?: return false
-    return outputLifetimes.any { it is Unnamed } && inputLifetimes.size != 1
+    return outputLifetimes.lifetimes.any { it is Unnamed } && inputLifetimes.lifetimes.size != 1
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
@@ -395,7 +395,7 @@ class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifeti
 
         #[allow(clippy)]
         fn foo5<'a>(_: &'a str) {}
-    """)
+    """, checkWeakWarn = true)
 
     fun `test global allow`() = checkByText("""
         #![allow(clippy::needless_lifetimes)]
@@ -403,7 +403,15 @@ class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifeti
         fn foo1<'a>(_: &'a str) {}
 
         fn foo2<'a>(_: &'a str) {}
-    """)
+    """, checkWeakWarn = true)
+
+    fun `test async fn`() = checkByText("""
+        struct S<'a>(&'a str);
+
+        async fn foo1<'a>(a: S<'a>) -> S<'a> {}
+
+        async <weak_warning>fn foo2<'a>(a: &'a str) -> &'a str</weak_warning> {}
+    """, checkWeakWarn = true)
 
     private fun doTest(
         @Language("Rust") text: String


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/9210.

changelog: Fix `Needless lifetimes` inspection in case of async functions
