### PR TITLE
TY: fix `Self` substitution in the case of trait inheritance

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -174,7 +174,7 @@ interface ParamEnv {
                         else -> Unit
                     }
                 }
-            }.flatMap { ref -> ref.trait.flattenHierarchy.map { TraitRef(ref.selfTy, it) } }
+            }.flatMap { it.flattenHierarchy }
                 .distinct()
 
             when (rawBounds.size) {
@@ -304,7 +304,7 @@ class ImplLookup(
                 val subst = ty.trait.subst + mapOf(TyTypeParameter.self() to ty.type).toTypeSubst()
                 implsAndTraits += ty.trait.element.bounds.asSequence()
                     .filter { ctx.probe { ctx.combineTypes(it.selfTy.substitute(subst), ty) }.isOk }
-                    .flatMap { it.trait.flattenHierarchy.asSequence() }
+                    .flatMap { it.trait.getFlattenHierarchy().asSequence() }
                     .map { TraitImplSource.ProjectionBound(it.element) }
                     .distinct()
 
@@ -761,7 +761,7 @@ class ImplLookup(
             val subst = selfTy.trait.subst + mapOf(TyTypeParameter.self() to selfTy.type).toTypeSubst()
             selfTy.trait.element.bounds.asSequence()
                 .filter { ctx.probe { ctx.combineTypes(it.selfTy.substitute(subst), selfTy) }.isOk }
-                .flatMap { it.trait.flattenHierarchy.asSequence() }
+                .flatMap { it.trait.getFlattenHierarchy().asSequence() }
                 .distinct()
                 .filter { ctx.probe { ctx.combineBoundElements(it.substitute(subst), ref.trait) } }
                 .forEach { candidates.list.add(ProjectionCandidate(it)) }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -560,7 +560,7 @@ private fun processQualifiedPathResolveVariants1(
         // to only members of the current impl or implemented trait or its parent traits
         val restrictedTraits = if (Namespace.Types in ns && base is RsImplItem && qualifier.hasCself) {
             NameResolutionTestmarks.SelfRelatedTypeSpecialCase.hit()
-            base.implementedTrait?.flattenHierarchy
+            base.implementedTrait?.getFlattenHierarchy()
         } else {
             null
         }
@@ -669,7 +669,7 @@ private fun processTraitRelativePath(
     ns: Set<Namespace>,
     processor: RsResolveProcessor
 ): Boolean {
-    for (boundTrait in baseBoundTrait.flattenHierarchy) {
+    for (boundTrait in baseBoundTrait.getFlattenHierarchy()) {
         val source = TraitImplSource.Trait(boundTrait.element)
         if (processTraitMembers(boundTrait.element, ns, boundTrait.subst, TyUnknown, source, processor)) return true
     }

--- a/src/main/kotlin/org/rust/lang/core/types/TraitRef.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/TraitRef.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.types
 
 import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.ext.getFlattenHierarchy
 import org.rust.lang.core.psi.ext.typeParameters
 import org.rust.lang.core.types.infer.TypeFoldable
 import org.rust.lang.core.types.infer.TypeFolder
@@ -19,6 +20,9 @@ import org.rust.lang.core.types.ty.TyUnknown
  *     `T : Foo<U>`
  */
 data class TraitRef(val selfTy: Ty, val trait: BoundElement<RsTraitItem>) : TypeFoldable<TraitRef> {
+    val flattenHierarchy: List<TraitRef>
+        get() = trait.getFlattenHierarchy(selfTy).map { TraitRef(selfTy, it) }
+
     override fun superFoldWith(folder: TypeFolder): TraitRef =
         TraitRef(selfTy.foldWith(folder), trait.foldWith(folder))
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyAnon.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyAnon.kt
@@ -7,7 +7,7 @@ package org.rust.lang.core.types.ty
 
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTraitType
-import org.rust.lang.core.psi.ext.flattenHierarchy
+import org.rust.lang.core.psi.ext.getFlattenHierarchy
 import org.rust.lang.core.psi.ext.isImpl
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.HAS_TY_OPAQUE_MASK
@@ -36,5 +36,5 @@ data class TyAnon(
         traits.any { it.visitWith(visitor) }
 
     fun getTraitBoundsTransitively(): Collection<BoundElement<RsTraitItem>> =
-        traits.flatMap { it.flattenHierarchy }
+        traits.flatMap { it.getFlattenHierarchy(this) }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
@@ -8,7 +8,7 @@ package org.rust.lang.core.types.ty
 import com.intellij.codeInsight.completion.CompletionUtil
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTypeAlias
-import org.rust.lang.core.psi.ext.flattenHierarchy
+import org.rust.lang.core.psi.ext.getFlattenHierarchy
 import org.rust.lang.core.psi.ext.isAuto
 import org.rust.lang.core.psi.ext.typeParameters
 import org.rust.lang.core.psi.ext.withDefaultSubst
@@ -53,7 +53,7 @@ class TyTraitObject(
     override fun withAlias(aliasedBy: BoundElement<RsTypeAlias>): Ty = TyTraitObject(traits, region, aliasedBy)
 
     fun getTraitBoundsTransitively(): Collection<BoundElement<RsTraitItem>> =
-        traits.flatMap { it.flattenHierarchy }
+        traits.flatMap { it.getFlattenHierarchy(TyUnknown) }
 
     val baseTrait: RsTraitItem?
         get() {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -31,7 +31,7 @@ class TyTypeParameter private constructor(
 
     @Deprecated("Use ImplLookup.getEnvBoundTransitivelyFor")
     fun getTraitBoundsTransitively(): Collection<BoundElement<RsTraitItem>> =
-        traitBounds.flatMap { it.flattenHierarchy }
+        traitBounds.flatMap { it.getFlattenHierarchy() }
 
     val name: String? get() = parameter.name
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1804,6 +1804,15 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl Bar for S<Q> {}
     """)
 
+    fun `test no E0277 with PartialEq and Eq impls`() = checkErrors("""
+        struct Box<T>(T);
+        trait PartialEq<Rhs = Self> {}
+        trait Eq: PartialEq<Self> {}
+
+        impl<T: PartialEq> PartialEq for Box<T> {}
+        impl<T: Eq> Eq for Box<T> {}
+    """)
+
     @MockRustcVersion("1.27.1")
     fun `test crate visibility feature E0658`() = checkErrors("""
         <error descr="`crate` visibility modifier is experimental [E0658]">crate</error> struct Foo;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -724,6 +724,23 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
                                              //^
     """)
 
+    fun `test bound associated type inside where clause`() = checkByCode("""
+        trait Tr { type Item; }
+                      //X
+        struct S<A>(A);
+        impl<B: Tr> S<B> { fn foo(self) where B::Item: Sized { unimplemented!() } }
+                                               //^
+    """)
+
+    fun `test bound inherited associated type inside where clause`() = checkByCode("""
+        trait Tr1 { type Item; }
+                       //X
+        trait Tr2: Tr1 {}
+        struct S<A>(A);
+        impl<B: Tr2> S<B> { fn foo(self) where B::Item: Sized { unimplemented!() } }
+                                                //^
+    """)
+
     fun `test no stack overflow on self unification with Eq bound`() = checkByCode("""
         pub trait PartialEq<Rhs: ?Sized> {}
         pub trait Eq: PartialEq<Self> {}

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1933,6 +1933,19 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ X
     """)
 
+    fun `test assoc type bound selection 7`() = testExpr("""
+        struct X;
+        trait Foo { type Item: Bar; }
+        trait Bar: Baz<Self> {}
+        trait Baz<T> {}
+        fn baz<A: Baz<B>, B>(t: A) -> B { unimplemented!() }
+
+        fn foobar<T: Foo>(a: T::Item) {
+            let b = baz(a);
+            b;
+        } //^ T
+    """)
+
     fun `test assoc type bound in path selection`() = testExpr("""
         struct X;
         trait Foo<T> {}
@@ -2281,5 +2294,35 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a: <Foo<_> as Bar>::SelfTy = Foo(1);
             a;
         } //^ Foo<i32>
+    """)
+
+    fun `test select a supertrait with Self subst 1`() = testExpr("""
+        trait Foo<T: ?Sized> {}
+        trait Bar<T: ?Sized>: Foo<T> {}
+
+        trait Baz: Sized {
+            fn bar<T: Bar<Self>>(t: T) {
+                let a = foo(t);
+                a;
+            } //^ Self
+        }
+
+        fn foo<A: Foo<B>, B>(t: A) -> B { todo!() }
+    """)
+
+    fun `test select a supertrait with Self subst 2`() = testExpr("""
+        trait Foo {
+            type Item;
+        }
+        trait Bar: Foo {}
+
+        trait Baz: Sized {
+            fn bar<T: Bar<Item=Self>>(t: T) {
+                let a = foo(t);
+                a;
+            } //^ Self
+        }
+
+        fn foo<A: Foo>(t: A) -> A::Item { todo!() }
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1316,6 +1316,16 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ u8
     """)
 
+    fun `test invalid inherited generic trait object bound with Self`() = testExpr("""
+        trait Tr1<A> {}
+        trait Tr2: Tr1<Self> {}
+        fn foo<B, C>(_: &B) -> C where B: Tr1<C> + ?Sized { unimplemented!() }
+        fn bar(a: &dyn Tr2) { // error[E0038]: the trait `Tr2` cannot be made into an object
+            let b = foo(a);
+            b;
+        } //^ <unknown>
+    """)
+
     fun `test generic 'impl Trait' method`() = testExpr("""
         trait Tr<A> { fn foo(&self) -> A { unimplemented!() } }
         fn new() -> impl Tr<u8> { unimplemented!() }
@@ -1354,6 +1364,17 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = foo(new());
             a;
         } //^ u8
+    """)
+
+    fun `test inherited generic 'impl Trait' bound with Self`() = testExpr("""
+        trait Tr1<A> {}
+        trait Tr2: Tr1<Self> + Sized {}
+        fn new() -> impl Tr2 { unimplemented!() }
+        fn foo<B, C>(_: B) -> C where B: Tr1<C> { unimplemented!() }
+        fn main() {
+            let a = foo(new());
+            a;
+        } //^ impl Tr2
     """)
 
     fun `test inherited generic type parameter method`() = testExpr("""
@@ -2324,5 +2345,17 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
 
         fn foo<A: Foo>(t: A) -> A::Item { todo!() }
+    """)
+
+    fun `test select a supertrait with Self subst 3`() = testExpr("""
+        trait Foo<T: ?Sized> {}
+        trait Bar: Foo<Self> {}
+
+        fn bar<T: Bar>(t: T) {
+            let a = foo(t);
+            a;
+        } //^ T
+
+        fn foo<A: Foo<B>, B>(t: A) -> B { todo!() }
     """)
 }


### PR DESCRIPTION
Fixes #7685, fixes #7729, fixes #8583

Fixes several bugs in type inference. First of all, this fixes annoying `trait bound is not satisfied E0277` false-positives usually observable when implementing `Ord`/`Eq` types:

```rust
struct Box<T>(T);

impl<T: PartialEq> PartialEq for Box<T> {}
impl<T: Eq> Eq for Box<T> {} // No false-positives now!
```

On a lower level, now we correctly infer a type of `a` in such cases:

```rust
trait Foo<T: ?Sized> {}
trait Bar: Foo<Self> {} // `Self` in trait inheritance!

fn bar<T: Bar>(t: T) {
    let a = foo(t);
    a;
} //^ T

fn foo<A: Foo<B>, B>(t: A) -> B { todo!() }
```

And similarly for `impl Trait`:

```rust
trait Tr1<A> {}
trait Tr2: Tr1<Self> + Sized {}
fn new() -> impl Tr2 { unimplemented!() }
fn foo<B, C>(_: B) -> C where B: Tr1<C> { unimplemented!() }
fn main() {
    let a = foo(new());
    a;
} //^ impl Tr2
```

changelog: 1. Fix `trait bound is not satisfied E0277` false-positives when implementing `Ord`/`Eq` traits 2. Correctly infer types when `Self` type is used in trait inheritance like `trait Bar: Foo<Self>`