### PR TITLE
Deterministically select RsFile containing crate if there are multiple

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -726,8 +726,15 @@ fun findModDataFor(file: RsFile): ModData? {
             val fileInfo = defMap.fileInfos[virtualFile.id] ?: return@mapNotNull null
             fileInfo.modData
         }
-        .singleOrFirstCfgEnabled()
+        .pickSingleModData()
 }
 
-private fun List<ModData>.singleOrFirstCfgEnabled(): ModData? =
-    singleOrNull() ?: firstOrNull { it.isDeeplyEnabledByCfg } ?: firstOrNull()
+private fun List<ModData>.pickSingleModData(): ModData? {
+    singleOrNull()?.let { return it }
+
+    val cfgEnabled = filter { it.isDeeplyEnabledByCfg }.ifEmpty { this }
+    cfgEnabled.singleOrNull()?.let { return it }
+
+    // If after filtering cfg-enabled modules there are still multiple options, choose one deterministically
+    return cfgEnabled.minByOrNull { it.crate }
+}


### PR DESCRIPTION
It seems like when we have to choose one containing crate for a file from multiple variants, we choosing it in a non-deterministic manner, i.e. randomly. This can lead to flaky tests and difficulties in reproducing bugs. Let's choose some deterministic strategy for choosing a containing crate