### PR TITLE
Fix plugin publication to Marketplace

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -331,11 +331,6 @@ project(":plugin") {
             dependsOn(mergePluginJarTask)
             enabled = prop("enableBuildSearchableOptions").toBoolean()
         }
-        verifyPlugin {
-            // We don't want to fail `verifyPlugin` task because of too short description
-            ignoreUnacceptableWarnings.set(true)
-        }
-
         withType<PrepareSandboxTask> {
             dependsOn(named(compileNativeCodeTaskName))
 

--- a/plugin/description.html
+++ b/plugin/description.html
@@ -1,1 +1,1 @@
-Rust language support
+The plugin provides support for Rust language


### PR DESCRIPTION
Since https://github.com/JetBrains/gradle-intellij-plugin/pull/1092, `gradle-intellij-plugin` checks "unacceptable warnings" and doesn't allow you to publish plugin to Marketplace with them.
One of such warnings is about the length of plugin description. 40 symbols is the minimal plugin description length required by JetBrains Marketplace. And previously, our description was shorter

This change will affect description in https://plugins.jetbrains.com/plugin/8182-rust and in plugin card in  `Plugins` settings in IDE