### PR TITLE
ANN: annotate usage of `wasm` abi as experimental

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
+++ b/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
@@ -207,6 +207,7 @@ class CompilerFeature(
         val SLICE_PATTERNS: CompilerFeature get() = get("slice_patterns")
         val START: CompilerFeature get() = get("start")
         val UNBOXED_CLOSURES: CompilerFeature get() = get("unboxed_closures")
+        val WASM_ABI: CompilerFeature get() = get("wasm_abi")
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -50,6 +50,7 @@ import org.rust.lang.core.CompilerFeature.Companion.C_UNWIND
 import org.rust.lang.core.CompilerFeature.Companion.INTRINSICS
 import org.rust.lang.core.CompilerFeature.Companion.PLATFORM_INTRINSICS
 import org.rust.lang.core.CompilerFeature.Companion.UNBOXED_CLOSURES
+import org.rust.lang.core.CompilerFeature.Companion.WASM_ABI
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
@@ -1777,8 +1778,7 @@ val SUPPORTED_CALLING_CONVENTIONS = mapOf(
     "avr-interrupt" to ABI_AVR_INTERRUPT,
     "avr-non-blocking-interrupt" to ABI_AVR_INTERRUPT,
     "C-cmse-nonsecure-call" to ABI_C_CMSE_NONSECURE_CALL,
-    // TODO: update compiler features and use `WASM_ABI` here
-    "wasm" to null,
+    "wasm" to WASM_ABI,
     "system" to null,
     "system-unwind" to C_UNWIND,
     "rust-intrinsic" to INTRINSICS,

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -4647,7 +4647,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         extern <error descr="avr-interrupt ABI is experimental [E0658]">"avr-interrupt"</error> fn fn19() {}
         extern <error descr="avr-non-blocking-interrupt ABI is experimental [E0658]">"avr-non-blocking-interrupt"</error> fn fn20() {}
         extern <error descr="C-cmse-nonsecure-call ABI is experimental [E0658]">"C-cmse-nonsecure-call"</error> fn fn21() {}
-        extern "wasm" fn fn22() {}
+        extern <error descr="wasm ABI is experimental [E0658]">"wasm"</error> fn fn22() {}
         extern "system" fn fn23() {}
         extern <error descr="system-unwind ABI is experimental [E0658]">"system-unwind"</error> fn fn24() {}
         extern <error descr="rust-intrinsic ABI is experimental [E0658]">"rust-intrinsic"</error> fn fn25() {}


### PR DESCRIPTION
Continuation of #7640. Previously, `wasm` abi was missed because the plugin didn't know about the corresponding compiler feature for some reason


changelog: Annotate usage of `wasm` abi as experimental
