### PR TITLE
TY: fix mixed type/const type arguments

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
@@ -127,7 +127,7 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
         fn main() {
             let x = foo::foo::<0, usize>();
             x;
-          //^ S<usize, 0>
+          //^ S<T1, <unknown>>
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -6,8 +6,7 @@
 package org.rust.lang.core.type
 
 import org.intellij.lang.annotations.Language
-import org.rust.ide.presentation.render
-import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.presentation.*
 import org.rust.lang.core.psi.RsTypeReference
 import org.rust.lang.core.type.RsTypeResolvingTest.RenderMode.*
 import org.rust.lang.core.types.normType
@@ -554,6 +553,17 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         impl Trait for S {}
         type A = <S as Trait>::f64;
                              //^ <unknown>
+    """)
+
+    fun `test mixed type and const arguments`() = testType("""
+        struct A1;
+        const B1: i32 = 1;
+        struct C1;
+
+        struct Foo<A, const B: i32, C>(A, C);
+
+        type T = Foo<A1, B1, C1>;
+               //^ Foo<A1, 1, C1>
     """)
 
     /**

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -7,10 +7,17 @@ package org.rust.lang.core.type
 
 import org.intellij.lang.annotations.Language
 import org.rust.ide.presentation.*
+import org.rust.lang.core.macros.setContext
+import org.rust.lang.core.psi.RsPathType
+import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsTypeReference
+import org.rust.lang.core.psi.ext.RsGenericDeclaration
+import org.rust.lang.core.resolve.ref.pathPsiSubst
 import org.rust.lang.core.type.RsTypeResolvingTest.RenderMode.*
+import org.rust.lang.core.types.infer.containsTyOfClass
 import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.rawType
+import org.rust.lang.core.types.ty.TyUnknown
 
 class RsTypeResolvingTest : RsTypificationTestBase() {
     fun `test path`() = testType("""
@@ -577,6 +584,31 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         InlineFile(code)
         val (typeAtCaret, expectedType) = findElementAndDataInEditor<RsTypeReference>()
 
+        checkType(normalize, typeAtCaret, renderMode, expectedType)
+
+        // Additionally test RsPsiSubstitution and PsiSubstitutingPsiRenderer
+        if (typeAtCaret is RsPathType && !typeAtCaret.rawType.containsTyOfClass(TyUnknown.javaClass)) {
+            val path = typeAtCaret.path
+            val resolved = path.reference?.resolve()
+            if (resolved is RsGenericDeclaration) {
+                val psiSubst = pathPsiSubst(path, resolved)
+                val renderedType = PsiSubstitutingPsiRenderer(PsiRenderingOptions(shortPaths = false), listOf(psiSubst))
+                    .renderTypeReference(typeAtCaret)
+                val reconstructedType = RsPsiFactory(project)
+                    .createType(renderedType)
+                    .apply { setContext(typeAtCaret) }
+
+                checkType(normalize, reconstructedType, renderMode, expectedType)
+            }
+        }
+    }
+
+    private fun checkType(
+        normalize: Boolean,
+        typeAtCaret: RsTypeReference,
+        renderMode: RenderMode,
+        expectedType: String
+    ) {
         val ty = if (normalize) {
             typeAtCaret.normType
         } else {


### PR DESCRIPTION
Fixes such a case:
```rust
struct A;
const B: i32 = 1;
struct C;

struct Foo<A, const B: i32, C>(A, C);

fn main() {
    let foo: Foo<A, B, C> = Foo(A, C);
    let bar = foo; // should have `Foo<A, 1, C>` type, previously was `Foo<A, ?, ?>`
}
```

changelog: fix inference of types with mixed type/const type arguments
