### PR TITLE
Disable intention preview for some intentions

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddFeatureAttributeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddFeatureAttributeFix.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator.fixes
 
+import com.intellij.codeInsight.intention.FileModifier
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
@@ -12,7 +13,10 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsInnerAttr
 import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.lang.core.psi.ext.name
 
 class AddFeatureAttributeFix(
     private val featureName: String,
@@ -21,6 +25,9 @@ class AddFeatureAttributeFix(
 
     override fun getFamilyName(): String = "Add feature attribute"
     override fun getText(): String = "Add `$featureName` feature"
+
+    // TODO: Add intention preview
+    override fun getFileModifierForPreview(target: PsiFile): FileModifier? = null
 
     override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
         addFeatureAttribute(project, startElement, featureName)

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddModuleFileFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddModuleFileFix.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator.fixes
 
+import com.intellij.codeInsight.intention.FileModifier
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
@@ -28,6 +29,9 @@ class AddModuleFileFix(
     override fun getText() = text
 
     override fun getFamilyName() = "Create module file"
+
+    // No intention preview because it creates new file
+    override fun getFileModifierForPreview(target: PsiFile): FileModifier? = null
 
     enum class Location {
         /**

--- a/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
@@ -5,9 +5,11 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInsight.intention.FileModifier
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.RsModItem
 import org.rust.lang.core.psi.RsPsiFactory
@@ -20,6 +22,9 @@ import org.rust.openapiext.Testmark
 class ExtractInlineModuleIntention : RsElementBaseIntentionAction<RsModItem>() {
     override fun getFamilyName() = "Extract inline module structure"
     override fun getText() = "Extract inline module"
+
+    // No intention preview because it creates new file
+    override fun getFileModifierForPreview(target: PsiFile): FileModifier? = null
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsModItem? {
         val mod = element.ancestorOrSelf<RsModItem>() ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/ToggleFeatureIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ToggleFeatureIntention.kt
@@ -5,10 +5,12 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInsight.intention.FileModifier
 import com.intellij.codeInsight.intention.HighPriorityAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import org.rust.RsBundle
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.PackageOrigin
@@ -20,6 +22,9 @@ class ToggleFeatureIntention : RsElementBaseIntentionAction<ToggleFeatureIntenti
     data class Context(val featureName: String, val element: RsElement)
 
     override fun getFamilyName() = RsBundle.message("intention.Rust.ToggleFeatureIntention.family.name")
+
+    // No intention preview because it doesn't modify any code
+    override fun getFileModifierForPreview(target: PsiFile): FileModifier? = null
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val featureMetaItem = element.ancestorOrSelf<RsMetaItem>()


### PR DESCRIPTION
I disable intention preview in cases when intention creates new files or does something else not related to code, thus showing intention preview is not possible

Fixes #9560
Meta: #9561

changelog: Fix `Create module file` quick-fix in 2022.3