### PR TITLE
RES: resolve assoc type in where pred with generic decl on upper level

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt
@@ -16,13 +16,15 @@ import org.rust.lang.core.stubs.RsTypeParameterStub
 import org.rust.lang.core.types.RsPsiTypeImplUtil
 import org.rust.lang.core.types.ty.Ty
 
+val RsTypeParameter.owner: RsGenericDeclaration?
+    get() = parent?.parent as? RsGenericDeclaration
+
 /**
  * Returns all bounds for type parameter.
  *
  * Don't use it for stub creation because it will cause [com.intellij.openapi.project.IndexNotReadyException]!
  */
 val RsTypeParameter.bounds: List<RsPolybound> get() {
-    val owner = parent?.parent as? RsGenericDeclaration
     val whereBounds =
         owner?.whereClause?.wherePredList.orEmpty()
             .filter { (it.typeReference?.skipParens() as? RsBaseType)?.path?.reference?.resolve() == this }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLitExprReferenceContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLitExprReferenceContributor.kt
@@ -91,7 +91,7 @@ private fun isPathLitExpr(expr: RsLitExpr): Boolean {
     val (function, arguments) = getFunctionAndArguments(expr) ?: return false
     val owner = function.owner as? RsAbstractableOwner.Impl
     val ownerType = (owner?.impl?.typeReference?.normType as? TyAdt)?.item
-    val (implLookup, knownItems) = expr.implLookupAndKnownItems
+    val (implLookup, knownItems) = function.implLookupAndKnownItems
     val isCallExpr = arguments.parent is RsCallExpr
 
     return when {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -35,7 +35,7 @@ import org.rust.stdext.RsResult.Ok
 
 fun inferTypesIn(element: RsInferenceContextOwner): RsInferenceResult {
     val items = element.knownItems
-    val paramEnv = if (element is RsGenericDeclaration) ParamEnv.buildFor(element) else ParamEnv.EMPTY
+    val paramEnv = if (element is RsItemElement) ParamEnv.buildFor(element) else ParamEnv.EMPTY
     val lookup = ImplLookup(element.project, element.containingCrate, items, paramEnv)
     return recursionGuard(element, { lookup.ctx.infer(element) }, memoize = false)
         ?: error("Can not run nested type inference")

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -35,15 +35,15 @@ class TyTypeParameter private constructor(
 
     val name: String? get() = parameter.name
 
-    interface TypeParameter {
-        val name: String?
+    sealed class TypeParameter {
+        abstract val name: String?
     }
 
-    object Self : TypeParameter {
+    object Self : TypeParameter() {
         override val name: String get() = "Self"
     }
 
-    data class Named(val parameter: RsTypeParameter) : TypeParameter {
+    data class Named(val parameter: RsTypeParameter) : TypeParameter() {
         override val name: String? get() = parameter.name
     }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -784,6 +784,17 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }    //^
     """)
 
+    fun `test resolve assoc constant in assoc constant initializer`() = checkByCode("""
+        trait WithConst {
+            const C: i32;
+        }       //X
+
+        struct S<T>(T);
+        impl<T: WithConst> WithConst for S<T> {
+            const C: i32 = T::C;
+        }                   //^
+    """)
+
     fun `test assoc type in fn parameter`() = checkByCode("""
         pub trait Iter {
             type Item;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1434,4 +1434,17 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             W(1u8).foo();
         }        //^
     """)
+
+    fun `test resolve associated type in where predicate with type parameter declared on upper level`() = checkByCode("""
+        trait Foo { type Item; }
+                       //X
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn foo()
+                where
+                    T: Foo,
+                    T::Item: ?Sized
+            {}       //^
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #8905

changelog: Fix name resolution of an associated type of a type parameter inside a trait bound, in the case where the type parameter is declared on a level other than the bound