### PR TITLE
IDE: fold foreign mods (extern blocks)

### DIFF
--- a/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
@@ -106,6 +106,8 @@ class RsFoldingBuilder : CustomFoldingBuilder(), DumbAware {
 
         override fun visitModItem(o: RsModItem) = foldBetween(o, o.lbrace, o.rbrace)
 
+        override fun visitForeignModItem(o: RsForeignModItem) = foldBetween(o, o.lbrace, o.rbrace)
+
         override fun visitMacroArgument(o: RsMacroArgument) {
             val macroCall = o.parent as? RsMacroCall
             if (macroCall?.bracesKind == MacroBraces.BRACES) {

--- a/src/test/kotlin/org/rust/ide/folding/RsFoldingBuilderTest.kt
+++ b/src/test/kotlin/org/rust/ide/folding/RsFoldingBuilderTest.kt
@@ -39,6 +39,7 @@ class RsFoldingBuilderTest : RsTestBase() {
     fun `test custom region in match expr`() = doTest()
     fun `test custom region in trait`() = doTest()
     fun `test where`() = doTest()
+    fun `test extern`() = doTest()
 
     private fun doTest() {
         myFixture.testFolding("$testDataPath/$fileName")

--- a/src/test/resources/org/rust/ide/folding/fixtures/extern.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/extern.rs
@@ -1,0 +1,11 @@
+extern "C"  <fold text='{...}'>{
+    fn foo();
+}</fold>;
+
+extern <fold text='{...}'>{
+    fn foo();
+}</fold>;
+
+extern
+
+extern <fold text='{...}'>{}</fold>


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/9497

changelog: Foreign mod declarations (`extern "C" { ... }`) arenow folded by the plugin.
