### PR TITLE
ANN: detect E0317 missing else block

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -879,8 +879,12 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             val ty = if (expr.type != TyUnknown) {
                 expr.type
             } else {
+                expr.expectedType ?: TyUnknown
+            }
+
+            if (ty.isEquivalentTo(TyUnknown)) {
                 // If both expected and actual types are unknown, inspection is not applicable.
-                expr.expectedType ?: return
+                return
             }
             if (ty is TyUnit) {
                 // If an `if` expression returns `()`, it doesn't need an `else`.
@@ -890,6 +894,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
                 // `!` is coercible to any type, in particular to `()` (see above).
                 return
             }
+
             RsDiagnostic.MissingElseBranch(expr).addToHolder(holder)
         }
     }

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -882,11 +882,11 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
                 // If both expected and actual types are unknown, inspection is not applicable.
                 expr.expectedType ?: return
             }
-            if (ty.isEquivalentTo(TyUnit.INSTANCE)) {
+            if (ty is TyUnit) {
                 // If an `if` expression returns `()`, it doesn't need an `else`.
                 return
             }
-            if (ty.isEquivalentTo(TyNever)) {
+            if (ty == TyNever) {
                 // `!` is coercible to any type, in particular to `()` (see above).
                 return
             }

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -69,6 +69,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             override fun visitEnumVariant(o: RsEnumVariant) = checkEnumVariant(rsHolder, o)
             override fun visitExternAbi(o: RsExternAbi) = checkExternAbi(rsHolder, o)
             override fun visitFunction(o: RsFunction) = checkFunction(rsHolder, o)
+            override fun visitIfExpr(o: RsIfExpr) = checkIfExpr(rsHolder, o)
             override fun visitImplItem(o: RsImplItem) = checkImpl(rsHolder, o)
             override fun visitLetDecl(o: RsLetDecl) = checkLetDecl(rsHolder, o)
             override fun visitLetElseBranch(o: RsLetElseBranch) = checkLetElseBranch(rsHolder, o)
@@ -870,6 +871,26 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
         if (modDecl.reference.resolve() == null && modDecl.semicolon != null) {
             RsDiagnostic.ModuleNotFound(modDecl).addToHolder(holder)
+        }
+    }
+
+    private fun checkIfExpr(holder: RsAnnotationHolder, expr: RsIfExpr) {
+        if (expr.elseBranch == null) {
+            val ty = if (expr.type != TyUnknown) {
+                expr.type
+            } else {
+                // If both expected and actual types are unknown, inspection is not applicable.
+                expr.expectedType ?: return
+            }
+            if (ty.isEquivalentTo(TyUnit.INSTANCE)) {
+                // If an `if` expression returns `()`, it doesn't need an `else`.
+                return
+            }
+            if (ty.isEquivalentTo(TyNever)) {
+                // `!` is coercible to any type, in particular to `()` (see above).
+                return
+            }
+            RsDiagnostic.MissingElseBranch(expr).addToHolder(holder)
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1044,7 +1044,11 @@ class RsTypeInferenceWalker(
             blockTys.add(elseBranch.ifExpr?.inferType(expected))
             blockTys.add(elseBranch.block?.inferType(expected))
         }
-        return if (expr.elseBranch == null) TyUnit.INSTANCE else getMoreCompleteType(blockTys.filterNotNull())
+        return if (expr.elseBranch == null && expr.parent is RsBlock) {
+            TyUnit.INSTANCE
+        } else {
+            getMoreCompleteType(blockTys.filterNotNull())
+        }
     }
 
     private fun RsCondition.inferTypes() {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1044,7 +1044,8 @@ class RsTypeInferenceWalker(
             blockTys.add(elseBranch.ifExpr?.inferType(expected))
             blockTys.add(elseBranch.block?.inferType(expected))
         }
-        return if (expr.elseBranch == null && expr.parent is RsBlock) {
+        val parent = expr.parent
+        return if (expr.elseBranch == null && parent is RsExprStmt && !parent.isTailStmt) {
             TyUnit.INSTANCE
         } else {
             getMoreCompleteType(blockTys.filterNotNull())

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -861,6 +861,16 @@ sealed class RsDiagnostic(
         }
     }
 
+    class MissingElseBranch(
+        element: PsiElement
+    ): RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0317,
+            "An `if` expression is missing an `else` block"
+        )
+    }
+
     class ImplSizedError(
         element: PsiElement
     ) : RsDiagnostic(element) {
@@ -1576,7 +1586,7 @@ enum class RsErrorCode {
     E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
-    E0308, E0322, E0328, E0364, E0365, E0379, E0384,
+    E0308, E0317, E0322, E0328, E0364, E0365, E0379, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0449, E0451, E0463,
     E0517, E0518, E0537, E0552, E0554, E0562, E0569, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0688, E0695,

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -2841,6 +2841,50 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl <error descr="Can impl only `struct`s, `enum`s, `union`s and trait objects [E0118]"><Struct as Trait>::Item</error> {}
     """)
 
+    fun `test missing else branch 1 E0317`() = checkErrors("""
+        fn f(x: u32) {
+            let a = <error descr="An `if` expression is missing an `else` block [E0317]">if x == 5 {
+                1
+            }</error>;
+            foo(a);
+            let _b = <error descr="An `if` expression is missing an `else` block [E0317]">if x == 5 {
+                1
+            }</error>;
+            let _: u32 = <error descr="An `if` expression is missing an `else` block [E0317]">if x == 5 {
+                1
+            }</error>;
+            let _ = if x == 5 {};
+            let _: () = if x == 5 {};
+            let _ = if x == 5 {
+                ()
+            };
+        }
+
+        fn foo(x: u32) {}
+    """)
+
+    fun `test missing else branch 2 E0317`() = checkErrors("""
+        fn f(x: u32) {
+            let a = <error descr="An `if` expression is missing an `else` block [E0317]">if let 5 = x {
+                1
+            }</error>;
+            foo(a);
+            let _b = <error descr="An `if` expression is missing an `else` block [E0317]">if let 5 = x {
+                1
+            }</error>;
+            let _: u32 = <error descr="An `if` expression is missing an `else` block [E0317]">if let 5 = x {
+                1
+            }</error>;
+            let _ = if let 5 = x {};
+            let _: () = if let 5 = x {};
+            let _ = if let 5 = x {
+                ()
+            };
+        }
+
+        fn foo(x: u32) {}
+    """)
+
     fun `test impl sized for struct E0322`() = checkErrors("""
         #[lang = "sized"]
         trait Sized {}

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -407,9 +407,9 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         fn main() {
             let x = if true { 92 };
             x
-          //^ ()
+          //^ i32
         }
-    """)
+    """, allowErrors = true)
 
     fun `test if`() = testExpr("""
         fn main() {

--- a/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
@@ -492,7 +492,7 @@ class RsPatternMatchingTest : RsTypificationTestBase() {
             if let S(x) = s { x }
                             //^ i32
         }
-    """)
+    """, allowErrors = true)
 
     fun `test generic struct pattern`() = testExpr("""
         struct S<T> { s: T }


### PR DESCRIPTION
Also slightly change type inference for if expressions without else block.
Previously such expressions were always inferred to `()`. This is right for expression statements,
but wrong for nested expressions. We change it to infer `()` only if the parent is a block, otherwise
type inference returns the type of the `if` block.

changelog: Detect [E0317](https://doc.rust-lang.org/error-index.html#E0317), An `if` expression is missing an `else` block.
