### PR TITLE
REF: Partially support macros in `Move refactoring`

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -1549,6 +1549,33 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
+    fun `test outside references to macro from other crate`() = doTest("""
+    //- lib.rs
+        #[macro_export]
+        macro_rules! gen { () => {} }
+    //- main.rs
+        mod mod1 {
+            use test_package::gen;
+            fn foo/*caret*/() {
+                gen!();
+            }
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        #[macro_export]
+        macro_rules! gen { () => {} }
+    //- main.rs
+        mod mod1 {}
+        mod mod2 {
+            use test_package::gen;
+
+            fn foo() {
+                gen!();
+            }
+        }
+    """)
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test outside reference to items from stdlib`() = doTest("""
     //- lib.rs


### PR DESCRIPTION
Fixes #9193

changelog: Support adding imports for macros in [`Move refactoring`](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-refactorings.html#move-refactoring) (currently only macros from dependencies crates are supported)