### PR TITLE
CARGO: don't fail build script evaluation without native helper

### DIFF
--- a/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
@@ -11,15 +11,13 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.BuildViewTestFixture
-import org.rust.MinRustcVersion
-import org.rust.WithExperimentalFeatures
+import org.rust.*
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.toolwindow.CargoToolWindow
-import org.rust.fileTree
+import org.rust.cargo.toolchain.tools.Cargo
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
-import org.rust.launchAction
 import java.nio.file.Path
 
 @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
@@ -410,6 +408,36 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
                  -${project.root.name}
                   Failed to run custom build command for `with-build-script v0.1.0 (${FileUtil.toSystemDependentName(project.root.path)}/with-build-script)`
                 Build scripts evaluation failed
+               Getting Rust stdlib
+        """)
+    }
+
+    @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
+    fun `test build script evaluation without build script wrapper`() {
+        setRegistryOptionEnabled(Cargo.USE_BUILD_SCRIPT_WRAPPER, false, testRootDisposable)
+
+        val project = buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    fn main() {}
+                """)
+            }
+        }
+        checkSyncViewTree("""
+            -
+             -finished
+              -Sync ${project.root.name} project
+               Getting toolchain version
+               -Updating workspace info
+                -Build scripts evaluation
+                 Checking hello v0.1.0
                Getting Rust stdlib
         """)
     }

--- a/src/test/kotlin/org/rust/common.kt
+++ b/src/test/kotlin/org/rust/common.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.ui.TestDialog
 import com.intellij.openapi.ui.TestDialogManager
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.registry.RegistryValue
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiReference
@@ -237,4 +238,10 @@ fun setExperimentalFeatureEnabled(featureId: String, enabled: Boolean, disposabl
     val oldValue = isFeatureEnabled(featureId)
     setFeatureEnabled(featureId, enabled)
     Disposer.register(disposable) { setFeatureEnabled(featureId, oldValue) }
+}
+
+fun setRegistryOptionEnabled(registryValue: RegistryValue, enabled: Boolean, disposable: Disposable) {
+    val oldValue = registryValue.asBoolean()
+    registryValue.setValue(enabled)
+    Disposer.register(disposable) { registryValue.setValue(oldValue) }
 }


### PR DESCRIPTION
Previously, the plugin passed `RUSTC_BOOTSTRAP=1` only if its own native helper binary was used that broke evaluation with stable toolchain when native helper wasn't used (for example, because it wasn't found for some reason)

Now it properly set `RUSTC_BOOTSTRAP` variable regardless usage of native helper

Currently, I know two options how to reproduce initial issue:
- turn off `org.rust.cargo.evaluate.build.scripts.wrapper` registry option manually (artificial way)
- use the plugin on the platform where we don't have native helper binary. For example, Windows ARM

changelog: Don't fail build script evaluation without native helper binary
