### PR TITLE
Ty: normalize associated type in `impl` item trait ref

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -948,7 +948,7 @@ class RsInferenceContext(
             }
             ProjectionCacheEntry.InProgress -> {
                 // While normalized A::B we are asked to normalize A::B.
-                // TODO rustc halts the compilation immediately (panics) here
+                TypeInferenceMarks.RecursiveProjectionNormalization.hit()
                 TyWithObligations(TyUnknown)
             }
             ProjectionCacheEntry.Error -> {
@@ -1429,6 +1429,7 @@ data class ExpectedType(val ty: Ty, val coercable: Boolean = false) : TypeFoldab
 
 object TypeInferenceMarks {
     object CyclicType : Testmark()
+    object RecursiveProjectionNormalization : Testmark()
     object QuestionOperator : Testmark()
     object MethodPickTraitScope : Testmark()
     object MethodPickTraitsOutOfScope : Testmark()

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -2370,4 +2370,46 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             b;
         } //^ <unknown>
     """)
+
+    @CheckTestmarkHit(TypeInferenceMarks.RecursiveProjectionNormalization::class)
+    fun `test recursive projection in impl trait ref`() = testExpr("""
+        struct S;
+        trait Trait<T> { type Item; }
+        impl Trait<<S as Trait<()>>::Item> for S { type Item = (); }
+        fn foo<A: Trait<B>, B>(_: A) -> B { todo!() }
+        fn bar(a: S) {
+            let b = foo(a);
+            b;
+        } //^ <unknown>
+    """)
+
+    fun `test associated type projection in impl trait ref`() = testExpr("""
+        struct S;
+        struct X;
+        trait Foo { type Item; }
+        impl Foo for S { type Item = X; }
+
+        trait Bar<T> {}
+        impl Bar<<S as Foo>::Item> for S {}
+        fn foo<A: Bar<B>, B>(_: A) -> B { todo!() }
+        fn bar(a: S) {
+            let b = foo(a);
+            b;
+        } //^ X
+    """)
+
+    fun `test associated type projection in impl trait ref via type parameter default`() = testExpr("""
+        struct S;
+        struct X;
+        trait Foo { type Item; }
+        impl Foo for S { type Item = X; }
+
+        trait Bar<T = <Self as Foo>::Item> {}
+        impl Bar for S {}
+        fn foo<A: Bar<B>, B>(_: A) -> B { todo!() }
+        fn bar(a: S) {
+            let b = foo(a);
+            b;
+        } //^ X
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -2358,4 +2358,16 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
 
         fn foo<A: Foo<B>, B>(t: A) -> B { todo!() }
     """)
+
+    @CheckTestmarkHit(TypeInferenceMarks.RecursiveProjectionNormalization::class)
+    fun `test recursive projection in impl type`() = testExpr("""
+        struct S<T>(T);
+        trait Trait { type Item; }
+        impl Trait for S<<S<()> as Trait>::Item> { type Item = (); }
+        fn foo<T: Trait>(_: T) -> T::Item { todo!() }
+        fn bar(a: S<()>) {
+            let b = foo(a);
+            b;
+        } //^ <unknown>
+    """)
 }


### PR DESCRIPTION
Fixes #9521.

Examples:

```rust
struct S;
struct X;
trait Foo { type Item; }
impl Foo for S { type Item = X; }

trait Bar<T> {}
impl Bar<<S as Foo>::Item> for S {}
fn foo<A: Bar<B>, B>(_: A) -> B { todo!() }
fn bar(a: S) {
    let b = foo(a);
    b;
} //^ X
```

```rust
struct S;
struct X;
trait Foo { type Item; }
impl Foo for S { type Item = X; }

trait Bar<T = <Self as Foo>::Item> {}
impl Bar for S {}
fn foo<A: Bar<B>, B>(_: A) -> B { todo!() }
fn bar(a: S) {
    let b = foo(a);
    b;
} //^ X
```
