### PR TITLE
MACRO: fix `format` macro expansion when param name is keyword (`self`) or there is a syntax error in param name

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1539,7 +1539,7 @@ ExprMacroArgument ::= <<any_braces [ AnyExpr ','? ]>>
 //noinspection BnfUnusedRule
 FormatMacroArgument ::= <<any_braces [ <<comma_separated_list FormatMacroArg>> ] >>
 //noinspection BnfUnusedRule
-FormatMacroArg ::= [ identifier '=' ] AnyExpr
+FormatMacroArg ::= [ <<macroIdentifier>> '=' ] AnyExpr
 //noinspection BnfUnusedRule
 AssertMacroArgument ::= <<any_braces (AnyExpr [ ',' <<comma_separated_list FormatMacroArg>> ])>>
 //noinspection BnfUnusedRule

--- a/src/main/kotlin/org/rust/ide/annotator/format/impl.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/format/impl.kt
@@ -407,7 +407,7 @@ private fun checkArgument(argument: RsFormatMacroArg, ctx: FormatContext): List<
     val hasPositionalParameter = ctx.positionalParameters.find { it.second.position == position } != null
 
     if (name == null) {
-        val firstNamed = ctx.arguments.indexOfFirst { it.identifier != null }
+        val firstNamed = ctx.arguments.indexOfFirst { it.eq != null }
         if (firstNamed != -1 && firstNamed < position) {
             errors.add(ErrorAnnotation(argument.textRange, "Positional arguments cannot follow named arguments"))
         } else if (!hasPositionalParameter) {
@@ -474,4 +474,5 @@ fun getFormatMacroCtx(formatMacro: RsMacroCall): Pair<Int, List<RsFormatMacroArg
     return Pair(position, formatMacroArgs)
 }
 
-private fun RsFormatMacroArg.name(): String? = this.identifier?.text
+fun RsFormatMacroArg.name(): String? =
+    if (eq != null) node.findChildByType(RS_IDENTIFIER_TOKENS)?.text else null

--- a/src/main/kotlin/org/rust/ide/refactoring/RsNamesValidator.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsNamesValidator.kt
@@ -7,8 +7,7 @@ package org.rust.ide.refactoring
 
 import com.intellij.lang.refactoring.NamesValidator
 import com.intellij.openapi.project.Project
-import com.intellij.psi.tree.IElementType
-import org.rust.lang.core.lexer.RsLexer
+import org.rust.lang.core.lexer.getRustLexerTokenType
 import org.rust.lang.core.psi.RS_KEYWORDS
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsElementTypes.QUOTE_IDENTIFIER
@@ -22,19 +21,13 @@ class RsNamesValidator : NamesValidator {
     companion object {
         val RESERVED_LIFETIME_NAMES: Set<String> = setOf("'static", "'_")
 
-        fun isIdentifier(name: String): Boolean = when (getLexerType(name)) {
+        fun isIdentifier(name: String): Boolean = when (name.getRustLexerTokenType()) {
             IDENTIFIER, QUOTE_IDENTIFIER -> true
             else -> false
         }
 
-        fun isKeyword(name: String): Boolean = getLexerType(name) in RS_KEYWORDS
+        fun isKeyword(name: String): Boolean = name.getRustLexerTokenType() in RS_KEYWORDS
     }
 }
 
-fun isValidRustVariableIdentifier(name: String): Boolean = getLexerType(name) == IDENTIFIER
-
-private fun getLexerType(text: String): IElementType? {
-    val lexer = RsLexer()
-    lexer.start(text)
-    return if (lexer.tokenEnd == text.length) lexer.tokenType else null
-}
+fun isValidRustVariableIdentifier(name: String): Boolean = name.getRustLexerTokenType() == IDENTIFIER

--- a/src/main/kotlin/org/rust/lang/core/lexer/utils.kt
+++ b/src/main/kotlin/org/rust/lang/core/lexer/utils.kt
@@ -16,3 +16,9 @@ fun CharSequence.tokenize(lexer: Lexer): Sequence<Pair<IElementType, String>> =
         lexer.advance()
         lexer.tokenType?.to(lexer.tokenText)
     })
+
+fun String.getRustLexerTokenType(): IElementType? {
+    val lexer = RsLexer()
+    lexer.start(this)
+    return if (lexer.tokenEnd == length) lexer.tokenType else null
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
@@ -6,15 +6,13 @@
 package org.rust.lang.core.macros.builtin
 
 import com.intellij.openapi.project.Project
-import org.rust.ide.annotator.format.ParameterLookup
-import org.rust.ide.annotator.format.buildParameters
-import org.rust.ide.annotator.format.checkSyntaxErrors
-import org.rust.ide.annotator.format.parseParameters
+import org.rust.ide.annotator.format.*
 import org.rust.lang.core.lexer.getRustLexerTokenType
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.macros.errors.BuiltinMacroExpansionError
 import org.rust.lang.core.parser.RustParser
 import org.rust.lang.core.parser.createAdaptedRustPsiBuilder
+import org.rust.lang.core.psi.RS_IDENTIFIER_TOKENS
 import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsFormatMacroArgument
 import org.rust.lang.core.psi.RsLitExpr
@@ -44,7 +42,7 @@ class BuiltinMacroExpander(val project: Project) : MacroExpander<RsBuiltinMacroD
     companion object {
         private val BUILTIN_FORMAT_MACROS: Set<String> = setOf("format_args", "format_args_nl")
 
-        const val EXPANDER_VERSION = 2
+        const val EXPANDER_VERSION = 3
     }
 }
 
@@ -73,9 +71,9 @@ private fun handleFormatMacro(macroName: String, macroText: String, format: RsFo
 
     val namedArguments = mutableSetOf<String>()
     for (argument in format.formatMacroArgList) {
-        val identifier = argument.identifier
-        if (identifier != null) {
-            namedArguments.add(identifier.text)
+        val name = argument.name()
+        if (name != null) {
+            namedArguments.add(name)
         }
     }
 
@@ -103,7 +101,7 @@ private fun handleFormatMacro(macroName: String, macroText: String, format: RsFo
     for (parameter in parameters) {
         if (parameter.lookup is ParameterLookup.Named) {
             val name = parameter.lookup.name
-            if (name.getRustLexerTokenType() != RsElementTypes.IDENTIFIER) {
+            if (name.getRustLexerTokenType() !in RS_IDENTIFIER_TOKENS) {
                 return null
             }
             if (name !in namedArguments) {

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -104,6 +104,6 @@ class RustParserDefinition : ParserDefinition {
         /**
          * Should be increased after any change of parser rules
          */
-        const val PARSER_VERSION: Int = LEXER_VERSION + 39
+        const val PARSER_VERSION: Int = LEXER_VERSION + 40
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/builtin/RsBuiltinMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/builtin/RsBuiltinMacroExpansionTest.kt
@@ -121,4 +121,16 @@ class RsBuiltinMacroExpansionTest : RsMacroExpansionTestBase() {
             //^
         }
     """)
+
+    fun `test self`() = checkSingleMacro("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args {}
+
+        fn foo() {
+            format_args!("{self}");
+            //^
+        }
+    """, """
+        format_args!("{self}", self = self)
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/builtin/RsBuiltinMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/builtin/RsBuiltinMacroExpansionTest.kt
@@ -3,10 +3,9 @@
  * found in the LICENSE file.
  */
 
-package org.rust.lang.core.macros.decl
+package org.rust.lang.core.macros.builtin
 
 import org.rust.lang.core.macros.*
-import org.rust.lang.core.macros.builtin.BuiltinMacroExpander
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsPossibleMacroCall

--- a/src/test/kotlin/org/rust/lang/core/macros/builtin/RsBuiltinMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/builtin/RsBuiltinMacroExpansionTest.kt
@@ -109,4 +109,16 @@ class RsBuiltinMacroExpansionTest : RsMacroExpansionTestBase() {
     """, """
         format_args!("{a}", a = a)
     """)
+
+    // Issue https://github.com/intellij-rust/intellij-rust/issues/9282
+    fun `test incorrect syntax`() = doErrorTest("""
+        #[rustc_builtin_macro]
+        macro_rules! format_args {}
+
+        fn foo() {
+            let a = 2;
+            format_args!("{a+5}");
+            //^
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #9282
