### PR TITLE
COMP: Complete crates from workspace in `extern crate`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -27,7 +27,6 @@ import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.util.AutoInjectedCrates.CORE
 import org.rust.cargo.util.AutoInjectedCrates.STD
-import org.rust.ide.injected.isDoctestInjection
 import org.rust.lang.RsConstants
 import org.rust.lang.core.FeatureAvailability
 import org.rust.lang.core.IN_BAND_LIFETIMES
@@ -274,7 +273,8 @@ fun processExternCrateResolveVariants(
 
     val visitedDeps = mutableSetOf<String>()
     fun processPackage(crate: Crate, dependencyName: String): Boolean {
-        if (isCompletion && crate.origin != PackageOrigin.DEPENDENCY) return false
+        val isDependencyOrWorkspace = crate.origin == PackageOrigin.DEPENDENCY || crate.origin == PackageOrigin.WORKSPACE
+        if (isCompletion && !isDependencyOrWorkspace) return false
 
         if (crate.origin == PackageOrigin.STDLIB && dependencyName in visitedDeps) return false
         visitedDeps.add(dependencyName)

--- a/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt
@@ -20,7 +20,16 @@ class RsExternCrateCompletionTest : RsCompletionTestBase() {
     """)
 
     fun `test extern crate does not suggest our crate`() = checkNoCompletion("""
+    //- lib.rs
         extern crate tes/*caret*/
+    """)
+
+    fun `test complete lib target of our package`() = doSingleCompletionByFileTree("""
+    //- lib.rs
+    //- main.rs
+        extern crate tes/*caret*/
+    """, """
+        extern crate test_package/*caret*/
     """)
 
     fun `test extern crate does not suggest transitive dependency`() = checkNoCompletion("""


### PR DESCRIPTION
This is simplified version of #4300 for workspace crates

Fixes #4780

changelog: Complete crates from workspace in `extern crate`