### PR TITLE
REF: Fix adding imports in "Change signature" refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
@@ -141,7 +141,7 @@ private fun changeArguments(
     }
     for (parameter in config.parameters) {
         val defaultValue = parameter.defaultValue.item ?: continue
-        RsImportHelper.importTypeReferencesFromElements(arguments, setOf(defaultValue))
+        RsImportHelper.importTypeReferencesFromElement(arguments, defaultValue)
     }
     val argumentsCopy = arguments.copy() as RsValueArgumentList
     val argumentsList = argumentsCopy.exprList
@@ -282,7 +282,7 @@ private fun PsiElement.collectSurroundingWhiteSpaceAndComments(): List<PsiElemen
 
 private fun importParameterTypes(descriptors: List<Parameter>, context: RsElement) {
     for (descriptor in descriptors) {
-        RsImportHelper.importTypeReferencesFromElements(context, setOf(descriptor.typeReference))
+        RsImportHelper.importTypeReferencesFromElement(context, descriptor.typeReference)
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
@@ -58,6 +58,20 @@ Cannot change signature of function with cfg-disabled parameters""")
         }
     """) {}
 
+    fun `test do not change anything 2`() = doTest("""
+        mod inner {
+            pub struct Struct {}
+        }
+
+        fn func/*caret*/(a: inner::Struct) {}
+    """, """
+        mod inner {
+            pub struct Struct {}
+        }
+
+        fn func(a: inner::Struct) {}
+    """) {}
+
     fun `test rename function reference`() = doTest("""
         fn foo/*caret*/() {}
         fn id<T>(t: T) {}


### PR DESCRIPTION
Fixes #9292

changelog: Fix adding imports in `Change signature` refactoring