### PR TITLE
GRD: use relative paths in `GenerateParserTask`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -423,8 +423,8 @@ project(":") {
     val generateRustParser = task<GenerateParserTask>("generateRustParser") {
         source.set("src/main/grammars/RustParser.bnf")
         targetRoot.set("src/gen")
-        pathToParser.set("/org/rust/lang/core/parser/RustParser.java")
-        pathToPsiRoot.set("/org/rust/lang/core/psi")
+        pathToParser.set("org/rust/lang/core/parser/RustParser.java")
+        pathToPsiRoot.set("org/rust/lang/core/psi")
         purgeOldFiles.set(true)
     }
 


### PR DESCRIPTION
Otherwise, the task can't remove old files