### PR TITLE
RUN: Don't show line markers for tests in dependence crates

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoBenchRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoBenchRunConfigurationProducer.kt
@@ -6,6 +6,8 @@
 package org.rust.cargo.runconfig.test
 
 import com.intellij.psi.PsiElement
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.RsMod
@@ -23,12 +25,14 @@ class CargoBenchRunConfigurationProducer : CargoTestRunConfigurationProducerBase
         registerDirectoryConfigProvider { dir -> createConfigForDirectory(dir) }
     }
 
-    override fun isSuitable(element: PsiElement): Boolean =
-        when (element) {
+    override fun isSuitable(element: PsiElement): Boolean {
+        if (!super.isSuitable(element)) return false
+        return when (element) {
             is RsMod -> hasBenchFunction(element)
             is RsFunction -> element.isBench
             else -> false
         }
+    }
 
     companion object {
         private fun hasBenchFunction(mod: RsMod): Boolean =

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducerBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducerBase.kt
@@ -20,6 +20,7 @@ import org.rust.cargo.runconfig.command.CargoRunConfigurationProducer
 import org.rust.cargo.runconfig.mergeWithDefault
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.ide.refactoring.RsNamesValidator
+import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.psi.RS_RAW_PREFIX
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
@@ -135,7 +136,10 @@ abstract class CargoTestRunConfigurationProducerBase : CargoRunConfigurationProd
         return base.ancestorOrSelf()
     }
 
-    protected abstract fun isSuitable(element: PsiElement): Boolean
+    protected open fun isSuitable(element: PsiElement): Boolean {
+        val crate = (element as? RsElement)?.containingCrate?.asNotFake
+        return crate?.origin == PackageOrigin.WORKSPACE
+    }
 
     protected fun isIgnoredTest(element: PsiElement): Boolean =
         element is RsFunction && element.findOuterAttr("ignore") != null

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -8,6 +8,8 @@ package org.rust.ide.lineMarkers
 import com.intellij.psi.PsiFileFactory
 import org.intellij.lang.annotations.Language
 import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.cargo.icons.CargoIcons
 import org.rust.fileTree
 import org.rust.lang.RsFileType
@@ -224,6 +226,20 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         /// ```
         fn foo() {}
     """.trimIndent())
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test tests in dependency`() = doTestByFileTree("dep-lib/lib.rs") {
+        dir("dep-lib") {
+            rust("lib.rs", """
+                /// ```
+                /// let a = 5;
+                /// ```
+                fn foo() {}
+                #[test]
+                fn test() {}
+            """)
+        }
+    }
 
     private inline fun <reified E : RsElement> checkElement(@Language("Rust") code: String, callback: (E) -> Unit) {
         val element = PsiFileFactory.getInstance(project)


### PR DESCRIPTION
changelog: Don't show line markers for tests in dependence crates
