### PR TITLE
Temporarily disable structured nav bar

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -264,7 +264,7 @@
         <elementDescriptionProvider implementation="org.rust.ide.presentation.RsDescriptionProvider"/>
         <breadcrumbsInfoProvider implementation="org.rust.ide.miscExtensions.RsBreadcrumbsInfoProvider"/>
 
-        <navbar implementation="org.rust.ide.navigationToolbar.RsNavBarModelExtension" order="first"/>
+        <!-- <navbar implementation="org.rust.ide.navigationToolbar.RsNavBarModelExtension" order="first"/> -->
 
         <!-- Spell-checker -->
 

--- a/src/test/kotlin/org/rust/ide/miscExtensions/RsNavBarTest.kt
+++ b/src/test/kotlin/org/rust/ide/miscExtensions/RsNavBarTest.kt
@@ -123,6 +123,7 @@ class RsNavBarTest : RsTestBase() {
     """, "foo")
 
     fun doTest(@Language("Rust") code: String, vararg items: String) {
+        return  // TODO
         InlineFile(code).withCaret()
 
         val model = NavBarModel(myFixture.project)


### PR DESCRIPTION
Looks like there are still some unsupported cases [e.g. with pat bindings](https://user-images.githubusercontent.com/6505554/193650079-8c746a9e-f3e5-408e-a62f-d26c4401e8dc.png) (thanks @mili-l for finding this)
I will fix them in separate PR

See #6581 for details