### PR TITLE
Enable build script evaluation by default

### DIFF
--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -12,6 +12,7 @@ object RsExperiments {
     @EnabledInStable
     const val TEST_TOOL_WINDOW = "org.rust.cargo.test.tool.window"
 
+    @EnabledInStable
     const val EVALUATE_BUILD_SCRIPTS = "org.rust.cargo.evaluate.build.scripts"
 
     const val CARGO_FEATURES_SETTINGS_GUTTER = "org.rust.cargo.features.settings.gutter"

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -18,7 +18,7 @@
         <experimentalFeature id="org.rust.cargo.emulate.terminal" percentOfUsers="0">
             <description>Emulate terminal in output console by default</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
+        <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="100">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
     </extensions>


### PR DESCRIPTION
Fixes #4631
Fixes #6135
Fixes #7145
FIxes #8007
Fixes #6539
Fixes #9093
Fixes #9535

Closes #9402

changelog: Enable [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html) evaluation by default. Now the plugin builds and executes all build scripts in the project (including build scripts in external dependencies) during project model loading to create source code generated during compilation and collect information about generated environment variables and `cfg` options. A typical use case is to generate some code by a build script and include it via `include!(concat!(env!("OUT_DIR"), "/path_to_generated_file.rs"))`. Now the plugin understands where generated code is located and includes them into its own analysis.
Under the hood, build script evaluation uses `cargo check` call modified in a way to compile and execute only host code (i.e. only buil scripts and procedural macros as well as their dependencies). Besides execution of build scripts code, it also allows the plugin to compile all procedural macro libraries which is required for procedural macro expansion. Note, procedural macro expansion is still disabled by default. To turn it on, enable `org.rust.macros.proc` [experimental](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features) feature