### PR TITLE
PERF: optimize `getRootCachingElement` for stub-based case

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -901,6 +901,7 @@ upper TraitAlias ::= trait identifier TypeParameterList? '=' TraitAliasBounds? W
 
 private TypeAscription ::= ':' TypeReference { pin = 1 }
 
+// Note: don't forget to add new TypeReference element types to [org.rust.lang.core.psi.RS_TYPES]
 TypeReference ::= ArrayType
                 | RefLikeType
                 | FnPointerType

--- a/src/main/kotlin/org/rust/lang/core/psi/RsTokenType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsTokenType.kt
@@ -114,6 +114,19 @@ val RS_ITEMS = tokenSetOf(
     USE_ITEM
 )
 
+/** Successors of [org.rust.lang.core.psi.RsTypeReference] */
+val RS_TYPES = tokenSetOf(
+    ARRAY_TYPE,
+    REF_LIKE_TYPE,
+    FN_POINTER_TYPE,
+    TUPLE_TYPE,
+    PAREN_TYPE,
+    TRAIT_TYPE,
+    BASE_TYPE,
+    MACRO_TYPE,
+    FOR_IN_TYPE,
+)
+
 val RS_MOD_OR_FILE = tokenSetOf(MOD_ITEM, RsFileStub.Type)
 
 /**

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -9,9 +9,13 @@ import com.intellij.openapi.util.RecursionGuard
 import com.intellij.openapi.util.RecursionManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveResult
+import com.intellij.psi.tree.TokenSet
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsElementTypes.PATH_EXPR
+import org.rust.lang.core.psi.RsElementTypes.TYPE_ARGUMENT_LIST
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.*
+import org.rust.lang.core.stubs.RsPathStub
 import org.rust.lang.core.types.*
 import org.rust.lang.core.types.RsPsiSubstitution.*
 import org.rust.lang.core.types.infer.*
@@ -213,12 +217,22 @@ private val guard: RecursionGuard<PsiElement> =
  * [getRootCachingElement] returns `Foo` for `Baz`.
  */
 private fun getRootCachingElement(path: RsPath): RsElement {
+    // Optimization: traversing a stub is much faster than PSI traversing
+    val stub = path.greenStub
+    return if (stub != null) {
+        getRootCachingElementStub(stub)
+    } else {
+        getRootCachingElementPsi(path)
+    }
+}
+
+private fun getRootCachingElementPsi(path: RsPath): RsElement {
     var rootPath = path
-    var parent = path.stubParent
-    while (parent is RsTypeReference || parent is RsTypeArgumentList) {
-        parent = parent.stubParent
+    var parent = path.parent
+    while (parent != null && parent.elementType in TYPE_REFS_AND_TYPE_ARG_LIST) {
+        parent = parent.parent
         if (parent is RsPath) {
-            val parentParent = parent.stubParent
+            val parentParent = parent.parent
             if (parentParent !is RsPathExpr) {
                 rootPath = parent
                 parent = parentParent
@@ -227,6 +241,24 @@ private fun getRootCachingElement(path: RsPath): RsElement {
     }
     return rootPath
 }
+
+private fun getRootCachingElementStub(path: RsPathStub): RsElement {
+    var rootPath = path
+    var parent = path.parentStub
+    while (parent.stubType in TYPE_REFS_AND_TYPE_ARG_LIST) {
+        parent = parent.parentStub
+        if (parent is RsPathStub) {
+            val parentParent = parent.parentStub
+            if (parentParent.stubType != PATH_EXPR) {
+                rootPath = parent
+                parent = parentParent
+            }
+        }
+    }
+    return rootPath.psi
+}
+
+private val TYPE_REFS_AND_TYPE_ARG_LIST = TokenSet.orSet(RS_TYPES, tokenSetOf(TYPE_ARGUMENT_LIST))
 
 /**
  * Returns all nested [RsPath]s for which [getRootCachingElement] returns [root]


### PR DESCRIPTION
Further optimization of "resolve nested paths at once", see #9211.

changelog: Slightly speed up name resolution