### PR TITLE
GRD: update IDE and plugin dependencies for 223 builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ val compileNativeCodeTaskName = "compileNativeCode"
 plugins {
     idea
     kotlin("jvm") version "1.7.20"
-    id("org.jetbrains.intellij") version "1.8.1"
+    id("org.jetbrains.intellij") version "1.10.0-SNAPSHOT"
     id("org.jetbrains.grammarkit") version "2021.2.2"
     id("net.saliman.properties") version "1.5.2"
     id("org.gradle.test-retry") version "1.4.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -600,8 +600,8 @@ project(":ml-completion") {
 
 task("runPrettyPrintersTests") {
     doLast {
-        // https://github.com/intellij-rust/intellij-rust/issues/8482
-        if (platformVersion == 221) return@doLast
+        // https://github.com/intellij-rust/intellij-rust/issues/9554
+        if (platformVersion == 223 && isFamily(FAMILY_WINDOWS)) return@doLast
         val lldbPath = when {
             // TODO: Use `lldb` Python module from CLion distribution
             isFamily(FAMILY_MAC) -> "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -330,6 +330,10 @@ project(":plugin") {
             dependsOn(mergePluginJarTask)
             enabled = prop("enableBuildSearchableOptions").toBoolean()
         }
+        verifyPlugin {
+            // We don't want to fail `verifyPlugin` task because of too short description
+            ignoreUnacceptableWarnings.set(true)
+        }
 
         withType<PrepareSandboxTask> {
             dependsOn(named(compileNativeCodeTaskName))

--- a/gradle-223.properties
+++ b/gradle-223.properties
@@ -1,11 +1,11 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-223.4884-EAP-CANDIDATE-SNAPSHOT
-clionVersion=CL-223.4884-EAP-CANDIDATE-SNAPSHOT
+ideaVersion=IU-223.6646-EAP-CANDIDATE-SNAPSHOT
+clionVersion=CL-223.6646-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=223.4884.65
+nativeDebugPluginVersion=223.6646.99
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPluginVersion=223-SNAPSHOT
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,3 +24,10 @@ buildCache {
         removeUnusedEntriesAfterDays = 30
     }
 }
+
+pluginManagement {
+    repositories {
+        maven("https://oss.sonatype.org/content/repositories/snapshots/")
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
Also, temporarily use snapshot version of gradle-intellij-plugin because it contains fixes to properly launch the atest 2022.3 IDEs
