### PR TITLE
RES: Fix resolve absolute paths for aliased crate in extern prelude

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/PathResolutionContext.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/PathResolutionContext.kt
@@ -29,6 +29,7 @@ class PathResolutionContext(
     var lazyContainingModInfo: Lazy<RsModInfo?> = lazy(NONE) {
         getModInfo(containingMod)
     }
+    val containingModInfo: RsModInfo? get() = lazyContainingModInfo.value
     val implLookup: ImplLookup by lazy(NONE) {
         givenImplLookup ?: ImplLookup.relativeTo(context)
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -86,10 +86,7 @@ fun processItemDeclarationsUsingModInfo(
             val existingItemInScope = modData.visibleItems[name]
             if (existingItemInScope != null && existingItemInScope.types.any { !it.visibility.isInvisible }) continue
 
-            val externCrateRoot = externCrateDefMap.root.toRsMod(info)
-                // crate root can't multiresolve
-                .singleOrNull()
-                ?: continue
+            val externCrateRoot = externCrateDefMap.rootAsRsMod(info.project) ?: continue
             processor(name, externCrateRoot) && return true
         }
     }
@@ -465,7 +462,7 @@ private fun isModShadowedByOtherMod(mod: RsMod, modData: ModData, crate: Crate):
     }
 }
 
-private fun <T> Map<String, T>.entriesWithNames(names: Set<String>?): Map<String, T> {
+fun <T> Map<String, T>.entriesWithNames(names: Set<String>?): Map<String, T> {
     return if (names.isNullOrEmpty()) {
         this
     } else if (names.size == 1) {
@@ -645,6 +642,8 @@ private fun ModData.toRsModNullable(project: Project): List<RsMod> {
             }
         }
 }
+
+fun CrateDefMap.rootAsRsMod(project: Project): RsMod? = root.toRsMod(project).singleOrNull()
 
 private inline fun <reified T : RsNamedElement> RsItemsOwner.getExpandedItemsWithName(name: String): List<T> =
     expandedItemsCached.named[name]?.filterIsInstance<T>() ?: emptyList()

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -81,6 +81,12 @@ abstract class RsCompletionTestBase(private val defaultFileName: String = "main.
     ) = completionFixture.checkContainsCompletion(code, variants, render)
 
     protected fun checkContainsCompletionByFileTree(
+        variant: String,
+        @Language("Rust") code: String,
+        render: LookupElement.() -> String = { lookupString }
+    ) = completionFixture.checkContainsCompletionByFileTree(code, listOf(variant), render)
+
+    protected fun checkContainsCompletionByFileTree(
         variants: List<String>,
         @Language("Rust") code: String,
         render: LookupElement.() -> String = { lookupString }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -82,22 +82,26 @@ abstract class RsCompletionTestFixtureBase<IN>(
         }
     }
 
-    fun checkContainsCompletion(
-        code: IN,
-        variants: Iterable<String>,
-        render: LookupElement.() -> String = { lookupString }
-    ) {
+    private fun withNoInsertCompletion(action: () -> Unit) {
         val oldAutocomplete = CodeInsightSettings.getInstance().AUTOCOMPLETE_ON_CODE_COMPLETION
         CodeInsightSettings.getInstance().AUTOCOMPLETE_ON_CODE_COMPLETION = false
         try {
-            prepare(code)
-            doContainsCompletion(variants.toSet(), render)
+            action()
         } finally {
             CodeInsightSettings.getInstance().AUTOCOMPLETE_ON_CODE_COMPLETION = oldAutocomplete
         }
     }
 
-    fun doContainsCompletion(variants: Set<String>, render: LookupElement.() -> String) {
+    fun checkContainsCompletion(
+        code: IN,
+        variants: Iterable<String>,
+        render: LookupElement.() -> String = { lookupString }
+    ) {
+        prepare(code)
+        doContainsCompletion(variants.toSet(), render)
+    }
+
+    fun doContainsCompletion(variants: Set<String>, render: LookupElement.() -> String) = withNoInsertCompletion {
         val lookups = myFixture.completeBasic()
 
         checkNotNull(lookups) {
@@ -115,7 +119,7 @@ abstract class RsCompletionTestFixtureBase<IN>(
         code: IN,
         variants: Set<String>,
         render: LookupElement.() -> String = { lookupString }
-    ) {
+    ) = withNoInsertCompletion {
         prepare(code)
         val lookups = myFixture.completeBasic()
         checkNotNull(lookups) {
@@ -126,7 +130,7 @@ abstract class RsCompletionTestFixtureBase<IN>(
         }
     }
 
-    fun checkContainsCompletionPrefixes(code: IN, prefixes: List<String>) {
+    fun checkContainsCompletionPrefixes(code: IN, prefixes: List<String>) = withNoInsertCompletion {
         prepare(code)
         val lookups = myFixture.completeBasic()
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt
@@ -35,4 +35,37 @@ class RsExternCrateCompletionTest : RsCompletionTestBase() {
     fun `test extern crate does not suggest transitive dependency`() = checkNoCompletion("""
         extern crate trans_l/*caret*/
     """)
+
+    fun `test absolute path suggest dependency`() = checkContainsCompletionByFileTree("test_package", """
+    //- lib.rs
+    //- main.rs
+        fn main() {
+            ::test_packa/*caret*/
+        }
+    """)
+
+    fun `test absolute path suggest std`() = checkContainsCompletionByFileTree("std", """
+    //- lib.rs
+    //- main.rs
+        fn main() {
+            ::st/*caret*/
+        }
+    """)
+
+    fun `test absolute path suggest aliased extern crate`() = checkContainsCompletionByFileTree(
+        listOf("test_package", "test_package2"), """
+    //- lib.rs
+    //- main.rs
+        extern crate test_package as test_package2;
+        fn main() {
+            ::test_packa/*caret*/
+        }
+    """)
+
+    fun `test absolute path don't suggest self`() = checkNoCompletionByFileTree("""
+    //- lib.rs
+        fn main() {
+            ::self/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -765,6 +765,35 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                                    //^ dep-lib/lib.rs
     """)
 
+    fun `test absolute path using aliased extern crate 1`() = stubOnlyResolve("""
+    //- lib.rs
+        pub fn func() {}
+    //- main.rs
+        extern crate test_package as foo;
+
+        fn main() {
+            ::foo::func();
+        }        //^ lib.rs
+    """)
+
+    fun `test absolute path using aliased extern crate 2`() = stubOnlyResolve("""
+    //- lib.rs
+        extern crate self as foo;
+
+        fn main() {
+            ::foo::func();
+        }        //^ lib.rs
+        pub fn func() {}
+    """)
+
+    fun `test unresolved absolute path self`() = stubOnlyResolve("""
+    //- lib.rs
+        pub fn func() {}
+        fn main() {
+            ::self::func();
+        }         //^ unresolved
+    """)
+
     fun `test extern crate in super chain (edition 2018)`() = stubOnlyResolve("""
     //- dep-lib/lib.rs
         pub struct Foo;


### PR DESCRIPTION
Fixes #9543

changelog: Fix resolve of absolute path when there is `extern crate` with alias