### PR TITLE
T: Fix pretty-printers tests for Unicode strings on Windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -626,8 +626,6 @@ project(":ml-completion") {
 
 task("runPrettyPrintersTests") {
     doLast {
-        // https://github.com/intellij-rust/intellij-rust/issues/9554
-        if (platformVersion == 223 && isFamily(FAMILY_WINDOWS)) return@doLast
         val lldbPath = when {
             // TODO: Use `lldb` Python module from CLion distribution
             isFamily(FAMILY_MAC) -> "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python"

--- a/pretty_printers_tests/lldb_batchmode.py
+++ b/pretty_printers_tests/lldb_batchmode.py
@@ -87,6 +87,11 @@ def execute_command(command_interpreter, command):
     if res.Succeeded():
         if res.HasResult():
             output = res.GetOutput() or ''
+            # 'win32' is returned on both x32 and x64 Windows,
+            # see https://docs.python.org/3/library/sys.html#sys.platform
+            if sys.platform == 'win32':
+                # Workaround for https://github.com/intellij-rust/intellij-rust/issues/9554
+                output = output.encode('utf-8', errors='replace').decode('utf-8')
             print(normalize_whitespace(output), end='\n')
 
         # If the command introduced any breakpoints, make sure to register


### PR DESCRIPTION
Fixes #9554.

The problem with `UnicodeEncodeError` presumably appeared after upgrading to Python 3.10 (see https://youtrack.jetbrains.com/issue/CPP-30260). Particularly, this error occurred when the test runner tried to print the children nodes of Unicode strings, i.e. single Unicode characters. Unicode strings summaries provided by our pretty-printers were printed fine though. This allows us to safely use `.encode('utf-8', errors='replace').decode('utf-8')` workaround, leaving the corresponding tests valid: the tests will still properly compare the summaries containing only valid Unicode characters.