### PR TITLE
TYPE: provide human-readable name to some refactorings

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFile.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFile.kt
@@ -18,6 +18,7 @@ import com.intellij.psi.impl.file.PsiFileImplUtil
 import com.intellij.refactoring.RefactoringActionHandler
 import com.intellij.refactoring.actions.BaseRefactoringAction
 import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
+import org.rust.RsBundle
 import org.rust.lang.RsConstants
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsFile
@@ -47,11 +48,16 @@ class RsDowngradeModuleToFile : BaseRefactoringAction() {
         }
 
         override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
-            runWriteCommandAction(project) {
-                for (element in elements) {
-                    contractModule(element as PsiFileSystemItem)
+            runWriteCommandAction(
+                project,
+                RsBundle.message("action.Rust.RsDowngradeModuleToFile.text"),
+                "action.Rust.RsDowngradeModuleToFile",
+                {
+                    for (element in elements) {
+                        contractModule(element as PsiFileSystemItem)
+                    }
                 }
-            }
+            )
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryAction.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryAction.kt
@@ -17,6 +17,7 @@ import com.intellij.psi.impl.file.PsiFileImplUtil
 import com.intellij.refactoring.RefactoringActionHandler
 import com.intellij.refactoring.actions.BaseRefactoringAction
 import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
+import org.rust.RsBundle
 import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.lang.RsConstants
 import org.rust.lang.RsLanguage
@@ -48,11 +49,18 @@ class RsPromoteModuleToDirectoryAction : BaseRefactoringAction() {
         }
 
         override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
-            WriteCommandAction.runWriteCommandAction(project) {
-                for (element in elements.filterIsInstance<RsFile>()) {
-                    expandModule(element)
-                }
-            }
+            val files = elements.filterIsInstance<RsFile>()
+            WriteCommandAction.runWriteCommandAction(
+                project,
+                RsBundle.message("action.Rust.RsPromoteModuleToDirectoryAction.text"),
+                "action.Rust.RsPromoteModuleToDirectoryAction",
+                {
+                    for (element in files) {
+                        expandModule(element)
+                    }
+                },
+                *files.toTypedArray()
+            )
         }
     }
 


### PR DESCRIPTION
This includes RsDowngradeModuleToFile and RsPromoteModuleToDirectoryAction.
The human-readable name provides a nice name in the undo stack, instead of "Undo Undefined".

| Before | After |
| - | - |
| <img width="352" alt="Screenshot 2022-09-07 at 14 13 30" src="https://user-images.githubusercontent.com/2539310/188875701-4fb715a9-57ff-45ce-8124-45a93c8c4742.png"> | <img width="356" alt="Screenshot 2022-09-07 at 14 06 51" src="https://user-images.githubusercontent.com/2539310/188874694-3f24c2b7-e3eb-4329-8b45-52b35b01643b.png"> |
| <img width="353" alt="Screenshot 2022-09-07 at 14 13 38" src="https://user-images.githubusercontent.com/2539310/188875738-500c1101-f42b-4150-a13b-f40056c566ab.png"> | <img width="351" alt="Screenshot 2022-09-07 at 14 06 59" src="https://user-images.githubusercontent.com/2539310/188874730-6ef45d6a-a2fc-4b12-8aee-0c6cf547135d.png"> |
| <img width="301" alt="Screenshot 2022-09-07 at 14 14 04" src="https://user-images.githubusercontent.com/2539310/188875776-d2f7fae2-ef62-4b7d-a206-80638ab6a544.png"> | <img width="357" alt="Screenshot 2022-09-07 at 14 08 12" src="https://user-images.githubusercontent.com/2539310/188874786-97256390-8399-4a2e-90a1-ca2a4253505c.png"> |


changelog: Provide proper names for `Undo`/`Redo` actions and records in [Local history](https://www.jetbrains.com/help/idea/local-history.html) for changes made by `Promote Module to Directory` and `Downgrade Module to File` refactorings
