### PR TITLE
REF: Convert `Self` usages in "Convert struct to tuple" refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/convertStruct/RsConvertToNamedFieldsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/convertStruct/RsConvertToNamedFieldsProcessor.kt
@@ -37,8 +37,7 @@ class RsConvertToNamedFieldsProcessor(
 
     override fun findUsages(): Array<UsageInfo> {
         if (!convertUsages) return arrayOf()
-        var usages = ReferencesSearch
-            .search(element)
+        var usages = element.searchReferencesWithSelf()
             .asSequence()
             .map { MyUsageInfo(it) }
 
@@ -162,3 +161,4 @@ class RsConvertToNamedFieldsProcessor(
 
     override fun getRefactoringId(): String = "refactoring.convertToNamedFields"
 }
+

--- a/src/main/kotlin/org/rust/ide/refactoring/convertStruct/RsConvertToTupleProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/convertStruct/RsConvertToTupleProcessor.kt
@@ -28,8 +28,7 @@ class RsConvertToTupleProcessor(
     override fun findUsages(): Array<UsageInfo> {
         if (!convertUsages) return arrayOf()
 
-        var usages = ReferencesSearch
-            .search(element)
+        var usages = element.searchReferencesWithSelf()
             .asSequence()
             .map { UsageInfo(it) }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -9,11 +9,12 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
 import com.intellij.psi.*
-import com.intellij.psi.search.SearchScope
+import com.intellij.psi.search.*
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
 import com.intellij.util.Query
+import com.intellij.util.containers.addIfNotNull
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
@@ -215,4 +216,46 @@ fun RsElement.searchReferences(scope: SearchScope? = null): Query<PsiReference> 
     } else {
         ReferencesSearch.search(this, scope)
     }
+}
+
+/**
+ * struct Foo {}
+ * ~~~~~~~~~~~~~ this
+ * impl Foo {
+ *     fn new() -> Self { ... }
+ *                 ~~~~ this resolves to impl, so usual [searchReferences] will not find it
+ * }
+ */
+fun RsElement.searchReferencesWithSelf(): List<PsiReference> {
+    val references = ReferencesSearch.search(this).toMutableList()
+    val searchHelper = PsiSearchHelper.getInstance(project)
+    references += references.flatMap {
+        it.findSelfReferences(searchHelper) ?: emptyList()
+    }
+    return references
+}
+
+/**
+ * impl Foo {
+ *      ~~~~ this
+ *     fn new() -> Self { ... }
+ *                 ~~~~ result
+ * }
+ */
+private fun PsiReference.findSelfReferences(searchHelper: PsiSearchHelper): List<PsiReference>? {
+    val implPath = element as? RsPath ?: return null
+    val implType = implPath.parent as? RsPathType ?: return null
+    val impl = implType.parent as? RsImplItem ?: return null
+    if (impl.typeReference != implType) return null
+
+    val result = mutableListOf<PsiReference>()
+    val processor = TextOccurenceProcessor run@{ element, offset ->
+        if (offset != 0) return@run true
+        val path = (element.parent as? RsPath)?.takeIf { it.cself == element } ?: return@run true
+        result.addIfNotNull(path.reference.takeIf { it?.resolve() == impl })
+        true
+    }
+    val searchScope = LocalSearchScope(impl)
+    searchHelper.processElementsWithWord(processor, searchScope, "Self", UsageSearchContext.IN_CODE, true, false)
+    return result
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
@@ -211,6 +211,25 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
         }
     """)
 
+    fun `test convert Self in impls`() = doAvailableTest("""
+        struct Test/*caret*/(i32);
+        impl Test {
+            fn new() -> Self {
+                Self(0)
+            }
+        }
+    """, """
+        struct Test {
+            _0: i32,
+        }
+
+        impl Test {
+            fn new() -> Self {
+                Self { _0: 0 }
+            }
+        }
+    """)
+
     private fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
         InlineFile(before.trimIndent()).withCaret()
         myFixture.launchAction("Rust.RsConvertToNamedFields")

--- a/src/test/kotlin/org/rust/ide/refactoring/ConvertToTupleRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/ConvertToTupleRefactoringTest.kt
@@ -169,6 +169,25 @@ class ConvertToTupleRefactoringTest : RsTestBase() {
                 T2: Trait;
     """)
 
+    fun `test replace Self in impls`() = doAvailableTest("""
+        struct Test/*caret*/ { a: i32, b: i32 }
+        impl Test {
+            fn new() -> Self {
+                let b = 1;
+                Self { a: 0, b }
+            }
+        }
+    """, """
+        struct Test(i32, i32);
+
+        impl Test {
+            fn new() -> Self {
+                let b = 1;
+                Self(0, b)
+            }
+        }
+    """)
+
     private fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
         InlineFile(before.trimIndent()).withCaret()
         myFixture.launchAction("Rust.RsConvertToTuple")


### PR DESCRIPTION
Fixes #5851

changelog: Convert `Self` usages in `Convert struct to tuple` refactoring