### PR TITLE
Fix auto import of attr proc macros

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -24,7 +24,6 @@ import org.rust.ide.utils.import.ImportContext2
 import org.rust.ide.utils.import.import
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.resolve.TYPES_N_VALUES
 import org.rust.lang.core.types.infer.ResolvedPath
 import org.rust.lang.core.types.inference
 import org.rust.openapiext.Testmark
@@ -122,16 +121,6 @@ class AutoImportFix(element: RsElement, private val context: Context) :
             }
 
             val referenceName = basePath.referenceName ?: return null
-
-            val isNameInScope = path.hasInScope(referenceName, TYPES_N_VALUES) && path.parent !is RsMacroCall
-            if (isNameInScope) {
-                // Don't import names that are already in scope but cannot be resolved
-                // because namespace of psi element prevents correct name resolution.
-                // It's possible for incorrect or incomplete code like "let map = HashMap"
-                Testmarks.NameInScope.hit()
-                return null
-            }
-
             val importContext = ImportContext2.from(path, ImportContext2.Type.AUTO_IMPORT) ?: return null
             val candidates = ImportCandidatesCollector2.getImportCandidates(importContext, referenceName)
 
@@ -180,6 +169,5 @@ class AutoImportFix(element: RsElement, private val context: Context) :
 
     object Testmarks {
         object PathInUseItem : Testmark()
-        object NameInScope : Testmark()
     }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -107,7 +107,6 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         }
     """)
 
-    @CheckTestmarkHit(AutoImportFix.Testmarks.NameInScope::class)
     fun `test do not highlight unresolved path references if name is in scope`() = checkByText("""
         use foo::Foo;
 


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/6505554/187554387-c2842b8d-ddeb-4fd6-bad4-b7ea5a84e142.gif" width="50%">

changelog: Fix auto import of attr proc macro with the same name as crate