### PR TITLE
CI: don't install custom python to run python scripts on CI

### DIFF
--- a/.github/actions/preparations-for-updates/action.yml
+++ b/.github/actions/preparations-for-updates/action.yml
@@ -12,11 +12,6 @@ runs:
               components: rust-src, rustfmt, clippy # should be synchronized with `check` workflow
               default: true
 
-        - name: Set up Python
-          uses: actions/setup-python@v3
-          with:
-              python-version: '3.10'
-
         - name: Set up git user
           run: |
               git config --local user.email "intellij.rust@gmail.com"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,11 +31,6 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: '3.10'
-
             - name: Calculate git info
               id: calculate-git-info
               run: |
@@ -53,11 +48,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: '3.10'
 
             - name: Check license
               run: python scripts/check_license.py

--- a/.github/workflows/create-changelog.yml
+++ b/.github/workflows/create-changelog.yml
@@ -18,11 +18,6 @@ jobs:
                   repository: ${{ github.repository_owner }}/intellij-rust.github.io
                   path: intellij-rust.github.io
 
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.9
-
             - name: Install python packages
               run: pip install -r intellij-rust.github.io/requirements.txt
 

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -10,11 +10,6 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.7
-
             - name: Set milestone
               if: github.event.pull_request.merged && github.event.pull_request.milestone == null
               run: python scripts/set_milestone.py --token ${{ github.token }} --pull-request ${{ github.event.pull_request.number }}

--- a/.github/workflows/notify-doc.yml
+++ b/.github/workflows/notify-doc.yml
@@ -14,11 +14,6 @@ jobs:
             - name: Checkout repo content
               uses: actions/checkout@v2
 
-            - name: Setup python
-              uses: actions/setup-python@v2
-              with:
-                  python-version: 3.9
-
             - name: Install python packages
               run: pip install -r scripts/requirements.txt
 

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -76,11 +76,6 @@ jobs:
                   distribution: corretto
                   java-version: 17
 
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.7
-
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -13,11 +13,6 @@ jobs:
               with:
                   token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.7
-
             - name: Set up git user
               run: |
                   git config --local user.email "intellij.rust@gmail.com"

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -29,11 +29,6 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.7
-
             - name: Fetch latest commits
               id: fetch-commits
               run: |
@@ -97,11 +92,6 @@ jobs:
               with:
                   fetch-depth: 0
                   token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
-
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.7
 
             - name: Save commits
               run: |

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -34,11 +34,6 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.7
-
             - id: get-release-branch
               run: |
                   branch=$(python scripts/get_release_branch.py)
@@ -53,11 +48,6 @@ jobs:
                   token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
             - run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.7
 
             - name: Set up git user
               run: |
@@ -94,11 +84,6 @@ jobs:
               with:
                   ref: ${{ needs.get-release-branch.outputs.release-branch }}
                   fetch-depth: 0
-
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.7
 
             - name: Fetch latest commits
               id: fetch-commits
@@ -164,11 +149,6 @@ jobs:
               with:
                   fetch-depth: 0
                   token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
-
-            - name: Set up Python
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.7
 
             - name: Save commits
               run: |


### PR DESCRIPTION
We use such scripts only on ubuntu runners which already have preinstalled python. Also, we didn't care about updating either version of `actions/setup-python` action or python version.

At the same time, we have quite simple python scripts which don't use the latest features from python, so I think it's ok to use preinstalled pythin version

All preinstalled software can be found [here](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md)
