### PR TITLE
Make implementation query async

### DIFF
--- a/src/222/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilder.kt
+++ b/src/222/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilder.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.util.NotNullLazyValue
 import com.intellij.psi.SmartPsiElementPointer
 import javax.swing.Icon
 
-class ImplsGutterIconBuilder(icon: Icon) : ImplsGutterIconBuilderBase(icon) {
+class ImplsGutterIconBuilder(elementName: String, icon: Icon) : ImplsGutterIconBuilderBase(elementName, icon) {
     override fun createGutterIconRenderer(
         pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
         renderer: Computable<PsiElementListCellRenderer<*>>,

--- a/src/223/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilder.kt
+++ b/src/223/main/kotlin/org/rust/ide/lineMarkers/ImplsGutterIconBuilder.kt
@@ -14,7 +14,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.SmartPsiElementPointer
 import javax.swing.Icon
 
-class ImplsGutterIconBuilder(icon: Icon) : ImplsGutterIconBuilderBase(icon) {
+class ImplsGutterIconBuilder(elementName: String, icon: Icon) : ImplsGutterIconBuilderBase(elementName, icon) {
     override fun createGutterIconRenderer(
         pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
         renderer: Computable<PsiElementListCellRenderer<*>>,

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
@@ -39,7 +39,7 @@ class RsImplsLineMarkerProvider : LineMarkerProvider {
             // if (query.isEmptyQuery) return null
             val query = implsQuery(el) ?: continue
             val targets: NotNullLazyValue<Collection<PsiElement>> = NotNullLazyValue.createValue { query.findAll() }
-            val info = ImplsGutterIconBuilder(RsIcons.IMPLEMENTED)
+            val info = ImplsGutterIconBuilder(el.text, RsIcons.IMPLEMENTED)
                 .setTargets(targets)
                 .setTooltipText("Has implementations")
                 .setCellRenderer { RsGoToImplRenderer() }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/LineMarkerTestHelper.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/LineMarkerTestHelper.kt
@@ -10,6 +10,9 @@ import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
 import com.intellij.lang.LanguageCommenters
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.UserDataHolder
+import com.intellij.openapi.util.UserDataHolderBase
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
@@ -67,4 +70,16 @@ class LineMarkerTestHelper(private val fixture: CodeInsightTestFixture) {
 
 fun LineMarkerInfo<PsiElement>.invokeNavigationHandler(element: PsiElement?) {
     navigationHandler.navigate(MouseEvent(JLabel(), 0, 0, 0, 0, 0, 0, false), element)
+}
+
+fun <T> LineMarkerInfo<PsiElement>.invokeNavigationHandler(element: PsiElement?, key: Key<T>): T? {
+    val event = object : MouseEvent(JLabel(), 0, 0, 0, 0, 0, 0, false), UserDataHolder {
+        private val dataHolder = UserDataHolderBase()
+        override fun <T> getUserData(key: Key<T>): T? = dataHolder.getUserData(key)
+        override fun <T> putUserData(key: Key<T>, value: T?) = dataHolder.putUserData(key, value)
+    }
+
+    navigationHandler.navigate(event, element)
+
+    return event.getUserData(key)
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
@@ -77,8 +77,7 @@ class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
 
         @Suppress("UNCHECKED_CAST")
         val markerInfo = (myFixture.findGuttersAtCaret().first() as LineMarkerInfo.LineMarkerGutterIconRenderer<PsiElement>).lineMarkerInfo
-        markerInfo.invokeNavigationHandler(element)
-        val renderedImpls = element.getUserData(RsImplsLineMarkerProvider.RENDERED_IMPLS)!!
+        val renderedImpls = markerInfo.invokeNavigationHandler(element, RsImplsLineMarkerProvider.RENDERED_IMPLS)!!
         assertEquals(expectedItems.toList(), renderedImpls)
     }
 }


### PR DESCRIPTION
Previously, when you pressed on `Has implementation` line marker to see all implementations of struct/enum, trait or trait item, the search was performed in EDT. As a result, if the search was long, your IDE froze for this time

Now, this search query is performed in background thread, and the loading icon is shown during the search. So, no more freeze in case of looking for implementations

Fixes #9457

changelog: Fix IDE freezing on searching implementation via `Has Implementation` line marker in gutter
