### PR TITLE
RUN: Enable Debugger, Profiler, Valgrind, Code Coverage, and Build/Test tool windows for `bench` command

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandRunner.kt
@@ -24,7 +24,7 @@ open class CargoCommandRunner : RsDefaultProgramRunnerBase() {
         val cleaned = profile.clean().ok ?: return false
         val isLocalRun = !profile.hasRemoteTarget || profile.buildTarget.isRemote
         val isLegacyTestRun = !profile.isBuildToolWindowAvailable &&
-            cleaned.cmd.command == "test" &&
+            cleaned.cmd.command in listOf("test", "bench") &&
             getBuildConfiguration(profile) != null
         return isLocalRun && !isLegacyTestRun
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
@@ -34,7 +34,7 @@ class CargoTestCommandRunner : AsyncProgramRunner<RunnerSettings>() {
         val cleaned = profile.clean().ok ?: return false
         val isLocalRun = !profile.hasRemoteTarget || profile.buildTarget.isRemote
         val isLegacyTestRun = !profile.isBuildToolWindowAvailable &&
-            cleaned.cmd.command == "test" &&
+            cleaned.cmd.command in listOf("test", "bench") &&
             getBuildConfiguration(profile) != null
         return isLocalRun && isLegacyTestRun
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
@@ -90,7 +90,7 @@ abstract class RsExecutableRunner(
 
         val runCargoCommand = state.prepareCommandLine().copy(emulateTerminal = false)
         val workingDirectory = pkg?.rootDirectory
-            ?.takeIf { runCargoCommand.command == "test" }
+            ?.takeIf { runCargoCommand.command in listOf("test", "bench") }
             ?: runCargoCommand.workingDirectory
         val environmentVariables = runCargoCommand.environmentVariables.run { with(envs + pkg?.env.orEmpty()) }
         val (_, executableArguments) = parseArgs(runCargoCommand.command, runCargoCommand.additionalArguments)
@@ -100,7 +100,7 @@ abstract class RsExecutableRunner(
             runCargoCommand.redirectInputFrom,
             runCargoCommand.backtraceMode,
             environmentVariables,
-            executableArguments,
+            executableArguments.let { if (runCargoCommand.command == "bench") it + "--bench" else it },
             runCargoCommand.emulateTerminal,
             runCargoCommand.withSudo,
             patchToRemote = false // patching is performed for debugger/profiler/valgrind on CLion side if needed

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -50,7 +50,7 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
 
 object CargoBuildManager {
-    private val BUILDABLE_COMMANDS: List<String> = listOf("run", "test")
+    private val BUILDABLE_COMMANDS: List<String> = listOf("run", "test", "bench")
 
     private val CANCELED_BUILD_RESULT: Future<CargoBuildResult> =
         CompletableFuture.completedFuture(CargoBuildResult(succeeded = false, canceled = true, started = 0))
@@ -90,7 +90,7 @@ object CargoBuildManager {
             environment = environment,
             taskName = "Build",
             progressTitle = "Building...",
-            isTestBuild = state.commandLine.command == "test",
+            isTestBuild = state.commandLine.command in listOf("test", "bench"),
             buildId = buildId,
             parentId = buildId
         )) {
@@ -196,7 +196,7 @@ object CargoBuildManager {
         val parsed = ParsedCommand.parse(configuration.command) ?: return false
         return when (val command = parsed.command) {
             "build", "check", "clippy" -> true
-            "test" -> {
+            "test", "bench" -> {
                 val (commandArguments, _) = parseArgs(command, parsed.additionalArguments)
                 "--no-run" in commandArguments
             }
@@ -220,6 +220,7 @@ object CargoBuildManager {
         buildConfiguration.command = ParametersListUtil.join(when (parsed.command) {
             "run" -> listOfNotNull(parsed.toolchain, "build", *commandArguments.toTypedArray())
             "test" -> listOfNotNull(parsed.toolchain, "test", "--no-run", *commandArguments.toTypedArray())
+            "bench" -> listOfNotNull(parsed.toolchain, "bench", "--no-run", *commandArguments.toTypedArray())
             else -> return null
         })
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/RsBuildEventsConverter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/RsBuildEventsConverter.kt
@@ -103,7 +103,7 @@ class RsBuildEventsConverter(private val context: CargoBuildContextBase) : Build
                 // TODO: support cases when crate types list contains not only binary
                 rustcArtifact.target.cleanCrateTypes.singleOrNull() == CargoMetadata.CrateType.BIN
             }
-            CargoMetadata.TargetKind.TEST -> true
+            CargoMetadata.TargetKind.TEST, CargoMetadata.TargetKind.BENCH -> true
             CargoMetadata.TargetKind.LIB -> rustcArtifact.profile.test
             else -> false
         }

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -205,7 +205,7 @@ open class CargoCommandConfiguration(
 
     private fun showTestToolWindow(commandLine: CargoCommandLine): Boolean = when {
         !isFeatureEnabled(RsExperiments.TEST_TOOL_WINDOW) -> false
-        commandLine.command != "test" -> false
+        commandLine.command !in listOf("test", "bench") -> false
         "--nocapture" in commandLine.additionalArguments -> false
         Cargo.TEST_NOCAPTURE_ENABLED_KEY.asBoolean() -> false
         else -> !hasRemoteTarget

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -71,7 +71,7 @@ abstract class RsAsyncRunner(
         val (commandArguments, executableArguments) = parseArgs(commandLine.command, commandLine.additionalArguments)
         val additionalBuildArgs = state.runConfiguration.localBuildArgsForRemoteRun
 
-        val isTestRun = commandLine.command == "test"
+        val isTestRun = commandLine.command in listOf("test", "bench")
         val cmdHasNoRun = "--no-run" in commandLine.additionalArguments
         val buildCommand = if (isTestRun) {
             if (cmdHasNoRun) commandLine else commandLine.prependArgument("--no-run")
@@ -190,7 +190,7 @@ abstract class RsAsyncRunner(
                                             // TODO: support cases when crate types list contains not only binary
                                             target.cleanCrateTypes.singleOrNull() == CargoMetadata.CrateType.BIN
                                         }
-                                        CargoMetadata.TargetKind.TEST -> true
+                                        CargoMetadata.TargetKind.TEST, CargoMetadata.TargetKind.BENCH -> true
                                         CargoMetadata.TargetKind.LIB -> profile.test
                                         else -> false
                                     }

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -573,7 +573,7 @@ class Cargo(
             val (pre, post) = splitOnDoubleDash()
                 .let { (pre, post) -> pre.toMutableList() to post.toMutableList() }
 
-            if (command == "test") {
+            if (command in listOf("test", "bench")) {
                 if (allFeatures && !pre.contains("--all-features")) {
                     pre.add("--all-features")
                 }

--- a/src/main/kotlin/org/rust/cargo/util/CargoArgsParser.kt
+++ b/src/main/kotlin/org/rust/cargo/util/CargoArgsParser.kt
@@ -53,7 +53,7 @@ class CargoArgsParser private constructor(
         fun parseArgs(commandName: String, cargoArgs: List<String>): ParsedCargoArgs =
             when (commandName) {
                 "run" -> parseRunArgs(cargoArgs)
-                "test" -> parseTestArgs(cargoArgs)
+                "test", "bench" -> parseTestArgs(cargoArgs)
                 else -> error("Unsupported command")
             }
 

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RunConfigurationTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RunConfigurationTest.kt
@@ -5,6 +5,7 @@
 
 package org.rustSlowTests.cargo.runconfig
 
+import org.rust.cargo.toolchain.RustChannel
 import org.rust.fileTree
 
 class RunConfigurationTest : RunConfigurationTestBase() {
@@ -61,6 +62,44 @@ class RunConfigurationTest : RunConfigurationTestBase() {
         check("""{ "type": "test", "event": "started", "name": "foo" }""" in result.stdout)
     }
 
+    fun `test single bench configuration 1`() {
+        if (channel != RustChannel.NIGHTLY) return
+
+        val testProject = fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    #![feature(test)]
+
+                    extern crate test;
+
+                    use test::Bencher;
+
+                    fn main() {
+                        println!("Hello, world!");
+                    }
+
+                    #[bench]
+                    fn foo(b: &mut Bencher) {
+                        /*caret*/
+                    }
+                """)
+            }
+        }.create()
+        myFixture.configureFromTempProjectFile(testProject.fileWithCaret)
+
+        val configuration = createBenchRunConfigurationFromContext()
+        val result = executeAndGetOutput(configuration)
+        check("""{ "type": "test", "event": "started", "name": "foo" }""" in result.stdout)
+        check("""{ "type": "bench", "name": "foo", "median": 0, "deviation": 0 }""" in result.stdout)
+    }
+
     fun `test single test configuration 2`() {
         val testProject = fileTree {
             toml("Cargo.toml", """
@@ -97,6 +136,51 @@ class RunConfigurationTest : RunConfigurationTestBase() {
         check("""{ "type": "test", "event": "started", "name": "tests::bar" }""" !in result.stdout)
     }
 
+    fun `test single bench configuration 2`() {
+        if (channel != RustChannel.NIGHTLY) return
+
+        val testProject = fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    #![feature(test)]
+
+                    extern crate test;
+
+                    fn main() {
+                        println!("Hello, world!");
+                    }
+
+                    #[cfg(test)]
+                    mod benches {
+                        use test::Bencher;
+
+                        #[bench]
+                        fn foo(b: &mut Bencher) {
+                            /*caret*/
+                        }
+
+                        #[bench]
+                        fn bar(b: &mut Bencher) {}
+                    }
+                """)
+            }
+        }.create()
+        myFixture.configureFromTempProjectFile(testProject.fileWithCaret)
+
+        val configuration = createBenchRunConfigurationFromContext()
+        val result = executeAndGetOutput(configuration)
+        check("""{ "type": "test", "event": "started", "name": "benches::foo" }""" in result.stdout)
+        check("""{ "type": "test", "event": "started", "name": "benches::bar" }""" !in result.stdout)
+        check("""{ "type": "suite", "event": "ok", "passed": 0, "failed": 0, "ignored": 0, "measured": 1, "filtered_out": 1, "exec_time": """ in result.stdout)
+    }
+
     fun `test mod test configuration`() {
         val testProject = fileTree {
             toml("Cargo.toml", """
@@ -130,6 +214,50 @@ class RunConfigurationTest : RunConfigurationTestBase() {
         val result = executeAndGetOutput(configuration)
         check("""{ "type": "test", "event": "started", "name": "tests::foo" }""" in result.stdout)
         check("""{ "type": "test", "event": "started", "name": "tests::bar" }""" in result.stdout)
+    }
+
+    fun `test mod bench configuration`() {
+        if (channel != RustChannel.NIGHTLY) return
+
+        val testProject = fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    #![feature(test)]
+
+                    extern crate test;
+
+                    fn main() {
+                        println!("Hello, world!");
+                    }
+
+                    #[cfg(test)]
+                    mod benches {
+                        use test::Bencher;
+                        /*caret*/
+
+                        #[bench]
+                        fn foo(b: &mut Bencher) {}
+
+                        #[bench]
+                        fn bar(b: &mut Bencher) {}
+                    }
+                """)
+            }
+        }.create()
+        myFixture.configureFromTempProjectFile(testProject.fileWithCaret)
+
+        val configuration = createBenchRunConfigurationFromContext()
+        val result = executeAndGetOutput(configuration)
+        check("""{ "type": "test", "event": "started", "name": "benches::foo" }""" in result.stdout)
+        check("""{ "type": "test", "event": "started", "name": "benches::bar" }""" in result.stdout)
+        check("""{ "type": "suite", "event": "ok", "passed": 0, "failed": 0, "ignored": 0, "measured": 2, "filtered_out": 0, "exec_time": """ in result.stdout)
     }
 
     fun `test redirect input (absolute path)`() {

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RunConfigurationTestBase.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RunConfigurationTestBase.kt
@@ -29,9 +29,15 @@ import org.rust.cargo.runconfig.buildtool.CargoBuildResult
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfigurationType
 import org.rust.cargo.runconfig.command.CargoExecutableRunConfigurationProducer
+import org.rust.cargo.runconfig.test.CargoBenchRunConfigurationProducer
 import org.rust.cargo.runconfig.test.CargoTestRunConfigurationProducer
+import org.rust.cargo.toolchain.RustChannel
+import org.rust.cargo.toolchain.tools.rustc
 
 abstract class RunConfigurationTestBase : RsWithToolchainTestBase() {
+    protected val channel: RustChannel
+        get() = rustupFixture.toolchain?.rustc()?.queryVersion()?.channel
+            ?: error("Can't get toolchain channel")
 
     override fun setUp() {
         super.setUp()
@@ -57,6 +63,10 @@ abstract class RunConfigurationTestBase : RsWithToolchainTestBase() {
     protected fun createTestRunConfigurationFromContext(
         location: Location<PsiElement>? = null
     ): CargoCommandConfiguration = createRunConfigurationFromContext(CargoTestRunConfigurationProducer(), location)
+
+    protected fun createBenchRunConfigurationFromContext(
+        location: Location<PsiElement>? = null
+    ): CargoCommandConfiguration = createRunConfigurationFromContext(CargoBenchRunConfigurationProducer(), location)
 
     private fun createRunConfigurationFromContext(
         producer: RunConfigurationProducer<CargoCommandConfiguration>,


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/8878.

https://youtrack.jetbrains.com/issue/CPP-30242/Profiling-Support-for-Rust-cargo-bench-profile-dev

Note: default bench profile doesn't contain debug info. You have to use, for example, dev profile (add `--profile=dev` to your command).

changelog: Enable Debugger, Profiler, Valgrind, Code Coverage, and Build/Test tool windows for `bench` command
