### PR TITLE
INT: fix nesting of renamed imports

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
@@ -78,13 +78,16 @@ class NestUseStatementsIntention : RsElementBaseIntentionAction<NestUseStatement
 
     private fun makeGroupedPath(basePath: String, useSpecks: List<RsUseSpeck>): String {
         val useSpecksInGroup = useSpecks.flatMap { useSpeck ->
-            // Remove first group
-            val useGroup = useSpeck.useGroup
-            if (useSpeck.path?.referenceName == basePath && useGroup != null) {
-                useGroup.useSpeckList.map { it.text }
-            } else {
-                listOf(deleteBasePath(useSpeck.text, basePath))
+            if (useSpeck.path?.text == basePath) {
+                // Remove first group
+                useSpeck.useGroup?.let { useGroup ->
+                    return@flatMap useGroup.useSpeckList.map { it.text }
+                }
+                useSpeck.alias?.let { alias ->
+                    return@flatMap listOf("self ${alias.text}")
+                }
             }
+            listOf(deleteBasePath(useSpeck.text, basePath))
         }
         return useSpecksInGroup.joinToString(",\n", "$basePath::{\n", "\n}")
     }

--- a/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
@@ -335,4 +335,111 @@ class NestUseStatementsIntentionTest : RsIntentionTestBase(NestUseStatementsInte
         };
 
     """)
+
+    fun `test imported item with same name as module 1`() = doAvailableTest("""
+        use a::/*caret*/a;
+        use a::b;
+    """, """
+        use a::{
+            a,
+            b
+        };
+
+    """)
+
+    fun `test imported item with same name as module 2`() = doAvailableTest("""
+        use ::a::/*caret*/a;
+        use ::a::b;
+    """, """
+        use ::a::{
+            a,
+            b
+        };
+
+    """)
+
+    fun `test imported item with same name as module renamed 1`() = doAvailableTest("""
+        use a::/*caret*/a as x;
+        use a::b;
+    """, """
+        use a::{
+            a as x,
+            b
+        };
+
+    """)
+
+    fun `test imported item with same name as module renamed 2`() = doAvailableTest("""
+        use ::a::/*caret*/a as x;
+        use ::a::b;
+    """, """
+        use ::a::{
+            a as x,
+            b
+        };
+
+    """)
+
+    fun `test renamed import 1`() = doAvailableTest("""
+        use foo/*caret*/::bar as baz;
+        use foo::quux;
+    """, """
+        use foo::{
+            bar as baz,
+            quux
+        };
+
+    """)
+
+    fun `test renamed import 2`() = doAvailableTest("""
+        use foo/*caret*/::quux;
+        use foo::bar as baz;
+    """, """
+        use foo::{
+            quux,
+            bar as baz
+        };
+
+    """)
+
+    fun `test renamed import 3`() = doAvailableTest("""
+        use top::{
+            foo::quux,
+            foo/*caret*/::bar as baz,
+        };
+    """, """
+        use top::{
+            foo::{
+                quux,
+                bar as baz
+            }
+        };
+    """)
+
+    fun `test renamed import as nesting root 1`() = doAvailableTest("""
+        use /*caret*/top as hop;
+        use top::foo;
+    """, """
+        use top::{
+            self as hop,
+            foo
+        };
+
+    """)
+
+    fun `test renamed import as nesting root 2`() = doAvailableTest("""
+        use top::{
+            /*caret*/foo::bar,
+            foo as boo,
+        };
+
+    """, """
+        use top::{
+            foo::{
+                bar,
+                self as boo
+            }
+        };
+
+    """)
 }


### PR DESCRIPTION
Closes #9284

The intention code is quite hacky, parsing and replacing strings instead of working with proper PSI elements and respecting the code style & formatting. I'm considering reworking it in a different PR, but here I'm following the already used hacks,

changelog: fix nesting of renamed imports
