### PR TITLE
REF: Use function name instead of signature in "Inline function" dialog

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionDialog.kt
@@ -12,7 +12,6 @@ import org.rust.ide.refactoring.RsInlineDialog
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsUseItem
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.declaration
 import org.rust.lang.core.psi.ext.isMethod
 import org.rust.lang.core.resolve.ref.RsReference
 
@@ -25,6 +24,7 @@ class RsInlineFunctionDialog(
 ) : RsInlineDialog(function, refElement, project) {
 
     private val occurrencesNumber: Int = getNumberOfOccurrences(function)
+    private val callableType: String = if (function.isMethod) "Method" else "Function"
 
     init {
         init()
@@ -44,13 +44,10 @@ class RsInlineFunctionDialog(
         invokeRefactoring(processor)
     }
 
-    override fun getBorderTitle(): String =
-        RefactoringBundle.message("inline.method.border.title")
+    override fun getBorderTitle(): String = "Inline $callableType"
 
-    override fun getNameLabelText(): String {
-        val callableType = if (function.isMethod) "Method" else "Function"
-        return "$callableType ${function.declaration} ${getOccurrencesText(occurrencesNumber)}"
-    }
+    override fun getNameLabelText(): String =
+        "$callableType ${function.name} ${getOccurrencesText(occurrencesNumber)}"
 
     override fun getInlineAllText(): String {
         val text = if (function.isWritable) {

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionHandler.kt
@@ -30,7 +30,7 @@ class RsInlineFunctionHandler : InlineActionHandler() {
         val reference = TargetElementUtil.findReference(editor, editor.caretModel.offset)
 
         if (RsInlineFunctionProcessor.doesFunctionHaveMultipleReturns(function)) {
-            errorHint(project, editor, "cannot inline function with more than one exit points")
+            errorHint(project, editor, "Cannot inline function with more than one exit points")
             return
         }
 
@@ -39,13 +39,13 @@ class RsInlineFunctionHandler : InlineActionHandler() {
             if (reference != null) {
                 allowInlineThisOnly = true
             } else {
-                errorHint(project, editor, "cannot inline function with recursive calls")
+                errorHint(project, editor, "Cannot inline function with recursive calls")
                 return
             }
         }
 
         if (reference != null && RsInlineFunctionProcessor.checkIfLoopCondition(function, reference.element)) {
-            errorHint(project, editor, "cannot inline multiline function into \"while\" loop condition")
+            errorHint(project, editor, "Cannot inline multiline function into \"while\" loop condition")
             return
         }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
@@ -195,7 +195,7 @@ class RsInlineFunctionProcessor(
         returnExpr.replace(returnValue)
     }
 
-    override fun getCommandName(): String = "Inline function ${originalFunction.declaration}"
+    override fun getCommandName(): String = "Inline function ${originalFunction.name}"
 
     override fun createUsageViewDescriptor(usages: Array<UsageInfo>): UsageViewDescriptor =
         RsInlineUsageViewDescriptor(originalFunction, "Function to inline")


### PR DESCRIPTION
Inline function dialog may look [strange](https://user-images.githubusercontent.com/6505554/188288463-5494af27-3736-4c47-afe5-cce7572778f4.png) for functions with a large number of parameters, so it is better to use just function name there

Meta: #5511

changelog: Improve UI of ["Inline function"](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-refactorings.html#extractmethod-refactoring) dialog for functions with a large number of parameters