### PR TITLE
MACRO: fix local proc macro expansion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
@@ -104,7 +104,7 @@ val RsPossibleMacroCall.shouldSkipMacroExpansion: Boolean
 val RsPossibleMacroCall.isTopLevelExpansion: Boolean
     get() = when (val kind = kind) {
         is MacroCall -> kind.call.isTopLevelExpansion
-        is MetaItem -> kind.meta.canBeMacroCall
+        is MetaItem -> kind.meta.canBeMacroCall && kind.meta.owner?.parent is RsMod
     }
 
 val RsPossibleMacroCall.macroBody: MacroCallBody?


### PR DESCRIPTION
It seems like local (located inside function bodies) derive/attr procedural macros and attr macros located inside `impl` bodies are almost ignored for now. Furthermore, they lead to weid bugs:

```toml
[dependencies]
serde = { version = "1.0.144", features = ["derive"] }
```

```rust
use serde::Serialize;

fn main() {
    #[derive(Serialize)] // Try to see the expansion
    struct Foo;
    println!("Hello, World");
}


#[derive(Serialize)]
struct Bar;
```

If you try to see the expansion of the derive for `struct Foo`, you will actually see the expansion of the derive for  `struct Bar`!
This PR fixes basic proc macro expansion. Interesting that name resolution still doesn't work in most cases.

This PR fixes @HolgerGottChristensen's case from https://github.com/intellij-rust/intellij-rust/issues/8966#issuecomment-1230092324

changelog: fix expansion of local (located inside function bodies) attr/derive procedural macros
