### PR TITLE
(INSP): Allow empty precision in string formatting parameter

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/format/impl.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/format/impl.kt
@@ -134,7 +134,7 @@ private val formatParameterParser = Regex("""(?x) # enable comments
     (.?[\^<>])?[+\-]?\#?
     0?(?!\$) # negative lookahead to parse 0$ as width and 00$ as zero padding followed by width
     (?<width>$argument\$|\d+)?
-    (\.(?<precision>$argument\$|\d+|\*))?
+    (\.(?<precision>$argument\$|\d+|\*)?)? # specifying no precision after a dot is allowed
     (?<type>\w?\??)?
 )?\s*""")
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -413,6 +413,18 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
     """)
 
+    fun `test check precision after dot omitted`() = checkErrors("""
+        $implDisplayI32
+
+        fn main() {
+            println!("<FORMAT_PARAMETER>{:.}</FORMAT_PARAMETER>", 1);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:.}</FORMAT_PARAMETER>", 1);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<FORMAT_SPECIFIER>name</FORMAT_SPECIFIER>:.}</FORMAT_PARAMETER>", 1, name=2);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<FORMAT_SPECIFIER>1</FORMAT_SPECIFIER>:.}</FORMAT_PARAMETER>", 1, 2);
+            println!("<FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>a${'$'}</FORMAT_SPECIFIER>.}</FORMAT_PARAMETER>!", 5, a=3);
+        }
+    """)
+
     fun `test check precision asterisk wrong parameter`() = checkErrors("""
         use std::fmt;
 


### PR DESCRIPTION
Although this is not clearly documented [here](https://doc.rust-lang.org/std/fmt/#precision), the precision in a formatting string is allowed to be empty. Arguably this is not useful, but it is still valid code:

```rust
// these two are equivalent:
println!("{:.}", 0.45);
println!("{}", 0.45);
```

The plugin used to incorrectly reject this code with the error _Invalid format string_.

This PR fixes that, by changing the regex used to parse format parameters. The capture groups work out such that both cases above give the exact same regex parse result, ensuring no differences in (future) behavior are introduced.

I don't really think this is important enough to include this in the changelog, but just in case:

changelog: Allow empty precision in formatting parameter
