### PR TITLE
MACRO: split `org.rust.macros.proc` experimental feature into 3 features

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1609,7 +1609,7 @@ private fun checkConstGenerics(holder: RsAnnotationHolder, constParameter: RsCon
     }
 
     val lookup = ImplLookup.relativeTo(constParameter)
-    if (ProcMacroApplicationService.isEnabled() && !(lookup.isPartialEq(ty) && lookup.isEq(ty))) {
+    if (ProcMacroApplicationService.isFullyEnabled() && !(lookup.isPartialEq(ty) && lookup.isEq(ty))) {
         RsDiagnostic.NonStructuralMatchTypeAsConstGenericParameter(typeReference, ty.shortPresentableText)
             .addToHolder(holder)
     }

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -18,6 +18,9 @@ object RsExperiments {
     const val CARGO_FEATURES_SETTINGS_GUTTER = "org.rust.cargo.features.settings.gutter"
 
     const val PROC_MACROS = "org.rust.macros.proc"
+    const val FN_LIKE_PROC_MACROS = "org.rust.macros.proc.function-like"
+    const val DERIVE_PROC_MACROS = "org.rust.macros.proc.derive"
+    const val ATTR_PROC_MACROS = "org.rust.macros.proc.attr"
 
     @EnabledInStable
     const val FETCH_ACTUAL_STDLIB_METADATA = "org.rust.cargo.fetch.actual.stdlib.metadata"

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -33,7 +33,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
 
                 val rootPathParent = path.rootPath().parent
                 if (rootPathParent is RsMetaItem) {
-                    if (!rootPathParent.isMacroCall || !ProcMacroApplicationService.isEnabled()) return
+                    if (!rootPathParent.isMacroCall || !ProcMacroApplicationService.isFullyEnabled()) return
                 }
 
                 val isPathUnresolved = path.resolveStatus != PathResolveStatus.RESOLVED

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -43,7 +43,7 @@ class RsUnusedImportInspection : RsLintInspection() {
 
             // It's common to include more imports than needed in doctest sample code
             if (ignoreDoctest && item.containingCrate is DoctestCrate) return
-            if (enableOnlyIfProcMacrosEnabled && !ProcMacroApplicationService.isEnabled() && !isUnitTestMode) return
+            if (enableOnlyIfProcMacrosEnabled && !ProcMacroApplicationService.isFullyEnabled() && !isUnitTestMode) return
 
             val owner = item.parent as? RsItemsOwner ?: return
             val usage = owner.pathUsage
@@ -123,7 +123,7 @@ class RsUnusedImportInspection : RsLintInspection() {
             val toolWrapper = profile.getInspectionTool(SHORT_NAME, project)
             val tool = toolWrapper?.tool as? RsUnusedImportInspection ?: return true
             if (!tool.enableOnlyIfProcMacrosEnabled) return true
-            return ProcMacroApplicationService.isEnabled()
+            return ProcMacroApplicationService.isFullyEnabled()
         }
 
         const val SHORT_NAME: String = "RsUnusedImport"

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroApplicationService.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroApplicationService.kt
@@ -46,7 +46,7 @@ class ProcMacroApplicationService : Disposable {
 
     @Synchronized
     fun getServer(toolchain: RsToolchainBase, procMacroExpanderPath: Path): ProcMacroServerPool? {
-        if (!isEnabled()) return null
+        if (!isAnyEnabled()) return null
 
         val id = toolchain.distributionId
         val key = DistributionIdAndExpanderPath(id, procMacroExpanderPath)
@@ -83,8 +83,38 @@ class ProcMacroApplicationService : Disposable {
 
     companion object {
         fun getInstance(): ProcMacroApplicationService = service()
-        fun isEnabled(): Boolean = isFeatureEnabled(RsExperiments.PROC_MACROS)
-            && isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)
+        fun isFullyEnabled(): Boolean = isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)
+            && (
+            isFeatureEnabled(RsExperiments.PROC_MACROS) || isFeatureEnabled(RsExperiments.FN_LIKE_PROC_MACROS)
+                && isFeatureEnabled(RsExperiments.DERIVE_PROC_MACROS)
+                && isFeatureEnabled(RsExperiments.ATTR_PROC_MACROS)
+            )
+
+        fun isAnyEnabled(): Boolean = isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)
+            && (
+            isFeatureEnabled(RsExperiments.PROC_MACROS)
+                || isFeatureEnabled(RsExperiments.FN_LIKE_PROC_MACROS)
+                || isFeatureEnabled(RsExperiments.DERIVE_PROC_MACROS)
+                || isFeatureEnabled(RsExperiments.ATTR_PROC_MACROS)
+            )
+
+        fun isFunctionLikeEnabled(): Boolean = isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)
+            && (
+            isFeatureEnabled(RsExperiments.PROC_MACROS)
+                || isFeatureEnabled(RsExperiments.FN_LIKE_PROC_MACROS)
+            )
+
+        fun isDeriveEnabled(): Boolean = isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)
+            && (
+            isFeatureEnabled(RsExperiments.PROC_MACROS)
+                || isFeatureEnabled(RsExperiments.DERIVE_PROC_MACROS)
+            )
+
+        fun isAttrEnabled(): Boolean = isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)
+            && (
+            isFeatureEnabled(RsExperiments.PROC_MACROS)
+                || isFeatureEnabled(RsExperiments.ATTR_PROC_MACROS)
+            )
 
         private val RsToolchainBase.distributionId: String
             get() = if (this is RsWslToolchain) wslPath.distributionId else "Local"

--- a/src/main/kotlin/org/rust/lang/core/psi/ProcMacroAttribute.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ProcMacroAttribute.kt
@@ -120,10 +120,11 @@ sealed class ProcMacroAttribute<out T : RsMetaItemPsiOrStub> {
             explicitCustomAttributes: CustomAttributes? = null,
             ignoreProcMacrosDisabled: Boolean = false
         ): ProcMacroAttribute<T> {
-            if (!ignoreProcMacrosDisabled && !ProcMacroApplicationService.isEnabled()) return None
+            if (!ignoreProcMacrosDisabled && !ProcMacroApplicationService.isAnyEnabled()) return None
             if (stub != null) {
                 if (!stub.mayHaveCustomAttrs) {
                     return if (stub.mayHaveCustomDerive && RsProcMacroPsiUtil.canOwnDeriveAttrs(owner)) {
+                        if (!ignoreProcMacrosDisabled && !ProcMacroApplicationService.isDeriveEnabled()) return None
                         if (withDerives) {
                             val queryAttributes = owner.getQueryAttributes(explicitCrate, stub, outerAttrsOnly = true)
                             Derive(queryAttributes.customDeriveMetaItems)
@@ -150,6 +151,7 @@ sealed class ProcMacroAttribute<out T : RsMetaItemPsiOrStub> {
             queryAttributes.metaItems.forEachIndexed { index, meta ->
                 if (meta.name == "derive") {
                     return if (RsProcMacroPsiUtil.canOwnDeriveAttrs(owner)) {
+                        if (!ignoreProcMacrosDisabled && !ProcMacroApplicationService.isDeriveEnabled()) return None
                         if (withDerives) {
                             Derive(queryAttributes.customDeriveMetaItems)
                         } else {
@@ -159,7 +161,8 @@ sealed class ProcMacroAttribute<out T : RsMetaItemPsiOrStub> {
                         None
                     }
                 }
-                if (RsProcMacroPsiUtil.canBeProcMacroAttributeCallWithoutContextCheck(meta, customAttributes)) {
+                if (RsProcMacroPsiUtil.canBeProcMacroAttributeCallWithoutContextCheck(meta, customAttributes)
+                    && (ignoreProcMacrosDisabled || ProcMacroApplicationService.isAttrEnabled())) {
                     return Attr(meta, index)
                 }
             }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsProcMacroPsiUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsProcMacroPsiUtil.kt
@@ -17,16 +17,18 @@ import org.rust.lang.core.stubs.common.RsMetaItemPsiOrStub
 
 object RsProcMacroPsiUtil {
     fun canBeInProcMacroCallBody(psiElement: PsiElement): Boolean {
-        if (!ProcMacroApplicationService.isEnabled()) return false
+        if (!ProcMacroApplicationService.isAnyEnabled()) return false
         return psiElement.ancestors.any { it is RsAttrProcMacroOwner && canHaveProcMacroCall(it) }
     }
 
     private fun canHaveProcMacroCall(item: RsAttrProcMacroOwner): Boolean {
         val checkDerives = item is RsStructOrEnumItemElement
         for (meta in item.getTraversedRawAttributes(withCfgAttrAttribute = false).metaItems) {
-            if (canBeProcMacroAttributeCall(meta)) return true
+            if (canBeProcMacroAttributeCall(meta) && ProcMacroApplicationService.isAttrEnabled()) return true
             if (checkDerives && meta.name == "derive") {
-                if (meta.metaItemArgs?.metaItemList.orEmpty().any(::canBeCustomDerive)) return true
+                if (meta.metaItemArgs?.metaItemList.orEmpty().any(::canBeCustomDerive)) {
+                    return ProcMacroApplicationService.isDeriveEnabled()
+                }
             }
         }
         return false

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
@@ -24,11 +24,9 @@ import org.rust.lang.core.macros.*
 import org.rust.lang.core.macros.decl.MACRO_DOLLAR_CRATE_IDENTIFIER
 import org.rust.lang.core.macros.errors.GetMacroExpansionError
 import org.rust.lang.core.macros.errors.ResolveMacroWithoutPsiError
-import org.rust.lang.core.macros.proc.ProcMacroApplicationService
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsPossibleMacroCallKind.MacroCall
 import org.rust.lang.core.psi.ext.RsPossibleMacroCallKind.MetaItem
-import org.rust.lang.core.resolve.KnownDerivableTrait
 import org.rust.lang.core.resolve.resolveDollarCrateIdentifier
 import org.rust.lang.core.resolve2.getRecursionLimit
 import org.rust.lang.core.resolve2.resolveToMacroWithoutPsi
@@ -95,13 +93,6 @@ val RsPossibleMacroCall.canBeMacroCall: Boolean
     get() = when (val kind = kind) {
         is MacroCall -> true
         is MetaItem -> RsProcMacroPsiUtil.canBeProcMacroCall(kind.meta)
-    }
-
-val RsPossibleMacroCall.shouldSkipMacroExpansion: Boolean
-    get() = when (val kind = kind) {
-        is MetaItem -> !ProcMacroApplicationService.isEnabled()
-            || RsProcMacroPsiUtil.canBeCustomDerive(kind.meta) && KnownDerivableTrait.shouldUseHardcodedTraitDerive(kind.meta.name)
-        else -> false
     }
 
 val RsPossibleMacroCall.isTopLevelExpansion: Boolean

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -206,7 +206,7 @@ enum class KnownDerivableTrait(
     /** Hardcoded trait impl vs proc macro expansion usage */
     fun shouldUseHardcodedTraitDerive(): Boolean {
         // We don't use hardcoded impls for non-std derives if proc macro expansion is enabled
-        return isStd || !ProcMacroApplicationService.isEnabled()
+        return isStd || !ProcMacroApplicationService.isDeriveEnabled()
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateModificationTracker.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateModificationTracker.kt
@@ -16,6 +16,7 @@ import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.FeatureState
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.macros.proc.ProcMacroApplicationService
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.rustFile
 import org.rust.lang.core.psi.shouldIndexFile
@@ -93,6 +94,9 @@ data class CrateMetaData(
     private val dependencies: Set<CratePersistentId>,
     private val dependenciesNames: Set<String>,
     val procMacroArtifact: CargoWorkspaceData.ProcMacroArtifact?,
+    private val isFunctionLikeProcMacroExpansionEnabled: Boolean,
+    private val isDeriveProcMacroExpansionEnabled: Boolean,
+    private val isAttrProcMacroExpansionEnabled: Boolean,
 ) {
     constructor(crate: Crate) : this(
         name = crate.normName,
@@ -102,7 +106,10 @@ data class CrateMetaData(
         env = crate.env,
         dependencies = crate.flatDependencies.mapNotNullToSet { it.id },
         dependenciesNames = crate.dependencies.mapToSet { it.normName },
-        procMacroArtifact = crate.procMacroArtifact
+        procMacroArtifact = crate.procMacroArtifact,
+        isFunctionLikeProcMacroExpansionEnabled = ProcMacroApplicationService.isFunctionLikeEnabled(),
+        isDeriveProcMacroExpansionEnabled = ProcMacroApplicationService.isDeriveEnabled(),
+        isAttrProcMacroExpansionEnabled = ProcMacroApplicationService.isAttrEnabled(),
     )
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -15,6 +15,7 @@ import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.macros.decl.MACRO_DOLLAR_CRATE_IDENTIFIER
+import org.rust.lang.core.macros.proc.ProcMacroApplicationService
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.body
 import org.rust.lang.core.resolve.Namespace
@@ -366,6 +367,12 @@ class DefCollector(
         val defData = RsMacroDataWithHash.fromDefInfo(def).ok() ?: return null
         val callData = RsMacroCallDataWithHash(RsMacroCallData(call.body, defMap.metaData.env), call.bodyHash)
         val mixHash = defData.mixHash(callData) ?: return null
+
+        if (defData.data is RsProcMacroData && callData.data.macroBody is MacroCallBody.FunctionLike) {
+            if (!ProcMacroApplicationService.isFunctionLikeEnabled()) {
+                return null
+            }
+        }
         val (expandedFile, expansion) =
             macroExpanderShared.createExpansionStub(project, macroExpander, defData.data, callData.data, mixHash).ok()
                 ?: (null to null)

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -10,7 +10,16 @@
             <description>Fetch metadata of actual stdlib crates instead of using hardcoded data</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.macros.proc" percentOfUsers="0">
-            <description>Enables procedural macro expansion</description>
+            <description>Enables all types of procedural macro expansion</description>
+        </experimentalFeature>
+        <experimentalFeature id="org.rust.macros.proc.function-like" percentOfUsers="0">
+            <description>Enables function-like procedural macro expansion</description>
+        </experimentalFeature>
+        <experimentalFeature id="org.rust.macros.proc.derive" percentOfUsers="0">
+            <description>Enables derive procedural macro expansion</description>
+        </experimentalFeature>
+        <experimentalFeature id="org.rust.macros.proc.attr" percentOfUsers="0">
+            <description>Enables attribute procedural macro expansion</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="100">
             <description>Enables crates local index</description>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -10,7 +10,16 @@
             <description>Fetch metadata of actual stdlib crates instead of using hardcoded data</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.macros.proc" percentOfUsers="0">
-            <description>Enables procedural macro expansion</description>
+            <description>Enables all types of procedural macro expansion</description>
+        </experimentalFeature>
+        <experimentalFeature id="org.rust.macros.proc.function-like" percentOfUsers="0">
+            <description>Enables function-like procedural macro expansion</description>
+        </experimentalFeature>
+        <experimentalFeature id="org.rust.macros.proc.derive" percentOfUsers="0">
+            <description>Enables derive procedural macro expansion</description>
+        </experimentalFeature>
+        <experimentalFeature id="org.rust.macros.proc.attr" percentOfUsers="0">
+            <description>Enables attribute procedural macro expansion</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="100">
             <description>Enables crates local index</description>

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
@@ -6,7 +6,10 @@
 package org.rust.lang.core.macros.proc
 
 import org.rust.*
+import org.rust.ide.experiments.RsExperiments.ATTR_PROC_MACROS
+import org.rust.ide.experiments.RsExperiments.DERIVE_PROC_MACROS
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
+import org.rust.ide.experiments.RsExperiments.FN_LIKE_PROC_MACROS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.macros.RsMacroExpansionErrorTestBase
@@ -24,6 +27,32 @@ import org.rust.lang.core.macros.errors.GetMacroExpansionError
 class RsProcMacroErrorTest : RsMacroExpansionErrorTestBase() {
     @WithExperimentalFeatures()
     fun `test macro expansion is disabled`() = checkError<GetMacroExpansionError.ExpansionError>("""
+        use test_proc_macros::attr_as_is;
+
+        #[attr_as_is]
+        //^ procedural macro expansion is not enabled
+        fn foo() {}
+    """)
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, DERIVE_PROC_MACROS, ATTR_PROC_MACROS)
+    fun `test function-like macro expansion is disabled`() = checkError<GetMacroExpansionError.ExpansionError>("""
+        use test_proc_macros::function_like_as_is;
+
+        function_like_as_is! {}
+        //^ procedural macro expansion is not enabled
+    """)
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, FN_LIKE_PROC_MACROS, ATTR_PROC_MACROS)
+    fun `test derive macro expansion is disabled`() = checkError<GetMacroExpansionError.ExpansionError>("""
+        use test_proc_macros::DeriveImplForFoo;
+
+        #[derive(DeriveImplForFoo)]
+               //^ procedural macro expansion is not enabled
+        struct Foo;
+    """)
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, FN_LIKE_PROC_MACROS, DERIVE_PROC_MACROS)
+    fun `test attr macro expansion is disabled`() = checkError<GetMacroExpansionError.ExpansionError>("""
         use test_proc_macros::attr_as_is;
 
         #[attr_as_is]

--- a/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
@@ -9,6 +9,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.intellij.lang.annotations.Language
 import org.rust.*
+import org.rust.ide.experiments.RsExperiments.ATTR_PROC_MACROS
+import org.rust.ide.experiments.RsExperiments.DERIVE_PROC_MACROS
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
 import org.rust.lang.core.psi.ProcMacroAttributeTest.TestProcMacroAttribute.*
@@ -378,6 +380,29 @@ class ProcMacroAttributeTest : RsTestBase() {
             #[attr_as_is]
             mod foo {}
         """, None)
+    }
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
+    fun `test not a macro if attr macro expansion is disabled 1`() {
+        setExperimentalFeatureEnabled(ATTR_PROC_MACROS, false, testRootDisposable)
+        doTest("""
+            use test_proc_macros::attr_as_is;
+
+            #[attr_as_is]
+            mod foo {}
+        """, None)
+    }
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, DERIVE_PROC_MACROS)
+    fun `test not a macro if attr macro expansion is disabled 2`() {
+        setExperimentalFeatureEnabled(ATTR_PROC_MACROS, false, testRootDisposable)
+        doTest("""
+            use test_proc_macros::attr_as_is;
+
+            #[attr_as_is]
+            #[derive(Foo)]
+            struct S;
+        """, Derive)
     }
 
     private fun doTest(@Language("Rust") code: String, expectedAttr: TestProcMacroAttribute) {


### PR DESCRIPTION
Namely,
- `org.rust.macros.proc.function-like`
- `org.rust.macros.proc.derive`
- `org.rust.macros.proc.attr`

`org.rust.macros.proc` still exists and equivalent to enabling all these 3 features