### PR TITLE
CARGO: enable build script evaluation in nightly plugin builds

### DIFF
--- a/src/221/main/resources/META-INF/platform-experiments.xml
+++ b/src/221/main/resources/META-INF/platform-experiments.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
+            <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
+        </experimentalFeature>
+    </extensions>
+</idea-plugin>

--- a/src/222/main/resources-nightly/META-INF/platform-experiments.xml
+++ b/src/222/main/resources-nightly/META-INF/platform-experiments.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="100">
+            <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
+        </experimentalFeature>
+    </extensions>
+</idea-plugin>

--- a/src/222/main/resources-stable/META-INF/platform-experiments.xml
+++ b/src/222/main/resources-stable/META-INF/platform-experiments.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
+            <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
+        </experimentalFeature>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -1,13 +1,12 @@
-<idea-plugin>
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="/META-INF/platform-experiments.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
     <extensions defaultExtensionNs="com.intellij">
         <experimentalFeature id="org.rust.cargo.build.tool.window" percentOfUsers="100">
             <description>Enable Cargo tasks to use Build Tool Window. Requires Rust +1.48.0</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.test.tool.window" percentOfUsers="100">
             <description>Show test results in Test Tool Window</description>
-        </experimentalFeature>
-        <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
-            <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.fetch.actual.stdlib.metadata" percentOfUsers="100">
             <description>Fetch metadata of actual stdlib crates instead of using hardcoded data</description>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -1,13 +1,12 @@
-<idea-plugin>
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="/META-INF/platform-experiments.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
     <extensions defaultExtensionNs="com.intellij">
         <experimentalFeature id="org.rust.cargo.build.tool.window" percentOfUsers="100">
             <description>Enable Cargo tasks to use Build Tool Window</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.test.tool.window" percentOfUsers="100">
             <description>Show test results in Test Tool Window</description>
-        </experimentalFeature>
-        <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
-            <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.fetch.actual.stdlib.metadata" percentOfUsers="100">
             <description>Fetch metadata of actual stdlib crates instead of using hardcoded data</description>

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
@@ -20,6 +20,7 @@ import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.launchAction
 import java.nio.file.Path
 
+@WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
 class SyncToolWindowTest : RsWithToolchainTestBase() {
 
     private lateinit var buildViewTestFixture: BuildViewTestFixture
@@ -65,7 +66,9 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
              -finished
               -Sync ${project.root.name} project
                Getting toolchain version
-               Updating workspace info
+               -Updating workspace info
+                -Build scripts evaluation
+                 Checking hello v0.1.0
                Getting Rust stdlib
         """)
     }
@@ -107,11 +110,15 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
              -finished
               -Sync crate1 project
                Getting toolchain version
-               Updating workspace info
+               -Updating workspace info
+                -Build scripts evaluation
+                 Checking crate1 v0.1.0
                Getting Rust stdlib
               -Sync crate2 project
                Getting toolchain version
-               Updating workspace info
+               -Updating workspace info
+                -Build scripts evaluation
+                 Checking crate2 v0.1.0
                Getting Rust stdlib
         """)
     }
@@ -155,11 +162,15 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
              -finished
               -Sync crate1 project
                Getting toolchain version
-               Updating workspace info
+               -Updating workspace info
+                -Build scripts evaluation
+                 Checking crate1 v0.1.0
                Getting Rust stdlib
               -Sync crate2 project
                Getting toolchain version
-               Updating workspace info
+               -Updating workspace info
+                -Build scripts evaluation
+                 Checking crate2 v0.1.0
                Getting Rust stdlib
         """)
     }
@@ -220,12 +231,13 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
              -finished
               -Sync crate project
                Getting toolchain version
-               Updating workspace info
+               -Updating workspace info
+                -Build scripts evaluation
+                 Checking crate v0.1.0
                Getting Rust stdlib
         """)
     }
 
-    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
     fun `test with build script evaluation`() {
         val project = buildProject {
             toml("Cargo.toml", """
@@ -256,7 +268,6 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
         """)
     }
 
-    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
     fun `test with compile error in build script`() {
         val project = buildProject {
             toml("Cargo.toml", """
@@ -292,7 +303,6 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
         """)
     }
 
-    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
     fun `test with panic in build script`() {
         val project = buildProject {
             toml("Cargo.toml", """

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpanderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpanderTest.kt
@@ -89,6 +89,7 @@ class RsProcMacroExpanderTest : RsTestBase() {
     }
 
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @WithoutExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS)
     fun `test ProcMacroExpansionIsDisabled error 2`() {
         val expander = ProcMacroExpander.new(project, server = null)
         expander.checkError<ProcMacroExpansionError.ProcMacroExpansionIsDisabled>("", "", "")


### PR DESCRIPTION
changelog: Enable build script evaluation in nightly plugin builds for 2022.2 platform
