### PR TITLE
INSP: Add unused_labels warning and fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -34,6 +34,7 @@ enum class RsLint(
     UnusedQualifications("unused_qualifications", listOf("unused")),
     UnusedMustUse("unused_must_use", listOf("unused")),
     RedundantSemicolons("redundant_semicolons", listOf("unused")),
+    UnusedLabels("unused_labels", listOf("unused")),
     // errors
     UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
     // CLippy lints

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedLabelsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedLabelsInspection.kt
@@ -1,0 +1,31 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.psi.PsiElement
+import org.rust.RsBundle
+import org.rust.ide.fixes.RemoveElementFix
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.lang.core.psi.RsLabelDecl
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.searchReferences
+
+/** Analogue of rustc's unused_labels. */
+class RsUnusedLabelsInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement) = RsLint.UnusedLabels
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+        override fun visitLabelDecl(o: RsLabelDecl) {
+            val isLabelUsed = o.searchReferences().findFirst() != null
+            if (!isLabelUsed) {
+                val highlighting = RsLintHighlightingType.UNUSED_SYMBOL
+                val description = RsBundle.message("inspection.UnusedLabels.description")
+                val fixes = listOf(RemoveElementFix(o))
+                holder.registerLintProblem(o, description, highlighting, fixes)
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -677,6 +677,11 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.RsWrongAssocTypeArgumentsInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Unused labels"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsUnusedLabelsInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsUnusedLabels.html
+++ b/src/main/resources/inspectionDescriptions/RsUnusedLabels.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<body>
+Detects labels that are never used.  Unused labels may signal a mistake or unfinished code.
+
+Corresponds to the <a href="https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-labels">unused_labels</a>
+rust warning.
+</body>
+</html>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -273,4 +273,6 @@ inspection.RedundantSemicolons.fix.name=Remove unnecessary trailing semicolons
 inspection.DoubleMustUse.description=This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`
 inspection.DoubleMustUse.FixRemoveMustUseAttr.name=Remove `#[must_use]` from the function
 
+inspection.UnusedLabels.description=Unused label
+
 rust.code.vision.usage.hint={0,choice, 0#no usages|1#1 usage|2#{0,number} usages}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedLabelsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedLabelsInspectionTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsUnusedLabelsInspectionTest : RsInspectionsTestBase(RsUnusedLabelsInspection::class) {
+    fun `test unused label with empty block`() = checkByText("""
+        fn main() {
+            /*warning descr="Unused label"*/'label:/*warning**/ {}
+        }
+    """)
+
+    fun `test unused label with while`() = checkByText("""
+        fn main() {
+            /*warning descr="Unused label"*/'label:/*warning**/ while 0 == 0 {}
+        }
+    """)
+
+    fun `test unused label with while let`() = checkByText("""
+        fn main() {
+            enum E<T> { A(T), B }
+            let opt = E::A(0);
+            /*warning descr="Unused label"*/'label:/*warning**/ while let E::A(_) = opt {}
+        }
+    """)
+
+    fun `test unused label with for`() = checkByText("""
+        fn main() {
+            /*warning descr="Unused label"*/'label:/*warning**/ for _ in 0..10 {}
+        }
+    """)
+
+    fun `test unused label with loop`() = checkByText("""
+        fn main() {
+            /*warning descr="Unused label"*/'label:/*warning**/ loop {}
+        }
+    """)
+
+    fun `test no unused label with nested for`() = checkByText("""
+        fn main() {
+            'a: for _ in 0..10 {
+                'b: for _ in 0..10 {
+                    break 'b;
+                }
+                break 'a;
+            }
+        }
+    """)
+
+    fun `test unused label with nested for`() = checkByText("""
+        fn main() {
+            'a: for _ in 0..10 {
+                /*warning descr="Unused label"*/'b:/*warning**/ for _ in 0..10 {
+                    break 'a;
+                }
+            }
+
+            /*warning descr="Unused label"*/'c:/*warning**/ for _ in 0..10 {
+                'd: for _ in 0..10 {
+                    break 'd;
+                }
+            }
+        }
+    """)
+
+    fun `test unused label with loop and many breaks`() = checkByText("""
+        fn main() {
+            'label: loop {
+                if true {
+                    break 'label;
+                } else {
+                    break 'label;
+                }
+            }
+        }
+    """)
+
+    fun `test unused label with nested for and shadowing`() = checkByText("""
+        fn main() {
+            /*warning descr="Unused label"*/'a:/*warning**/ for _ in 0..2 {
+                'a: for _ in 0..2 {
+                    break 'a;
+                }
+            }
+        }
+    """)
+
+    fun `test unused label with nested for `() = checkByText("""
+        fn main() {
+            /*warning descr="Unused label"*/'a:/*warning**/ for _ in 0..2 {
+                'a: for _ in 0..2 {
+                    break 'a;
+                }
+            }
+        }
+    """)
+
+    fun `test unused label with use inside macro`() = checkByText("""
+        macro_rules! mac_break { ($ lt:lifetime) => { break $ lt; } }
+        fn main() {
+            /*warning descr="Unused label"*/'shadowed:/*warning**/ for _ in 0..2 {
+                'shadowed: for _ in 0..2 {
+                    mac_break!('shadowed);
+                }
+            }
+
+            'shadowed: for _ in 0..2 {
+                mac_break!('shadowed);
+                /*warning descr="Unused label"*/'shadowed:/*warning**/ for _ in 0..2 {}
+            }
+        }
+    """)
+
+    fun `test allow unused_labels`() = checkByText("""
+        #[allow(unused_labels)]
+        fn main() {
+            'label: while 0 == 0 {}
+        }
+    """)
+
+    fun `test allow unused`() = checkByText("""
+        #[allow(unused)]
+        fn main() {
+            'label: while 0 == 0 {}
+        }
+    """)
+
+    fun `test remove quick fix`() = checkFixByText("Remove `'label:`", """
+        fn main() {
+            /*warning descr="Unused label"*/'label:/*caret*//*warning**/ while 0 == 0 {}
+        }
+    """, """
+        fn main() {
+            /*caret*/while 0 == 0 {}
+        }
+    """)
+
+    fun `test suppression quick fix for main fn`() = checkFixByText("Suppress `unused_labels` for fn main", """
+        fn main() {
+            /*warning descr="Unused label"*/'label:/*caret*//*warning**/ while 0 == 0 {}
+        }
+    """, """
+        #[allow(unused_labels)]
+        fn main() {
+            'label:/*caret*/ while 0 == 0 {}
+        }
+    """)
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/662976/194504239-b3fed609-4323-45ce-ac03-489bd795fb0e.png)

Depends on https://github.com/intellij-rust/intellij-rust/pull/9374 (_"RES: Fix nested labels shadowing"_)
Part of #5888 (_"Compiler lints support"_)

changelog: Add [labels](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-labels) inspection and quick-fixes for it