### PR TITLE
TY: fix `todo!()` macro type inference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1333,7 +1333,7 @@ class RsTypeInferenceWalker(
             name == "format_args" -> items.Arguments.asTy()
             name == "unimplemented" || name == "unreachable" || name == "panic" -> TyNever
             name == "write" || name == "writeln" -> inferredTy
-            else -> TyUnknown
+            else -> inferredTy
         }
     }
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspectionTest.kt
@@ -291,4 +291,15 @@ class RsUnreachableCodeInspectionTest : RsInspectionsTestBase(RsUnreachableCodeI
             return;</warning>
         }
     """)
+
+    // Issue https://github.com/intellij-rust/intellij-rust/issues/9355
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no false-positive when todo macro is used`() = checkByText("""
+        fn foo(a: u32) -> u32 {
+            match a {
+                42 => todo!(),
+                _ => return 123,
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -1016,4 +1016,12 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             b;
         } //^ Option<String>
     """)
+
+    fun `test todo macro`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            let a = todo!();
+            a;
+        } //^ !
+    """)
 }


### PR DESCRIPTION
Fixes #9355

changelog: Fix `todo!()` macro type inference