### PR TITLE
Await macro expansion in `CargoCommandLineInspectionProjectConfigurator`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -296,6 +296,13 @@ class MacroExpansionTask(
         return true
     }
 
+    override fun onFinished() {
+        if (project.isDisposed) return
+
+        project.messageBus.syncPublisher(MacroExpansionTaskListener.MACRO_EXPANSION_TASK_TOPIC)
+            .onMacroExpansionTaskFinished()
+    }
+
     override val waitForSmartMode: Boolean
         get() = true
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTaskListener.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTaskListener.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.util.messages.Topic
+
+interface MacroExpansionTaskListener {
+    fun onMacroExpansionTaskFinished()
+
+    companion object {
+        @JvmStatic
+        val MACRO_EXPANSION_TASK_TOPIC: Topic<MacroExpansionTaskListener> = Topic(
+            "rust macro expansion task",
+            MacroExpansionTaskListener::class.java
+        )
+    }
+}


### PR DESCRIPTION
Improves #8944

changelog: await finish of macro expansion task when running inspection from [command line](https://www.jetbrains.com/help/idea/command-line-code-inspector.html) or via [Qodana](https://www.jetbrains.com/qodana/)