### PR TITLE
Make `RsDocComment` inherit `RsElement`

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AttachFileToModuleFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AttachFileToModuleFix.kt
@@ -25,11 +25,13 @@ import org.rust.lang.RsConstants
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.lang.core.psi.ext.containingCargoPackage
+import org.rust.lang.core.psi.ext.firstItem
 import org.rust.lang.core.psi.rustFile
+import org.rust.openapiext.fullWidthCell
 import org.rust.openapiext.isUnitTestMode
 import org.rust.openapiext.pathAsPath
-import org.rust.openapiext.fullWidthCell
 import org.rust.openapiext.toPsiFile
 
 /**
@@ -198,5 +200,3 @@ fun withMockModuleAttachSelector(
         MOCK = null
     }
 }
-
-private val RsFile.firstItem: RsElement? get() = itemsAndMacros.firstOrNull { it !is RsAttr }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
@@ -17,6 +17,7 @@ import org.rust.ide.utils.import.COMPARATOR_FOR_SPECKS_IN_USE_GROUP
 import org.rust.ide.utils.import.UseItemWrapper
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.doc.psi.RsDocComment
 import org.rust.stdext.withNext
 
 class RsImportOptimizer : ImportOptimizer {
@@ -33,8 +34,7 @@ class RsImportOptimizer : ImportOptimizer {
     }
 
     private fun reorderExternCrates(file: RsFile) {
-        val first = file.childrenOfType<RsElement>()
-            .firstOrNull { it !is RsInnerAttr } ?: return
+        val first = file.firstItem ?: return
         val externCrateItems = file.childrenOfType<RsExternCrateItem>()
         externCrateItems
             .sortedBy { it.referenceName }
@@ -132,7 +132,7 @@ class RsImportOptimizer : ImportOptimizer {
             // We should ignore all items before `{` in inline modules
             val offset = if (mod is RsModItem) mod.lbrace.textOffset + 1 else 0
             val first = mod.childrenOfType<RsElement>()
-                .firstOrNull { it.textOffset >= offset && it !is RsExternCrateItem && it !is RsAttr } ?: return
+                .firstOrNull { it.textOffset >= offset && it !is RsExternCrateItem && it !is RsAttr && it !is RsDocComment } ?: return
             val psiFactory = RsPsiFactory(mod.project)
             val sortedUses = uses
                 .asSequence()

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesProcessor.kt
@@ -20,7 +20,10 @@ import org.rust.ide.refactoring.move.common.RsModDeclUsageInfo
 import org.rust.ide.refactoring.move.common.RsMoveCommonProcessor
 import org.rust.ide.utils.import.lastElement
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.lang.core.psi.ext.firstItem
+import org.rust.lang.core.psi.ext.getChildModule
 
 /** See overview of move refactoring in comment for [RsMoveCommonProcessor] */
 class RsMoveFilesOrDirectoriesProcessor(
@@ -120,8 +123,7 @@ fun RsMod.insertModDecl(psiFactory: RsPsiFactory, modDecl: PsiElement) {
     if (anchor != null) {
         addAfter(modDecl, anchor)
     } else {
-        val firstItem = itemsAndMacros.firstOrNull { it !is RsAttr && it !is RsVis }
-            ?: (this as? RsModItem)?.rbrace
+        val firstItem = firstItem ?: (this as? RsModItem)?.rbrace
         addBefore(modDecl, firstItem)
     }
 

--- a/src/main/kotlin/org/rust/ide/template/RsContextType.kt
+++ b/src/main/kotlin/org/rust/ide/template/RsContextType.kt
@@ -21,6 +21,7 @@ import org.rust.lang.core.psi.ext.RsAttr
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.doc.psi.RsDocComment
 import kotlin.reflect.KClass
 
 sealed class RsContextType(
@@ -95,8 +96,8 @@ sealed class RsContextType(
 
     companion object {
         private fun owner(element: PsiElement): PsiElement? = PsiTreeUtil.findFirstParent(element) {
-            it is RsBlock || it is RsPat || it is RsItemElement || it is RsAttr || it is PsiFile
-                || it is RsMacro || it is RsMacroCall
+            it is RsBlock || it is RsPat || it is RsItemElement || it is PsiFile
+                || it is RsAttr || it is RsDocComment || it is RsMacro || it is RsMacroCall
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -193,7 +193,6 @@ private val RsUseItem.importingNames: Set<String>?
 private val RsUseItem.pathAsList: List<String>?
     get() = useSpeck?.path?.text?.split("::")
 
-private val RsItemsOwner.firstItem: RsElement get() = itemsAndMacros.first { it !is RsAttr && it !is RsVis }
 val <T : RsElement> List<T>.lastElement: T? get() = maxByOrNull { it.textOffset }
 
 val RsElement.stdlibAttributes: RsFile.Attributes

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.VisibleForTesting
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve2.getRecursionLimit
 import org.rust.lang.core.resolve2.util.SmartListMap
+import org.rust.lang.doc.psi.RsDocComment
 import org.rust.lang.utils.evaluation.ThreeValuedLogic
 import org.rust.stdext.optimizeList
 import org.rust.stdext.replaceTrivialMap
@@ -200,3 +201,9 @@ private fun RsElement.processItem(
 private fun RsElement.isEnabledByCfgSelf() =
     this !is RsDocAndAttributeOwner || evaluateCfg() != ThreeValuedLogic.False
 
+val RsItemsOwner.firstItem: RsElement?
+    get() = itemsAndMacros.firstOrNull {
+        it !is RsAttr                   // #[outer] mod foo { #![inner] }
+            && it !is RsVis             // pub mod foo {}
+            && it !is RsDocComment      // mod foo { //! comment }
+    }

--- a/src/main/kotlin/org/rust/lang/doc/psi/RsDocComment.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/RsDocComment.kt
@@ -7,11 +7,12 @@ package org.rust.lang.doc.psi
 
 import com.intellij.psi.PsiDocCommentBase
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
+import org.rust.lang.core.psi.ext.RsElement
 
 /**
  * Psi element for [Rust documentation comments](https://doc.rust-lang.org/reference/comments.html#doc-comments)
  */
-interface RsDocComment : PsiDocCommentBase {
+interface RsDocComment : PsiDocCommentBase, RsElement {
     override fun getOwner(): RsDocAndAttributeOwner?
 
     val codeFences: List<RsDocCodeFence>

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileTest.kt
@@ -541,4 +541,29 @@ class RsMoveFileTest : RsMoveFileTestBase() {
             foo::foo_func();
         }
     """)
+
+    fun `test add mod declaration after doc comments`() = doTest(
+        "mod1/foo.rs",
+        "mod2",
+        """
+    //- main.rs
+        mod mod1;
+        mod mod2;
+    //- mod1/mod.rs
+        mod foo;
+    //- mod2.rs
+        //! comment
+    //- mod1/foo.rs
+        pub fn func() {}
+    """, """
+    //- main.rs
+        mod mod1;
+        mod mod2;
+    //- mod1/mod.rs
+    //- mod2.rs
+        //! comment
+        mod foo;
+    //- mod2/foo.rs
+        pub fn func() {}
+    """)
 }


### PR DESCRIPTION
This is needed for #7353 for resolving paths inside doc links (see [`walkUp`](https://github.com/intellij-rust/intellij-rust/blob/36320712696a5628fe3c62eb6a5be85d3042db2e/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt#L1793) implementation)
I extracted it to separate PR for easier review