### PR TITLE
Ty: infer const arguments in struct literal paths

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1193,7 +1193,8 @@ LambdaExpr ::= OuterAttr* [asyncBlock | static] move? LambdaParameters RetType? 
 }
 
 StructLiteral ::= <<checkStructAllowed>> OuterAttr* ValuePathGenericArgsNoTypeQual StructLiteralBody {
-  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
+                 "org.rust.lang.core.psi.ext.RsInferenceContextOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsInferenceContextOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsInferenceContextOwner.kt
@@ -23,7 +23,10 @@ val RsInferenceContextOwner.body: RsElement?
         is RsFunction -> block
         is RsVariantDiscriminant -> expr
         is RsExpressionCodeFragment -> expr
+        is RsReplCodeFragment -> this
+        is RsPathCodeFragment -> this
         is RsPathType -> path.typeArgumentList
         is RsTraitRef -> path.typeArgumentList
+        is RsStructLiteral -> path.typeArgumentList
         else -> null
     }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -221,10 +221,11 @@ class RsInferenceContext(
                 }
                 RsTypeInferenceWalker(this, TyUnknown).inferReplCodeFragment(element)
             }
-            is RsPathType, is RsTraitRef -> {
+            is RsPathType, is RsTraitRef, is RsStructLiteral -> {
                 val path = when (element) {
                     is RsPathType -> element.path
                     is RsTraitRef -> element.path
+                    is RsStructLiteral -> element.path
                     else -> null
                 }
                 val declaration = path?.let { resolvePathRaw(it, lookup) }?.singleOrNull()?.element as? RsGenericDeclaration

--- a/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
@@ -314,4 +314,19 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ S<42>
     """)
+
+    fun `test const argument in struct literal`() = stubOnlyTypeInfer("""
+    //- foo.rs
+        #![feature(const_generics)]
+        pub struct S<const N1: usize>;
+        pub const C: usize = 42;
+    //- lib.rs
+        mod foo;
+        use foo::*;
+
+        fn main() {
+            let a = S::<{ C }> {};
+            a;
+        } //^ S<42>
+    """)
 }


### PR DESCRIPTION
Fixes #9564

```rust
pub struct S<const N1: usize>;
pub const C: usize = 42;

fn main() {
    let a = S::<{ C }> {};
    a;
} //^ S<42>
```