### PR TITLE
REF: Substitute `Self` in "Inline function" refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
@@ -23,20 +23,24 @@ import org.rust.ide.inspections.RsFieldInitShorthandInspection
 import org.rust.ide.inspections.fixes.deleteUseSpeck
 import org.rust.ide.refactoring.RsInlineUsageViewDescriptor
 import org.rust.ide.refactoring.freshenName
+import org.rust.ide.refactoring.inlineTypeAlias.replacePathWithTypeReference
 import org.rust.ide.refactoring.inlineValue.replaceWithAddingParentheses
 import org.rust.lang.core.dfa.ExitPoint
 import org.rust.lang.core.macros.setContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.RsReference
+import org.rust.lang.core.types.Substitution
+import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.liveness
 import org.rust.openapiext.isUnitTestMode
 import org.rust.stdext.mapNotNullToSet
 
 /** `foo()` */
-private class FunctionCallUsage(val functionCall: RsCallExpr, reference: PsiReference) : UsageInfo(reference)
+private class FunctionCallUsage(val functionCall: RsCallExpr, reference: PsiReference) : CallUsage(reference)
 /** `foo.func()` */
-private class MethodCallUsage(val methodCall: RsMethodCall, reference: PsiReference) : UsageInfo(reference)
+private class MethodCallUsage(val methodCall: RsMethodCall, reference: PsiReference) : CallUsage(reference)
+private sealed class CallUsage(reference: PsiReference) : UsageInfo(reference)
 
 /** `use inner::foo;` */
 private class UseSpeckUsage(val useSpeck: RsUseSpeck, reference: PsiReference) : UsageInfo(reference)
@@ -91,7 +95,7 @@ class RsInlineFunctionProcessor(
             (pathExpr.parent as? RsCallExpr)?.takeIf { it.expr == pathExpr }
         }
         return when {
-            element is RsMethodCall -> MethodCallUsage(element, reference)
+            element is RsMethodCall && element.parent is RsDotExpr -> MethodCallUsage(element, reference)
             functionCall != null -> FunctionCallUsage(functionCall, reference)
             useSpeck != null -> UseSpeckUsage(useSpeck, reference)
             else -> ReferenceUsage(reference)
@@ -128,20 +132,20 @@ class RsInlineFunctionProcessor(
                 deleteUseSpeck(usage.useSpeck)
                 true
             }
-            else -> inlineSingleUsage(usage, function)
+            is CallUsage -> inlineCallUsage(usage, function)
+            else -> false
         }
 
-    private fun inlineSingleUsage(usage: UsageInfo, function: RsFunction): Boolean {
-        val functionCall = when (usage) {
-            is FunctionCallUsage -> usage.functionCall
-            is MethodCallUsage -> replaceMethodCallWithUFCS(usage.methodCall, function) ?: return false
-            else -> return false
+    private fun inlineCallUsage(usage: CallUsage, function: RsFunction): Boolean {
+        val arguments = when (usage) {
+            is FunctionCallUsage -> usage.functionCall.valueArgumentList.exprList
+            is MethodCallUsage -> getArgumentsOfMethodCall(usage.methodCall, function) ?: return false
         }
-        return InlineSingleUsage(functionCall, function).invoke()
+        return InlineSingleUsage(arguments, usage, function).invoke()
     }
 
-    // `self.foo(arg1, arg2)` to `foo(&self, arg1, arg2)`
-    private fun replaceMethodCallWithUFCS(methodCall: RsMethodCall, function: RsFunction): RsCallExpr? {
+    // `self.foo(arg1, arg2)` -> listOf(`&self`, `arg1`, `arg2`)
+    private fun getArgumentsOfMethodCall(methodCall: RsMethodCall, function: RsFunction): List<RsExpr>? {
         val dotExpr = methodCall.parent as? RsDotExpr ?: return null
         val callee = if (function.isFirstParameterReference()) {
             // https://doc.rust-lang.org/book/ch05-03-method-syntax.html#wheres-the---operator
@@ -149,9 +153,7 @@ class RsInlineFunctionProcessor(
         } else {
             dotExpr.expr
         }
-        val arguments = listOf(callee) + methodCall.valueArgumentList.exprList
-        val functionCall = factory.createFunctionCall(methodCall.referenceName, arguments)
-        return dotExpr.replace(functionCall) as RsCallExpr
+        return listOf(callee) + methodCall.valueArgumentList.exprList
     }
 
     private fun RsFunction.isFirstParameterReference(): Boolean {
@@ -238,10 +240,16 @@ class RsInlineFunctionProcessor(
 }
 
 private class InlineSingleUsage(
-    private val functionCall: RsCallExpr,
+    private val arguments: List<RsExpr>,
+    private val usage: CallUsage,
     originalFunction: RsFunction,
 ) {
 
+    /** The expression which should be replaced by function body */
+    private val functionCall: RsExpr = when (usage) {
+        is FunctionCallUsage -> usage.functionCall
+        is MethodCallUsage -> usage.methodCall.parent as RsDotExpr
+    }
     private val factory: RsPsiFactory = RsPsiFactory(functionCall.project)
     private val function: RsFunction = preprocessFunction(originalFunction)
 
@@ -260,7 +268,6 @@ private class InlineSingleUsage(
             ?.valueParameterList
             ?.map { it.pat ?: return null }
             ?: return null
-        val arguments = functionCall.valueArgumentList.exprList
         if (parameters.size != arguments.size) return null
 
         return matchPatternsAndExpressions(parameters, arguments)
@@ -469,7 +476,7 @@ private class InlineSingleUsage(
 }
 
 private class InsertFunctionBody(
-    private val functionCall: RsCallExpr,
+    private val functionCall: RsExpr,
     private val function: RsFunction,
     private val letDeclarations: List<RsLetDecl>,
 ) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -142,6 +142,9 @@ class RsInferenceResult(
     fun getResolvedMethodType(call: RsMethodCall): TyFunction? =
         resolvedMethods[call]?.type
 
+    fun getResolvedMethodSubst(call: RsMethodCall): Substitution =
+        resolvedMethods[call]?.subst ?: emptySubstitution
+
     fun getResolvedField(call: RsFieldLookup): List<RsElement> =
         resolvedFields[call] ?: emptyList()
 


### PR DESCRIPTION
Related: #9429
Meta: #5511

changelog: Substitute `Self` in [`Inline function`](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-refactorings.html#extractmethod-refactoring) refactoring