### PR TITLE
COMP: Improve completion of proc macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -305,7 +305,11 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
     override fun getIcon(flags: Int): Icon {
         val baseIcon = when (val owner = owner) {
             is RsAbstractableOwner.Free, is RsAbstractableOwner.Foreign ->
-                if (isTest) RsIcons.FUNCTION.addTestMark() else RsIcons.FUNCTION
+                when {
+                    isTest -> RsIcons.FUNCTION.addTestMark()
+                    isProcMacroDef -> RsIcons.MACRO
+                    else -> RsIcons.FUNCTION
+                }
 
             is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl -> {
                 val icon = when {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt
@@ -283,7 +283,7 @@ class RsAttributeCompletionTest : RsAttributeCompletionTestBase() {
         fn func() {}
     """, """
         use dep_proc_macro::attr_as_is;
-        #[attr_as_is]/*caret*/
+        #[attr_as_is/*caret*/]
         fn func() {}
     """)
 
@@ -296,7 +296,7 @@ class RsAttributeCompletionTest : RsAttributeCompletionTestBase() {
         #[dep_proc_macro::attr_as_/*caret*/]
         fn func() {}
     """, """
-        #[dep_proc_macro::attr_as_is]/*caret*/
+        #[dep_proc_macro::attr_as_is/*caret*/]
         fn func() {}
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -775,6 +775,19 @@ class RsCompletionTest : RsCompletionTestBase() {
         use bar::foo;/*caret*/
     """)
 
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test complete bang proc macro unqualified`() = doSingleCompletionByFileTree("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro]
+        pub fn function_like_as_is(input: TokenStream) -> TokenStream { input }
+    //- lib.rs
+        use dep_proc_macro::*;
+        function_like/*caret*/
+    """, """
+        use dep_proc_macro::*;
+        function_like_as_is!(/*caret*/)
+    """)
+
     // https://github.com/intellij-rust/intellij-rust/issues/1598
     fun `test no macro completion in item element definition`() {
         for (itemKeyword in listOf("fn", "struct", "enum", "union", "trait", "type", "impl")) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
@@ -536,7 +536,7 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
     """, """
         use dep_proc_macro::attr_as_is;
 
-        #[attr_as_is]/*caret*/
+        #[attr_as_is/*caret*/]
         fn func() {}
     """)
 


### PR DESCRIPTION
* Complete bang proc macros with `!`
* Use macro icon for bang and attr proc macros
* Don't show parameters like `TokenStream` for bang and attr proc macros

| Before | After |
|:------:|:-----:|
| ![image](https://user-images.githubusercontent.com/6505554/188512966-8c1c4871-5807-4650-8f7c-9943a070fc9f.png) | ![image](https://user-images.githubusercontent.com/6505554/188513591-f7c53d52-30a0-48d6-9d71-8ee3a28946eb.png) |

changelog: Complete function-like proc macros with `!`