### PR TITLE
Filter not bang proc macros in completion

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
@@ -53,6 +53,7 @@ class ImportContext2 private constructor(
         val rootPathAllowedNamespaces: Set<Namespace>?,
         val nextSegments: List<String>?,
         val namespaceFilter: (RsQualifiedNamedElement) -> Boolean,
+        val parentIsMetaItem: Boolean,
     ) {
         companion object {
             fun from(path: RsPath, isCompletion: Boolean): PathInfo {
@@ -63,6 +64,7 @@ class ImportContext2 private constructor(
                     rootPathAllowedNamespaces = rootPath?.allowedNamespaces(isCompletion),
                     nextSegments = path.getNextSegments(),
                     namespaceFilter = path.namespaceFilter(isCompletion),
+                    parentIsMetaItem = path.parent is RsMetaItem,
                 )
             }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -100,7 +100,10 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
     ) {
         val parent = element.parent
         when {
-            parent is RsMacroCall -> processMacroCallPathResolveVariants(element, true, processor)
+            parent is RsMacroCall -> {
+                val filtered = filterNotAttributeAndDeriveProcMacros(processor)
+                processMacroCallPathResolveVariants(element, true, filtered)
+            }
             parent is RsMetaItem -> {
                 // Derive is handled by [RsDeriveCompletionProvider]
                 if (!RsProcMacroPsiUtil.canBeProcMacroAttributeCall(parent)) return
@@ -115,6 +118,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
                     addProcessedPathName(processor, processedPathElements),
                     lookup
                 )
+                filtered = filterNotAttributeAndDeriveProcMacros(filtered)
                 // Filters are applied in reverse order (the last filter is applied first)
                 val filters = listOf(
                     ::filterCompletionVariantsByVisibility,

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -354,6 +354,13 @@ fun filterCompletionVariantsByVisibility(context: RsElement, processor: RsResolv
     }
 }
 
+fun filterNotAttributeAndDeriveProcMacros(processor: RsResolveProcessor): RsResolveProcessor =
+    createProcessor(processor.names) { e ->
+        val element = e.element
+        if (element is RsFunction && element.isProcMacroDef && !element.isBangProcMacroDef) return@createProcessor false
+        processor(e)
+    }
+
 fun filterAttributeProcMacros(processor: RsResolveProcessor): RsResolveProcessor =
     createProcessor(processor.names) { e ->
         val function = e.element as? RsFunction ?: return@createProcessor false

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -3190,4 +3190,14 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         #[derive(<error descr="Unresolved reference: `Builder`">Builder/*caret*/</error>)]
         struct Foo {}
     """)
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test no attr proc macro for bang call`() = checkAutoImportFixIsUnavailableByFileTree("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_attribute]
+        pub fn attr_as_is(_attr: TokenStream, item: TokenStream) -> TokenStream { item }
+    //- lib.rs
+        <error descr="Unresolved reference: `attr_as_is`">attr_as_is/*caret*/</error>!();
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -701,6 +701,32 @@ class RsCompletionTest : RsCompletionTestBase() {
         mod1::mod2::foo!(/*caret*/)
     """)
 
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test no attr proc macro completion inside block`() = checkNoCompletion("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_attribute]
+        pub fn macro_attr(_attr: TokenStream, item: TokenStream) -> TokenStream { item }
+        #[proc_macro_derive(macro_derive)]
+        pub fn macro_derive(_item: TokenStream) -> TokenStream { "".parse().unwrap() }
+    //- lib.rs
+        use dep_proc_macro::*;
+        fn main() {
+            macro_/*caret*/
+        }
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test no attr proc macro completion at top-level`() = checkNoCompletion("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_attribute]
+        pub fn macro_attr(_attr: TokenStream, item: TokenStream) -> TokenStream { item }
+        #[proc_macro_derive(macro_derive)]
+        pub fn macro_derive(_item: TokenStream) -> TokenStream { "".parse().unwrap() }
+    //- lib.rs
+        use dep_proc_macro::*;
+        macro_/*caret*/
+    """)
+
     fun `test no items completion at top-level`() = checkNoCompletion("""
         mod inner {
             pub mod foo1 {}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
@@ -550,6 +550,30 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         fn func() {}
     """)
 
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test no attr proc macro inside block`() = checkNoCompletionByFileTree("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_attribute]
+        pub fn macro_attr(_attr: TokenStream, item: TokenStream) -> TokenStream { item }
+        #[proc_macro_derive(macro_derive)]
+        pub fn macro_derive(_item: TokenStream) -> TokenStream { "".parse().unwrap() }
+    //- lib.rs
+        fn main() {
+            macro_/*caret*/
+        }
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test no attr proc macro at top level`() = checkNoCompletionByFileTree("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_attribute]
+        pub fn macro_attr(_attr: TokenStream, item: TokenStream) -> TokenStream { item }
+        #[proc_macro_derive(macro_derive)]
+        pub fn macro_derive(_item: TokenStream) -> TokenStream { "".parse().unwrap() }
+    //- lib.rs
+        macro_/*caret*/
+    """)
+
     private fun doTestByText(
         @Language("Rust") before: String,
         @Language("Rust") after: String,


### PR DESCRIPTION

| Before | After |
|:------:|:-----:|
| ![image](https://user-images.githubusercontent.com/6505554/188499390-869de748-feb2-4f84-8f1d-e31e8419542c.png) | ![image](https://user-images.githubusercontent.com/6505554/188499464-e0c64760-9ffa-4d83-b25c-31d7116f9d3b.png) |



changelog: Filter out attr and derive proc macros in usual macro calls completion