### PR TITLE
DBG: Enable native Rust support in MSVC LLDB in 2022.3 builds

### DIFF
--- a/src/222/main/resources/META-INF/platform-rust-core.xml
+++ b/src/222/main/resources/META-INF/platform-rust-core.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <registryKey key="org.rust.debugger.lldb.rust.msvc" defaultValue="false" restartRequired="false"
+                     description="Enable Rust MSVC support in LLDB (Windows-only)"/>
+    </extensions>
+</idea-plugin>

--- a/src/223/main/resources/META-INF/platform-rust-core.xml
+++ b/src/223/main/resources/META-INF/platform-rust-core.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <registryKey key="org.rust.debugger.lldb.rust.msvc" defaultValue="true" restartRequired="false"
+                     description="Enable Rust MSVC support in LLDB (Windows-only)"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -4,6 +4,7 @@
     <depends>com.intellij.modules.lang</depends>
 
     <xi:include href="/META-INF/experiments.xml" xpointer="xpointer(/idea-plugin/*)"/>
+    <xi:include href="/META-INF/platform-rust-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Rust -->
@@ -1214,8 +1215,6 @@
                      description="The maximum time (in milliseconds) allotted to one procedural macro expansion"/>
         <registryKey key="org.rust.external.linter.max.duration" defaultValue="3000" restartRequired="false"
                      description="Show notification warning if the external linter is running longer than the set value (ms)"/>
-        <registryKey key="org.rust.debugger.lldb.rust.msvc" defaultValue="false" restartRequired="false"
-                     description="Enable Rust MSVC support in LLDB (Windows-only)"/>
         <registryKey key="org.rust.cargo.new.auto.import"
                      defaultValue="true"
                      description="Enable new Cargo project model reloading"


### PR DESCRIPTION
Part of #5632.

MSVC LLDB bundled with 2022.2.2+ builds includes several fixes that make the native Rust support more stable. Since the plugin still supports earlier 222 builds (such as 2022.2.1), this commit only enables it by default in 223 builds.

In general, the native Rust support in MSVC LLDB works as follows:
- when disabled, MSVC LLDB uses Clang-based implementation and treats Rust types and expressions as C++ types and expressions;
- when enabled, MSVC LLDB detects if a PDB file corresponds to Rust source code, and in that case, the new Rust-aware implementation is used to manipulate debug information, types and expressions.

From the user's perspective, the native Rust support in MSVC LLDB currently improves a few things:
- Rust primitive type names are displayed properly, such as `u64` instead of `unsigned long long`;
- No more endless and memory-leaking "Collecting data..." for certain function parameters described in https://github.com/intellij-rust/intellij-rust/issues/6676#issuecomment-1286534705 (but the debugger is still unable to show the actual values though).

| Before | With native Rust support |
| - | - |
<img width="420" alt="Before" src="https://user-images.githubusercontent.com/4854600/198998060-c58b1a1a-8d49-46de-b045-1718180b6e0c.PNG"> | <img width="400" alt="With native Rust support" src="https://user-images.githubusercontent.com/4854600/198998065-37563a85-da5a-489e-b6d0-cdaec615a9f0.PNG">


Note, in case of problems, the native Rust support in MSVC LLDB can be turned off via `org.rust.debugger.lldb.rust.msvc` flag in `Registry...`.

changelog: Enable native Rust support in [MSVC LLDB](https://blog.jetbrains.com/clion/2019/06/clion-2019-2-eap-msvc-debugger-unused-includes-check-and-more/#msvc_debug) in 2022.3 IDE builds on Windows. Currently, the most visible improvement of the native support is the proper displaying of Rust primitive type names, such as `u64` instead of `unsigned long long`.