### PR TITLE
Filter single mod in auto-import when root path resolves to same item

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
@@ -127,6 +127,7 @@ object ImportCandidatesCollector2 {
 
 private fun ImportContext2.convertToCandidates(itemsPaths: List<ItemUsePath>): List<ImportCandidate> =
     itemsPaths
+        .filterForSingleRootItem(this)
         .groupBy { it.toItemWithNamespace() }
         .mapValues { (item, paths) -> filterForSingleItem(paths, item) }
         .flatMap { (item, paths) ->
@@ -343,7 +344,7 @@ private fun ItemWithNamespace.toPsi(info: RsModInfo): List<RsNamedElement> =
     VisItem(path, Visibility.Public, isModOrEnum).toPsi(info, namespace)
 
 private fun filterForSingleItem(paths: List<ItemUsePath>, item: ItemWithNamespace): List<ItemUsePath> =
-    filterForSingleCrate(paths, item)
+    filterForSingleCrate(paths, item.path.crate)
         .groupBy { it.crate }
         .mapValues { filterShortestPath(it.value) }
         .flatMap { it.value }
@@ -352,10 +353,10 @@ private fun filterForSingleItem(paths: List<ItemUsePath>, item: ItemWithNamespac
  * If we can access crate of item ⇒ ignore paths through other crates.
  * Exception: when item is declared in `core` and reexported in `std`, we should use `std` path.
  */
-private fun filterForSingleCrate(paths: List<ItemUsePath>, item: ItemWithNamespace): List<ItemUsePath> {
+private fun filterForSingleCrate(paths: List<ItemUsePath>, itemCrate: CratePersistentId): List<ItemUsePath> {
     return paths.filter { it.crate.normName == AutoInjectedCrates.STD }
         .ifEmpty {
-            paths.filter { it.crate.id == item.path.crate }
+            paths.filter { it.crate.id == itemCrate }
         }
         .ifEmpty {
             paths
@@ -366,6 +367,43 @@ private fun filterForSingleCrate(paths: List<ItemUsePath>, item: ItemWithNamespa
 private fun filterShortestPath(paths: List<ItemUsePath>): List<ItemUsePath> {
     val minPathSize = paths.minOf { it.path.size }
     return paths.filter { it.path.size == minPathSize }
+}
+
+/**
+ * error::Error
+ * ~~~~~ this = [std::error, core::error]
+ * ~~~~~~~~~~~~ root path - same item for both, so keep only `std::error`
+ */
+private fun List<ItemUsePath>.filterForSingleRootItem(context: ImportContext2): List<ItemUsePath> {
+    if (size <= 1 || !all { it.item.isModOrEnum }) return this
+    if (context.type == ImportContext2.Type.COMPLETION) return this
+    val segments = context.pathInfo?.nextSegments ?: return this
+    return groupBy { resolveRootPath(context.rootDefMap, it, segments) ?: return this }
+        .mapValues { (perNs, paths) ->
+            val crate = perNs.singleCrate() ?: return this
+            filterForSingleCrate(paths, crate)
+        }
+        .flatMap { it.value }
+}
+
+private fun PerNs.singleCrate(): CratePersistentId? =
+    (types + values + macros)
+        .mapTo(hashSetOf()) { it.crate }
+        .singleOrNull()
+
+/**
+ * mod1::mod2::Item
+ *       ~~~~~~~~~~ segments
+ * ~~~~ path
+ */
+private fun resolveRootPath(defMap: CrateDefMap, path: ItemUsePath, segments: List<String>): PerNs? {
+    var perNs = PerNs.types(path.item)
+    for (segment in segments) {
+        val visItem = perNs.types.singleOrNull { !it.visibility.isInvisible } ?: return null
+        val modData = defMap.tryCastToModData(visItem) ?: return null
+        perNs = modData.getVisibleItem(segment)
+    }
+    return perNs
 }
 
 private fun ImportContext2.isUsefulTraitImport(usePath: String): Boolean {

--- a/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
@@ -46,10 +46,11 @@ class ImportContext2 private constructor(
         OTHER,
     }
 
-    class PathInfo(
+    class PathInfo private constructor(
         val rootPathText: String?,
         val rootPathParsingMode: RustParserUtil.PathParsingMode?,
         val rootPathAllowedNamespaces: Set<Namespace>?,
+        val nextSegments: List<String>?,
         val namespaceFilter: (RsQualifiedNamedElement) -> Boolean,
     ) {
         companion object {
@@ -59,8 +60,20 @@ class ImportContext2 private constructor(
                     rootPathText = rootPath?.text,
                     rootPathParsingMode = rootPath?.pathParsingMode,
                     rootPathAllowedNamespaces = rootPath?.allowedNamespaces(isCompletion),
+                    nextSegments = path.getNextSegments(),
                     namespaceFilter = path.namespaceFilter(isCompletion),
                 )
+            }
+
+            /**
+             * foo1::foo2::foo3::foo4
+             * ~~~~~~~~~~ this
+             *             ~~~~~~~~~~ next segments
+             */
+            private fun RsPath.getNextSegments(): List<String>? {
+                val parent = parent as? RsPath ?: return null
+                return generateSequence(parent) { it.parent as? RsPath }
+                    .mapTo(mutableListOf()) { it.referenceName ?: return null }
             }
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/util/PerNsHashMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/util/PerNsHashMap.kt
@@ -157,7 +157,7 @@ class PerNsHashMap<K : Any>(
         }
 }
 
-private fun PerNs.asSingleVisItem(): Pair<VisItem, Namespace>? {
+fun PerNs.asSingleVisItem(): Pair<VisItem, Namespace>? {
     if (types.size + values.size + macros.size != 1) return null
     types.singleOrNull()?.let { return it to Namespace.Types }
     values.singleOrNull()?.let { return it to Namespace.Values }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -3074,4 +3074,27 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             foo();
         }
     """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test filter single mod when root path resolves to same item`() = checkAutoImportFixByFileTreeWithoutHighlighting("""
+    //- dep-lib/lib.rs
+        pub mod foo {
+            pub struct Foo;
+        }
+    //- lib.rs
+        pub mod foo {
+            pub use dep_lib_target::foo::Foo;
+        }
+    //- main.rs
+        fn main() {
+            let _ = foo/*caret*/::Foo;
+        }
+    """, """
+    //- main.rs
+        use dep_lib_target::foo;
+
+        fn main() {
+            let _ = foo::Foo;
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #9263

The `Error` trait [was recently moved](https://github.com/rust-lang/rust/commit/bf7611d55ee6e24647aefc4d1c82b1dba0164536#diff-ea30f57e78f3b861b784ae315b3ac31358b7cea2aa14a668084ad412de12e586R306) to the `core` crate, so we started to show two variants of auto-import for `error` mod. Technically this is not a bug, but I think it make sense to filter only std variant in such cases.

changelog: Fix auto-import variants for `error::Error` path on nightly toolchain
