### PR TITLE
Fix #9565 stack overflow when dyn trait used as Self ty in where clause

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -562,6 +562,13 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
                              //^ <unknown>
     """)
 
+    fun `test no stack overflow when dyn trait used as a Self type in where clause`() = testType("""
+        trait Foo<T = ()> {}
+        trait Bar {}
+        fn foo<T>() where dyn Foo: Bar {}
+                        //^ dyn Foo<()>
+    """)
+
     fun `test mixed type and const arguments`() = testType("""
         struct A1;
         const B1: i32 = 1;


### PR DESCRIPTION
Fixes #9565

The type inference bug existed since a while, but it escalated to a stack overflow after one of these PRs: #9211, #9337, #9338

changelog: Fix possible stack overflow during type inference