### PR TITLE
ANN: Don't show fix to make function async for function returning Future

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1494,8 +1494,15 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     private fun checkIsAsyncContext(holder: RsAnnotationHolder, element: RsElement) {
         if (element.isInAsyncContext) return
         val function = element.ancestorStrict<RsFunctionOrLambda>() ?: return
-        val fix = MakeAsyncFix(function)
+        val fix = MakeAsyncFix(function).takeIf { !function.returnsFuture() }
         RsDiagnostic.AwaitOutsideAsyncContext(element, fix).addToHolder(holder)
+    }
+
+    private fun RsFunctionOrLambda.returnsFuture(): Boolean {
+        val lookup = implLookup
+        val returnType = retType?.typeReference?.normType ?: return false
+        val futureTrait = lookup.items.Future ?: return false
+        return lookup.canSelect(TraitRef(returnType, BoundElement(futureTrait)))
     }
 
     private fun isInTrait(o: RsVis): Boolean =

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1541,12 +1541,12 @@ sealed class RsDiagnostic(
         )
     }
 
-    class AwaitOutsideAsyncContext(element: PsiElement, private val fix: LocalQuickFix) : RsDiagnostic(element) {
+    class AwaitOutsideAsyncContext(element: PsiElement, private val fix: LocalQuickFix?) : RsDiagnostic(element) {
         override fun prepare(): PreparedAnnotation = PreparedAnnotation(
             ERROR,
             E0728,
             "`await` is only allowed inside `async` functions and blocks",
-            fixes = listOf(fix)
+            fixes = listOfNotNull(fix)
         )
     }
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/MakeAsyncFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/MakeAsyncFixTest.kt
@@ -55,4 +55,14 @@ class MakeAsyncFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             };
         }
     """)
+
+    fun `test await inside function returns impl Future`() = checkFixIsUnavailable("Make function async", """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        async fn get() {}
+        fn func() -> impl Future<Output = ()> {
+            get().<error descr="`await` is only allowed inside `async` functions and blocks [E0728]">await</error>;
+            async {}
+        }
+    """)
 }


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/pull/9251#pullrequestreview-1095715405

changelog: Don't show fix to make function async when function returns `impl Future`