### PR TITLE
COMP: Take into account some stdlib macro types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsTupleFieldCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsTupleFieldCompletionProvider.kt
@@ -20,6 +20,7 @@ import org.rust.lang.core.psi.RsFieldLookup
 import org.rust.lang.core.psi.ext.parentDotExpr
 import org.rust.lang.core.psi.ext.receiver
 import org.rust.lang.core.psiElement
+import org.rust.lang.core.resolve.KnownItems
 import org.rust.lang.core.types.expectedTypeCoercable
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTuple
@@ -52,7 +53,7 @@ object RsTupleFieldCompletionProvider : RsCompletionProvider() {
 
         val elements = type.types.withIndex().map { (index, ty) ->
             createLookupElement(object : CompletionEntity {
-                override val ty: Ty get() = ty
+                override fun retTy(items: KnownItems): Ty = ty
                 override fun getBaseLookupElementProperties(context: RsCompletionContext): RsLookupElementProperties =
                     RsLookupElementProperties(elementKind = RsLookupElementProperties.ElementKind.FIELD_DECL)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsGenericDeclaration.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsGenericDeclaration.kt
@@ -5,7 +5,15 @@
 
 package org.rust.lang.core.psi.ext
 
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.emptySubstitution
+import org.rust.lang.core.types.rawType
+import org.rust.lang.core.types.toTypeSubst
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyTypeParameter
 
 interface RsGenericDeclaration : RsElement {
     val typeParameterList: RsTypeParameterList?
@@ -39,3 +47,23 @@ val RsGenericDeclaration.requiredGenericParameters: List<RsGenericParameter>
             else -> false
         }
     }
+
+fun <T : RsGenericDeclaration> T.withSubst(vararg subst: Ty): BoundElement<T> {
+    val typeParameterList = typeParameters
+    val nonDefaultCount = typeParameterList.asSequence()
+        .takeWhile { it.typeReference == null }
+        .count()
+    val substitution = if (subst.size < nonDefaultCount || subst.size > typeParameterList.size) {
+        val name = if (this is RsNamedElement) name else "unnamed"
+        LOG.warn("Item `$name` has ${typeParameterList.size} type parameters but received ${subst.size} types for substitution")
+        emptySubstitution
+    } else {
+        typeParameterList.withIndex().associate { (i, par) ->
+            val paramTy = TyTypeParameter.named(par)
+            paramTy to (subst.getOrNull(i) ?: par.typeReference?.rawType ?: paramTy)
+        }.toTypeSubst()
+    }
+    return BoundElement(this, substitution)
+}
+
+private val LOG: Logger = logger<RsGenericDeclaration>()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -6,8 +6,6 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
-import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.SearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
@@ -30,8 +28,6 @@ import org.rust.openapiext.filterIsInstanceQuery
 import org.rust.openapiext.filterQuery
 import org.rust.openapiext.mapQuery
 import javax.swing.Icon
-
-private val LOG: Logger = logger<RsTraitItem>()
 
 val RsTraitItem.langAttribute: String? get() = queryAttributes.langAttribute
 
@@ -124,20 +120,6 @@ val RsTraitItem.isSized: Boolean
     get() {
         return implementedTrait?.flattenHierarchy.orEmpty().any { it.element.isSizedTrait }
     }
-
-fun RsTraitItem.withSubst(vararg subst: Ty): BoundElement<RsTraitItem> {
-    val typeParameterList = typeParameters
-    val substitution = if (typeParameterList.size != subst.size) {
-        LOG.warn("Trait has ${typeParameterList.size} type parameters but received ${subst.size} types for substitution")
-        emptySubstitution
-    } else {
-        typeParameterList.withIndex().associate { (i, par) ->
-            val param = TyTypeParameter.named(par)
-            param to (subst.getOrNull(i) ?: param)
-        }.toTypeSubst()
-    }
-    return BoundElement(this, substitution)
-}
 
 fun RsTraitItem.withDefaultSubst(): BoundElement<RsTraitItem> =
     BoundElement(this, defaultSubstitution(this))

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -191,6 +191,16 @@ val RsInferenceContextOwner.borrowCheckResult: BorrowCheckResult?
 fun RsNamedElement?.asTy(): Ty =
     (this as? RsTypeDeclarationElement)?.declaredType ?: TyUnknown
 
+fun RsNamedElement?.asTy(vararg subst: Ty): Ty {
+    if (this !is RsTypeDeclarationElement) return TyUnknown
+    val declaredType = declaredType
+    return if (this is RsGenericDeclaration) {
+        declaredType.substitute(withSubst(*subst).subst)
+    } else {
+        declaredType
+    }
+}
+
 private val CONTROL_FLOW_KEY: Key<CachedValue<ControlFlowGraph>> = Key.create("CONTROL_FLOW_KEY")
 
 val RsInferenceContextOwner.controlFlowGraph: ControlFlowGraph?

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
@@ -477,7 +477,7 @@ class RsCompletionSortingTest : RsTestBase() {
         RsFunction::class to "foo2", // &i32
     ))
 
-    fun `test tuple field order`() = doTest("""
+    fun `test expected types priority (tuple field order)`() = doTest("""
         fn main() {
             let tuple = (0, "", 0.0);
             let d: f64 = tuple./*caret*/
@@ -486,6 +486,22 @@ class RsCompletionSortingTest : RsTestBase() {
         Int::class to "2",
         Int::class to "0",
         Int::class to "1"
+    ))
+
+    fun `test expected types priority (vec macro)`() = doTest("""
+        #[lang = "alloc::vec::Vec"]
+        struct Vec<T>(T);
+        #[intellij_rust_std_macro]
+        macro_rules! vec { () => {}; }
+        macro_rules! vec_local { () => {}; }
+        fn vec() -> i32 { 0 }
+        fn main() {
+            let v: Vec<i32> = ve/*caret*/
+        }
+    """, listOf(
+        RsMacro::class to "vec",
+        RsFunction::class to "vec",
+        RsMacro::class to "vec_local",
     ))
 
     private fun doTest(@Language("Rust") code: String, expected: List<Pair<KClass<out Any>, String>>) {


### PR DESCRIPTION
E.g. in this case the `vec![]` macro will be prioritized in the completion list (because it returns a `Vec` type and that type is expected):
```rust
fn vec() -> i32 { 0 }
fn main() {
    let v: Vec<i32> = ve/*caret*/
}
```

Macros taken into account: `format`, `vec`, `addr_of`, `addr_of_mut`, `env`.

changelog: Take into account some stdlib macro types in completion sorting. For example, Now `vec![]` will be bubbled up in the completion list if expected expression type is `Vec`