### PR TITLE
QDOC: fix doc urls for proc macros

### DIFF
--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
@@ -5,8 +5,8 @@
 
 package org.rust.ide.docs
 
-import org.rust.CheckTestmarkHit
 import org.intellij.lang.annotations.Language
+import org.rust.CheckTestmarkHit
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.ide.docs.RsDocumentationProvider.Testmarks
@@ -150,6 +150,27 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
         }            //^
 
     """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/foo/macro.bar.html")
+
+    fun `test bang proc macro`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        #[proc_macro]
+        fn foo(_input: TokenStream) -> TokenStream {}
+          //^
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/macro.foo.html")
+
+    fun `test derive proc macro`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        #[proc_macro_derive(MyDerive)]
+                           //^
+        fn foo(_input: TokenStream) -> TokenStream {}
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/derive.MyDerive.html")
+
+    fun `test attribute proc macro`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        #[proc_macro_attribute]
+        fn foo(_attr: TokenStream, _input: TokenStream) -> TokenStream {}
+          //^
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/attr.foo.html")
 
     @CheckTestmarkHit(Testmarks.NonDependency::class)
     fun `test not external url for workspace package`() = doUrlTestByFileTree("""

--- a/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
@@ -111,6 +111,30 @@ class RsResolveLinkTest : RsTestBase() {
               //^
     """, "test_package/fn.foo.html")
 
+    fun `test bang proc macro fqn link`() = doTest("""
+        #[proc_macro]
+        pub fn foo(_item: TokenStream) -> TokenStream {}
+             //X
+        struct Bar;
+              //^
+    """, "test_package/macro.foo.html")
+
+    fun `test derive proc macro fqn link`() = doTest("""
+        #[proc_macro_derive(Derive)]
+        pub fn foo(_item: TokenStream) -> TokenStream {}
+             //X
+        struct Bar;
+              //^
+    """, "test_package/derive.Derive.html")
+
+    fun `test attribute proc macro fqn link`() = doTest("""
+        #[proc_macro_attribute]
+        pub fn foo(_attr: TokenStream, _item: TokenStream) -> TokenStream {}
+             //X
+        struct Bar;
+              //^
+    """, "test_package/attr.foo.html")
+
     fun `test const fqn link`() = doTest("""
         const FOO: i32 = 0;
             //X


### PR DESCRIPTION
Closes #9353

changelog: fix docs.rs documentation hyperlinks for proc macros
