### PR TITLE
IDE: Temporary disable adding imports after pasting code

### DIFF
--- a/src/main/kotlin/org/rust/ide/settings/RsCodeInsightSettings.kt
+++ b/src/main/kotlin/org/rust/ide/settings/RsCodeInsightSettings.kt
@@ -18,7 +18,7 @@ class RsCodeInsightSettings : PersistentStateComponent<RsCodeInsightSettings> {
     var importOutOfScopeItems: Boolean = true
     var suggestOutOfScopeItems: Boolean = true
     var addUnambiguousImportsOnTheFly: Boolean = false
-    var importOnPaste: Boolean = true
+    var importOnPaste: Boolean = false
 
     override fun getState(): RsCodeInsightSettings = this
 

--- a/src/test/kotlin/org/rust/ide/typing/paste/RsAddImportOnCopyPasteTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/paste/RsAddImportOnCopyPasteTest.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.actionSystem.IdeActions
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
+import org.rust.ide.settings.RsCodeInsightSettings
 
 class RsAddImportOnCopyPasteTest : RsTestBase() {
     fun `test type reference`() = doCopyPasteTest("""
@@ -612,7 +613,7 @@ class RsAddImportOnCopyPasteTest : RsTestBase() {
     private fun doCopyPasteTest(
         @Language("Rust") before: String,
         @Language("Rust") after: String
-    ) {
+    ) = withImportOnPaste {
         val testProject = fileTreeFromText(before).create()
         myFixture.configureFromTempProjectFile(testProject.fileWithSelection)
         myFixture.performEditorAction(IdeActions.ACTION_COPY)
@@ -621,5 +622,16 @@ class RsAddImportOnCopyPasteTest : RsTestBase() {
         myFixture.performEditorAction(IdeActions.ACTION_PASTE)
 
         fileTreeFromText(after).assertEquals(myFixture.findFileInTempDir("."))
+    }
+
+    private fun withImportOnPaste(action: () -> Unit) {
+        val settings = RsCodeInsightSettings.getInstance()
+        val oldValue = settings.importOnPaste
+        settings.importOnPaste = true
+        try {
+            action()
+        } finally {
+            settings.importOnPaste = oldValue
+        }
     }
 }


### PR DESCRIPTION
Looks like ["Insert imports on paste"](https://github.com/intellij-rust/intellij-rust/pull/7597) may be slow (https://youtrack.jetbrains.com/issue/VIM-2769, https://github.com/intellij-rust/intellij-rust/pull/9441#discussion_r996454390), so lets disable it by default for now
