### PR TITLE
INSP: Don't register problems with `INFORMATION` level in batch mode

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
@@ -82,13 +82,13 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
         highlightType: ProblemHighlightType,
         vararg fixes: LocalQuickFix
     ) {
-        if (element.existsAfterExpansion) {
+        if (element.existsAfterExpansion && isProblemWithTypeAllowed(highlightType)) {
             holder.registerProblem(element, descriptionTemplate, highlightType, *fixes)
         }
     }
 
     fun registerProblem(problemDescriptor: ProblemDescriptor) {
-        if (problemDescriptor.psiElement.existsAfterExpansion) {
+        if (problemDescriptor.psiElement.existsAfterExpansion && isProblemWithTypeAllowed(problemDescriptor.highlightType)) {
             holder.registerProblem(problemDescriptor)
         }
     }
@@ -106,10 +106,13 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
         rangeInElement: TextRange,
         vararg fixes: LocalQuickFix?
     ) {
-        if (element.existsAfterExpansion) {
+        if (element.existsAfterExpansion && isProblemWithTypeAllowed(highlightType)) {
             holder.registerProblem(element, message, highlightType, rangeInElement, *fixes)
         }
     }
+
+    private fun isProblemWithTypeAllowed(highlightType: ProblemHighlightType): Boolean =
+        highlightType != ProblemHighlightType.INFORMATION || holder.isOnTheFly
 }
 
 fun ProblemDescriptor.findExistingEditor(): Editor? {


### PR DESCRIPTION
Fixes #9498

This should not affect users (problems with `INFORMATION` level are filtered out in batch mode anyway)