### PR TITLE
ACT: Remove resolve engine info from "Create new issue" action

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/diagnostic/CreateNewGithubIssue.kt
+++ b/src/main/kotlin/org/rust/ide/actions/diagnostic/CreateNewGithubIssue.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.io.URLUtil
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.RustProjectSettingsService.MacroExpansionEngine
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.runconfig.hasCargoProject
 import org.rust.cargo.toolchain.impl.RustcVersion
@@ -44,7 +45,10 @@ class CreateNewGithubIssue : DumbAwareAction() {
             ?.displayText
         val ideNameAndVersion = ideNameAndVersion
         val os = SystemInfo.getOsNameAndVersion()
-        val macroEngine = project.rustSettings.macroExpansionEngine.name.toLowerCase()
+        val macroExpansionState = when (project.rustSettings.macroExpansionEngine) {
+            MacroExpansionEngine.DISABLED -> "disabled"
+            else -> "enabled"
+        }
         val additionalExperimentalFeatures = additionalExperimentalFeatures
         val codeSnippet = e.getData(PlatformDataKeys.EDITOR)?.codeExample.orEmpty()
 
@@ -53,8 +57,7 @@ class CreateNewGithubIssue : DumbAwareAction() {
             toolchainVersion,
             ideNameAndVersion,
             os,
-            macroEngine,
-            "new",
+            macroExpansionState,
             additionalExperimentalFeatures
         )
         val body = ISSUE_TEMPLATE.format(environmentInfo, codeSnippet)
@@ -91,16 +94,14 @@ class CreateNewGithubIssue : DumbAwareAction() {
             toolchainVersion: String?,
             ideNameAndVersion: String,
             os: String,
-            macroEngine: String,
-            resolveEngine: String,
+            macroExpansionState: String,
             additionalExperimentalFeatures: String?,
         ): String = """
             * **IntelliJ Rust plugin version:** $pluginVersion
             * **Rust toolchain version:** $toolchainVersion
             * **IDE name and version:** $ideNameAndVersion
             * **Operating system:** $os
-            * **Macro expansion engine:** $macroEngine
-            * **Name resolution engine:** $resolveEngine
+            * **Macro expansion:** $macroExpansionState
             ${additionalExperimentalFeatures?.let { "* **Additional experimental features:** $it" }.orEmpty()}
         """.trimEnd().trimIndent()
 


### PR DESCRIPTION
Option to use old resolve was removed in #9187, and option to use old macro expander was removed in #8900, so I guess it make sense to update github issue template