### PR TITLE
REF: Support renaming derive procedural macros

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/Utils.kt
@@ -68,6 +68,7 @@ fun getPresentationForStructure(psi: RsElement): ItemPresentation {
 
 private fun presentableName(psi: RsElement): String? {
     return when (psi) {
+        is RsFunction -> psi.functionName
         is RsNamedElement -> psi.name
         is RsImplItem -> {
             val type = psi.typeReference?.text ?: return null

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -341,5 +341,37 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
         return shouldInc
     }
 
+    override fun getNameIdentifier(): PsiElement? =
+        getDeriveProcMacroNameIdentifier() ?: super.getNameIdentifier()
+
+    /**
+     * #[proc_macro_derive(Foo)]
+     *                     ~~~ returns this identifier
+     * pub fn func(_item: TokenStream) -> TokenStream { "".parse().unwrap() }
+     *
+     * returns null in case it is not possible to determine without resolve whether it is proc macro or not
+     */
+    private fun getDeriveProcMacroNameIdentifier(): PsiElement? {
+        val stub = greenStub
+        if (stub != null && !stub.mayBeProcMacroDef) return null  // fast path
+
+        val metaItem = rawOuterMetaItems.singleOrNull {
+            if (it.canBeAttrProcMacro()) return null
+            it.name == "proc_macro_derive"
+        } ?: return null
+        return metaItem.metaItemArgs?.metaItemList?.firstOrNull()?.path?.identifier
+    }
+
+    val functionName: String?
+        get() = if (isProcMacroDef) super.getNameIdentifier()?.unescapedText else name
+
     override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }
+
+private fun RsMetaItem.canBeAttrProcMacro(): Boolean =
+    name == "cfg_attr"
+        || RsProcMacroPsiUtil.canBeProcMacroAttributeCallWithoutContextCheck(this, CustomAttributes.EMPTY)
+
+/** See also [procMacroName] */
+val RsFunction.functionName: String?
+    get() = (this as RsFunctionImplMixin).functionName

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -328,8 +328,15 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
     ) {
         fun String.trimIndentIfNeeded(): String = if (trimIndent) trimIndent() else this
 
-        checkByText(before.trimIndentIfNeeded(), after.trimIndentIfNeeded()) {
-            myFixture.performEditorAction(actionId)
+        if ("//-" in before) {
+            checkByDirectory(before, after) {
+                myFixture.configureFromTempProjectFile(it.fileWithCaret)
+                myFixture.performEditorAction(actionId)
+            }
+        } else {
+            checkByText(before.trimIndentIfNeeded(), after.trimIndentIfNeeded()) {
+                myFixture.performEditorAction(actionId)
+            }
         }
     }
 

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -15,7 +15,6 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.LightProjectDescriptor
-import com.intellij.testFramework.VfsTestUtil
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.util.Urls
 import org.rust.cargo.CfgOptions
@@ -334,13 +333,6 @@ open class WithCustomStdlibRustProjectDescriptor(
 }
 
 object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
-
-    override fun setUp(fixture: CodeInsightTestFixture) {
-        val root = fixture.findFileInTempDir(".")!!
-        for (source in listOf("dep-lib/lib.rs", "trans-lib/lib.rs")) {
-            VfsTestUtil.createFile(root, source)
-        }
-    }
 
     override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
         val testProcMacroArtifact1 = CargoWorkspaceData.ProcMacroArtifact(

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -180,7 +180,7 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
 
     @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
     fun `test crate`() = checkHighlightingWithMacro("""
-        extern crate <CRATE>dep_lib_target</CRATE>;
+        extern crate <CRATE>std</CRATE>;
 
         use <CRATE>std</CRATE>::<MODULE>io</MODULE>::<TRAIT>Read</TRAIT>;
     """)

--- a/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
@@ -431,6 +431,9 @@ class RsImportOptimizerTest: RsTestBase() {
 
     @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
     fun `test group imports by semantics`() = doTest("""
+    //- dep-lib/lib.rs
+    //- lib.rs
+        /*caret*/
         extern crate dep_lib_target;
 
         use bbb::{fff, eee};
@@ -443,6 +446,8 @@ class RsImportOptimizerTest: RsTestBase() {
 
         fn main() {}
     """, """
+    //- dep-lib/lib.rs
+    //- lib.rs
         extern crate dep_lib_target;
 
         use std::{io, mem};

--- a/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt
@@ -10,16 +10,19 @@ import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
 class RsExternCrateCompletionTest : RsCompletionTestBase() {
-    fun `test extern crate`() = doSingleCompletion(
-        "extern crate dep_l/*caret*/",
-        "extern crate dep_lib_target/*caret*/"
-    )
+    fun `test extern crate`() = doSingleCompletionByFileTree("""
+    //- dep-lib/lib.rs
+    //- lib.rs
+        extern crate dep_l/*caret*/
+    """, """
+        extern crate dep_lib_target/*caret*/
+    """)
 
     fun `test extern crate does not suggest core`() = checkNoCompletion("""
         extern crate cor/*caret*/
     """)
 
-    fun `test extern crate does not suggest our crate`() = checkNoCompletion("""
+    fun `test extern crate does not suggest our crate`() = checkNoCompletionByFileTree("""
     //- lib.rs
         extern crate tes/*caret*/
     """)

--- a/toml/src/test/kotlin/org/rust/toml/resolve/CargoTomlKeyResolveTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/resolve/CargoTomlKeyResolveTest.kt
@@ -48,5 +48,8 @@ class CargoTomlKeyResolveTest : CargoTomlResolveTestBase() {
 
     private fun checkResolve(@Language("TOML") code: String) = doResolveTest<TomlKeySegment> {
         toml("Cargo.toml", code)
+        dir("dep-lib") {
+            rust("lib.rs", "")
+        }
     }
 }


### PR DESCRIPTION
Changes `nameIdentifier` of derive proc macros. As a result rename and search for references now works for them

changelog: Support renaming derive procedural macros