### PR TITLE
Increase minimal supported version of rustc to 1.56

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -80,7 +80,7 @@ jobs:
                 include:
                     - os: ubuntu-latest
                       # Don't forget to update condition in `Set up additional env variables` step
-                      rust-version: 1.41.0
+                      rust-version: 1.56.0
                       base-ide: idea
                       platform-version: 222
                       verify-plugin: true
@@ -159,7 +159,7 @@ jobs:
                   cargo install --list
 
             - name: Set up additional env variables
-              if: matrix.rust-version == '1.41.0'
+              if: matrix.rust-version == '1.56.0'
               # see https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
               run: |
                   echo "ORG_GRADLE_PROJECT_ideaVersion=IU-2022.2" >> $GITHUB_ENV

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
@@ -117,7 +117,7 @@ abstract class RsToolchainBase(val location: Path) {
     }
 
     companion object {
-        val MIN_SUPPORTED_TOOLCHAIN = "1.41.0".parseSemVer()
+        val MIN_SUPPORTED_TOOLCHAIN = "1.56.0".parseSemVer()
 
         /** Environment variable to unlock unstable features of rustc and cargo.
          *  It doesn't change real toolchain.


### PR DESCRIPTION
It should "fix" tests with old compiler version.

A combination of the following facts:
- stdlib 1.41.0 depends on `cmake` crate
- `cmake` crate switched from `2018` edition to 2021` in recent patch version
- cargo from `1.41.0` toolchain knows nothing about `2021` edition

caused test failures with 1.41.0

Probably, it's possible to fix it properly without increasing a minimal supported version of rustc, but 1.41 is **too** old version of the compiler and only very small part of users use such old compiler, I think it's more efficient just update a minimal supported version. 1.56 was chosen as the first version with support for 2021 edition

Now users will see notification if they still use old compiler

<img width="430" alt="Screenshot 2022-10-31 at 16 17 15" src="https://user-images.githubusercontent.com/2539310/199043946-f66f1e91-22e2-42c1-93f2-a9a354ac7c02.png">



I intentionally didn't fix the corresponding `BACKCOMPAT: Rust *` comments since I want to cherry-pick this change to 182 release branch

changelog: Increase the minimal supported version of Rust to 1.56