### PR TITLE
COMP: improve completion in the middle of identifier

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -17,6 +17,8 @@ import org.rust.lang.core.completion.lint.RsRustcLintCompletionProvider
 import org.rust.lang.core.completion.sort.RS_COMPLETION_WEIGHERS
 import org.rust.lang.core.completion.sort.RsCompletionWeigher
 import org.rust.lang.core.or
+import org.rust.lang.core.psi.RsElementTypes
+import org.rust.lang.core.psi.ext.elementType
 import org.rust.stdext.exhaustive
 
 class RsCompletionContributor : CompletionContributor() {
@@ -50,6 +52,14 @@ class RsCompletionContributor : CompletionContributor() {
 
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {
         extend(type, provider.elementPattern, provider)
+    }
+
+    override fun beforeCompletion(context: CompletionInitializationContext) {
+        super.beforeCompletion(context)
+        // TODO use `in RS_IDENTIFIER_TOKENS` instead of `== RsElementTypes.IDENTIFIER`
+        if (context.file.findElementAt(context.startOffset)?.elementType == RsElementTypes.IDENTIFIER) {
+            context.dummyIdentifier = CompletionInitializationContext.DUMMY_IDENTIFIER_TRIMMED
+        }
     }
 
     override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsFullMacroArgumentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsFullMacroArgumentCompletionTest.kt
@@ -90,4 +90,21 @@ class RsFullMacroArgumentCompletionTest : RsCompletionTestBase() {
         impl Foo { fn bar(&self) {} }
         foo!(Foo, bar(/*caret*/));
     """)
+
+    // TODO extra `()`
+    fun `test method with a caret in the middle if the identifier`() = doSingleCompletion("""
+        macro_rules! foo {
+            ($ e:expr, $ i:ident) => { fn foo() { $ e.$ i(); } };
+        }
+        struct Foo;
+        impl Foo { fn bar(&self) {} }
+        foo!(Foo, b/*caret*/ar);
+    """, """
+        macro_rules! foo {
+            ($ e:expr, $ i:ident) => { fn foo() { $ e.$ i(); } };
+        }
+        struct Foo;
+        impl Foo { fn bar(&self) {} }
+        foo!(Foo, bar(/*caret*/)ar);
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
@@ -256,4 +256,18 @@ class RsTypeAwareCompletionTest : RsCompletionTestBase() {
             S.fo/*caret*/;
         }
     """)
+
+    fun `test complete associated type inside a where bound in the middle of an identifier`() = doSingleCompletion("""
+        trait Foo { type Item; }
+        struct S<T>(T);
+        impl<T: Foo> S<T> {
+            fn foo() where T::It/*caret*/m: ?Sized {}
+        }
+    """, """
+        trait Foo { type Item; }
+        struct S<T>(T);
+        impl<T: Foo> S<T> {
+            fn foo() where T::Item/*caret*/m: ?Sized {}
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #9465

Improves completion in the case when the caret is placed in the middle of an identifier like `foo/*caret*bar`.

~Unfortunately, it breaks some tests, e.g. `test no completion for function after extern`. @Kobzol, maybe you could suggest a possible fix of the test?~

changelog: improve completion when the caret is placed in the middle of an identifier