### PR TITLE
GRD: fix searchable options building

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,7 +109,7 @@ allprojects {
         }
 
         // All these tasks don't make sense for non-root subprojects
-        // Root project (i.e. `:plugin`) enables them itlsef if needed
+        // Root project (i.e. `:plugin`) enables them itself if needed
         runIde { enabled = false }
         prepareSandbox { enabled = false }
         buildSearchableOptions { enabled = false }
@@ -321,6 +321,10 @@ project(":plugin") {
             enabled = true
         }
         buildSearchableOptions {
+            // Force `mergePluginJarTask` be executed before `buildSearchableOptions`
+            // Otherwise, `buildSearchableOptions` task can't load the plugin and searchable options are not built.
+            // Should be dropped when jar merging is implemented in `gradle-intellij-plugin` itself
+            dependsOn(mergePluginJarTask)
             enabled = prop("enableBuildSearchableOptions").toBoolean()
         }
 

--- a/src/222/main/kotlin/org/rust/cargo/project/model/impl/compatUtils.kt
+++ b/src/222/main/kotlin/org/rust/cargo/project/model/impl/compatUtils.kt
@@ -14,6 +14,10 @@ import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsCh
 import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsListener
 
 fun registerProjectAware(project: Project, disposable: Disposable) {
+    // There is no sense to register `CargoExternalSystemProjectAware` for default project.
+    // Moreover, it may break searchable options building
+    if (project.isDefault) return
+
     val cargoProjectAware = CargoExternalSystemProjectAware(project)
     val projectTracker = ExternalSystemProjectTracker.getInstance(project)
     projectTracker.register(cargoProjectAware, disposable)


### PR DESCRIPTION
Building of searchable options was broken by migration to new plugin model (#8709).
As a result, `Find Action` dialog and settings search cannot find options provided by the plugin.

These changes fix Gradle `buildSearchableOptions` task

| Before | After |
| - | - |
| <img width="716" alt="Screenshot 2022-09-03 at 17 17 07" src="https://user-images.githubusercontent.com/2539310/188277053-c0333e4c-cb54-4dcb-adf8-d0cd796e2bd0.png"> | <img width="716" alt="Screenshot 2022-09-03 at 17 07 17" src="https://user-images.githubusercontent.com/2539310/188277059-5ece0e97-4905-4dc6-ae67-c3324f1e11fe.png"> |
| <img width="1012" alt="Screenshot 2022-09-03 at 17 17 17" src="https://user-images.githubusercontent.com/2539310/188277069-7002bcd7-33c0-4873-9e89-5869a04fa9d4.png"> | <img width="1094" alt="Screenshot 2022-09-03 at 17 07 43" src="https://user-images.githubusercontent.com/2539310/188277081-3a591d24-9eff-4f2a-90c2-941477873178.png"> |

changelog: Fix search of the plugin settings in `Find Action` dialog and `Settings` window which was broken in [#8709](https://github.com/intellij-rust/intellij-rust/pull/8709)
