### PR TITLE
PERF: Calculate path usage once when optimizing imports

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -148,12 +148,10 @@ private fun isApplicableForUseItem(item: RsUseItem): Boolean {
  * A usage can be either a path that uses the import of the use speck or a method call/associated item available through
  * a trait that is imported by this use speck.
  */
-fun RsUseSpeck.isUsed(): Boolean {
+fun RsUseSpeck.isUsed(pathUsage: PathUsageMap): Boolean {
     val useItem = ancestorStrict<RsUseItem>() ?: return true
     if (!isApplicableForUseItem(useItem)) return true
-    val owner = useItem.parent as? RsItemsOwner ?: return true
-    val usage = owner.pathUsage
-    return isUseSpeckUsed(this, usage)
+    return isUseSpeckUsed(this, pathUsage)
 }
 
 private fun isUseSpeckUsed(useSpeck: RsUseSpeck, usage: PathUsageMap): Boolean {


### PR DESCRIPTION
Fixes #9250

Path usage was calculated multiple times during import optimization (since we modify PSI during optimization which increments the tracker). Now path usage will be calculated only once before the optimization (actually it will most likely be taken from cache used for "Unused imports" inspection)

changelog: Speed up "Optimize import" action when "Unused imports" inspection is enabled
