### PR TITLE
Simplify `.containingMod` and `.crateRoot` of `RsElement`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -32,8 +32,11 @@ interface RsElement : PsiElement, UserDataHolderEx {
      * Find parent module *in this file*. See [RsMod.super]
      */
     val containingMod: RsMod
+        get() = contextStrict<RsMod>()?.getOriginalOrSelf()
+            ?: error("Element outside of module: $text")
 
     val crateRoot: RsMod?
+        get() = containingRsFileSkippingCodeFragments?.crateRoot
 }
 
 val RsElement.cargoProject: CargoProject?
@@ -105,12 +108,6 @@ fun RsElement.findDependencyCrateRoot(dependencyName: String): RsFile? {
 }
 
 abstract class RsElementImpl(node: ASTNode) : ASTWrapperPsiElement(node), RsElement {
-    override val containingMod: RsMod
-        get() = contextStrict<RsMod>()?.getOriginalOrSelf()
-            ?: error("Element outside of module: $text")
-
-    final override val crateRoot: RsMod?
-        get() = containingRsFileSkippingCodeFragments?.crateRoot
 
     override fun getNavigationElement(): PsiElement {
         return findNavigationTargetIfMacroExpansion() ?: super.getNavigationElement()
@@ -122,13 +119,6 @@ abstract class RsStubbedElementImpl<StubT : StubElement<*>> : StubBasedPsiElemen
     constructor(node: ASTNode) : super(node)
 
     constructor(stub: StubT, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
-
-    override val containingMod: RsMod
-        get() = contextStrict<RsMod>()?.getOriginalOrSelf()
-            ?: error("Element outside of module: $text")
-
-    final override val crateRoot: RsMod?
-        get() = containingRsFileSkippingCodeFragments?.crateRoot
 
     override fun getNavigationElement(): PsiElement {
         return findNavigationTargetIfMacroExpansion() ?: super.getNavigationElement()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -160,7 +160,7 @@ abstract class RsPathImplMixin : RsStubbedElementImpl<RsPathStub>,
             //          //^ containingMod == `foo`
             // ```
             val visParent = (rootPath().parent as? RsVisRestriction)?.parent?.parent
-            return if (visParent is RsMod) visParent.containingMod else super.containingMod
+            return if (visParent is RsMod) visParent.containingMod else super<RsStubbedElementImpl>.containingMod
         }
 
     override val hasColonColon: Boolean get() = greenStub?.hasColonColon ?: (coloncolon != null)

--- a/src/main/kotlin/org/rust/lang/doc/psi/impl/Psi.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/impl/Psi.kt
@@ -15,7 +15,6 @@ import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.text.CharArrayUtil
 import org.rust.ide.injected.RsDoctestLanguageInjector
-import org.rust.lang.core.completion.getOriginalOrSelf
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.SimpleMultiLineTextEscaper
 import org.rust.lang.core.psi.ext.*
@@ -24,13 +23,6 @@ import org.rust.lang.doc.psi.*
 abstract class RsDocElementImpl(type: IElementType) : CompositePsiElement(type), RsDocElement {
     protected open fun <T: Any> notNullChild(child: T?): T =
         child ?: error("$text parent=${parent.text}")
-
-    override val containingMod: RsMod
-        get() = contextStrict<RsMod>()?.getOriginalOrSelf()
-            ?: error("Element outside of module: $text")
-
-    final override val crateRoot: RsMod?
-        get() = containingRsFileSkippingCodeFragments?.crateRoot
 
     override val containingDoc: RsDocComment
         get() = ancestorStrict()


### PR DESCRIPTION
Extracted from #7353 for easier review