### PR TITLE
REF: Fix "Inline function" dialog when number of occurrences is unknown

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionDialog.kt
@@ -64,12 +64,15 @@ class RsInlineFunctionDialog(
     override fun getInlineThisText(): String =
         RefactoringBundle.message("this.invocation.only.and.keep.the.method")
 
-    override fun getKeepTheDeclarationText(): String? =
-        if (function.isWritable && (occurrencesNumber > 1 || !myInvokedOnReference)) {
+    override fun getKeepTheDeclarationText(): String? {
+        // `occurrencesNumber` can be negative if calculating it takes too long
+        val mightHaveMultipleOccurrences = occurrencesNumber < 0 || occurrencesNumber > 1
+        return if (function.isWritable && (mightHaveMultipleOccurrences || !myInvokedOnReference)) {
             "Inline all and keep the method"
         } else {
             null
         }
+    }
 
     override fun getHelpId(): String =
         "refactoring.inlineMethod"


### PR DESCRIPTION
When refactoring is invoked on reference, we may show different options [based on number of usages](https://github.com/intellij-rust/intellij-rust/pull/8563):
* One usage - two options (inline all and remove, inline this only)
* Two and more usages - three options (inline all and remove, inline all and keep, inline this only)

In some cases number of occurrences may be unknown. In such case we should show all three options, but because of bug we showed only two.

Meta: #5511

changelog: Fix ["Inline function"](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-refactorings.html#extractmethod-refactoring) dialog when number of occurrences is unknown