### PR TITLE
COMP: Don't suggest out-of-scope deprecated modules

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
@@ -75,8 +75,12 @@ object ImportCandidatesCollector2 {
         val itemsPaths = modPaths
             .flatMap { context.getAllItemPathsInMod(it, nameToPriority::containsKey) }
         return context.convertToCandidates(itemsPaths)
-            /** we need this filter in addition to [hasVisibleItemInRootScope] because there can be local imports */
-            .filter { it.qualifiedNamedItem.item !in processedElements[it.qualifiedNamedItem.itemName] }
+            .filter {
+                val item = it.qualifiedNamedItem.item
+                /** we need this filter in addition to [hasVisibleItemInRootScope] because there can be local imports */
+                item !in processedElements[it.qualifiedNamedItem.itemName]
+                    && (item !is RsMod || item.queryAttributes.deprecatedAttribute == null)
+            }
             .sortedBy { nameToPriority[it.qualifiedNamedItem.itemName] }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -240,7 +240,8 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         val referenceName = qualifier.referenceName ?: return
         val itemToCandidates = ImportCandidatesCollector2.getImportCandidates(importContext, referenceName)
             .groupBy { it.qualifiedNamedItem.item }
-        for ((_, candidates) in itemToCandidates) {
+        for ((item, candidates) in itemToCandidates) {
+            if (item is RsMod && item.queryAttributes.deprecatedAttribute != null) continue
             // Here all use path resolves to the same item, so we can just use the first of them
             val firstUsePath = candidates.first().info.usePath
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsOutOfScopeItemsCompletionTest.kt
@@ -568,6 +568,16 @@ class RsOutOfScopeItemsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test don't suggest deprecated modules`() = doTestNoCompletion("""
+        fn main() {
+            inn/*caret*/
+        }
+        mod mod1 {
+            #[deprecated]
+            pub mod inner {}
+        }
+    """)
+
     private fun doTestByText(
         @Language("Rust") before: String,
         @Language("Rust") after: String,


### PR DESCRIPTION
We started to suggest modules in more cases in #9332, and sometimes it causes unwanted suggestions, e.g. for deprecated integer modules (thanks @neonaot for finding this)

<img src="https://user-images.githubusercontent.com/6505554/194532437-1c32faa1-e5b0-4d8b-a3b6-d0b04e6d88a9.png" width="50%">

changelog: Don't suggest deprecated modules in completion