### PR TITLE
Don't suggest auto-import fix for assoc type binding

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -111,6 +111,11 @@ class AutoImportFix(element: RsElement, private val context: Context) :
         fun findApplicableContext(path: RsPath): Context? {
             if (path.reference == null) return null
 
+            // `impl Future<Output=i32>`
+            //              ~~~~~~ path
+            val parent = path.parent
+            if (parent is RsAssocTypeBinding && parent.eq != null && parent.path == path) return null
+
             val basePath = path.basePath()
             if (basePath.resolveStatus != PathResolveStatus.UNRESOLVED) return null
 

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -3120,4 +3120,17 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         mod attr_as_is {}
     """)
+
+    fun `test don't import assoc type binding`() = checkAutoImportFixIsUnavailable("""
+        mod inner {
+            pub trait Trait {
+                type Output;
+            }
+            pub struct Output {}
+        }
+
+        fn func(_: impl <error descr="Unresolved reference: `Trait`">Trait</error><
+            <error descr="Unresolved reference: `Output`">Output/*caret*/</error>=i32
+        >) {}
+    """)
 }


### PR DESCRIPTION
Fixes that auto-import fix is suggested for `Output` in code `impl Future<Output=i32>`. The fix should be suggested only for `Future`

changelog: Don't suggest auto-import fix for assoc type binding