### PR TITLE
CI: use new syntax to put value into outputs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,9 +34,9 @@ jobs:
             - name: Calculate git info
               id: calculate-git-info
               run: |
-                  echo "::set-output name=is_bors_branch::${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/trying' }}"
-                  echo "::set-output name=is_master_branch::${{ github.ref == 'refs/heads/master'}}"
-                  echo "::set-output name=checked::$(python scripts/has_successful_status.py --token ${{ github.token }} --ref ${{ github.sha }} --check_name check)"
+                  echo "is_bors_branch=${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/trying' }}" >> $GITHUB_OUTPUT
+                  echo "is_master_branch=${{ github.ref == 'refs/heads/master'}}" >> $GITHUB_OUTPUT
+                  echo "checked=$(python scripts/has_successful_status.py --token ${{ github.token }} --ref ${{ github.sha }} --check_name check)" >> $GITHUB_OUTPUT
 
             - name: Check git info
               run: |

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -34,7 +34,7 @@ jobs:
 
             - name: Emit base commit
               id: base-commit
-              run: echo "::set-output name=base-commit::$BASE_COMMIT"
+              run: echo "base-commit=$BASE_COMMIT" >> $GITHUB_OUTPUT
 
             - name: Show commits
               run: |

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Check date
               if: github.event_name == 'schedule'
               id: check-date
-              run: echo "::set-output name=result::$(python scripts/check_release_branch_date.py)"
+              run: echo "result=$(python scripts/check_release_branch_date.py)" >> $GITHUB_OUTPUT
 
             - name: Make release branch
               if: github.event_name != 'schedule' || fromJSON(steps.check-date.outputs.result).create_release_branch

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -32,8 +32,8 @@ jobs:
             - name: Fetch latest commits
               id: fetch-commits
               run: |
-                  echo "::set-output name=rust-commit::$(git log -n 1 --format=format:%H)"
-                  echo "::set-output name=rust-nightly::$(python scripts/get_tag_commit.py --tag "rust-nightly")"
+                  echo "rust-commit=$(git log -n 1 --format=format:%H)" >> $GITHUB_OUTPUT
+                  echo "rust-nightly=$(python scripts/get_tag_commit.py --tag "rust-nightly")" >> $GITHUB_OUTPUT
 
             - name: Show commits
               run: |

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -37,7 +37,7 @@ jobs:
             - id: get-release-branch
               run: |
                   branch=$(python scripts/get_release_branch.py)
-                  echo "::set-output name=release-branch::$branch"
+                  echo "release-branch=$branch" >> $GITHUB_OUTPUT
 
     update-changelog-link:
         runs-on: ubuntu-latest
@@ -67,9 +67,9 @@ jobs:
               run: |
                 if ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'stable' }}
                 then
-                  echo "::set-output name=channel::stable"
+                  echo "channel=stable" >> $GITHUB_OUTPUT
                 else
-                  echo "::set-output name=channel::beta"
+                  echo "channel=beta" >> $GITHUB_OUTPUT
                 fi
 
     fetch-latest-changes:
@@ -88,8 +88,8 @@ jobs:
             - name: Fetch latest commits
               id: fetch-commits
               run: |
-                  echo "::set-output name=rust-commit::$(git log -n 1 --format=format:%H)"
-                  echo "::set-output name=rust-release::$(python scripts/get_tag_commit.py --tag "rust-${{ needs.get-channel.outputs.channel }}")"
+                  echo "rust-commit=$(git log -n 1 --format=format:%H)" >> $GITHUB_OUTPUT
+                  echo "rust-release=$(python scripts/get_tag_commit.py --tag "rust-${{ needs.get-channel.outputs.channel }}")" >> $GITHUB_OUTPUT
 
             - name: Show commits
               run: |


### PR DESCRIPTION
`::set-output` command is deprecated now. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for details