### PR TITLE
PERF: move path caching root to a root type reference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt
@@ -10,7 +10,7 @@ import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.types.BoundElement
 
-interface RsTraitOrImpl : RsItemElement, RsGenericDeclaration, RsAttrProcMacroOwner, RsInnerAttributeOwner {
+interface RsTraitOrImpl : RsItemElement, RsGenericDeclaration, RsAttrProcMacroOwner, RsInnerAttributeOwner, RsTypeDeclarationElement {
     val members: RsMembers?
 
     val implementedTrait: BoundElement<RsTraitItem>?

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -1747,7 +1747,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
 
     fun `test macro type`() = testExpr("""
         fn main() {
-          macro_rules! i32_ty {
+            macro_rules! i32_ty {
                 () => { i32 }
             }
             let a: i32_ty!() = unresolved();
@@ -1757,7 +1757,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
 
     fun `test infinite macro type`() = testExpr("""
         fn main() {
-          macro_rules! infinite {
+            macro_rules! infinite {
                 () => { infinite!() }
             }
             let a: infinite!() = unresolved();

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -606,6 +606,33 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
                               //^ X
     """, normalize = true)
 
+    fun `test macro type`() = testType("""
+        struct Foo<T>(T);
+        struct Bar;
+        macro_rules! foo {
+            () => { Foo<Bar> }
+        }
+        type T = (foo!(), foo!());
+               //^ (Foo<Bar>, Foo<Bar>)
+    """)
+
+    fun `test incorrect Self type in macro in impl self type`() = testType("""
+        struct Foo<T>(T);
+        macro_rules! foo {
+            () => { Self }
+        }
+        impl Foo<(foo!(), foo!())> {}
+           //^ Foo<(<unknown>, <unknown>)>
+    """)
+
+    fun `test recursive associated type projection`() = testType("""
+        trait Trait<A> {
+            type Item;
+        }
+        type T = <T as Trait<T>>::Item;
+               //^ <<unknown> as Trait<<unknown>>>::Item
+    """)
+
     /**
      * Checks the type of the element in [code] pointed to by `//^` marker.
      */


### PR DESCRIPTION
Continuation of #9211. Now we resolve nested paths at once in cases like `type T = (Foo, Foo, Foo, Foo, ...)`. Previously, all `Foo`s was resolved independently.

changelog: Slightly speed up name resolution
