### PR TITLE
RES: Refactor `MacroResolver.isAttrOrDerive`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -486,7 +486,7 @@ private fun processQualifiedPathResolveVariants1(
 
         val containingMod = ctx?.containingMod ?: path.containingMod
         if (Namespace.Macros in ns) {
-            if (processMacros(base, processor, path, isAttrOrDerive = false)) return true
+            if (processMacros(base, processor, path)) return true
         }
 
         // Proc macro crates are not allowed to export anything but procedural macros,
@@ -838,7 +838,7 @@ fun processProcMacroResolveVariants(
         }
     }
     return if (qualifier == null) {
-        processMacroCallVariantsInScope(path, isAttrOrDerive = true, processor)
+        processMacroCallVariantsInScope(path, ignoreLegacyMacros = true, processor)
     } else {
         processMacroCallPathResolveVariants(path, isCompletion, processor)
     }
@@ -885,7 +885,7 @@ fun processMacroCallPathResolveVariants(path: RsPath, isCompletion: Boolean, pro
     val qualifier = path.qualifier
     return if (qualifier == null) {
         if (isCompletion) {
-            processMacroCallVariantsInScope(path, isAttrOrDerive = false, processor)
+            processMacroCallVariantsInScope(path, ignoreLegacyMacros = false, processor)
         } else {
             if (!path.cameFromMacroCall()) {
                 // Handles `#[macro_export(local_inner_macros)]`
@@ -899,7 +899,7 @@ fun processMacroCallPathResolveVariants(path: RsPath, isCompletion: Boolean, pro
             }
 
             val resolved = pickFirstResolveEntry(path.referenceName) {
-                processMacroCallVariantsInScope(path, isAttrOrDerive = false, it)
+                processMacroCallVariantsInScope(path, ignoreLegacyMacros = false, it)
             }
             resolved?.let { processor(it) } ?: false
         }
@@ -934,10 +934,10 @@ private fun processMacrosExportedByCrate(crateRoot: RsFile, processor: RsResolve
 
 fun processMacroCallVariantsInScope(
     path: RsPath,
-    isAttrOrDerive: Boolean,
+    ignoreLegacyMacros: Boolean,
     processor: RsResolveProcessor
 ): Boolean {
-    val (result, usedNewResolve) = MacroResolver.processMacrosInLexicalOrderUpward(path, isAttrOrDerive, processor)
+    val (result, usedNewResolve) = MacroResolver.processMacrosInLexicalOrderUpward(path, ignoreLegacyMacros, processor)
     if (result || usedNewResolve) return result
 
     val crateRoot = path.crateRoot as? RsFile ?: return false
@@ -954,10 +954,10 @@ private data class MacroResolveResult(val result: Boolean, val usedNewResolve: B
 
 private class MacroResolver private constructor(
     private val processor: RsResolveProcessor,
-    private val isAttrOrDerive: Boolean,
+    ignoreLegacyMacros: Boolean,
     private val path: RsPath,
 ) : RsVisitor() {
-    private val visitor = MacroResolvingVisitor(reverse = true, ignoreLegacyMacros = isAttrOrDerive) { processor(it) }
+    private val visitor = MacroResolvingVisitor(reverse = true, ignoreLegacyMacros) { processor(it) }
 
     private fun processMacrosInLexicalOrderUpward(startElement: PsiElement): MacroResolveResult {
         val result = processScopesInLexicalOrderUpward(startElement)
@@ -985,7 +985,7 @@ private class MacroResolver private constructor(
     }
 
     private tailrec fun psiBasedProcessScopesInLexicalOrderUpward(element: PsiElement): MacroResolveResult {
-        tryProcessAllMacrosUsingNewResolve(element, isAttrOrDerive)?.let { return it }
+        tryProcessAllMacrosUsingNewResolve(element)?.let { return it }
 
         for (e in element.leftSiblings) {
             if (visitor.processMacros(e)) return MacroResolveResult.True
@@ -1015,7 +1015,7 @@ private class MacroResolver private constructor(
     }
 
     private tailrec fun stubBasedProcessScopesInLexicalOrderUpward(element: StubElement<*>): MacroResolveResult {
-        tryProcessAllMacrosUsingNewResolve(element.psi, isAttrOrDerive)?.let { return it }
+        tryProcessAllMacrosUsingNewResolve(element.psi)?.let { return it }
 
         val parentStub = element.parentStub ?: return MacroResolveResult.False
         val siblings = parentStub.childrenStubs
@@ -1058,10 +1058,10 @@ private class MacroResolver private constructor(
     }
 
     /** Try using new resolve if [element] is top-level item or expanded from top-level macro call. */
-    private fun tryProcessAllMacrosUsingNewResolve(element: PsiElement, isAttrOrDerive: Boolean): MacroResolveResult? {
+    private fun tryProcessAllMacrosUsingNewResolve(element: PsiElement): MacroResolveResult? {
         if (element !is RsElement) return null
         val scope = element.context as? RsItemsOwner ?: return null // we are interested only in top-level elements
-        val result = processMacros(scope, processor, path, isAttrOrDerive)
+        val result = processMacros(scope, processor, path)
         if (scope !is RsMod && !result) return null  // we should search in parent scopes
         return result.toResult(usedNewResolve = true)
     }
@@ -1075,10 +1075,10 @@ private class MacroResolver private constructor(
     companion object {
         fun processMacrosInLexicalOrderUpward(
             path: RsPath,
-            isAttrOrDerive: Boolean,
+            ignoreLegacyMacros: Boolean,
             processor: RsResolveProcessor
         ): MacroResolveResult {
-            return MacroResolver(processor, isAttrOrDerive, path).processMacrosInLexicalOrderUpward(path)
+            return MacroResolver(processor, ignoreLegacyMacros, path).processMacrosInLexicalOrderUpward(path)
         }
 
         private fun Boolean.toResult(usedNewResolve: Boolean = false): MacroResolveResult =

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -100,19 +100,18 @@ fun processMacros(
     processor: RsResolveProcessor,
     /** Needed to filter textual scoped macros if path is unqualified. */
     macroPath: RsPath,
-    isAttrOrDerive: Boolean,
 ): Boolean {
     val info = getModInfo(scope) ?: return false
-    return info.modData.processMacros(macroPath, isAttrOrDerive, processor, info)
+    return info.modData.processMacros(macroPath, processor, info)
 }
 
 private fun ModData.processMacros(
     macroPath: RsPath,
-    isAttrOrDerive: Boolean,
     processor: RsResolveProcessor,
     info: RsModInfo,
 ): Boolean {
     val isQualified = macroPath.qualifier != null
+    val isAttrOrDerive = macroPath.parent is RsMetaItem
 
     val stop = processScopedMacros(processor, info) { name ->
         val isLegacyMacroDeclaredInSameMod = !isQualified && legacyMacros[name].orEmpty().any {
@@ -206,12 +205,7 @@ fun RsMacroCall.resolveToMacroAndProcessLocalInnerMacros(processor: RsResolvePro
     if (def !is DeclMacroDefInfo || !def.hasLocalInnerMacros) return null
     val project = info.project
     val defMap = project.defMapService.getOrUpdateIfNeeded(def.crate) ?: return null
-    return defMap.root.processMacros(
-        macroPath = path,
-        isAttrOrDerive = false,
-        processor = processor,
-        info = info,
-    )
+    return defMap.root.processMacros(path, processor, info)
 }
 
 private fun RsPossibleMacroCall.resolveToMacroInfo(): Pair<MacroDefInfo, RsModInfo>? {

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.VisibleForTesting
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.refactoring.move.common.RsMoveUtil.containingModOrSelf
-import org.rust.lang.core.completion.RsMacroCompletionProvider
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.crate.crateGraph
@@ -99,12 +98,8 @@ fun processItemDeclarationsUsingModInfo(
 fun processMacros(
     scope: RsItemsOwner,
     processor: RsResolveProcessor,
-    /**
-     * `RsPath` in resolve, `PsiElement(identifier)` in completion by [RsMacroCompletionProvider].
-     * Needed to filter textual scoped macros if path is unqualified.
-     * null if path is qualified.
-     */
-    macroPath: PsiElement?,
+    /** Needed to filter textual scoped macros if path is unqualified. */
+    macroPath: RsPath,
     isAttrOrDerive: Boolean,
 ): Boolean {
     val info = getModInfo(scope) ?: return false
@@ -112,13 +107,12 @@ fun processMacros(
 }
 
 private fun ModData.processMacros(
-    /** null if path is qualified */
-    macroPath: PsiElement?,
+    macroPath: RsPath,
     isAttrOrDerive: Boolean,
     processor: RsResolveProcessor,
     info: RsModInfo,
 ): Boolean {
-    val isQualified = macroPath == null || macroPath is RsPath && macroPath.qualifier != null
+    val isQualified = macroPath.qualifier != null
 
     val stop = processScopedMacros(processor, info) { name ->
         val isLegacyMacroDeclaredInSameMod = !isQualified && legacyMacros[name].orEmpty().any {
@@ -133,7 +127,6 @@ private fun ModData.processMacros(
     if (stop) return true
 
     if (!isQualified) {
-        check(macroPath != null)
         val macroIndex = info.getMacroIndex(macroPath, info.crate)
         for ((name, macroInfos) in legacyMacros.entriesWithNames(processor.names)) {
             val macroInfo = if (!isAttrOrDerive) {
@@ -214,7 +207,7 @@ fun RsMacroCall.resolveToMacroAndProcessLocalInnerMacros(processor: RsResolvePro
     val project = info.project
     val defMap = project.defMapService.getOrUpdateIfNeeded(def.crate) ?: return null
     return defMap.root.processMacros(
-        macroPath = null,  // null because we resolve qualified macro path
+        macroPath = path,
         isAttrOrDerive = false,
         processor = processor,
         info = info,


### PR DESCRIPTION
An internal change which should not affect users. Needed for https://github.com/intellij-rust/intellij-rust/pull/9312#pullrequestreview-1110876747

Macro path in resolve is always `RsPath` after #9156 (previously it can be `PsiElement(identifier)`)
