### PR TITLE
Support let if match arm guards in data flow analysis

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
@@ -634,8 +634,14 @@ class CFGBuilder(
 
     override fun visitMatchArmGuard(guard: RsMatchArmGuard) {
         // TODO: support `if let guard` feature
-        val conditionExit = process(guard.expr, pred)
-        finishWithAstNode(guard, conditionExit)
+        val conditionExpr = process(guard.expr, pred)
+        if (guard.let != null) {
+            val patExpr = process(guard.pat, conditionExpr)
+            finishWithAstNode(guard, patExpr)
+        } else {
+            finishWithAstNode(guard, conditionExpr)
+        }
+
     }
 
     override fun visitParenExpr(parenExpr: RsParenExpr) {

--- a/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
@@ -449,6 +449,11 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
         val guard = arm.matchArmGuard
         if (guard?.let == null) { // TODO: support `if let guard` syntax
             guard?.expr?.let { consumeExpr(it) }
+        } else {
+            val init = guard.expr!!
+            walkExpr(init)
+            val initCmt = mc.processExpr(init)
+            guard.pat?.let { walkIrrefutablePat(initCmt, it) }
         }
         arm.expr?.let { consumeExpr(it) }
     }


### PR DESCRIPTION
Work in progress implementation for let if match arm guards in DFA.

Example code:
```rust
#![feature(if_let_guard)]
fn main() {
    let arr1 = vec![];
    let arr = vec![Some("Something".to_string())];

    match arr.len() {
        1 if let Some(s) = arr.iter().next() => {
            let one = s;
            let two = s;

            let a = String::new();
            let b = a;
            let c = a;
        }
        _ => {}
    }
}
```

changelog: TODO
