### PR TITLE
RES: Resolve stdlib items in detached files

### DIFF
--- a/ml-completion/src/main/kotlin/org/rust/ml/RsElementFeatureProvider.kt
+++ b/ml-completion/src/main/kotlin/org/rust/ml/RsElementFeatureProvider.kt
@@ -58,9 +58,7 @@ class RsElementFeatureProvider : ElementFeatureProvider {
             result[KIND] = MLFeatureValue.categorical(psiElementKind)
         }
         val containingCrate = psiElement.containingMod.containingCrate
-        if (containingCrate != null) {
-            result[IS_FROM_STDLIB] = MLFeatureValue.binary(containingCrate.isStd)
-        }
+        result[IS_FROM_STDLIB] = MLFeatureValue.binary(containingCrate.isStd)
 
         val rsElement = element.`as`(RsLookupElement::class.java)
         if (rsElement != null) {

--- a/src/main/kotlin/org/rust/ide/actions/ShareInPlaygroundAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/ShareInPlaygroundAction.kt
@@ -27,7 +27,6 @@ import com.intellij.util.net.ssl.CertificateManager
 import com.intellij.util.proxy.CommonProxy
 import org.jetbrains.annotations.TestOnly
 import org.rust.RsBundle
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.notifications.showBalloon
 import org.rust.ide.utils.USER_AGENT
 import org.rust.lang.core.psi.RsFile
@@ -73,7 +72,7 @@ class ShareInPlaygroundAction : DumbAwareAction() {
             if (!confirmShare(file, hasSelection)) return
 
             val channel = file.cargoProject?.rustcInfo?.version?.channel?.channel ?: "stable"
-            val edition = (file.crate?.edition ?: Edition.DEFAULT).presentation
+            val edition = file.crate.edition.presentation
 
             object : Task.Backgroundable(project, RsBundle.message("action.Rust.ShareInPlayground.progress.title")) {
 

--- a/src/main/kotlin/org/rust/ide/annotator/AnnotationSessionEx.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/AnnotationSessionEx.kt
@@ -10,6 +10,7 @@ import com.intellij.lang.annotation.AnnotationSession
 import com.intellij.openapi.util.Key
 import com.intellij.util.containers.orNull
 import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.psi.RsFile
 import org.rust.openapiext.getOrPut
 import java.util.*
@@ -18,7 +19,7 @@ private val CRATE_KEY = Key<Optional<Crate>>("org.rust.ide.annotator.currentCrat
 
 fun AnnotationSession.currentCrate(): Crate? {
     return getOrPut(CRATE_KEY) {
-        Optional.ofNullable((file as? RsFile)?.crate)
+        Optional.ofNullable((file as? RsFile)?.crate?.asNotFake)
     }.orNull()
 }
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -612,7 +612,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
     private fun checkUnstableAttribute(ref: RsReferenceElement, holder: RsAnnotationHolder) {
         val startElement = ref.referenceNameElement?.takeIf { it.elementType == IDENTIFIER } ?: return
-        if (ref.containingCrate?.origin == PackageOrigin.STDLIB) return
+        if (ref.containingCrate.origin == PackageOrigin.STDLIB) return
         val element = ref.reference?.resolve() as? RsOuterAttributeOwner ?: return
         for (attr in element.queryAttributes.unstableAttributes) {
             val metaItems = attr.metaItemArgs?.metaItemList ?: continue

--- a/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
@@ -23,6 +23,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.annotator.format.RsFormatMacroAnnotator
+import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMacroCall
@@ -95,7 +96,7 @@ class RsMacroExpansionHighlightingPass(
 
         if (macros.isEmpty()) return
 
-        val crate = (file as? RsFile)?.crate
+        val crate = (file as? RsFile)?.crate?.asNotFake
         val annotators = createAnnotators()
 
         while (macros.isNotEmpty()) {

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddAsyncAttributeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddAsyncAttributeFix.kt
@@ -44,7 +44,7 @@ class AddAsyncRecursionAttributeFix(function: RsFunction): LocalQuickFixAndInten
         }
 
         private fun hasAsyncRecursionDependency(context: RsElement): Boolean {
-            val crate = context.containingCrate ?: return false
+            val crate = context.containingCrate
             return crate.dependencies.any { it.normName == "async_recursion" }
         }
     }

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
@@ -95,7 +95,7 @@ class ChangeReturnTypeFix(
         private fun findCallableOwner(element: PsiElement): RsFunctionOrLambda? = element.contextStrict()
 
         fun createIfCompatible(element: RsElement, actualTy: Ty): ChangeReturnTypeFix? {
-            if (element.containingCrate?.origin != PackageOrigin.WORKSPACE) return null
+            if (element.containingCrate.origin != PackageOrigin.WORKSPACE) return null
 
             val owner = findCallableOwner(element)
             val isOverriddenFn = owner is RsFunction && owner.superItem != null

--- a/src/main/kotlin/org/rust/ide/annotator/format/impl.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/format/impl.kt
@@ -448,7 +448,7 @@ fun getFormatMacroCtx(formatMacro: RsMacroCall): Pair<Int, List<RsFormatMacroArg
     val macro = formatMacro.path.reference?.resolve() as? RsMacro ?: return null
     val macroName = macro.name ?: return null
 
-    val crate = macro.containingCrate ?: return null
+    val crate = macro.containingCrate
     val formatMacroArgs = formatMacro.formatMacroArgument?.formatMacroArgList
 
     if (crate.origin != PackageOrigin.STDLIB || formatMacroArgs === null) return null
@@ -464,7 +464,7 @@ fun getFormatMacroCtx(formatMacro: RsMacroCall): Pair<Int, List<RsFormatMacroArg
         // panic macro handles any literal (even with `{}`) if it's single argument in 2015 and 2018 editions,
         // but starting with edition 2021 the first string literal is always format string
         "panic" -> {
-            val edition = formatMacro.containingCrate?.edition ?: CargoWorkspace.Edition.DEFAULT
+            val edition = formatMacro.containingCrate.edition
             if (formatMacroArgs.size < 2 && edition < CargoWorkspace.Edition.EDITION_2021) null else 0
         }
         "write",

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -161,7 +161,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
     override fun getUrlFor(element: PsiElement, originalElement: PsiElement?): List<String> {
         val (qualifiedName, origin) = when {
             element is RsDocAndAttributeOwner && element is RsQualifiedNamedElement && element.hasExternalDocumentation -> {
-                val origin = element.containingCrate?.origin
+                val origin = element.containingCrate.origin
                 RsQualifiedName.from(element) to origin
             }
             else -> {

--- a/src/main/kotlin/org/rust/ide/icons/RsIconProvider.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RsIconProvider.kt
@@ -31,5 +31,5 @@ class RsIconProvider : IconProvider() {
             && element.isCrateRoot
 
     private fun isBuildRs(element: RsFile): Boolean = // TODO containingTarget
-        element.isCrateRoot && element.crate?.kind == CargoWorkspace.TargetKind.CustomBuild
+        element.isCrateRoot && element.crate.kind == CargoWorkspace.TargetKind.CustomBuild
 }

--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -59,7 +59,7 @@ class RsDoctestLanguageInjector : MultiHostInjector {
         val project = context.project
         if (!project.rustSettings.doctestInjectionEnabled) return
 
-        val crate = context.containingCrate ?: return
+        val crate = context.containingCrate
         if (!crate.areDoctestsEnabled) return // only library targets can have doctests
         val crateName = crate.normName
 
@@ -197,7 +197,7 @@ class DoctestInfo private constructor(
     companion object {
         fun fromCodeFence(codeFence: RsDocCodeFence): DoctestInfo? {
             if (!codeFence.project.rustSettings.doctestInjectionEnabled) return null
-            if (codeFence.containingCrate?.areDoctestsEnabled != true) return null
+            if (!codeFence.containingCrate.areDoctestsEnabled) return null
             if (hasUnbalancedCodeFencesBefore(codeFence)) return null
 
             val lang = codeFence.lang?.text ?: ""

--- a/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
@@ -59,7 +59,7 @@ class RsExternalLinterInspection : GlobalSimpleInspectionTool() {
         globalContext: GlobalInspectionContext,
         problemDescriptionsProcessor: ProblemDescriptionsProcessor
     ) {
-        if (file !is RsFile || file.containingCrate?.origin != PackageOrigin.WORKSPACE) return
+        if (file !is RsFile || file.containingCrate.origin != PackageOrigin.WORKSPACE) return
         val analyzedFiles = globalContext.getUserData(ANALYZED_FILES) ?: return
         analyzedFiles.add(file)
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
 import org.rust.lang.core.CompilerFeature.Companion.START
 import org.rust.lang.core.FeatureAvailability
+import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsVisitor
@@ -26,7 +27,7 @@ class RsMainFunctionNotFoundInspection : RsLocalInspectionTool() {
                 if (file is RsFile) {
                     if (file.childOfType<PsiErrorElement>() != null) return
 
-                    val crate = file.crate ?: return
+                    val crate = file.crate.asNotFake ?: return
                     if (!(crate.kind.isBin || crate.kind.isExampleBin || crate.kind.isCustomBuild)) return
                     if (!file.isCrateRoot) return
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -11,7 +11,6 @@ import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.inspections.fixes.QualifyPathFix
 import org.rust.ide.inspections.import.AutoImportFix
-import org.rust.ide.settings.RsCodeInsightSettings
 import org.rust.ide.utils.import.ImportCandidate
 import org.rust.lang.core.macros.proc.ProcMacroApplicationService
 import org.rust.lang.core.psi.*
@@ -73,7 +72,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
 
             override fun visitExternCrateItem(externCrate: RsExternCrateItem) {
                 if (externCrate.reference.multiResolve().isEmpty() &&
-                    externCrate.containingCrate?.origin == PackageOrigin.WORKSPACE) {
+                    externCrate.containingCrate.origin == PackageOrigin.WORKSPACE) {
                     RsDiagnostic.CrateNotFoundError(externCrate.referenceNameElement, externCrate.referenceName)
                         .addToHolder(holder)
                 }
@@ -87,7 +86,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
         val candidates = context?.candidates
         if (candidates.isNullOrEmpty() && ignoreWithoutQuickFix) return
 
-        if (element.containingCrate?.hasCyclicDevDependencies == true && element.isUnderCfgTest) {
+        if (element.containingCrate.hasCyclicDevDependencies && element.isUnderCfgTest) {
             return
         }
 

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/DeriveCopyFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/DeriveCopyFix.kt
@@ -63,7 +63,7 @@ class DeriveCopyFix(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiEl
         fun createIfCompatible(element: RsElement): DeriveCopyFix? {
             val pathExpr = element as? RsPathExpr ?: return null
             val item = (pathExpr.type as? TyAdt)?.item ?: return null
-            if (item.containingCrate?.origin != PackageOrigin.WORKSPACE) return null
+            if (item.containingCrate.origin != PackageOrigin.WORKSPACE) return null
 
             val implLookup = ImplLookup.relativeTo(element)
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsPathUsageAnalysis.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsPathUsageAnalysis.kt
@@ -59,7 +59,7 @@ val RsItemsOwner.pathUsage: PathUsageMap
 private fun calculatePathUsages(owner: RsItemsOwner): PathUsageMap {
     val usage = PathUsageMapMutable()
 
-    val crate = owner.containingCrate ?: return usage
+    val crate = owner.containingCrate
     if (!owner.existsAfterExpansion(crate)) return usage
 
     for (child in owner.children) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -18,6 +18,7 @@ import com.intellij.psi.search.UsageSearchContext
 import org.rust.ide.injected.isDoctestInjection
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.fixes.RemoveImportFix
+import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.crate.impl.DoctestCrate
 import org.rust.lang.core.macros.findExpansionElements
 import org.rust.lang.core.macros.proc.ProcMacroApplicationService
@@ -137,7 +138,7 @@ private fun getHighlightElement(useSpeck: RsUseSpeck): PsiElement {
 }
 
 private fun isApplicableForUseItem(item: RsUseItem): Boolean {
-    val crate = item.containingCrate ?: return false
+    val crate = item.containingCrate
     if (item.visibility == RsVisibility.Public && crate.kind.isLib) return false
     if (!item.existsAfterExpansion(crate)) return false
     return true
@@ -237,8 +238,8 @@ private fun isImportNeededForReference(
 
 private fun RsMod.hasTransitiveGlobImportTo(target: RsMod): Boolean {
     if (this == target) return true
-    val crateId = containingCrate?.id ?: return false
-    if (crateId != target.containingCrate?.id) {
+    val crateId = containingCrate.asNotFake?.id ?: return false
+    if (crateId != target.containingCrate.id) {
         // we consider `pub` imports as always used,
         // so any possible usage of import will be in same crate
         return false

--- a/src/main/kotlin/org/rust/ide/intentions/visibility/ChangeVisibilityIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/visibility/ChangeVisibilityIntention.kt
@@ -45,7 +45,7 @@ abstract class ChangeVisibilityIntention : RsElementBaseIntentionAction<ChangeVi
     companion object {
         fun isValidVisibilityOwner(visible: RsVisibilityOwner): Boolean {
             if (visible is RsEnumVariant) return false
-            if (visible.containingCrate?.origin != PackageOrigin.WORKSPACE) return false
+            if (visible.containingCrate.origin != PackageOrigin.WORKSPACE) return false
 
             val owner = (visible as? RsAbstractable)?.owner
             if (owner is RsAbstractableOwner.Trait || owner?.isTraitImpl == true) return false

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -8,6 +8,7 @@ package org.rust.ide.presentation
 import org.rust.ide.utils.import.ImportCandidate
 import org.rust.ide.utils.import.ImportCandidatesCollector2
 import org.rust.ide.utils.import.ImportContext2
+import org.rust.lang.core.crate.impl.FakeCrate
 import org.rust.lang.core.parser.RustParserUtil
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -752,7 +753,7 @@ class ImportingPsiRenderer(
                     }
                     if (importCandidate == null) {
                         val resolvedCrate = resolved.containingCrate
-                        if (resolvedCrate == null || resolvedCrate == context.containingCrate) {
+                        if (resolvedCrate is FakeCrate || resolvedCrate == context.containingCrate) {
                             sb.append("crate")
                         } else {
                             sb.append(resolvedCrate.normName)

--- a/src/main/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryAction.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryAction.kt
@@ -21,6 +21,7 @@ import org.rust.RsBundle
 import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.lang.RsConstants
 import org.rust.lang.RsLanguage
+import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.psi.RsFile
 import org.rust.openapiext.checkWriteAccessAllowed
 
@@ -82,7 +83,7 @@ private val PsiElement.isPromotable: Boolean
     get() {
         if (this !is RsFile) return false
         return if (isCrateRoot) {
-            name != RsConstants.MAIN_RS_FILE && containingCrate?.kind?.isPromotable == true
+            name != RsConstants.MAIN_RS_FILE && containingCrate.asNotFake?.kind?.isPromotable == true
         } else {
             name != RsConstants.MOD_RS_FILE
         }

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
@@ -86,7 +86,7 @@ class RsChangeSignatureHandler : ChangeSignatureHandler {
         @Suppress("UnstableApiUsage")
         @DialogMessage
         private fun checkFunction(function: RsFunction): String? {
-            if (function.containingCrate?.origin != PackageOrigin.WORKSPACE) {
+            if (function.containingCrate.origin != PackageOrigin.WORKSPACE) {
                 return "Cannot change signature of function in a foreign crate"
             }
             if (function.valueParameters != function.rawValueParameters) {

--- a/src/main/kotlin/org/rust/ide/template/postfix/editable/RsPostfixTemplateExpressionCondition.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/editable/RsPostfixTemplateExpressionCondition.kt
@@ -55,7 +55,7 @@ class RsPostfixTemplateExpressionCondition(private val expressionType: Type, pri
 
         return if (element.type.stripReferences() is TyAdt) {
             val adtItem = (element.type.stripReferences() as TyAdt).item
-            val adtFullPath = adtItem.containingCrate?.presentableName + adtItem.crateRelativePath
+            val adtFullPath = adtItem.containingCrate.presentableName + adtItem.crateRelativePath
 
             val useFullPath = typePath.isNotEmpty()
             if (useFullPath)

--- a/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
+++ b/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
@@ -25,6 +25,7 @@ import org.rust.ide.annotator.RsAnnotationHolder
 import org.rust.ide.annotator.fixes.AddFeatureAttributeFix
 import org.rust.lang.core.FeatureAvailability.*
 import org.rust.lang.core.FeatureState.ACCEPTED
+import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.stubs.index.RsFeatureIndex
 import org.rust.lang.utils.RsDiagnostic
@@ -61,7 +62,7 @@ class CompilerFeature(
             ThreeState.YES -> Unit
         }
 
-        val crate = rsElement.containingCrate ?: return UNKNOWN
+        val crate = rsElement.containingCrate.asNotFake ?: return UNKNOWN
         val cfgEvaluator = CfgEvaluator.forCrate(crate)
         val attrs = RsFeatureIndex.getFeatureAttributes(element.project, name)
         val possibleFeatureAttrs = attrs.asSequence()

--- a/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
@@ -15,6 +15,7 @@ import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.FeatureState
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.crate.impl.FakeCrate
 import org.rust.lang.core.psi.RsFile
 
 /**
@@ -115,3 +116,5 @@ fun Crate.findDependency(normName: String): Crate? =
 
 fun Crate.hasTransitiveDependencyOrSelf(other: Crate): Boolean =
     other == this || other in flatDependencies
+
+val Crate.asNotFake: Crate? get() = takeIf { this !is FakeCrate }

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/FakeCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/FakeCrate.kt
@@ -23,8 +23,25 @@ class FakeDetachedCrate(
     override val rootMod: RsFile,
     override val id: CratePersistentId,
     override val dependencies: Collection<Crate.Dependency>,
-) : UserDataHolderBase(), Crate {
+) : FakeCrate() {
     override val flatDependencies: LinkedHashSet<Crate> = dependencies.flattenTopSortedDeps()
+
+    override val rootModFile: VirtualFile? get() = rootMod.virtualFile
+    override val presentableName: String get() = "Fake for ${rootModFile?.path}"
+    override val project: Project get() = rootMod.project
+}
+
+/** Fake crate for cases when something is very wrong */
+class FakeInvalidCrate(override val project: Project) : FakeCrate() {
+    override val id: CratePersistentId? get() = null
+    override val dependencies: Collection<Crate.Dependency> get() = emptyList()
+    override val flatDependencies: LinkedHashSet<Crate> get() = linkedSetOf()
+    override val rootModFile: VirtualFile? get() = null
+    override val rootMod: RsFile? get() = null
+    override val presentableName: String get() = "Fake"
+}
+
+abstract class FakeCrate : UserDataHolderBase(), Crate {
 
     override val reverseDependencies: List<Crate> get() = emptyList()
 
@@ -39,13 +56,10 @@ class FakeDetachedCrate(
     override val env: Map<String, String> get() = emptyMap()
     override val outDir: VirtualFile? get() = null
 
-    override val rootModFile: VirtualFile? get() = rootMod.virtualFile
-    override val origin: PackageOrigin get() = PackageOrigin.WORKSPACE
+    override val origin: PackageOrigin get() = PackageOrigin.DEPENDENCY
     override val edition: CargoWorkspace.Edition get() = CargoWorkspace.Edition.values().last()
     override val areDoctestsEnabled: Boolean get() = false
-    override val presentableName: String get() = "Fake for ${rootModFile?.path}"
     override val normName: String get() = "__fake__"
-    override val project: Project get() = rootMod.project
     override val procMacroArtifact: CargoWorkspaceData.ProcMacroArtifact? get() = null
 
     override fun toString(): String = presentableName

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/FakeCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/FakeCrate.kt
@@ -57,7 +57,7 @@ abstract class FakeCrate : UserDataHolderBase(), Crate {
     override val outDir: VirtualFile? get() = null
 
     override val origin: PackageOrigin get() = PackageOrigin.DEPENDENCY
-    override val edition: CargoWorkspace.Edition get() = CargoWorkspace.Edition.values().last()
+    override val edition: CargoWorkspace.Edition get() = CargoWorkspace.Edition.DEFAULT
     override val areDoctestsEnabled: Boolean get() = false
     override val normName: String get() = "__fake__"
     override val procMacroArtifact: CargoWorkspaceData.ProcMacroArtifact? get() = null

--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroDataWithHash.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroDataWithHash.kt
@@ -44,7 +44,7 @@ class RsMacroDataWithHash<out T : RsMacroData>(
                 }
                 def is RsFunction && def.isProcMacroDef -> {
                     val name = def.procMacroName ?: return null
-                    val procMacro = def.containingCrate?.procMacroArtifact ?: return null
+                    val procMacro = def.containingCrate.procMacroArtifact ?: return null
                     val hash = HashCode.mix(procMacro.hash, HashCode.compute(name))
                     RsMacroDataWithHash(RsProcMacroData(name, procMacro), hash)
                 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ProcMacroAttribute.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ProcMacroAttribute.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi
 
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.macros.proc.ProcMacroApplicationService
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve2.resolveToProcMacroWithoutPsi
@@ -135,7 +136,7 @@ sealed class ProcMacroAttribute<out T : RsMetaItemPsiOrStub> {
                 }
             }
 
-            val crate = explicitCrate ?: owner.containingCrate ?: return None
+            val crate = explicitCrate ?: owner.containingCrate.asNotFake ?: return None
 
             // Stdlib uses many unstable built-in attributes that change frequently, and We may not be able to update
             // the `RS_BUILTIN_ATTRIBUTES` list in time. Let's just assume that stdlib can't have proc macros

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -175,7 +175,10 @@ class RsFile(
         // This occurs if the file is not included to the project's module structure, i.e. it's
         // most parent module is not mentioned in the `Cargo.toml` as a crate root of some target
         // (usually lib.rs or main.rs). It's anyway useful to know cargoProject&workspace in this case
-        val crate = FakeDetachedCrate(this, DefMapService.getNextNonCargoCrateId(), dependencies = emptyList())
+        val stdlibCrates = project.crateGraph.topSortedCrates
+            .filter { it.origin == PackageOrigin.STDLIB }
+            .map { Crate.Dependency(it.normName, it) }
+        val crate = FakeDetachedCrate(this, DefMapService.getNextNonCargoCrateId(), dependencies = stdlibCrates)
 
         val cargoProject = project.cargoProjects.findProjectForFile(virtualFile) ?: return CachedData(crate = crate)
         val workspace = cargoProject.workspace ?: return CachedData(cargoProject, crate =  crate)

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.SearchScope
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.lang.core.crate.impl.FakeCrate
 import org.rust.lang.core.macros.findMacroCallExpandedFrom
 import org.rust.lang.core.macros.isExpandedFromIncludeMacro
 import org.rust.lang.core.psi.ext.*
@@ -100,8 +101,8 @@ object RsPsiImplUtil {
     ): SearchScope? {
         val restrictedMod = when (val visibility = restrictedVis.intersect(element.visibility)) {
             RsVisibility.Public -> {
-                val crate = containingMod.containingCrate ?: return null
-                if (crate.kind is CargoWorkspace.TargetKind.Lib) return null
+                val crate = containingMod.containingCrate
+                if (crate is FakeCrate || crate.kind is CargoWorkspace.TargetKind.Lib) return null
                 crate.rootMod ?: return null
             }
             RsVisibility.Private -> containingMod

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
@@ -87,7 +87,7 @@ val PsiElement.isUnderCfgTest: Boolean
 
 private val RsElement.isUnderCfgTest: Boolean
     get() {
-        val crate = containingCrate ?: return false
+        val crate = containingCrate
         val trueEvaluator = LazyCfgEvaluator.NonLazy(CfgEvaluator.forCrate(crate, true, ThreeValuedLogic.True))
         val falseEvaluator = LazyCfgEvaluator.NonLazy(CfgEvaluator.forCrate(crate, true, ThreeValuedLogic.False))
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -15,6 +15,7 @@ import com.intellij.psi.stubs.StubBase
 import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.tree.IElementType
 import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsAttributeOwnerStub
 import org.rust.lang.core.stubs.RsFileStub
@@ -234,7 +235,7 @@ private fun <T : RsMetaItemPsiOrStub> RsAttributeOwnerPsiOrStub<T>.getExpandedAt
         rawMetaItems
     }
     if (!CFG_ATTRIBUTES_ENABLED_KEY.asBoolean()) return QueryAttributes(rawMetaItems)
-    val crate = explicitCrate ?: containingCrate ?: return QueryAttributes(rawMetaItems)
+    val crate = explicitCrate ?: containingCrate.asNotFake ?: return QueryAttributes(rawMetaItems)
     val evaluator = CfgEvaluator.forCrate(crate)
     return QueryAttributes(evaluator.expandCfgAttrs(rawMetaItems))
 }
@@ -500,7 +501,7 @@ sealed class LazyCfgEvaluator {
 
     object Lazy: LazyCfgEvaluator() {
         override fun createEvaluator(element: RsAttributeOwnerPsiOrStub<*>): CfgEvaluator? {
-            val crate = element.containingCrate ?: return null
+            val crate = element.containingCrate.asNotFake ?: return null
             return CfgEvaluator.forCrate(crate)
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -21,6 +21,7 @@ import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.lang.core.completion.getOriginalOrSelf
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.findDependency
+import org.rust.lang.core.crate.impl.FakeInvalidCrate
 import org.rust.lang.core.macros.findNavigationTargetIfMacroExpansion
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.*
@@ -47,16 +48,16 @@ fun PsiFileSystemItem.findCargoProject(): CargoProject? {
 }
 
 fun PsiFileSystemItem.findCargoPackage(): CargoWorkspace.Package? {
-    if (this is RsFile) return this.crate?.cargoTarget?.pkg
+    if (this is RsFile) return this.crate.cargoTarget?.pkg
     val vFile = virtualFile ?: return null
     return project.cargoProjects.findPackageForFile(vFile)
 }
 
 val RsElement.containingCargoTarget: CargoWorkspace.Target?
-    get() = containingCrate?.cargoTarget
+    get() = containingCrate.cargoTarget
 
-val RsElement.containingCrate: Crate?
-    get() = containingRsFileSkippingCodeFragments?.crate
+val RsElement.containingCrate: Crate
+    get() = containingRsFileSkippingCodeFragments?.crate ?: FakeInvalidCrate(project)
 
 val RsElement.containingCargoPackage: CargoWorkspace.Package? get() = containingCargoTarget?.pkg
 
@@ -98,7 +99,7 @@ val RsElement.isInAsyncContext: Boolean
 
 fun RsElement.findDependencyCrateRoot(dependencyName: String): RsFile? {
     return containingCrate
-        ?.findDependency(dependencyName)
+        .findDependency(dependencyName)
         ?.rootMod
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -115,7 +115,7 @@ private fun RsExpr.getValue(crateOrNull: Crate?): String? {
                 }
                 "env" -> {
                     val expr = macroCall.envMacroArgument?.variableNameExpr as? RsLitExpr ?: return null
-                    val crate = crateOrNull ?: expr.containingCrate ?: return null
+                    val crate = crateOrNull ?: expr.containingCrate
                     when (val variableName = expr.getValue(crate)) {
                         "OUT_DIR" -> crate.outDir?.path
                         else -> {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
@@ -143,7 +143,7 @@ private fun doPrepareProcMacroCallBody(
     return when (val attr = ProcMacroAttribute.getProcMacroAttributeWithoutResolve(owner, stub, explicitCrate)) {
         is ProcMacroAttribute.Attr -> {
             val attrIndex = attr.index
-            val crate = explicitCrate ?: owner.containingCrate ?: return null
+            val crate = explicitCrate ?: owner.containingCrate
             val body = doPrepareAttributeProcMacroCallBody(
                 project,
                 text,
@@ -155,7 +155,7 @@ private fun doPrepareProcMacroCallBody(
             PreparedProcMacroCallBody.Attribute(body, attr)
         }
         is ProcMacroAttribute.Derive -> {
-            val crate = explicitCrate ?: owner.containingCrate ?: return null
+            val crate = explicitCrate ?: owner.containingCrate
             val body = doPrepareCustomDeriveMacroCallBody(project, text, endOfAttrsOffset, crate) ?: return null
             PreparedProcMacroCallBody.Derive(body)
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -233,7 +233,7 @@ class LazyParamEnv(private val parentItem: RsGenericDeclaration) : ParamEnv {
 
 class ImplLookup(
     private val project: Project,
-    private val containingCrate: Crate?,
+    private val containingCrate: Crate,
     val items: KnownItems,
     private val paramEnv: ParamEnv = ParamEnv.EMPTY
 ) {
@@ -381,7 +381,7 @@ class ImplLookup(
             .filter { useImplsFromCrate(it.containingCrates) }
 
     private fun useImplsFromCrate(crates: List<Crate>): Boolean =
-        containingCrate == null || crates.any { containingCrate.hasTransitiveDependencyOrSelf(it) }
+        crates.any { containingCrate.hasTransitiveDependencyOrSelf(it) }
 
     private fun canCombineTypes(
         ty1: Ty,

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -244,7 +244,7 @@ enum class KnownMacro(val macroName: String) {
         private val NAME_TO_VALUE: Map<String, KnownMacro> = values().associateBy { it.macroName }
 
         fun of(macro: RsMacroDefinitionBase): KnownMacro? {
-            val isStdMacro = macro.containingCrate?.origin == PackageOrigin.STDLIB
+            val isStdMacro = macro.containingCrate.origin == PackageOrigin.STDLIB
                 || isUnitTestMode && macro.queryAttributes.hasAttribute("intellij_rust_std_macro")
             if (!isStdMacro) return null
             val name = macro.name ?: return null

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt
@@ -36,7 +36,7 @@ class RsLangItemIndex : AbstractStubIndex<String, RsItemElement>() {
             return if (elements.size < 2) {
                 elements.firstOrNull() as? RsNamedElement
             } else {
-                elements.find { it.containingCrate?.normName == crateName } as? RsNamedElement
+                elements.find { it.containingCrate.normName == crateName } as? RsNamedElement
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DetachedDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DetachedDefMap.kt
@@ -21,11 +21,8 @@ import org.rust.lang.core.psi.ext.getChildModule
 import org.rust.openapiext.getCachedOrCompute
 import java.lang.ref.SoftReference
 
-fun Project.getDetachedModInfo(scope: RsMod): RsModInfo? {
-    val rootMod = scope.containingFile as? RsFile ?: return null
-    val crate = FakeDetachedCrate(rootMod, DefMapService.getNextNonCargoCrateId(), dependencies = emptyList())
-    return getModInfoInDetachedCrate(scope, crate)
-}
+fun Project.getDetachedModInfo(scope: RsMod, crate: FakeDetachedCrate): RsModInfo? =
+    getModInfoInDetachedCrate(scope, crate)
 
 fun Project.getDoctestModInfo(scope: RsMod, crate: DoctestCrate): RsModInfo? =
     getModInfoInDetachedCrate(scope, crate)

--- a/src/main/kotlin/org/rust/lang/core/resolve2/actions/RsRebuildDefMapsAction.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/actions/RsRebuildDefMapsAction.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import org.rust.ide.notifications.setStatusBarText
 import org.rust.ide.notifications.showBalloon
+import org.rust.lang.core.crate.impl.FakeCrate
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.resolve2.forceRebuildDefMapForAllCrates
 import org.rust.lang.core.resolve2.forceRebuildDefMapForCrate
@@ -34,7 +35,8 @@ class RsRebuildCurrentDefMapAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val file = e.dataContext.psiFile as? RsFile ?: return
-        val crate = file.crate ?: return
+        val crate = file.crate
+        if (crate is FakeCrate) return
         val crateId = crate.id ?: return
         ApplicationManager.getApplication().executeOnPooledThread {
             val time = measureTimeMillis {

--- a/src/main/kotlin/org/rust/lang/core/stubs/common/PsiOrStubInterfaces.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/common/PsiOrStubInterfaces.kt
@@ -41,7 +41,7 @@ interface RsAttributeOwnerPsiOrStub<T : RsMetaItemPsiOrStub> {
     val rawOuterMetaItems: Sequence<T>
         get() = emptySequence()
 
-    val containingCrate: Crate?
+    val containingCrate: Crate
         get() = when (this) {
             is PsiElement -> (this as RsElement).containingCrate
             is StubElement<*> -> (psi as RsElement).containingCrate

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsExternCrateReexportIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsExternCrateReexportIndex.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndexKey
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
+import org.rust.lang.core.crate.impl.FakeCrate
 import org.rust.lang.core.psi.RsExternCrateItem
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.rustStructureOrAnyPsiModificationTracker
@@ -38,9 +39,9 @@ class RsExternCrateReexportIndex : StringStubIndexExtension<RsExternCrateItem>()
         fun findReexports(project: Project, crateRoot: RsMod): List<RsExternCrateItem> {
             checkCommitIsNotInProgress(project)
             return CachedValuesManager.getCachedValue(crateRoot) {
-                val targetName = crateRoot.containingCrate?.normName
-                val reexports = if (targetName != null) {
-                    getElements(KEY, targetName, project, GlobalSearchScope.allScope(project))
+                val targetCrate = crateRoot.containingCrate
+                val reexports = if (targetCrate !is FakeCrate) {
+                    getElements(KEY, targetCrate.normName, project, GlobalSearchScope.allScope(project))
                         .filter { externCrateItem -> externCrateItem.reference.resolve() == crateRoot }
                 } else {
                     emptyList()

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1788,7 +1788,7 @@ val SUPPORTED_CALLING_CONVENTIONS = mapOf(
 )
 
 fun RsElement.areUnstableFeaturesAvailable(version: RustcVersion): ThreeState {
-    val crate = containingCrate ?: return ThreeState.UNSURE
+    val crate = containingCrate
 
     val origin = crate.origin
     val isStdlibPart = origin == PackageOrigin.STDLIB || origin == PackageOrigin.STDLIB_DEPENDENCY

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -12,6 +12,7 @@ import junit.framework.ComparisonFailure
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
+import org.rust.lang.core.crate.impl.FakeCrate
 import org.rust.lang.core.macros.errors.*
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsPsiFactory
@@ -113,7 +114,8 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
         call: RsMacroCall,
         def: RsMacroData
     ): RsResult<MacroExpansion, MacroExpansionAndParsingError<MacroExpansionError>> {
-        val crate = call.containingCrate ?: error("`containingCrate` for the macro call is null")
+        val crate = call.containingCrate
+        check(crate !is FakeCrate) { "Invalid `containingCrate` for the macro call" }
         val expander = FunctionLikeMacroExpander.forCrate(crate)
         val expansionResult = expander.expandMacro(
             RsMacroDataWithHash(def, null),

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -7,6 +7,8 @@ package org.rust.lang.core.resolve
 
 import org.rust.CheckTestmarkHit
 import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 
 class RsStubOnlyResolveTest : RsResolveTestBase() {
     fun `test child mod`() = stubOnlyResolve("""
@@ -891,6 +893,14 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub mod foo {
             pub fn func() {}
         }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test resolve in detached file (stdlib item)`() = stubOnlyResolve("""
+    //- lib.rs
+    //- detached.rs
+        fn func(_: String) {}
+                 //^ ...string.rs
     """)
 
     fun `test method is not resolved to independent crate 1`() = stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateTestBase.kt
@@ -15,7 +15,7 @@ abstract class RsDefMapUpdateTestBase : RsTestBase() {
         val crateRoot = myFixture.findFileInTempDir("main.rs").toPsiFile(myFixture.project) as RsFile
         // Note: crate can change after `action`
         val getTimestamp = {
-            val crateId = crateRoot.crate!!.id!!
+            val crateId = crateRoot.crate.id!!
             val defMap = project.defMapService.getOrUpdateIfNeeded(crateId)!!
             defMap.timestamp
         }


### PR DESCRIPTION
Fixes #9422
Partial solution for #8853
Note that `containingCrate` of detached files is still null, so inspections will not work (and thus auto-import)

changelog: Now items from stdlib are resolved in detached and scratch files
