### PR TITLE
Don't use private reexport in crate root in auto-import

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector2.kt
@@ -274,7 +274,7 @@ private fun ImportContext2.checkVisibility(visItem: VisItem, modData: ModData): 
     val visibility = visItem.visibility
     if (!visibility.isVisibleFromMod(rootModData)) return false
     if (visibility is Visibility.Restricted) {
-        val isPrivate = visibility.inMod == modData && !visibility.inMod.isCrateRoot
+        val isPrivate = visibility.inMod == modData
         val isExplicitlyDeclared = !visItem.isCrateRoot && visItem.containingMod == modData.path
         if (isPrivate && !isExplicitlyDeclared) {
             Testmarks.IgnorePrivateImportInParentMod.hit()

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -518,6 +518,35 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    @CheckTestmarkHit(Testmarks.IgnorePrivateImportInParentMod::class)
+    fun `test don't try to import private reexport from crate root`() = checkAutoImportFixByText("""
+        use mod1::func;
+
+        mod mod1 {
+            pub fn func() {}
+        }
+
+        mod inner {
+            fn test() {
+                /*error descr="Unresolved reference: `func`"*//*caret*/func/*error**/();
+            }
+        }
+    """, """
+        use mod1::func;
+
+        mod mod1 {
+            pub fn func() {}
+        }
+
+        mod inner {
+            use crate::mod1::func;
+
+            fn test() {
+                func();
+            }
+        }
+    """)
+
     fun `test complex module structure`() = checkAutoImportFixByText("""
         mod aaa {
             mod bbb {


### PR DESCRIPTION
Fixes #9186

changelog: Improve auto-import of items from same crate in some cases
