### PR TITLE
MACRO: enable function-like procedural macro expansion in nightly plugin builds

### DIFF
--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -12,7 +12,7 @@
         <experimentalFeature id="org.rust.macros.proc" percentOfUsers="0">
             <description>Enables all types of procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.macros.proc.function-like" percentOfUsers="0">
+        <experimentalFeature id="org.rust.macros.proc.function-like" percentOfUsers="100">
             <description>Enables function-like procedural macro expansion</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.macros.proc.derive" percentOfUsers="0">

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
@@ -35,6 +35,7 @@ class RsProcMacroErrorTest : RsMacroExpansionErrorTestBase() {
     """)
 
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, DERIVE_PROC_MACROS, ATTR_PROC_MACROS)
+    @WithoutExperimentalFeatures(FN_LIKE_PROC_MACROS)
     fun `test function-like macro expansion is disabled`() = checkError<GetMacroExpansionError.ExpansionError>("""
         use test_proc_macros::function_like_as_is;
 
@@ -43,6 +44,7 @@ class RsProcMacroErrorTest : RsMacroExpansionErrorTestBase() {
     """)
 
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, FN_LIKE_PROC_MACROS, ATTR_PROC_MACROS)
+    @WithoutExperimentalFeatures(DERIVE_PROC_MACROS)
     fun `test derive macro expansion is disabled`() = checkError<GetMacroExpansionError.ExpansionError>("""
         use test_proc_macros::DeriveImplForFoo;
 
@@ -52,6 +54,7 @@ class RsProcMacroErrorTest : RsMacroExpansionErrorTestBase() {
     """)
 
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, FN_LIKE_PROC_MACROS, DERIVE_PROC_MACROS)
+    @WithoutExperimentalFeatures(ATTR_PROC_MACROS)
     fun `test attr macro expansion is disabled`() = checkError<GetMacroExpansionError.ExpansionError>("""
         use test_proc_macros::attr_as_is;
 

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpanderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpanderTest.kt
@@ -13,6 +13,9 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.ide.experiments.RsExperiments
+import org.rust.ide.experiments.RsExperiments.ATTR_PROC_MACROS
+import org.rust.ide.experiments.RsExperiments.DERIVE_PROC_MACROS
+import org.rust.ide.experiments.RsExperiments.FN_LIKE_PROC_MACROS
 import org.rust.lang.core.macros.errors.ProcMacroExpansionError
 import org.rust.lang.core.macros.errors.readMacroExpansionError
 import org.rust.lang.core.macros.errors.writeMacroExpansionError
@@ -83,6 +86,7 @@ class RsProcMacroExpanderTest : RsTestBase() {
     }
 
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS)
+    @WithoutExperimentalFeatures(FN_LIKE_PROC_MACROS, DERIVE_PROC_MACROS, ATTR_PROC_MACROS)
     fun `test ProcMacroExpansionIsDisabled error 1`() {
         val expander = ProcMacroExpander.new(project, server = null)
         expander.checkError<ProcMacroExpansionError.ProcMacroExpansionIsDisabled>("", "", "")


### PR DESCRIPTION
changelog: Enable [function-like](https://doc.rust-lang.org/reference/procedural-macros.html#function-like-procedural-macros) procedural macro expansion in [nightly plugin builds](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-quick-start.html#install-nightly).