### PR TITLE
REF: Improve `generateMissingTraitMembers`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFix.kt
@@ -65,7 +65,7 @@ class AddMissingSupertraitImplFix(implItem: RsImplItem) : LocalQuickFixAndIntent
         for ((superTrait, ref) in traits) {
             if (superTrait == trait) continue
             if (!implLookup.canSelect(TraitRef(type, superTrait))) {
-                implementTrait(impl, ref, typeRef, trait, substitutions)
+                implementTrait(impl, ref, typeRef, trait, substitutions, editor)
             }
         }
     }
@@ -76,7 +76,8 @@ private fun implementTrait(
     superTraitRef: RsTraitRef,
     typeReference: RsTypeReference,
     trait: BoundElement<RsTraitItem>,
-    substitutions: List<RsPsiSubstitution>
+    substitutions: List<RsPsiSubstitution>,
+    editor: Editor?,
 ) {
     val renderer = ImportingPsiRenderer(
         PsiRenderingOptions(),
@@ -102,7 +103,7 @@ private fun implementTrait(
     for (importCandidate in renderer.itemsToImport) {
         importCandidate.import(inserted)
     }
-    generateMissingTraitMembers(inserted)
+    generateMissingTraitMembers(inserted, editor)
 }
 
 private fun collectSuperTraits(

--- a/src/main/kotlin/org/rust/ide/intentions/AddImplTraitIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImplTraitIntention.kt
@@ -71,7 +71,7 @@ class AddImplTraitIntention : RsElementBaseIntentionAction<AddImplTraitIntention
             null
         }
 
-        generateMissingTraitMembers(impl)
+        generateMissingTraitMembers(impl, editor)
 
         showGenericArgumentsTemplate(
             editor,

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -49,11 +49,11 @@ fun generateTraitMembers(impl: RsImplItem, editor: Editor?) {
 /**
  * Generates missing trait members in a non-interactive way.
  */
-fun generateMissingTraitMembers(impl: RsImplItem) {
+fun generateMissingTraitMembers(impl: RsImplItem, editor: Editor?) {
     val (implInfo, trait) = findMembersToImplement(impl) ?: return
 
     RsIntentionPreviewUtils.write {
-        insertNewTraitMembers(implInfo.missingImplementations, impl, trait, null)
+        insertNewTraitMembers(implInfo.missingImplementations, impl, trait, editor)
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
@@ -50,7 +50,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
         struct S;
 
         impl A for S {
-            type FOO = ();
+            type FOO = <selection>()</selection>;
             const BAR: u32 = 0;
 
             fn foo(&self) {
@@ -58,7 +58,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
             }
         }
 
-        impl B/*caret*/ for S {}
+        impl B for S {}
     """)
 
     fun `test multiple supertraits`() = checkFixByText("Implement missing supertrait(s)", """
@@ -194,11 +194,11 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         impl A<u32> for S {
             fn foo(&self) -> u32 {
-                todo!()
+                <selection>todo!()</selection>
             }
         }
 
-        impl C<u32>/*caret*/ for S {}
+        impl C<u32> for S {}
     """)
 
     fun `test trait partially implemented for specific type`() = checkFixByText("Implement missing supertrait(s)", """

--- a/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
@@ -50,9 +50,9 @@ class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::cla
 
         struct S;
 
-        impl Foo/*caret*/ for S {
+        impl Foo for S {
             fn foo(&self) {
-                todo!()
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -70,7 +70,7 @@ class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::cla
 
         struct S;
 
-        impl Foo/*caret*/ for S { const FOO: u32 = 0; }
+        impl Foo for S { const FOO: u32 = <selection>0</selection>; }
     """)
 
     fun `test trait with associated type`() = doAvailableTestWithLiveTemplate("""
@@ -110,8 +110,8 @@ class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::cla
 
         struct S;
 
-        impl Foo/*caret*/ for S {
-            type Type = ();
+        impl Foo for S {
+            type Type = <selection>()</selection>;
             const FOO: u32 = 0;
 
             fn foo(&self) {
@@ -193,9 +193,9 @@ class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::cla
 
         struct S<'a, R, T>(R, &'a T);
 
-        impl<'a, R, T> Foo/*caret*/ for S<'a, R, T> {
+        impl<'a, R, T> Foo for S<'a, R, T> {
             fn foo(&self) -> u32 {
-                todo!()
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -213,9 +213,9 @@ class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::cla
 
         struct S<'a, R, T>(R, &'a T) where R: Foo;
 
-        impl<'a, R, T> Foo/*caret*/ for S<'a, R, T> where R: Foo {
+        impl<'a, R, T> Foo for S<'a, R, T> where R: Foo {
             fn foo(&self) -> u32 {
-                todo!()
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -239,9 +239,9 @@ class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::cla
 
         struct S;
 
-        impl Foo/*caret*/ for S {
+        impl Foo for S {
             fn foo(&self) -> u32 {
-                todo!()
+                <selection>todo!()</selection>
             }
         }
     """)


### PR DESCRIPTION
Extracted from #5651 for easier review

This affects `Implement missing supertrait` quick-fix and `Implement trait` intention. Now after the invocation of the action, in the editor the placeholder (e.g. `todo!()`) will be selected
No changelog since this is rather minor change mostly needed for #5651
