### PR TITLE
Suggest importing modules in completion

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
@@ -133,13 +133,7 @@ private fun ImportContext2.convertToCandidates(itemsPaths: List<ItemUsePath>): L
             val itemsPsi = item
                 .toPsi(rootInfo)
                 .filterIsInstance<RsQualifiedNamedElement>()
-                .let { list ->
-                    if (pathInfo != null) {
-                        list.filter(pathInfo.namespaceFilter)
-                    } else {
-                        list
-                    }
-                }
+                .filterByNamespace(this)
             // cartesian product of `itemsPsi` and `paths`
             itemsPsi.flatMap { itemPsi ->
                 paths.map { path ->
@@ -403,6 +397,14 @@ private fun resolveRootPath(defMap: CrateDefMap, path: ItemUsePath, segments: Li
         perNs = modData.getVisibleItem(segment)
     }
     return perNs
+}
+
+private fun List<RsQualifiedNamedElement>.filterByNamespace(context: ImportContext2): List<RsQualifiedNamedElement> {
+    val namespaceFilter = context.pathInfo?.namespaceFilter ?: return this
+    return filter {
+        namespaceFilter(it)
+            || context.type == ImportContext2.Type.COMPLETION && it is RsMod
+    }
 }
 
 private fun ImportContext2.isUsefulTraitImport(usePath: String): Boolean {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -269,8 +269,8 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         scopeEntry: ScopeEntry,
         context: RsCompletionContext,
         candidate: ImportCandidate
-    ): RsImportLookupElement {
-        return createLookupElement(
+    ): LookupElement {
+        val lookupElement = createLookupElement(
             scopeEntry = scopeEntry,
             context = context,
             locationString = candidate.info.usePath,
@@ -286,6 +286,14 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
                 }
             }
         ).withImportCandidate(candidate)
+
+        return if (context.isSimplePath && scopeEntry.element is RsMod) {
+            // TODO Use a weigher instead of a priority.
+            // TODO Consider dispreferring modules in other cases (not only auto-import)
+            PrioritizedLookupElement.withPriority(lookupElement, -1000.0)
+        } else {
+            lookupElement
+        }
     }
 
     private fun isInSameRustMod(element1: PsiElement, element2: PsiElement): Boolean =

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -701,7 +701,8 @@ class RsCompletionTest : RsCompletionTestBase() {
         mod1::mod2::foo!(/*caret*/)
     """)
 
-    fun `test no items completion at top-level`() = checkNoCompletion("""
+    // TODO Complete `foo3` as well
+    fun `test complete out-of-scope modules at top-level`() = checkContainsCompletion("foo1", """
         mod inner {
             pub mod foo1 {}
             pub fn foo2() {}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
@@ -550,6 +550,24 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         fn func() {}
     """)
 
+    fun `test suggest module in any namespace`() = doTestByText("""
+        fn main() {
+            inn/*caret*/
+        }
+        mod mod1 {
+            pub mod inner {}
+        }
+    """, """
+        use crate::mod1::inner;
+
+        fn main() {
+            inner/*caret*/
+        }
+        mod mod1 {
+            pub mod inner {}
+        }
+    """)
+
     private fun doTestByText(
         @Language("Rust") before: String,
         @Language("Rust") after: String,


### PR DESCRIPTION
Fixes #6979

TODO: Fix priority of `std::vec` crate and `vec!` macro, etc (#8984)

changelog: Suggest importing modules in completion