### PR TITLE
PERF: move recursion guard out of `advancedResolve`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -5,8 +5,6 @@
 
 package org.rust.lang.core.resolve.ref
 
-import com.intellij.openapi.util.RecursionGuard
-import com.intellij.openapi.util.RecursionManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveResult
 import org.rust.lang.core.psi.*
@@ -79,9 +77,7 @@ class RsPathReferenceImpl(
 
     override fun advancedResolve(): BoundElement<RsElement>? {
         val resolved = advancedMultiResolve().singleOrNull() ?: return null
-        return guard.doPreventingRecursion(element, /* memoize = */true) {
-            instantiatePathGenerics(element, resolved.element, resolved.resolvedSubst)
-        }
+        return instantiatePathGenerics(element, resolved.element, resolved.resolvedSubst)
     }
 
     override fun resolve(): RsElement? = advancedMultiResolve().singleOrNull()?.element
@@ -203,9 +199,6 @@ class RsPathReferenceImpl(
         }
     }
 }
-
-private val guard: RecursionGuard<PsiElement> =
-    RecursionManager.createGuard("org.rust.lang.core.resolve.ref.RsPathReferenceImpl")
 
 /**
  * Returns a PSI element considered a "caching root" for the [path]. Usually it is a topmost [RsPath],


### PR DESCRIPTION
... and use it only for default type parameter values.

The only purpose of that recursion guard is to prevent infinite recursion in such cases:

```
pub trait Foo<A=Foo> {
    type Output = Self;
}
type T = Foo;
```
(see `test no stack overflow when trait type parameter default value refers to the trait name`)

The PR is a further optimization of "resolve nested paths at once", see #9211.

changelog: Slightly speed up name resolution
