### PR TITLE
RES&COMP: Don't resolve and complete macros after `::`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -127,7 +127,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
                 }
 
                 // RsPathExpr can become a macro by adding a trailing `!`, so we add macros to completion
-                if (element.parent is RsPathExpr && element.qualifier == null) {
+                if (element.parent is RsPathExpr && !(element.hasColonColon && element.isAtLeastEdition2018)) {
                     processMacroCallPathResolveVariants(element, isCompletion = true, filtered)
                 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.RsPsiPattern
+import org.rust.lang.core.completion.RsCommonCompletionProvider
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.resolve.*
@@ -87,7 +88,7 @@ fun RsPath.allowedNamespaces(isCompletion: Boolean = false, parent: PsiElement? 
     }
     is RsPathExpr -> when {
         isCompletion && qualifier != null -> TYPES_N_VALUES_N_MACROS
-        /** unqualified macros are special cased in [processPathResolveVariants] */
+        /** unqualified macros are special cased in [RsCommonCompletionProvider.processPathVariants] */
         isCompletion && qualifier == null -> TYPES_N_VALUES
         else -> VALUES
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -887,6 +887,7 @@ fun processAssocTypeVariants(trait: RsTraitItem, processor: RsResolveProcessor):
 fun processMacroCallPathResolveVariants(path: RsPath, isCompletion: Boolean, processor: RsResolveProcessor): Boolean {
     val qualifier = path.qualifier
     return if (qualifier == null) {
+        if (path.hasColonColon && path.isAtLeastEdition2018) return false
         if (isCompletion) {
             processMacroCallVariantsInScope(path, ignoreLegacyMacros = false, processor)
         } else {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.completion
 
 import org.rust.*
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsCompletionTest : RsCompletionTestBase() {
     fun `test local variable`() = doSingleCompletion("""
@@ -720,6 +721,35 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
 
         mod1::mod2::fo/*caret*/
+    """)
+
+    fun `test no macro completion if absolute path (top-level)`() = checkNoCompletion("""
+        macro_rules! foo1 { () => {} }
+        mod mod1 {
+            pub macro foo2() {}
+        }
+
+        ::fo/*caret*/
+    """)
+
+    fun `test no macro completion if absolute path (inside function)`() = checkNoCompletion("""
+        macro_rules! foo1 { () => {} }
+        mod mod1 {
+            pub macro foo2() {}
+        }
+
+        fn main() {
+            ::fo/*caret*/
+        }
+    """)
+
+    @MockEdition(Edition.EDITION_2015)
+    fun `test complete macro if absolute path in 2015 edition`() = checkContainsCompletion("foo", """
+        #[macro_export]
+        macro_rules! foo { () => {} }
+        fn main() {
+            ::fo/*caret*/
+        }
     """)
 
     fun `test macro don't suggests as function name`() = checkNoCompletion("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -602,6 +602,24 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         } //^ unresolved
     """)
 
+    fun `test macro 2 (unresolved when absolute path)`() = stubOnlyResolve("""
+    //- lib.rs
+        pub macro foo() {}
+        fn main() {
+            ::foo!();
+        }   //^ unresolved
+    """)
+
+    @MockEdition(Edition.EDITION_2015)
+    fun `test macro 2 (resolved when absolute path in 2015 edition)`() = stubOnlyResolve("""
+    //- lib.rs
+        pub macro foo() {}
+                //x
+        fn main() {
+            ::foo!();
+        }   //^ lib.rs
+    """)
+
     fun `test import from crate root without 'pub' vis`() = stubOnlyResolve("""
     //- lib.rs
         mod foo {


### PR DESCRIPTION
| Before | After |
|:------:|:-----:|
| ![image](https://user-images.githubusercontent.com/6505554/196056972-df1432e9-a45e-410b-a97f-8f0f13d54f62.png) | ![image](https://user-images.githubusercontent.com/6505554/196057073-8d1b7c2a-c2dc-4a6d-90b9-8a5bef534b8e.png) |

(`if { ... }` and `match { ... }` also should be removed in this case)

changelog: Don't resolve and complete macros after `::`