### PR TITLE
CI: move used rust version to one place

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,9 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    get-rust-versions:
+        uses: ./.github/workflows/get-rust-versions.yml
+
     calculate-git-info:
         runs-on: ubuntu-latest
         outputs:
@@ -47,13 +50,13 @@ jobs:
     check-license:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v2
 
             - name: Check license
               run: python scripts/check_license.py
 
     build-native-code:
-        needs: [ calculate-git-info ]
+        needs: [ calculate-git-info, get-rust-versions ]
         # `fromJSON` is used here to convert string output to boolean
         # We always want to trigger all workflow jobs on `schedule` event because it creates/updates caches for other builds.
         # See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
@@ -61,17 +64,20 @@ jobs:
         if: ${{ github.event_name == 'schedule' || !fromJSON(needs.calculate-git-info.outputs.is_master_branch) || !fromJSON(needs.calculate-git-info.outputs.checked) }}
         uses: ./.github/workflows/build-native-code.yml
         with:
-            rust-version: 1.64.0
+            rust-version:  ${{ needs.get-rust-versions.outputs.stable }}
             cache: true
 
     check-plugin:
-        needs: [ calculate-git-info, build-native-code ]
+        needs: [ calculate-git-info, build-native-code, get-rust-versions ]
         strategy:
             # `fromJSON` is used here to convert string output to boolean
             fail-fast: ${{ fromJSON(needs.calculate-git-info.outputs.is_bors_branch) }}
             matrix:
                 os: [ ubuntu-latest, windows-latest ]
-                rust-version: [ 1.64.0, nightly-2022-11-05 ]
+                # `fromJSON` is used here to convert string output to sequence.
+                # `matrix-version` is a string with list of stable + nightly versions.
+                # Make sequence from two outputs with version is not possible here.
+                rust-version: ${{ fromJSON(needs.get-rust-versions.outputs.matrix) }}
                 base-ide: [ idea, clion ]
                 platform-version: [ 222, 223 ]
                 # it's enough to verify plugin structure only once per platform version
@@ -79,8 +85,7 @@ jobs:
                 default-edition-for-tests: [ 2021 ]
                 include:
                     - os: ubuntu-latest
-                      # Don't forget to update condition in `Set up additional env variables` step
-                      rust-version: 1.56.0
+                      rust-version: ${{ needs.get-rust-versions.outputs.old }}
                       base-ide: idea
                       platform-version: 222
                       verify-plugin: true
@@ -159,7 +164,7 @@ jobs:
                   cargo install --list
 
             - name: Set up additional env variables
-              if: matrix.rust-version == '1.56.0'
+              if: matrix.rust-version == needs.get-rust-versions.outputs.old
               # see https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
               run: |
                   echo "ORG_GRADLE_PROJECT_ideaVersion=IU-2022.2" >> $GITHUB_ENV

--- a/.github/workflows/get-rust-versions.yml
+++ b/.github/workflows/get-rust-versions.yml
@@ -1,0 +1,41 @@
+# This workflow exists to avoid using hardcoded versions of the toolchain in different places.
+# In an ideal world, top-level constants (not yet implemented) or workflow-level environment variables
+# would be used, but they are not supported in all needed places.
+
+name: get rust versions
+on:
+    workflow_call:
+        outputs:
+            stable:
+                value: ${{ jobs.get_versions.outputs.stable }}
+            nightly:
+                value: ${{ jobs.get_versions.outputs.nightly }}
+            old:
+                value: ${{ jobs.get_versions.outputs.old }}
+            matrix:
+                description: 'String like ["%stable%", "%nightly-yyyy-mm-dd%"].
+                         Added for `check` workflow, because there is no way to make a sequence from two outputs.'
+                value: ${{ jobs.get_versions.outputs.matrix }}
+
+env:
+    STABLE: "1.64.0"
+    NIGHTLY: "nightly-2022-11-05"
+    OLD: "1.56.0"
+
+jobs:
+    get_versions:
+        runs-on: ubuntu-latest
+        outputs:
+            stable: ${{ steps.versions.outputs.stable }}
+            nightly: ${{ steps.versions.outputs.nightly }}
+            old: ${{ steps.versions.outputs.old }}
+            matrix: ${{ steps.versions.outputs.matrix }}
+        steps:
+            -   name: setup all version
+                id: versions
+                run: |
+                    echo "stable=${{ env.STABLE }}" >> $GITHUB_OUTPUT
+                    echo "nightly=${{ env.NIGHTLY }}" >> $GITHUB_OUTPUT
+                    echo "old=${{ env.OLD }}" >> $GITHUB_OUTPUT
+                    echo "matrix=[\"${{ env.STABLE }}\", \"${{ env.NIGHTLY }}\"]" >> $GITHUB_OUTPUT
+

--- a/scripts/update_nightly.py
+++ b/scripts/update_nightly.py
@@ -4,9 +4,9 @@ import re
 from common import execute_command, env
 from updater import UpdaterBase
 
-CHECK_WORKFLOW_PATH = ".github/workflows/check.yml"
+WORKFLOW_PATH = ".github/workflows/get-rust-versions.yml"
 RUSTC_VERSION_RE = re.compile(r".* \(\w*\s*(\d{4}-\d{2}-\d{2})\)")
-WORKFLOW_RUSTC_VERSION_RE = re.compile(r"(rust-version: \[.*nightly-)\d{4}-\d{2}-\d{2}(.*])")
+WORKFLOW_RUSTC_VERSION_RE = re.compile(r'(?<=NIGHTLY: "nightly-)\d{4}-\d{2}-\d{2}')
 
 
 class NightlyUpdater(UpdaterBase):
@@ -15,19 +15,19 @@ class NightlyUpdater(UpdaterBase):
         output = execute_command("rustc", "-V")
         match_result = RUSTC_VERSION_RE.match(output)
         date = match_result.group(1)
-        with open(CHECK_WORKFLOW_PATH) as f:
+        with open(WORKFLOW_PATH) as f:
             workflow_text = f.read()
 
         result = re.search(WORKFLOW_RUSTC_VERSION_RE, workflow_text)
         if result is None:
             raise ValueError("Failed to find the current version of nightly rust")
 
-        new_workflow_text = re.sub(WORKFLOW_RUSTC_VERSION_RE, f"\\g<1>{date}\\g<2>", workflow_text)
+        new_workflow_text = re.sub(WORKFLOW_RUSTC_VERSION_RE, date, workflow_text)
         if new_workflow_text == workflow_text:
             print("The latest nightly rustc version is already used")
             return
 
-        with open(CHECK_WORKFLOW_PATH, "w") as f:
+        with open(WORKFLOW_PATH, "w") as f:
             f.write(new_workflow_text)
 
 


### PR DESCRIPTION
Historically, we had identical versions of the rust toolchain hardcoded in several places, which complicated their uniformity and automatic updating.  
This PR moves all used versions to one new workflow, and this workflow returns versions in output. 

And small update of nightly-version updater due to the above changes.