### PR TITLE
Support 2022.3 platform

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -39,10 +39,11 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
+            - name: Set up JDK 17
+              uses: actions/setup-java@v3
               with:
-                  java-version: 11
+                  distribution: corretto
+                  java-version: 17
 
             - name: Load native binaries
               uses: ./.github/actions/load-native-binaries

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -28,7 +28,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                platform-version: [ 222 ]
+                platform-version: [ 222, 223 ]
         env:
             ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -108,10 +108,11 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
+            - name: Set up JDK 17
+              uses: actions/setup-java@v3
               with:
-                  java-version: 11
+                  distribution: corretto
+                  java-version: 17
 
             - name: Set up Rust
               uses: actions-rs/toolchain@v1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,7 +83,7 @@ jobs:
                 os: [ ubuntu-latest, windows-latest ]
                 rust-version: [ 1.63.0, nightly-2022-09-17 ]
                 base-ide: [ idea, clion ]
-                platform-version: [ 222 ]
+                platform-version: [ 222, 223 ]
                 # it's enough to verify plugin structure only once per platform version
                 verify-plugin: [ false ]
                 default-edition-for-tests: [ 2021 ]

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -70,10 +70,11 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
+            - name: Set up JDK 17
+              uses: actions/setup-java@v3
               with:
-                  java-version: 11
+                  distribution: corretto
+                  java-version: 17
 
             - name: Set up Python
               uses: actions/setup-python@v1

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -74,10 +74,11 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
+            - name: Set up JDK 17
+              uses: actions/setup-java@v3
               with:
-                  java-version: 11
+                  distribution: corretto
+                  java-version: 17
 
             - name: Load native binaries
               uses: ./.github/actions/load-native-binaries

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -61,7 +61,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                platform-version: [ 222 ]
+                platform-version: [ 222, 223 ]
         env:
             ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -141,10 +141,11 @@ jobs:
               with:
                   ref: ${{ needs.get-release-branch.outputs.release-branch }}
 
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
+            - name: Set up JDK 17
+              uses: actions/setup-java@v3
               with:
-                  java-version: 11
+                  distribution: corretto
+                  java-version: 17
 
             - name: Load native binaries
               uses: ./.github/actions/load-native-binaries

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -126,7 +126,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                platform-version: [ 222 ]
+                platform-version: [ 222, 223 ]
         env:
             ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}

--- a/.idea/runConfigurations/RunCLion.xml
+++ b/.idea/runConfigurations/RunCLion.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="RunCLion" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="idea-221.log" path="$PROJECT_DIR$/plugin/build/clion-sandbox-221/system/log/idea.log" />
     <log_file alias="idea-222.log" path="$PROJECT_DIR$/plugin/build/clion-sandbox-222/system/log/idea.log" />
+    <log_file alias="idea-223.log" path="$PROJECT_DIR$/plugin/build/clion-sandbox-223/system/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.idea/runConfigurations/RunIDEA.xml
+++ b/.idea/runConfigurations/RunIDEA.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="RunIDEA" type="GradleRunConfiguration" factoryName="Gradle" singleton="true">
-    <log_file alias="idea-221.log" path="$PROJECT_DIR$/plugin/build/idea-sandbox-221/system/log/idea.log" />
     <log_file alias="idea-222.log" path="$PROJECT_DIR$/plugin/build/idea-sandbox-222/system/log/idea.log" />
+    <log_file alias="idea-223.log" path="$PROJECT_DIR$/plugin/build/idea-sandbox-223/system/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ IDE.
 
 ## Environment
 
-Java 11 is required for development.
-For example, you can install [openJDK](https://openjdk.java.net/install/) or [Amazon Corretto](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html).
+Java 17 is required for development.
+For example, you can install [openJDK](https://openjdk.java.net/install/) or [Amazon Corretto](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html).
 You can also [install](https://www.jetbrains.com/help/idea/sdk.html#set-up-jdk) Java just from your IntelliJ IDEA.
 
 ## Clone

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import groovy.json.JsonSlurper
 import groovy.xml.XmlParser
 import org.apache.tools.ant.taskdefs.condition.Os.*
 import org.gradle.api.JavaVersion.VERSION_11
+import org.gradle.api.JavaVersion.VERSION_17
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
@@ -93,10 +94,18 @@ allprojects {
         sandboxDir.set("$buildDir/$baseIDE-sandbox-$platformVersion")
     }
 
+    val javaVersion = if (platformVersion < 223) VERSION_11 else VERSION_17
+
+    configure<JavaPluginExtension> {
+        // BACKCOMPAT: 2022.2. Use VERSION_17
+        sourceCompatibility = VERSION_11
+        targetCompatibility = javaVersion
+    }
+
     tasks {
         withType<KotlinCompile> {
             kotlinOptions {
-                jvmTarget = "11"
+                jvmTarget = javaVersion.toString()
                 languageVersion = "1.7"
                 // see https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
                 apiVersion = "1.6"
@@ -160,11 +169,6 @@ allprojects {
                 enabled = prop("compileNativeCode").toBoolean()
             }
         }
-    }
-
-    configure<JavaPluginExtension> {
-        sourceCompatibility = VERSION_11
-        targetCompatibility = VERSION_11
     }
 
     sourceSets {

--- a/debugger/src/test/kotlin/org/rust/debugger/RsDebuggerToolchainServiceTest.kt
+++ b/debugger/src/test/kotlin/org/rust/debugger/RsDebuggerToolchainServiceTest.kt
@@ -23,7 +23,7 @@ class RsDebuggerToolchainServiceTest : RsTestBase() {
     override fun runTestRunnable(testRunnable: ThrowableRunnable<Throwable>) {
         @Suppress("UnstableApiUsage")
         if (PlatformUtils.isIdeaUltimate()) {
-            if (ApplicationInfo.getInstance().build >= BUILD_222) {
+            if (ApplicationInfo.getInstance().build < BUILD_223) {
                 // Temporarily hack to avoid https://youtrack.jetbrains.com/issue/CPP-29341/
                 ApplicationManager.getApplication().extensionArea.registerExtensionPoint(
                     PLUGIN_PATH_MAPPER_EP,
@@ -81,8 +81,8 @@ class RsDebuggerToolchainServiceTest : RsTestBase() {
     }
 
     companion object {
-        // BACKCOMPAT: 2022.1. Check if we still need this for 223
-        private val BUILD_222 = BuildNumber.fromString("222")!!
+        // BACKCOMPAT: 2022.2
+        private val BUILD_223 = BuildNumber.fromString("223")!!
         private const val PLUGIN_PATH_MAPPER_EP = "cidr.util.pluginPathMapper"
     }
 }

--- a/gradle-223.properties
+++ b/gradle-223.properties
@@ -1,14 +1,14 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-2022.2.2
-clionVersion=CL-2022.2.3
+ideaVersion=IU-223.4884-EAP-CANDIDATE-SNAPSHOT
+clionVersion=CL-223.4884-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=222.4167.21
+nativeDebugPluginVersion=223.4884.65
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
-psiViewerPluginVersion=222-SNAPSHOT
+psiViewerPluginVersion=223-SNAPSHOT
 
 # please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=222.3048
-untilBuild=222.*
+sinceBuild=223.4884
+untilBuild=231.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
-# Supported platforms: 222
+# Supported platforms: 222, 223
 platformVersion=222
 # Supported IDEs: idea, clion
 baseIDE=idea

--- a/src/222/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
+++ b/src/222/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
@@ -1,0 +1,14 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project
+
+import org.rust.cargo.icons.CargoIcons
+import javax.swing.Icon
+
+class CargoProjectOpenProcessor : CargoProjectOpenProcessorBase() {
+    override fun getIcon(): Icon = CargoIcons.ICON
+    override fun getName(): String = "Cargo"
+}

--- a/src/222/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilder.kt
+++ b/src/222/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilder.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.lineMarkers
+
+import com.intellij.codeInsight.navigation.NavigationGutterIconRenderer
+import com.intellij.ide.util.PsiElementListCellRenderer
+import com.intellij.openapi.util.Computable
+import com.intellij.openapi.util.NotNullLazyValue
+import com.intellij.psi.SmartPsiElementPointer
+import javax.swing.Icon
+
+class ImplsGutterIconBuilder(icon: Icon) : ImplsGutterIconBuilderBase(icon) {
+    override fun createGutterIconRenderer(
+        pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
+        renderer: Computable<PsiElementListCellRenderer<*>>,
+        empty: Boolean,
+    ): NavigationGutterIconRenderer {
+        return createGutterIconRendererInner(pointers, renderer, empty)
+    }
+}

--- a/src/223/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
+++ b/src/223/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
@@ -1,0 +1,14 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project
+
+import org.rust.cargo.icons.CargoIcons
+import javax.swing.Icon
+
+class CargoProjectOpenProcessor : CargoProjectOpenProcessorBase() {
+    override val icon: Icon get() = CargoIcons.ICON
+    override val name: String get() = "Cargo"
+}

--- a/src/223/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilder.kt
+++ b/src/223/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilder.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.lineMarkers
+
+import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
+import com.intellij.codeInsight.navigation.NavigationGutterIconRenderer
+import com.intellij.ide.util.PsiElementListCellRenderer
+import com.intellij.openapi.util.Computable
+import com.intellij.openapi.util.NotNullLazyValue
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPsiElementPointer
+import javax.swing.Icon
+
+class ImplsGutterIconBuilder(icon: Icon) : ImplsGutterIconBuilderBase(icon) {
+    override fun createGutterIconRenderer(
+        pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
+        renderer: Computable<PsiElementListCellRenderer<*>>,
+        empty: Boolean,
+        navigationHandler: GutterIconNavigationHandler<PsiElement>?
+    ): NavigationGutterIconRenderer {
+        return createGutterIconRendererInner(pointers, renderer, empty)
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessorBase.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessorBase.kt
@@ -12,13 +12,9 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.PlatformProjectOpenProcessor
 import com.intellij.projectImport.ProjectOpenProcessor
 import org.rust.cargo.CargoConstants
-import org.rust.cargo.icons.CargoIcons
 import org.rust.cargo.project.model.guessAndSetupRustProject
-import javax.swing.Icon
 
-class CargoProjectOpenProcessor : ProjectOpenProcessor() {
-    override fun getIcon(): Icon = CargoIcons.ICON
-    override fun getName(): String = "Cargo"
+abstract class CargoProjectOpenProcessorBase : ProjectOpenProcessor() {
 
     override fun canOpenProject(file: VirtualFile): Boolean {
         return FileUtil.namesEqual(file.name, CargoConstants.MANIFEST_FILE) ||

--- a/src/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilderBase.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilderBase.kt
@@ -1,0 +1,83 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.lineMarkers
+
+import com.intellij.codeInsight.CodeInsightBundle
+import com.intellij.codeInsight.daemon.impl.PsiElementListNavigator
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
+import com.intellij.codeInsight.navigation.NavigationGutterIconRenderer
+import com.intellij.ide.util.PsiElementListCellRenderer
+import com.intellij.openapi.util.Computable
+import com.intellij.openapi.util.NotNullLazyValue
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPsiElementPointer
+import org.rust.openapiext.isUnitTestMode
+import java.awt.event.MouseEvent
+import java.util.*
+import javax.swing.Icon
+
+abstract class ImplsGutterIconBuilderBase(icon: Icon) :
+    NavigationGutterIconBuilder<PsiElement>(icon, DEFAULT_PSI_CONVERTOR, PSI_GOTO_RELATED_ITEM_PROVIDER) {
+
+    protected fun createGutterIconRendererInner(
+        pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
+        renderer: Computable<PsiElementListCellRenderer<*>>,
+        empty: Boolean
+    ): NavigationGutterIconRenderer {
+        return ImplsNavigationGutterIconRenderer(
+            popupTitle = myPopupTitle,
+            emptyText = myEmptyText,
+            pointers = pointers,
+            cellRenderer = renderer,
+            alignment = myAlignment,
+            icon = myIcon,
+            tooltipText = myTooltipText,
+            empty = empty
+        )
+    }
+
+    private class ImplsNavigationGutterIconRenderer(
+        popupTitle: String?,
+        emptyText: String?,
+        pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
+        cellRenderer: Computable<PsiElementListCellRenderer<*>>,
+        private val alignment: Alignment,
+        private val icon: Icon,
+        private val tooltipText: String?,
+        private val empty: Boolean
+    ) : NavigationGutterIconRenderer(popupTitle, emptyText, cellRenderer, pointers) {
+        override fun isNavigateAction(): Boolean = !empty
+        override fun getIcon(): Icon = icon
+        override fun getTooltipText(): String? = tooltipText
+        override fun getAlignment(): Alignment = alignment
+
+        override fun navigate(event: MouseEvent?, elt: PsiElement?) {
+            if (event == null || elt == null) return
+
+            val targets = targetElements.filterIsInstance<NavigatablePsiElement>().toTypedArray()
+            val renderer = myCellRenderer.compute()
+
+            Arrays.sort(targets, Comparator.comparing(renderer::getComparingObject))
+
+            if (isUnitTestMode) {
+                val renderedItems = targets.map(renderer::getElementText)
+                elt.putUserData(RsImplsLineMarkerProvider.RENDERED_IMPLS, renderedItems)
+            } else {
+                val escapedName = StringUtil.escapeXmlEntities(elt.text)
+                @Suppress("DialogTitleCapitalization")
+                PsiElementListNavigator.openTargets(
+                    event,
+                    targets,
+                    CodeInsightBundle.message("goto.implementation.chooserTitle", escapedName, targets.size, ""),
+                    CodeInsightBundle.message("goto.implementation.findUsages.title", escapedName, targets.size),
+                    renderer
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
@@ -5,20 +5,11 @@
 
 package org.rust.ide.lineMarkers
 
-import com.intellij.codeInsight.CodeInsightBundle
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
-import com.intellij.codeInsight.daemon.impl.PsiElementListNavigator
-import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
-import com.intellij.codeInsight.navigation.NavigationGutterIconRenderer
-import com.intellij.ide.util.PsiElementListCellRenderer
-import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.NotNullLazyValue
-import com.intellij.openapi.util.text.StringUtil
-import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiElement
-import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.util.Query
 import org.jetbrains.annotations.TestOnly
 import org.rust.ide.icons.RsIcons
@@ -28,11 +19,7 @@ import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.filterQuery
-import org.rust.openapiext.isUnitTestMode
 import org.rust.openapiext.mapQuery
-import java.awt.event.MouseEvent
-import java.util.*
-import javax.swing.Icon
 
 /**
  * Annotates trait declaration with an icon on the gutter that allows to jump to
@@ -59,67 +46,6 @@ class RsImplsLineMarkerProvider : LineMarkerProvider {
                 .createLineMarkerInfo(el)
 
             result.add(info)
-        }
-    }
-
-    private class ImplsGutterIconBuilder(icon: Icon) :
-        NavigationGutterIconBuilder<PsiElement>(icon, DEFAULT_PSI_CONVERTOR, PSI_GOTO_RELATED_ITEM_PROVIDER) {
-
-        override fun createGutterIconRenderer(
-            pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
-            renderer: Computable<PsiElementListCellRenderer<*>>,
-            empty: Boolean
-        ): NavigationGutterIconRenderer {
-            return ImplsNavigationGutterIconRenderer(
-                popupTitle = myPopupTitle,
-                emptyText = myEmptyText,
-                pointers = pointers,
-                cellRenderer = renderer,
-                alignment = myAlignment,
-                icon = myIcon,
-                tooltipText = myTooltipText,
-                empty = empty
-            )
-        }
-    }
-
-    private class ImplsNavigationGutterIconRenderer(
-        popupTitle: String?,
-        emptyText: String?,
-        pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
-        cellRenderer: Computable<PsiElementListCellRenderer<*>>,
-        private val alignment: Alignment,
-        private val icon: Icon,
-        private val tooltipText: String?,
-        private val empty: Boolean
-    ) : NavigationGutterIconRenderer(popupTitle, emptyText, cellRenderer, pointers) {
-        override fun isNavigateAction(): Boolean = !empty
-        override fun getIcon(): Icon = icon
-        override fun getTooltipText(): String? = tooltipText
-        override fun getAlignment(): Alignment = alignment
-
-        override fun navigate(event: MouseEvent?, elt: PsiElement?) {
-            if (event == null || elt == null) return
-
-            val targets = targetElements.filterIsInstance<NavigatablePsiElement>().toTypedArray()
-            val renderer = myCellRenderer.compute()
-
-            Arrays.sort(targets, Comparator.comparing(renderer::getComparingObject))
-
-            if (isUnitTestMode) {
-                val renderedItems = targets.map(renderer::getElementText)
-                elt.putUserData(RENDERED_IMPLS, renderedItems)
-            } else {
-                val escapedName = StringUtil.escapeXmlEntities(elt.text)
-                @Suppress("DialogTitleCapitalization")
-                PsiElementListNavigator.openTargets(
-                    event,
-                    targets,
-                    CodeInsightBundle.message("goto.implementation.chooserTitle", escapedName, targets.size, ""),
-                    CodeInsightBundle.message("goto.implementation.findUsages.title", escapedName, targets.size),
-                    renderer
-                )
-            }
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsNavigationContributorBase.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsNavigationContributorBase.kt
@@ -79,7 +79,7 @@ abstract class RsNavigationContributorBase<T> protected constructor(
         return if (result.isEmpty()) NavigationItem.EMPTY_NAVIGATION_ITEM_ARRAY else result.toTypedArray()
     }
 
-    override fun getQualifiedName(item: NavigationItem?): String? = (item as? RsQualifiedNamedElement)?.qualifiedName
+    override fun getQualifiedName(item: NavigationItem): String? = (item as? RsQualifiedNamedElement)?.qualifiedName
 
     override fun getQualifiedNameSeparator(): String = "::"
 }

--- a/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
@@ -21,7 +21,6 @@ import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.Link
 import com.intellij.ui.dsl.builder.Panel
-import com.intellij.ui.dsl.builder.TopGap
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.ui.JBUI
 import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
@@ -149,15 +148,15 @@ class RsNewProjectPanel(
         rustProjectSettings.attachTo(this)
 
         if (showProjectTypeSelection) {
-            separator("Project Template")
-                .topGap(TopGap.MEDIUM)
-            row {
-                resizableRow()
-                fullWidthCell(templateToolbar.createPanel())
-                    .verticalAlign(VerticalAlign.FILL)
-            }
-            row {
-                cell(downloadCargoGenerateLink)
+            groupRowsRange(title = "Project Template", indent = false) {
+                row {
+                    resizableRow()
+                    fullWidthCell(templateToolbar.createPanel())
+                        .verticalAlign(VerticalAlign.FILL)
+                }
+                row {
+                    cell(downloadCargoGenerateLink)
+                }
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -183,6 +183,8 @@ class MacroExpansionTask(
                     for (segment in segmentsToCreate) {
                         newFileParent = newFileParent.createChildDirectory(TrustedRequestor, segment)
                     }
+                    oldFile.contentsToByteArray() // Ensure content is cached. If not, we can miss the modification
+                                                  // event (hence miss invalidating of some caches)
                     RsPsiManager.withIgnoredPsiEvents(oldPsiFile) {
                         if (newFileParent != oldFile.parent) {
                             oldFile.move(TrustedRequestor, newFileParent)

--- a/src/test/kotlin/org/rust/ide/inspections/import/RsReferenceImporterTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/RsReferenceImporterTest.kt
@@ -8,12 +8,15 @@ package org.rust.ide.inspections.import
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
 import org.intellij.lang.annotations.Language
+import org.rust.IgnoreInPlatform
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsUnresolvedReferenceInspection
 import org.rust.ide.settings.RsCodeInsightSettings
 
 class RsReferenceImporterTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
 
+    // https://github.com/intellij-rust/intellij-rust/issues/9418
+    @IgnoreInPlatform(223)
     fun `test single item`() = doTest("""
         fn main() {
             func();/*caret*/


### PR DESCRIPTION
The most interesting internal thing is migration to JDK 17. Now, you should use JDK 17 for development.
The reason is that 2022.3 is compiled with JDK 17, i.e. almost all classes have 61.0 bytecode version including kotlin ones. As a result, you should use the same (or above) JDK version as libraries use to call kotlin inline functions from these libraries.

But since 2022.2 still uses JDK 11, the plugin uses different target java versions for different platforms:
- java 11 for 222
- java 17 for 223

And not to introduce unncessesary compatibility problems, you can't use new features or API from Java 17 yet. But it doesn't look like even minor problem since we mostly use Koltin


changelog: Support 2022.3 platform. Internal: Use Java 17 for development
