### PR TITLE
INSP: fix false-positive `trait bound is not satisfied E0277`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -956,7 +956,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         for (bound in supertraits) {
             val requiredTrait = bound.traitRef ?: continue
             val boundTrait = requiredTrait.resolveToBoundTrait() ?: continue
-            val locallyBoundTrait = boundTrait.substitute(substitution)
+            val locallyBoundTrait = lookup.ctx.fullyNormalizeAssociatedTypesIn(boundTrait.substitute(substitution))
             if (locallyBoundTrait.containsTyOfClass(TyUnknown::class.java)) continue
 
             val canSelect = lookup.canSelect(TraitRef(type, locallyBoundTrait))

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -378,12 +378,7 @@ fun pathPsiSubst(
                 val selfTy = when (possibleTypeParamOrWherePred) {
                     is RsWherePred -> possibleTypeParamOrWherePred.typeReference?.rawType ?: TyUnknown
                     is RsTypeParameter -> possibleTypeParamOrWherePred.declaredType
-                    // TODO fix it properly and replace to `else -> null`
-                    else -> if ((parent as? RsTraitRef)?.parent is RsBound) {
-                        TyUnknown
-                    } else {
-                        null
-                    }
+                    else -> null
                 }
                 TypeDefault(defaultTy, selfTy)
             }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1813,6 +1813,19 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl<T: Eq> Eq for Box<T> {}
     """)
 
+    // Issue // https://github.com/intellij-rust/intellij-rust/issues/8786
+    fun `test no E0277 when Self-related associated type is mentioned in the parent trait`() = checkErrors("""
+        struct S;
+        trait Foo<T> {}
+        impl Foo<S> for S {}
+        trait Bar: Foo<Self::Foo> {
+            type Foo;
+        }
+        impl Bar for S {
+            type Foo = S;
+        }
+    """)
+
     @MockRustcVersion("1.27.1")
     fun `test crate visibility feature E0658`() = checkErrors("""
         <error descr="`crate` visibility modifier is experimental [E0658]">crate</error> struct Foo;


### PR DESCRIPTION
Fixes #8786, fixes 9162

changelog: Fix false-positive `trait bound is not satisfied E0277`. Can be merged with #9598 point