### PR TITLE
RES: Fix passing paths with $crate to derive proc macro

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroCallBody.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroCallBody.kt
@@ -9,7 +9,7 @@ import org.rust.lang.core.psi.RsProcMacroKind
 
 sealed class MacroCallBody {
     data class FunctionLike(val text: String) : MacroCallBody()
-    data class Derive(val item: String) : MacroCallBody()
+    data class Derive(val item: MappedText) : MacroCallBody()
 
     /**
      * An attribute procedural macro body consists of two parts: an [item] part and an [attribute][attr] part.

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -52,7 +52,7 @@ class ProcMacroExpander private constructor(
 
         val (macroCallBodyText, attrText) = when (val macroBody = call.macroBody) {
             is MacroCallBody.FunctionLike -> MappedText.single(macroBody.text, 0) to null
-            is MacroCallBody.Derive -> MappedText.single(macroBody.item, 0) to null
+            is MacroCallBody.Derive -> macroBody.item to null
             is MacroCallBody.Attribute -> {
                 val item = if (macroBody.fixupRustSyntaxErrors) {
                     fixupRustSyntaxErrors(macroBody.item)
@@ -206,7 +206,7 @@ class ProcMacroExpander private constructor(
         psi !is RsDotExpr && psi.childrenWithLeaves.any { it is PsiErrorElement || it !is RsExpr && hasErrorToHandle(it) }
 
     companion object {
-        const val EXPANDER_VERSION: Int = 5
+        const val EXPANDER_VERSION: Int = 6
 
         fun forCrate(crate: Crate): ProcMacroExpander {
             val project = crate.project

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
@@ -214,7 +214,7 @@ fun doPrepareCustomDeriveMacroCallBody(
         sb.appendAttr(meta)
     }
     sb.appendMapped(text.substring(endOfAttrsOffset, text.length), endOfAttrsOffset)
-    return MacroCallBody.Derive(sb.toString())
+    return MacroCallBody.Derive(sb.toMappedText())
 }
 
 /**
@@ -399,7 +399,10 @@ val MacroCallBody.bodyHash: HashCode
             IOUtil.writeString(attr.text, this)
             attr.ranges.writeTo(this)
         }
-        is MacroCallBody.Derive -> HashCode.compute(item)
+        is MacroCallBody.Derive -> HashCode.compute {
+            IOUtil.writeString(item.text, this)
+            item.ranges.writeTo(this)
+        }
         is MacroCallBody.FunctionLike -> error("unreachable")
     }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -499,6 +499,38 @@ class RsProcMacroExpansionResolveTest : RsResolveTestBase() {
         } //^ main.rs
     """)
 
+    fun `test $crate passed to attr proc macro`() = checkByCode("""
+        fn main() {
+            bar();
+        } //^
+        fn foo() {}
+         //X
+        macro_rules! gen {
+            () => {
+                #[test_proc_macros::attr_as_is]
+                use $ crate::foo as bar;
+            }
+        }
+        gen!();
+    """)
+
+    fun `test $crate passed to derive proc macro`() = checkByCode("""
+        macro_rules! gen {
+            () => {
+                #[derive(test_proc_macros::DeriveAsIsInNestedMod)]
+                pub struct Foo(pub $ crate::Struct);
+            }
+        }
+        gen!();
+
+        fn func(foo: inner::Foo) {
+            foo.0.field;
+        }       //^
+        pub struct Struct {
+            pub field: i32
+        }     //X
+    """)
+
     override val followMacroExpansions: Boolean
         get() = true
 }

--- a/testData/test-proc-macros/src/lib.rs
+++ b/testData/test-proc-macros/src/lib.rs
@@ -103,6 +103,15 @@ pub fn derive_macro_bar_invocation(_item: TokenStream) -> TokenStream {
    "bar!{}".parse().unwrap()
 }
 
+#[proc_macro_derive(DeriveAsIsInNestedMod)]
+pub fn derive_as_is_in_nested_mod(item: TokenStream) -> TokenStream {
+    vec![
+        Ident::new("mod", Span::call_site()).into(),
+        Ident::new("inner", Span::call_site()).into(),
+        TokenTree::Group(Group::new(Delimiter::Brace, item))
+    ].into_iter().collect()
+}
+
 #[proc_macro]
 pub fn function_like_generates_impl_for_foo(_input: TokenStream) -> TokenStream {
    "impl Foo { fn foo(&self) -> Bar {} }".parse().unwrap()


### PR DESCRIPTION
Fixes #9445

changelog: Fix handling of [`$crate`](https://doc.rust-lang.org/reference/macros-by-example.html#hygiene) in procedural macros in some cases