### PR TITLE
Mark unused public reexports in binary crates

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -137,8 +137,8 @@ private fun getHighlightElement(useSpeck: RsUseSpeck): PsiElement {
 }
 
 private fun isApplicableForUseItem(item: RsUseItem): Boolean {
-    if (item.visibility == RsVisibility.Public) return false
     val crate = item.containingCrate ?: return false
+    if (item.visibility == RsVisibility.Public && crate.kind.isLib) return false
     if (!item.existsAfterExpansion(crate)) return false
     return true
 }
@@ -189,7 +189,8 @@ private fun isItemUsedInOtherMods(item: RsNamedElement, importName: String, useS
             RsVisibility.Restricted(importMod)
         }
         is RsVisibility.Restricted -> visibility
-        RsVisibility.Public -> return true
+        // we handle public imports in binary crates only, so this is effectively `pub(crate)` import
+        RsVisibility.Public -> RsVisibility.Restricted(importMod.crateRoot ?: return true)
     }
     if (item is RsTraitItem) {
         // TODO we should search usages for all methods of the trait

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -105,12 +105,25 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    fun `test ignore public reexport`() = checkByText("""
+    fun `test public reexport in lib crate`() = checkByFileTree("""
+    //- lib.rs
+        /*caret*/
         pub mod foo {
             pub struct S {}
         }
 
         pub use foo::S;
+        <warning descr="Unused import: `foo::S`">pub(crate) use foo::S;</warning>
+    """)
+
+    fun `test public reexport in bin crate`() = checkByFileTree("""
+    //- main.rs
+        /*caret*/
+        pub mod foo {
+            pub struct S {}
+        }
+
+        <warning descr="Unused import: `foo::S`">pub use foo::S;</warning>
         <warning descr="Unused import: `foo::S`">pub(crate) use foo::S;</warning>
     """)
 
@@ -601,7 +614,7 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
             pub fn foo() {}
         }
         mod mod2 {
-            pub use crate::mod1::foo;
+            <warning descr="Unused import: `crate::mod1::foo`">pub use crate::mod1::foo;</warning>
             pub fn bar() {}
         }
         mod test {


### PR DESCRIPTION
Other crates can't depend on binary crates, so `pub` reexports in binary crates are effectively `pub(crate)` and can be marked unused if so.

changelog: Support "Unused imports" inspection for public reexports in binary crates
