### PR TITLE
COMP: don't prioritize functions that return `!` type (e.g. panic)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -458,6 +458,7 @@ private fun isCompatibleTypes(lookup: ImplLookup, actualTy: Ty?, expectedType: E
     val expectedTy = expectedType.ty
     if (
         actualTy is TyUnknown || expectedTy is TyUnknown ||
+        actualTy is TyNever || expectedTy is TyNever ||
         actualTy is TyTypeParameter || expectedTy is TyTypeParameter
     ) return false
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
@@ -302,6 +302,17 @@ class RsCompletionSortingTest : RsTestBase() {
         RsMacro::class to "foo09"
     ))
 
+    fun `test expected types priority (functions returning ! types are not prioritised)`() = doTest("""
+        fn foo_1_dont_panic() -> u8 { 0 }
+        fn foo_2_panic() -> ! { panic!() }
+        fn main() {
+            let a: i32 = foo_/*caret*/
+        }
+    """, listOf(
+        RsFunction::class to "foo_1_dont_panic",
+        RsFunction::class to "foo_2_panic",
+    ))
+
     fun `test expected types priority (fn arg)`() = doTest("""
         struct foo01<T>(T);
         struct foo02<T>(T);


### PR DESCRIPTION
When I worked on #9433 I found a weird behavior: the plugin prioritizes functions that return `!` type (e.g. "panic()" function). It is clearly visible when ML-assisted completion is disabled:
![image](https://user-images.githubusercontent.com/3221931/193321270-f5481589-71ff-4afa-8ce2-9637b25a74d8.png)


changelog: don't prioritize functions that return `!` type (e.g. `panic()`)
