### PR TITLE
CARGO: reload the project model after changes in toolchain settings

### DIFF
--- a/src/222/main/kotlin/org/rust/cargo/project/model/impl/compatUtils.kt
+++ b/src/222/main/kotlin/org/rust/cargo/project/model/impl/compatUtils.kt
@@ -23,7 +23,9 @@ fun registerProjectAware(project: Project, disposable: Disposable) {
         .subscribe(RustProjectSettingsService.RUST_SETTINGS_TOPIC, object : RustSettingsListener {
             override fun rustSettingsChanged(e: RustSettingsChangedEvent) {
                 if (e.affectsCargoMetadata) {
-                    AutoImportProjectTracker.getInstance(project).markDirty(cargoProjectAware.projectId)
+                    val tracker = AutoImportProjectTracker.getInstance(project)
+                    tracker.markDirty(cargoProjectAware.projectId)
+                    tracker.scheduleProjectRefresh()
                 }
             }
         })


### PR DESCRIPTION
Fixes #9286

changelog: Always reload the project model after changes in settings which affect the model
