### PR TITLE
RES: Fix nested labels shadowing

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -709,11 +709,12 @@ fun processPatBindingResolveVariants(
 }
 
 fun processLabelResolveVariants(label: RsLabel, processor: RsResolveProcessor): Boolean {
-    for (scope in label.ancestors) {
+    val prevScope = hashMapOf<String, Set<Namespace>>()
+    for (scope in label.contexts) {
         if (scope is RsLambdaExpr || scope is RsFunction) return false
         if (scope is RsLabeledExpression) {
             val labelDecl = scope.labelDecl ?: continue
-            if (processor(labelDecl)) return true
+            if (processWithShadowingAndUpdateScope(prevScope, LIFETIMES, processor) { it(labelDecl) }) return true
         }
     }
     return false

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -1257,6 +1257,43 @@ class RsResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test nested for loop shadowing`() = checkByCode("""
+        fn main() {
+            'shadowed: for _ in 0..2 {
+                'shadowed: for _ in 0..2 {
+               //X
+                    break 'shadowed;
+                         //^
+                }
+            }
+        }
+    """)
+
+    fun `test nested for loop without shadowing`() = checkByCode("""
+        fn main() {
+            'not_shadowed: for _ in 0..2 {
+           //X
+                'another_label: for _ in 0..2 {
+                    break 'not_shadowed;
+                         //^
+                }
+            }
+        }
+    """)
+
+    fun `test nested for loop shadowing and macro`() = checkByCode("""
+        macro_rules! match_lifetimes { ($ lt:lifetime) => { break $ lt; } }
+        fn main() {
+            'shadowed: for _ in 0..2 {
+                'shadowed: for _ in 0..2 {
+               //X
+                    match_lifetimes!('shadowed);
+                                    //^
+                }
+            }
+        }
+    """)
+
     fun `test pattern constant binding ambiguity`() = checkByCode("""
         const X: i32 = 0;
             //X


### PR DESCRIPTION
Atm name resolution doesn't take label shadowing into account and returns all the definitions:

![image](https://user-images.githubusercontent.com/662976/190985192-00ab3dad-8604-438c-8230-f3628b07e2a6.png)

changelog: Fix nested labels shadowing