### PR TITLE
INT: Support intention preview

### DIFF
--- a/src/222/main/kotlin/org/rust/lang/core/psi/ext/IntentionPreview.kt
+++ b/src/222/main/kotlin/org/rust/lang/core/psi/ext/IntentionPreview.kt
@@ -1,0 +1,10 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import com.intellij.psi.PsiElement
+
+val PsiElement.isIntentionPreviewElement: Boolean get() = false

--- a/src/222/test/kotlin/org/rust/ide/intentions/RsIntentionTestPlatformBase.kt
+++ b/src/222/test/kotlin/org/rust/ide/intentions/RsIntentionTestPlatformBase.kt
@@ -9,7 +9,7 @@ import com.intellij.codeInsight.intention.IntentionAction
 import org.rust.RsTestBase
 
 abstract class RsIntentionTestPlatformBase : RsTestBase() {
-    protected fun checkPreviewAndLaunchAction(intention: IntentionAction) {
+    protected fun checkPreviewAndLaunchAction(intention: IntentionAction, preview: String?) {
         myFixture.launchAction(intention)
     }
 }

--- a/src/222/test/kotlin/org/rust/ide/intentions/RsIntentionTestPlatformBase.kt
+++ b/src/222/test/kotlin/org/rust/ide/intentions/RsIntentionTestPlatformBase.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.codeInsight.intention.IntentionAction
+import org.rust.RsTestBase
+
+abstract class RsIntentionTestPlatformBase : RsTestBase() {
+    protected fun checkPreviewAndLaunchAction(intention: IntentionAction) {
+        myFixture.launchAction(intention)
+    }
+}

--- a/src/223/main/kotlin/org/rust/lang/core/psi/ext/IntentionPreview.kt
+++ b/src/223/main/kotlin/org/rust/lang/core/psi/ext/IntentionPreview.kt
@@ -1,0 +1,12 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import com.intellij.codeInsight.intention.preview.IntentionPreviewUtils
+import com.intellij.psi.PsiElement
+
+// BACKCOMPAT: 2022.2. Move to `src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt`
+val PsiElement.isIntentionPreviewElement: Boolean get() = IntentionPreviewUtils.isPreviewElement(this)

--- a/src/223/test/kotlin/org/rust/ide/intentions/RsIntentionTestPlatformBase.kt
+++ b/src/223/test/kotlin/org/rust/ide/intentions/RsIntentionTestPlatformBase.kt
@@ -1,0 +1,16 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.codeInsight.intention.IntentionAction
+import org.rust.RsTestBase
+
+// BACKCOMPAT: 2022.2. Merge into `RsIntentionTestBase`
+abstract class RsIntentionTestPlatformBase : RsTestBase() {
+    protected fun checkPreviewAndLaunchAction(intention: IntentionAction) {
+        myFixture.checkPreviewAndLaunchAction(intention)
+    }
+}

--- a/src/223/test/kotlin/org/rust/ide/intentions/RsIntentionTestPlatformBase.kt
+++ b/src/223/test/kotlin/org/rust/ide/intentions/RsIntentionTestPlatformBase.kt
@@ -10,7 +10,14 @@ import org.rust.RsTestBase
 
 // BACKCOMPAT: 2022.2. Merge into `RsIntentionTestBase`
 abstract class RsIntentionTestPlatformBase : RsTestBase() {
-    protected fun checkPreviewAndLaunchAction(intention: IntentionAction) {
-        myFixture.checkPreviewAndLaunchAction(intention)
+    protected fun checkPreviewAndLaunchAction(intention: IntentionAction, preview: String?) {
+        val text = myFixture.getIntentionPreviewText(intention)
+        check(text != null) { "No preview for intention ${intention.text}" }
+        myFixture.launchAction(intention)
+        assertEquals(
+            "Intention ${intention.text} produced different result when invoked in preview mode",
+            preview ?: myFixture.file.text,
+            text
+        )
     }
 }

--- a/src/main/kotlin/org/rust/ide/intentions/AddImplTraitIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImplTraitIntention.kt
@@ -6,12 +6,14 @@
 package org.rust.ide.intentions
 
 import com.intellij.codeInsight.CodeInsightUtilCore
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.codeInsight.template.impl.MacroCallNode
 import com.intellij.codeInsight.template.macro.CompleteMacro
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPsiElementPointer
 import org.rust.ide.inspections.fixes.insertGenericArgumentsIfNeeded
 import org.rust.ide.refactoring.implementMembers.generateMissingTraitMembers
@@ -105,4 +107,8 @@ class AddImplTraitIntention : RsElementBaseIntentionAction<AddImplTraitIntention
             tmp.runInline()
         }
     }
+
+    // No intention preview because user has to choose trait manually
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
 }

--- a/src/main/kotlin/org/rust/ide/intentions/AddImportIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImportIntention.kt
@@ -5,9 +5,11 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.parentOfType
@@ -67,6 +69,9 @@ class AddImportIntention : RsElementBaseIntentionAction<AddImportIntention.Conte
             pathReference.shorten(target)
         }
     }
+
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
 }
 
 /**

--- a/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-import com.intellij.codeInsight.intention.FileModifier
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
@@ -22,9 +22,6 @@ import org.rust.openapiext.Testmark
 class ExtractInlineModuleIntention : RsElementBaseIntentionAction<RsModItem>() {
     override fun getFamilyName() = "Extract inline module structure"
     override fun getText() = "Extract inline module"
-
-    // No intention preview because it creates new file
-    override fun getFileModifierForPreview(target: PsiFile): FileModifier? = null
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsModItem? {
         val mod = element.ancestorOrSelf<RsModItem>() ?: return null
@@ -51,6 +48,10 @@ class ExtractInlineModuleIntention : RsElementBaseIntentionAction<RsModItem>() {
 
         ctx.delete()
     }
+
+    // No intention preview because it creates new file
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
 
     object Testmarks {
         object CopyAttrs : Testmark()

--- a/src/main/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntention.kt
@@ -13,10 +13,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.elementType
 import org.rust.ide.utils.template.newTemplateBuilder
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.descendantsOfType
-import org.rust.lang.core.psi.ext.getNextNonWhitespaceSibling
-import org.rust.lang.core.psi.ext.getPrevNonWhitespaceSibling
+import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.Testmark
 import org.rust.openapiext.createSmartPointer
 
@@ -39,6 +36,7 @@ class ImplTraitToTypeParamIntention : RsElementBaseIntentionAction<ImplTraitToTy
         // will appear in type parameter constrains which is invalid
         if (argType.descendantsOfType<RsTraitType>().any { it.impl != null }) {
             OuterImplTestMark.hit()
+            if (fnSignature.isIntentionPreviewElement) return
             HintManager.getInstance().showErrorHint(
                 editor,
                 "Please convert innermost `impl Trait` first",

--- a/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
@@ -5,9 +5,11 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import org.rust.ide.refactoring.introduceVariable.extractExpression
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestors
@@ -39,4 +41,7 @@ class IntroduceLocalVariableIntention : RsElementBaseIntentionAction<RsExpr>() {
     override fun invoke(project: Project, editor: Editor, ctx: RsExpr) {
         extractExpression(editor, ctx, postfixLet = false)
     }
+
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
 }

--- a/src/main/kotlin/org/rust/ide/intentions/RsElementBaseIntentionAction.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RsElementBaseIntentionAction.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.intention.BaseElementAtCaretIntentionAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.ext.isIntentionPreviewElement
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.checkWriteAccessAllowed
 
@@ -42,7 +43,7 @@ abstract class RsElementBaseIntentionAction<Ctx> : BaseElementAtCaretIntentionAc
     final override fun invoke(project: Project, editor: Editor, element: PsiElement) {
         val ctx = findApplicableContext(project, editor, element) ?: return
 
-        if (startInWriteAction()) {
+        if (startInWriteAction() && !element.isIntentionPreviewElement) {
             checkWriteAccessAllowed()
         }
 

--- a/src/main/kotlin/org/rust/ide/intentions/ToggleFeatureIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ToggleFeatureIntention.kt
@@ -5,8 +5,8 @@
 
 package org.rust.ide.intentions
 
-import com.intellij.codeInsight.intention.FileModifier
 import com.intellij.codeInsight.intention.HighPriorityAction
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
@@ -22,9 +22,6 @@ class ToggleFeatureIntention : RsElementBaseIntentionAction<ToggleFeatureIntenti
     data class Context(val featureName: String, val element: RsElement)
 
     override fun getFamilyName() = RsBundle.message("intention.Rust.ToggleFeatureIntention.family.name")
-
-    // No intention preview because it doesn't modify any code
-    override fun getFileModifierForPreview(target: PsiFile): FileModifier? = null
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val featureMetaItem = element.ancestorOrSelf<RsMetaItem>()
@@ -53,7 +50,12 @@ class ToggleFeatureIntention : RsElementBaseIntentionAction<ToggleFeatureIntenti
         val state = pkg.featureState[ctx.featureName] ?: return
         project.cargoProjects.modifyFeatures(cargoProject, setOf(feature), !state)
     }
+
+    // No intention preview because it doesn't modify any code
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
 }
+
 private fun isFeatureEnabled(element: RsElement, name: String): Boolean? {
     val pkg = element.containingCargoPackage ?: return null
     if (pkg.origin != PackageOrigin.WORKSPACE) return null

--- a/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
@@ -75,12 +75,13 @@ class UnElideLifetimesIntention : RsElementBaseIntentionAction<LifetimeContext>(
         }
     }
 
-    private val nameGenerator = generateSequence(0) { it + 1 }.map {
-        val abcSize = 'z' - 'a' + 1
-        val letter = 'a' + it % abcSize
-        val index = it / abcSize
-        return@map if (index == 0) "'$letter" else "'$letter$index"
-    }
+    private val nameGenerator: Sequence<String>
+        get() = generateSequence(0) { it + 1 }.map {
+            val abcSize = 'z' - 'a' + 1
+            val letter = 'a' + it % abcSize
+            val index = it / abcSize
+            return@map if (index == 0) "'$letter" else "'$letter$index"
+        }
 
     data class LifetimeContext(
         val fn: RsFunction,

--- a/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
@@ -6,9 +6,11 @@
 package org.rust.ide.intentions.addFmtStringArgument
 
 import com.google.common.annotations.VisibleForTesting
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.lang.core.macros.expansionContext
 import org.rust.lang.core.macros.isExprOrStmtContext
@@ -24,6 +26,9 @@ import org.rust.openapiext.runWriteCommandAction
 class AddFmtStringArgumentIntention : RsElementBaseIntentionAction<AddFmtStringArgumentIntention.Context>() {
     override fun getText(): String = "Add format string argument"
     override fun getFamilyName(): String = text
+
+    override fun startInWriteAction(): Boolean = false
+    override fun getElementToMakeWritable(currentFile: PsiFile): PsiFile = currentFile
 
     class Context(val literal: RsLitExpr, val macroCall: RsMacroCall)
 
@@ -113,6 +118,9 @@ class AddFmtStringArgumentIntention : RsElementBaseIntentionAction<AddFmtStringA
             editor.caretModel.moveToOffset(editor.caretModel.offset + newPlaceholder.length)
         }
     }
+
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
 
     companion object {
         private val FORMAT_MACROS: Set<String> =

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
@@ -5,9 +5,11 @@
 
 package org.rust.ide.intentions.createFromUsage
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.util.parentOfType
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.intentions.RsElementBaseIntentionAction
@@ -281,4 +283,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
         )
         return item.parent.addAfter(newImpl, item) as RsImplItem
     }
+
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
 }

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
@@ -5,10 +5,12 @@
 
 package org.rust.ide.intentions.createFromUsage
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.util.parentOfType
 import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.ide.presentation.renderInsertionSafe
@@ -99,4 +101,7 @@ class CreateStructIntention : RsElementBaseIntentionAction<CreateStructIntention
 
         return factory.tryCreateStruct("${visibility}struct ${ctx.name}$suffix")
     }
+
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
 }

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateTupleStructIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateTupleStructIntention.kt
@@ -5,10 +5,12 @@
 
 package org.rust.ide.intentions.createFromUsage
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.util.parentOfType
 import org.rust.ide.inspections.lints.isCamelCase
 import org.rust.ide.intentions.RsElementBaseIntentionAction
@@ -80,4 +82,7 @@ class CreateTupleStructIntention : RsElementBaseIntentionAction<CreateTupleStruc
         }
         return factory.tryCreateStruct("${visibility}struct ${ctx.name}($fields);")
     }
+
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
 }

--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -25,6 +25,10 @@ import org.rust.stdext.isSortedWith
 fun ImportCandidate.import(context: RsElement) = info.import(context)
 
 fun ImportInfo.import(context: RsElement) {
+    // Imports are not very important for most intention preview,
+    // but would be nice to support it for `AddImportIntention`
+    if (context.isIntentionPreviewElement) return
+
     checkWriteAccessAllowed()
     val psiFactory = RsPsiFactory(context.project)
 

--- a/src/main/kotlin/org/rust/ide/utils/template/EditorExt.kt
+++ b/src/main/kotlin/org/rust/ide/utils/template/EditorExt.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.psi.impl.source.tree.injected.InjectedLanguageEditorUtil
+import org.rust.lang.core.psi.ext.isIntentionPreviewElement
 import org.rust.openapiext.checkWriteAccessAllowed
 
 fun Editor.buildAndRunTemplate(
@@ -20,7 +21,9 @@ fun Editor.buildAndRunTemplate(
     elementsToReplace: List<SmartPsiElementPointer<out PsiElement>>,
     listener: TemplateEditingListener? = null,
 ) {
-    checkWriteAccessAllowed()
+    if (!owner.isIntentionPreviewElement) {
+        checkWriteAccessAllowed()
+    }
     val tbl = newTemplateBuilder(owner) ?: return
     for (elementPointer in elementsToReplace) {
         val element = elementPointer.element ?: continue

--- a/src/test/kotlin/org/rust/ide/intentions/AddFmtStringArgumentIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddFmtStringArgumentIntentionTest.kt
@@ -9,6 +9,9 @@ import org.intellij.lang.annotations.Language
 import org.rust.ide.intentions.addFmtStringArgument.AddFmtStringArgumentIntention
 
 class AddFmtStringArgumentIntentionTest : RsIntentionTestBase(AddFmtStringArgumentIntention::class) {
+
+    override val previewExpected: Boolean get() = false
+
     fun `test no args`() = doTest("""
         fn main() {
             println!("x = /*caret*/");

--- a/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
@@ -6,6 +6,9 @@
 package org.rust.ide.intentions
 
 class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::class) {
+
+    override val previewExpected: Boolean get() = false
+
     fun `test empty trait`() = doAvailableTestWithLiveTemplate("""
         trait Foo {}
 

--- a/src/test/kotlin/org/rust/ide/intentions/AddImportIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImportIntentionTest.kt
@@ -6,6 +6,9 @@
 package org.rust.ide.intentions
 
 class AddImportIntentionTest : RsIntentionTestBase(AddImportIntention::class) {
+
+    override val previewExpected: Boolean get() = false
+
     fun `test not available in use statements`() = doUnavailableTest("""
         mod foo {
             pub struct Foo;

--- a/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
@@ -170,6 +170,23 @@ class AddRemainingArmsIntentionTest : RsIntentionTestBase(AddRemainingArmsIntent
                 Alias::Bar => {}
             }
         }
+    """, preview = """
+        mod foo {
+            pub enum Enum {
+                Foo,
+                Bar
+            }
+            pub type Alias = Enum;
+
+            pub fn bar() -> Alias { Enum::Foo }
+        }
+
+        fn bar() {
+            match foo::bar() {
+                Alias::Foo => {}
+                Alias::Bar => {}
+            }
+        }
     """)
 
     fun `test match aliased enum by alias`() = doAvailableTest("""

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntentionTest.kt
@@ -288,6 +288,17 @@ class ConvertMethodCallToUFCSIntentionTest : RsIntentionTestBase(ConvertMethodCa
         fn bar(a: foo::Foo) {
             Foo::bar(&a);
         }
+    """, preview = """
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                pub fn bar(&self) {}
+            }
+        }
+
+        fn bar(a: foo::Foo) {
+            Foo::bar(&a);
+        }
     """)
 
     fun `test generic trait`() = doAvailableTest("""
@@ -462,6 +473,19 @@ class ConvertMethodCallToUFCSIntentionTest : RsIntentionTestBase(ConvertMethodCa
     """, """
         use crate::foo::Bar;
 
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                pub fn foo(self) {}
+            }
+
+            pub type Bar = Foo;
+        }
+
+        fn bar(x: foo::Bar) {
+            Bar::foo(x);
+        }
+    """, preview = """
         mod foo {
             pub struct Foo;
             impl Foo {

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -10,6 +10,9 @@ import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.intentions.createFromUsage.CreateFunctionIntention
 
 class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention::class) {
+
+    override val previewExpected: Boolean get() = false
+
     fun `test function availability range`() = checkAvailableInSelectionOnly("""
         fn main() {
             <selection>foo</selection>(bar::baz);

--- a/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
@@ -8,6 +8,9 @@ package org.rust.ide.intentions
 import org.rust.ide.intentions.createFromUsage.CreateStructIntention
 
 class CreateStructIntentionTest : RsIntentionTestBase(CreateStructIntention::class) {
+
+    override val previewExpected: Boolean get() = false
+
     fun `test struct availability range`() = checkAvailableInSelectionOnly("""
         fn main() {
             <selection>Foo</selection> { a: 0 };

--- a/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
@@ -8,6 +8,9 @@ package org.rust.ide.intentions
 import org.rust.ide.intentions.createFromUsage.CreateTupleStructIntention
 
 class CreateTupleStructIntentionTest : RsIntentionTestBase(CreateTupleStructIntention::class) {
+
+    override val previewExpected: Boolean get() = false
+
     fun `test tuple struct availability range`() = checkAvailableInSelectionOnly("""
         fn main() {
             <selection>Foo</selection>(0);

--- a/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
@@ -343,6 +343,17 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention::class
         fn main() {
             let S {} = foo();
         }
+    """, preview = """
+        use crate::a::foo;
+
+        mod a {
+            pub struct S;
+            pub fn foo() -> S { S }
+        }
+
+        fn main() {
+            let S {} = foo();
+        }
     """)
 
     fun `test import unresolved type alias`() = doAvailableTest("""
@@ -359,6 +370,18 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention::class
         }
     """, """
         use crate::a::{foo, R};
+
+        mod a {
+            pub struct S;
+            pub type R = S;
+            pub fn foo() -> R { S }
+        }
+
+        fn main() {
+            let R {} = foo();
+        }
+    """, preview = """
+        use crate::a::foo;
 
         mod a {
             pub struct S;

--- a/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
@@ -11,6 +11,7 @@ import org.rust.fileTree
 
 class ExtractInlineModuleIntentionTest : RsIntentionTestBase(ExtractInlineModuleIntention::class) {
     override val dataPath = "org/rust/ide/intentions/fixtures/"
+    override val previewExpected: Boolean get() = false
 
     fun `test availability range`() = checkAvailableInSelectionOnly("""
         #[attr]

--- a/src/test/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntentionTest.kt
@@ -11,6 +11,9 @@ package org.rust.ide.intentions
  * [org.rust.ide.refactoring.RsIntroduceVariableHandlerTest] are also applicable.
  */
 class IntroduceLocalVariableIntentionTest : RsIntentionTestBase(IntroduceLocalVariableIntention::class) {
+
+    override val previewExpected: Boolean get() = false
+
     fun `test unavailable if there is a variable`() = doUnavailableTest("""
         fn main() {
             let a = /*caret*/foo();

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -43,10 +43,11 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
     protected fun doAvailableTest(
         @Language("Rust") before: String,
         @Language("Rust") after: String,
+        @Language("Rust") preview: String? = null,
         fileName: String = "main.rs"
     ) {
         InlineFile(before.trimIndent(), fileName).withCaret()
-        launchAction()
+        launchAction(preview?.trimIndent())
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }
 
@@ -92,13 +93,14 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
         fileTreeFromText(replaceCaretMarker(fileStructureAfter)).check(myFixture)
     }
 
-    protected fun launchAction() {
+    protected fun launchAction(@Language("Rust") preview: String? = null) {
         UIUtil.dispatchAllInvocationEvents()
         // Check preview only for intentions from Rust plugin
         if (intentionClass.isSubclassOf(RsElementBaseIntentionAction::class)) {
             if (previewExpected) {
-                checkPreviewAndLaunchAction(intention)
+                checkPreviewAndLaunchAction(intention, preview)
             } else {
+                val intention = intention
                 val previewInfo = IntentionPreviewPopupUpdateProcessor.getPreviewInfo(project, intention, myFixture.file, myFixture.editor)
                 assertEquals(IntentionPreviewInfo.EMPTY, previewInfo)
                 myFixture.launchAction(intention)

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -24,7 +24,7 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
     protected val intention: IntentionAction
         get() = findIntention() ?: error("Failed to find `${intentionClass.simpleName}` intention")
 
-    protected open val previewExpected: Boolean get() = true
+    protected open val previewExpected: Boolean get() = intention.startInWriteAction()
 
     fun `test intention has documentation`() {
         if (!intentionClass.isSubclassOf(RsElementBaseIntentionAction::class)) return

--- a/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
@@ -101,19 +101,26 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
     """)
 
     fun `test import unresolved type`() = doAvailableTest("""
-            use crate::a::foo;
-            mod a {
-                pub struct S;
-                pub fn foo() -> S { S }
-            }
-            fn main() { let var/*caret*/ = foo(); }
+        use crate::a::foo;
+        mod a {
+            pub struct S;
+            pub fn foo() -> S { S }
+        }
+        fn main() { let var/*caret*/ = foo(); }
     """, """
-            use crate::a::{foo, S};
-            mod a {
-                pub struct S;
-                pub fn foo() -> S { S }
-            }
-            fn main() { let var: S = foo(); }
+        use crate::a::{foo, S};
+        mod a {
+            pub struct S;
+            pub fn foo() -> S { S }
+        }
+        fn main() { let var: S = foo(); }
+    """, preview = """
+        use crate::a::foo;
+        mod a {
+            pub struct S;
+            pub fn foo() -> S { S }
+        }
+        fn main() { let var: S = foo(); }
     """)
 
     fun `test try import unresolved type`() = doAvailableTest("""
@@ -148,64 +155,97 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
                 pub fn foo() -> S<P> { S(P) }
             }
             fn main() { let var: S<P> = foo(); }
+    """, preview = """
+            use crate::a::foo;
+            mod a {
+                pub struct S<T>(T);
+                pub struct P;
+                pub fn foo() -> S<P> { S(P) }
+            }
+            fn main() { let var: S<P> = foo(); }
     """)
 
     fun `test import type alias`() = doAvailableTest("""
-            use crate::a::{foo, A};
-            mod a {
-                pub struct S;
-                pub type A = S;
-                pub type B = A;
-                pub fn foo() -> B { S }
-            }
-            fn main() { let var/*caret*/ = foo(); }
+        use crate::a::{foo, A};
+        mod a {
+            pub struct S;
+            pub type A = S;
+            pub type B = A;
+            pub fn foo() -> B { S }
+        }
+        fn main() { let var/*caret*/ = foo(); }
     """, """
-            use crate::a::{foo, A, B};
-            mod a {
-                pub struct S;
-                pub type A = S;
-                pub type B = A;
-                pub fn foo() -> B { S }
-            }
-            fn main() { let var: B = foo(); }
+        use crate::a::{foo, A, B};
+        mod a {
+            pub struct S;
+            pub type A = S;
+            pub type B = A;
+            pub fn foo() -> B { S }
+        }
+        fn main() { let var: B = foo(); }
+    """, preview = """
+        use crate::a::{foo, A};
+        mod a {
+            pub struct S;
+            pub type A = S;
+            pub type B = A;
+            pub fn foo() -> B { S }
+        }
+        fn main() { let var: B = foo(); }
     """)
 
     fun `test import skip default type argument`() = doAvailableTest("""
-            use crate::a::foo;
-            mod a {
-                pub struct R;
-                pub struct S<T = R>(T);
-                pub fn foo() -> S<R> { S(R) }
-            }
-            fn main() { let var/*caret*/ = foo(); }
+        use crate::a::foo;
+        mod a {
+            pub struct R;
+            pub struct S<T = R>(T);
+            pub fn foo() -> S<R> { S(R) }
+        }
+        fn main() { let var/*caret*/ = foo(); }
     """, """
-            use crate::a::{foo, S};
-            mod a {
-                pub struct R;
-                pub struct S<T = R>(T);
-                pub fn foo() -> S<R> { S(R) }
-            }
-            fn main() { let var: S = foo(); }
+        use crate::a::{foo, S};
+        mod a {
+            pub struct R;
+            pub struct S<T = R>(T);
+            pub fn foo() -> S<R> { S(R) }
+        }
+        fn main() { let var: S = foo(); }
+    """, preview = """
+        use crate::a::foo;
+        mod a {
+            pub struct R;
+            pub struct S<T = R>(T);
+            pub fn foo() -> S<R> { S(R) }
+        }
+        fn main() { let var: S = foo(); }
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test import std type`() = doAvailableTest("""
-            use a::foo;
+        use a::foo;
 
-            mod a {
-                use std::collections::HashMap;
-                pub fn foo() -> HashMap<i32, i32> { HashMap::new() }
-            }
-            fn main() { let var/*caret*/ = foo(); }
-    """, """
+        mod a {
             use std::collections::HashMap;
-            use a::foo;
+            pub fn foo() -> HashMap<i32, i32> { HashMap::new() }
+        }
+        fn main() { let var/*caret*/ = foo(); }
+    """, """
+        use std::collections::HashMap;
+        use a::foo;
 
-            mod a {
-                use std::collections::HashMap;
-                pub fn foo() -> HashMap<i32, i32> { HashMap::new() }
-            }
-            fn main() { let var: HashMap<i32, i32> = foo(); }
+        mod a {
+            use std::collections::HashMap;
+            pub fn foo() -> HashMap<i32, i32> { HashMap::new() }
+        }
+        fn main() { let var: HashMap<i32, i32> = foo(); }
+    """, preview = """
+        use a::foo;
+
+        mod a {
+            use std::collections::HashMap;
+            pub fn foo() -> HashMap<i32, i32> { HashMap::new() }
+        }
+        fn main() { let var: HashMap<i32, i32> = foo(); }
     """)
 
     fun `test ref pat`() = doAvailableTest(

--- a/src/test/kotlin/org/rust/ide/intentions/SubstituteTypeAliasIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SubstituteTypeAliasIntentionTest.kt
@@ -219,6 +219,16 @@ class SubstituteTypeAliasIntentionTest : RsIntentionTestBase(SubstituteTypeAlias
         fn foo<T: foo::Trait>() -> S {
             unimplemented!()
         }
+    """, preview = """
+        mod foo {
+            pub struct S;
+            pub trait Trait {
+                type Item = S;
+            }
+        }
+        fn foo<T: foo::Trait>() -> S {
+            unimplemented!()
+        }
     """)
 
     fun `test substitute type alias`() = doAvailableTest("""

--- a/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
@@ -14,6 +14,9 @@ import org.rust.singleProject
 import org.rust.workspaceOrFail
 
 class ToggleFeatureIntentionTest : RsIntentionTestBase(ToggleFeatureIntention::class) {
+
+    override val previewExpected: Boolean get() = false
+
     @MockCargoFeatures("foo")
     fun `test availability range`() = checkAvailableInSelectionOnly("""
         #[cfg(<selection>feature = "foo"</selection>)]

--- a/toml/src/main/kotlin/org/rust/toml/Util.kt
+++ b/toml/src/main/kotlin/org/rust/toml/Util.kt
@@ -49,7 +49,7 @@ private inline fun <reified T : Any> load(): String = T::class.java.name
 @Suppress("unused")
 private fun load(p: KProperty<*>): String = p.name
 
-val PsiFile.isCargoToml: Boolean get() = virtualFile?.name == CargoConstants.MANIFEST_FILE
+val PsiFile.isCargoToml: Boolean get() = name == CargoConstants.MANIFEST_FILE
 
 val TomlKeySegment.isDependencyKey: Boolean
     get() {

--- a/toml/src/main/kotlin/org/rust/toml/intentions/ExpandDependencySpecificationIntention.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/ExpandDependencySpecificationIntention.kt
@@ -9,8 +9,8 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.parentOfType
-import org.rust.cargo.CargoConstants
 import org.rust.lang.core.psi.ext.endOffset
+import org.rust.toml.isCargoToml
 import org.rust.toml.isDependencyListHeader
 import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlLiteral
@@ -24,7 +24,7 @@ class ExpandDependencySpecificationIntention : RsTomlElementBaseIntentionAction<
     override fun getFamilyName(): String = text
 
     override fun findApplicableContextInternal(project: Project, editor: Editor, element: PsiElement): TomlKeyValue? {
-        if (element.containingFile.name != CargoConstants.MANIFEST_FILE) return null
+        if (!element.containingFile.isCargoToml) return null
 
         val keyValue = element.parentOfType<TomlKeyValue>() ?: return null
         val table = keyValue.parent as? TomlTable ?: return null

--- a/toml/src/test/kotlin/org/rust/toml/intentions/CargoTomlIntentionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/intentions/CargoTomlIntentionTestBase.kt
@@ -14,7 +14,7 @@ abstract class CargoTomlIntentionTestBase(intentionClass: KClass<out IntentionAc
     protected fun doAvailableTest(
         @Language("TOML") before: String,
         @Language("TOML") after: String
-    ) = doAvailableTest(before, after, "Cargo.toml")
+    ) = doAvailableTest(before, after, fileName = "Cargo.toml")
 
     protected fun doUnavailableTest(@Language("TOML") before: String) =
         doUnavailableTest(before, "Cargo.toml")


### PR DESCRIPTION
I removed `checkWriteAccessAllowed` in `RsElementBaseIntentionAction` when intention is running in preview mode, so the preview can be generated correctly, and then checked all our intentions and disabled preview generation for intentions which are not intended to have a preview or are hard to support (so they should be handled in separate PRs).

Fixes #9431
Fixes #9450
Meta: #9561

---

Intentions which are not intended to have a preview:
- AddImplTraitIntention - user has to choose trait manually
- ConvertToStructIntention, ConvertToTupleIntention - shows dialog
- AddFmtStringArgumentIntention - shows popup

Intentions for which preview may be added in future:
- CreateFunctionIntention, CreateStructIntention, CreateTupleStructIntention
- AddImportForPatternIntention when one candidate
- AddImportIntention
- IntroduceLocalVariableIntention

changelog: Support [Intention preview](https://blog.jetbrains.com/idea/2022/09/intellij-idea-2022-3-eap/#Intention_action_preview_enabled_by_default) in 2022.3