### PR TITLE
RES: Remove `org.rust.resolve.new.engine.macros.parallel`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -9,8 +9,6 @@ import com.intellij.concurrency.SensitiveProgressWrapper
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.registry.Registry
-import com.intellij.openapi.util.registry.RegistryValue
 import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
 import gnu.trove.THashMap
 import org.rust.cargo.project.workspace.CargoWorkspaceData
@@ -34,7 +32,6 @@ import java.util.concurrent.ExecutorService
 import kotlin.math.ceil
 
 private const val CONSIDER_INDETERMINATE_IMPORTS_AS_RESOLVED: Boolean = false
-private val EXPAND_MACROS_IN_PARALLEL: RegistryValue = Registry.get("org.rust.resolve.new.engine.macros.parallel")
 
 /** Resolves all imports and expands macros (new items are added to [defMap]) using fixed point iteration algorithm */
 class DefCollector(
@@ -343,7 +340,7 @@ class DefCollector(
         if (macros.isEmpty()) return
         val batches = macros.splitInBatches(100)
 
-        val result = if (pool != null && EXPAND_MACROS_IN_PARALLEL.asBoolean()) {
+        val result = if (pool != null) {
             val indicator = indicator.toThreadSafeProgressIndicator()
             // Don't use `.parallelStream()` - for typical count of batches (10-20) it will run all tasks on current thread
             val tasks = batches.map { batch ->

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1211,8 +1211,6 @@
                      Run Tool Window instead of raw console"/>
         <registryKey key="org.rust.macros.proc.timeout" defaultValue="5000" restartRequired="false"
                      description="The maximum time (in milliseconds) allotted to one procedural macro expansion"/>
-        <registryKey key="org.rust.resolve.new.engine.macros.parallel" defaultValue="true" restartRequired="false"
-                     description="Expand macros in parallel"/>
         <registryKey key="org.rust.external.linter.max.duration" defaultValue="3000" restartRequired="false"
                      description="Show notification warning if the external linter is running longer than the set value (ms)"/>
         <registryKey key="org.rust.debugger.lldb.rust.msvc" defaultValue="false" restartRequired="false"


### PR DESCRIPTION
Parallel macro expansion was introduced in #7947 along with experimental feature `org.rust.resolve.new.engine.macros.parallel` to turn it off in case of any errors. Since there are no related error reports, I guess it makes sense to remove the experimental feature