### PR TITLE
Fix IndexNotReadyException in breadcrumbs

### DIFF
--- a/src/main/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProvider.kt
+++ b/src/main/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProvider.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.miscExtensions
 
+import com.intellij.openapi.project.DumbService
 import com.intellij.psi.PsiElement
 import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
 import org.rust.lang.RsLanguage
@@ -63,7 +64,7 @@ class RsBreadcrumbsInfoProvider : BreadcrumbsProvider {
 
     private object RsBlockExprHandler : RsElementHandler<RsBlockExpr> {
         override fun accepts(e: PsiElement): Boolean =
-            e is RsBlockExpr && (e.isTailExpr || e.parent is RsLetDecl)
+            e is RsBlockExpr && (e.parent is RsLetDecl || !DumbService.isDumb(e.project) && e.isTailExpr)
 
         override fun elementInfo(e: RsBlockExpr): String {
             return buildString {


### PR DESCRIPTION
Fixes exception when cursor is inside tail expr block in dumb mode:
```rust
fn main() {
    { /* cursor */ }
}
```
<details>

```
com.intellij.openapi.project.IndexNotReadyException: Please change caller according to com.intellij.openapi.project.IndexNotReadyException documentation
	at com.intellij.openapi.project.IndexNotReadyException.create(IndexNotReadyException.java:67)
	at com.intellij.openapi.project.IndexNotReadyException.create(IndexNotReadyException.java:62)
	at org.rust.openapiext.UtilsKt.checkIsSmartMode(utils.kt:130)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.getOrUpdateIfNeeded(FacadeUpdateDefMap.kt:48)
	at org.rust.lang.core.resolve2.FacadeResolveKt.findModDataFor(FacadeResolve.kt:666)
	at org.rust.lang.core.psi.RsFile.doGetCachedData(RsFile.kt:143)
	at org.rust.lang.core.psi.RsFile._get_cachedData_$lambda$1(RsFile.kt:107)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:114)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:44)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at org.rust.lang.core.psi.RsFile.getCachedData(RsFile.kt:106)
	at org.rust.lang.core.psi.RsFile.getCrate(RsFile.kt:84)
	at org.rust.lang.core.psi.ext.RsElementKt.getContainingCrate(RsElement.kt:60)
	at org.rust.lang.core.stubs.common.RsAttributeOwnerPsiOrStub.getContainingCrate(PsiOrStubInterfaces.kt:46)
	at org.rust.lang.core.psi.ext.LazyCfgEvaluator$Lazy.createEvaluator(RsDocAndAttributeOwner.kt:504)
	at org.rust.lang.core.psi.ext.RsDocAndAttributeOwnerKt.evaluateCfg(RsDocAndAttributeOwner.kt:484)
	at org.rust.lang.core.psi.ext.RsDocAndAttributeOwnerKt.evaluateCfg(RsDocAndAttributeOwner.kt:470)
	at org.rust.lang.core.psi.ext.RsDocAndAttributeOwnerKt.existsAfterExpansionSelf(RsDocAndAttributeOwner.kt:451)
	at org.rust.lang.core.psi.ext.RsDocAndAttributeOwnerKt.getExistsAfterExpansionSelf(RsDocAndAttributeOwner.kt:448)
	at org.rust.lang.core.psi.ext.RsBlockKt$doGetExpandedStmtsAndTailExpr$1.invoke(RsBlock.kt:32)
	at org.rust.lang.core.psi.ext.RsBlockKt$doGetExpandedStmtsAndTailExpr$1.invoke(RsBlock.kt:31)
	at org.rust.lang.core.psi.ext.RsBlockKt.processStmt(RsBlock.kt:139)
	at org.rust.lang.core.psi.ext.RsBlockKt.processExpandedStmtsInternal(RsBlock.kt:134)
	at org.rust.lang.core.psi.ext.RsBlockKt.doGetExpandedStmtsAndTailExpr(RsBlock.kt:31)
	at org.rust.lang.core.psi.ext.RsBlockKt._get_expandedStmtsAndTailExpr_$lambda$0(RsBlock.kt:24)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:114)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:44)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:121)
	at org.rust.lang.core.psi.ext.RsBlockKt.getExpandedStmtsAndTailExpr(RsBlock.kt:22)
	at org.rust.lang.core.psi.ext.RsBlockKt.getExpandedTailExpr(RsBlock.kt:56)
	at org.rust.lang.core.psi.ext.RsStmtKt.isTailStmt(RsStmt.kt:31)
	at org.rust.lang.core.psi.ext.RsExprKt.isTailExpr(RsExpr.kt:347)
	at org.rust.ide.miscExtensions.RsBreadcrumbsInfoProvider$RsBlockExprHandler.accepts(RsBreadcrumbsInfoProvider.kt:66)
	at org.rust.ide.miscExtensions.RsBreadcrumbsInfoProvider.handler(RsBreadcrumbsInfoProvider.kt:207)
	at org.rust.ide.miscExtensions.RsBreadcrumbsInfoProvider.acceptElement(RsBreadcrumbsInfoProvider.kt:213)
	at com.intellij.xml.breadcrumbs.PsiFileBreadcrumbsCollector.findFirstBreadcrumbedElement(PsiFileBreadcrumbsCollector.java:212)
	at com.intellij.xml.breadcrumbs.PsiFileBreadcrumbsCollector.findStartElement(PsiFileBreadcrumbsCollector.java:163)
	at com.intellij.xml.breadcrumbs.PsiFileBreadcrumbsCollector.getLineElements(PsiFileBreadcrumbsCollector.java:127)
	at com.intellij.xml.breadcrumbs.PsiFileBreadcrumbsCollector.computeCrumbs(PsiFileBreadcrumbsCollector.java:92)
	at com.intellij.xml.breadcrumbs.BreadcrumbsXmlWrapper.computeCrumbs(BreadcrumbsXmlWrapper.java:47)
	at com.intellij.xml.breadcrumbs.BreadcrumbsPanel.lambda$updateCrumbsAsync$3(BreadcrumbsPanel.java:187)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.insideReadAction(NonBlockingReadActionImpl.java:536)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$attemptComputation$3(NonBlockingReadActionImpl.java:501)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1154)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runInReadActionWithWriteActionPriority$0(ProgressIndicatorUtils.java:75)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:158)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runWithWriteActionPriority$1(ProgressIndicatorUtils.java:115)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:66)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:188)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:608)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:683)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:639)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:607)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:175)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:66)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runWithWriteActionPriority(ProgressIndicatorUtils.java:112)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runInReadActionWithWriteActionPriority(ProgressIndicatorUtils.java:75)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.attemptComputation(NonBlockingReadActionImpl.java:501)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$transferToBgThread$1(NonBlockingReadActionImpl.java:408)
	at com.intellij.util.concurrency.BoundedTaskExecutor.doRun(BoundedTaskExecutor.java:241)
	at com.intellij.util.concurrency.BoundedTaskExecutor.access$200(BoundedTaskExecutor.java:31)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.execute(BoundedTaskExecutor.java:214)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:206)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:702)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:699)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:699)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

</details>