### PR TITLE
Rename `ImportCandidatesCollector2` to `ImportCandidatesCollector`

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -19,8 +19,8 @@ import com.intellij.psi.PsiFile
 import org.rust.ide.inspections.import.AutoImportFix.Type.*
 import org.rust.ide.settings.RsCodeInsightSettings
 import org.rust.ide.utils.import.ImportCandidate
-import org.rust.ide.utils.import.ImportCandidatesCollector2
-import org.rust.ide.utils.import.ImportContext2
+import org.rust.ide.utils.import.ImportCandidatesCollector
+import org.rust.ide.utils.import.ImportContext
 import org.rust.ide.utils.import.import
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -130,15 +130,15 @@ class AutoImportFix(element: RsElement, private val context: Context) :
             }
 
             val referenceName = basePath.referenceName ?: return null
-            val importContext = ImportContext2.from(path, ImportContext2.Type.AUTO_IMPORT) ?: return null
-            val candidates = ImportCandidatesCollector2.getImportCandidates(importContext, referenceName)
+            val importContext = ImportContext.from(path, ImportContext.Type.AUTO_IMPORT) ?: return null
+            val candidates = ImportCandidatesCollector.getImportCandidates(importContext, referenceName)
 
             return Context(GENERAL_PATH, candidates)
         }
 
         fun findApplicableContext(pat: RsPatBinding): Context? {
-            val importContext = ImportContext2.from(pat, ImportContext2.Type.AUTO_IMPORT) ?: return null
-            val candidates = ImportCandidatesCollector2.getImportCandidates(importContext, pat.referenceName)
+            val importContext = ImportContext.from(pat, ImportContext.Type.AUTO_IMPORT) ?: return null
+            val candidates = ImportCandidatesCollector.getImportCandidates(importContext, pat.referenceName)
             if (candidates.isEmpty()) return null
             return Context(GENERAL_PATH, candidates)
         }
@@ -146,7 +146,7 @@ class AutoImportFix(element: RsElement, private val context: Context) :
         fun findApplicableContext(methodCall: RsMethodCall): Context? {
             val results = methodCall.inference?.getResolvedMethod(methodCall) ?: emptyList()
             if (results.isEmpty()) return Context(METHOD, emptyList())
-            val candidates = ImportCandidatesCollector2.getImportCandidates(methodCall, results) ?: return null
+            val candidates = ImportCandidatesCollector.getImportCandidates(methodCall, results) ?: return null
             return Context(METHOD, candidates)
         }
 
@@ -167,7 +167,7 @@ class AutoImportFix(element: RsElement, private val context: Context) :
                 if (it !is ResolvedPath.AssocItem) return null
                 it.source
             }
-            val candidates = ImportCandidatesCollector2.getTraitImportCandidates(path, sources) ?: return null
+            val candidates = ImportCandidatesCollector.getTraitImportCandidates(path, sources) ?: return null
             return Context(ASSOC_ITEM_PATH, candidates)
         }
     }

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -6,8 +6,8 @@
 package org.rust.ide.presentation
 
 import org.rust.ide.utils.import.ImportCandidate
-import org.rust.ide.utils.import.ImportCandidatesCollector2
-import org.rust.ide.utils.import.ImportContext2
+import org.rust.ide.utils.import.ImportCandidatesCollector
+import org.rust.ide.utils.import.ImportContext
 import org.rust.lang.core.crate.impl.FakeCrate
 import org.rust.lang.core.parser.RustParserUtil
 import org.rust.lang.core.psi.*
@@ -713,7 +713,7 @@ class ImportingPsiRenderer(
     private val context: RsElement
 ) : PsiSubstitutingPsiRenderer(options, substitutions) {
 
-    private val importContext = ImportContext2.from(context, ImportContext2.Type.OTHER)
+    private val importContext = ImportContext.from(context, ImportContext.Type.OTHER)
 
     private val visibleNames: Pair<MutableMap<Pair<String, Namespace>, RsElement>, MutableMap<RsElement, String>> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         val nameToElement = mutableMapOf<Pair<String, Namespace>, RsElement>()
@@ -755,7 +755,7 @@ class ImportingPsiRenderer(
                     sb.append(visibleElementName)
                 } else {
                     val importCandidate = importContext?.let {
-                        ImportCandidatesCollector2.findImportCandidate(it, resolved)
+                        ImportCandidatesCollector.findImportCandidate(it, resolved)
                     }
                     if (importCandidate == null) {
                         val resolvedCrate = resolved.containingCrate

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -5,8 +5,8 @@
 
 package org.rust.ide.presentation
 
-import org.rust.ide.utils.import.ImportCandidatesCollector2
-import org.rust.ide.utils.import.ImportContext2
+import org.rust.ide.utils.import.ImportCandidatesCollector
+import org.rust.ide.utils.import.ImportContext
 import org.rust.lang.core.psi.RsConstParameter
 import org.rust.lang.core.psi.RsLifetimeParameter
 import org.rust.lang.core.psi.RsTraitItem
@@ -299,8 +299,8 @@ private data class TypeRenderer(
         if (element is RsQualifiedNamedElement && element in useQualifiedName) {
             val candidate = run {
                 if (context == null) return@run null
-                val importContext = ImportContext2.from(context, ImportContext2.Type.OTHER) ?: return@run null
-                ImportCandidatesCollector2.findImportCandidate(importContext, element)
+                val importContext = ImportContext.from(context, ImportContext.Type.OTHER) ?: return@run null
+                ImportCandidatesCollector.findImportCandidate(importContext, element)
             }
             candidate?.info?.usePath ?: element.qualifiedName
         } else {

--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector.kt
@@ -56,15 +56,15 @@ import org.rust.stdext.mapToSet
  * - Dependencies
  * See [ImportCandidate.compareTo].
  */
-object ImportCandidatesCollector2 {
-    fun getImportCandidates(context: ImportContext2, targetName: String): List<ImportCandidate> {
+object ImportCandidatesCollector {
+    fun getImportCandidates(context: ImportContext, targetName: String): List<ImportCandidate> {
         val itemsPaths = context.getAllModPaths()
             .flatMap { context.getAllItemPathsInMod(it, targetName) }
         return context.convertToCandidates(itemsPaths)
     }
 
     fun getCompletionCandidates(
-        context: ImportContext2,
+        context: ImportContext,
         prefixMatcher: PrefixMatcher,
         processedElements: MultiMap<String, RsElement>
     ): List<ImportCandidate> {
@@ -96,7 +96,7 @@ object ImportCandidatesCollector2 {
             ?: return null
         val traitsPaths = traits.mapNotNullToSet { it.asModPath() }
 
-        val context = ImportContext2.from(scope, ImportContext2.Type.AUTO_IMPORT) ?: return emptyList()
+        val context = ImportContext.from(scope, ImportContext.Type.AUTO_IMPORT) ?: return emptyList()
         val modPaths = context.getAllModPaths()
         val itemsPaths = modPaths.flatMap { context.getTraitsPathsInMod(it, traitsPaths) }
         return context.convertToCandidates(itemsPaths)
@@ -110,7 +110,7 @@ object ImportCandidatesCollector2 {
         return if (traits.filterInScope(scope).isNotEmpty()) null else traits
     }
 
-    private fun getImportCandidates(context: ImportContext2, target: RsQualifiedNamedElement): List<ImportCandidate> {
+    private fun getImportCandidates(context: ImportContext, target: RsQualifiedNamedElement): List<ImportCandidate> {
         val name = if (target is RsFile) {
             target.modName
         } else {
@@ -120,11 +120,11 @@ object ImportCandidatesCollector2 {
             .filter { it.qualifiedNamedItem.item == target }
     }
 
-    fun findImportCandidate(context: ImportContext2, target: RsQualifiedNamedElement): ImportCandidate? =
+    fun findImportCandidate(context: ImportContext, target: RsQualifiedNamedElement): ImportCandidate? =
         getImportCandidates(context, target).firstOrNull()
 }
 
-private fun ImportContext2.convertToCandidates(itemsPaths: List<ItemUsePath>): List<ImportCandidate> =
+private fun ImportContext.convertToCandidates(itemsPaths: List<ItemUsePath>): List<ImportCandidate> =
     itemsPaths
         .filterForSingleRootItem(this)
         .groupBy { it.toItemWithNamespace() }
@@ -161,7 +161,7 @@ private data class ModUsePath(
     override fun toString(): String = path.joinToString("::")
 }
 
-private fun ImportContext2.getAllModPaths(): List<ModUsePath> {
+private fun ImportContext.getAllModPaths(): List<ModUsePath> {
     val defMaps = rootDefMap.getInitialDefMapsToSearch(project.crateGraph)
     val explicitCrates = defMaps.explicit.mapToSet { (_, defMap) -> defMap.crate }
     val result = mutableListOf<ModUsePath>()
@@ -175,7 +175,7 @@ private fun ImportContext2.getAllModPaths(): List<ModUsePath> {
 }
 
 /** bfs using [ModData.visibleItems] as edges */
-private fun ImportContext2.visitVisibleModules(
+private fun ImportContext.visitVisibleModules(
     rootPath: ModUsePath,
     filterCrate: (CratePersistentId) -> Boolean,
     processor: (ModUsePath) -> Unit
@@ -198,7 +198,7 @@ private fun ImportContext2.visitVisibleModules(
     }
 }
 
-private fun ImportContext2.findPathsToModulesInScope(path: ModUsePath): List<ModUsePath> =
+private fun ImportContext.findPathsToModulesInScope(path: ModUsePath): List<ModUsePath> =
     path.mod.visibleItems.mapNotNull { (name, perNs) ->
         val childMod = perNs.types.singleOrNull {
             it.isModOrEnum && checkVisibility(it, path.mod)
@@ -264,7 +264,7 @@ private fun Attributes.canUseCrate(crate: String): Boolean =
  * Checks that import is visible, and it is not private reexport.
  * We shouldn't use private reexports in order to not generate code like `use crate::HashSet;`.
  */
-private fun ImportContext2.checkVisibility(visItem: VisItem, modData: ModData): Boolean {
+private fun ImportContext.checkVisibility(visItem: VisItem, modData: ModData): Boolean {
     val visibility = visItem.visibility
     if (!visibility.isVisibleFromMod(rootModData)) return false
     if (visibility is Visibility.Restricted) {
@@ -294,33 +294,33 @@ private data class ItemUsePath(
     override fun toString(): String = "${path.joinToString("::")} for ${item.path}"
 }
 
-private fun ImportContext2.getAllItemPathsInMod(modPath: ModUsePath, itemNameFilter: (String) -> Boolean): Sequence<ItemUsePath> =
+private fun ImportContext.getAllItemPathsInMod(modPath: ModUsePath, itemNameFilter: (String) -> Boolean): Sequence<ItemUsePath> =
     modPath.mod.visibleItems
         .asSequence().filter { itemNameFilter(it.key) }
         .flatMap { (name, perNs) -> getPerNsPaths(modPath, perNs, name) }
 
-private fun ImportContext2.getAllItemPathsInMod(modPath: ModUsePath, itemName: String): List<ItemUsePath> {
+private fun ImportContext.getAllItemPathsInMod(modPath: ModUsePath, itemName: String): List<ItemUsePath> {
     val perNs = modPath.mod.visibleItems[itemName] ?: return emptyList()
     return getPerNsPaths(modPath, perNs, itemName)
 }
 
-private fun ImportContext2.getPerNsPaths(modPath: ModUsePath, perNs: PerNs, name: String): List<ItemUsePath> =
+private fun ImportContext.getPerNsPaths(modPath: ModUsePath, perNs: PerNs, name: String): List<ItemUsePath> =
     perNs.getVisItemsByNamespace().flatMap { (visItems, namespace) ->
         visItems
             .filter {
                 checkVisibility(it, modPath.mod)
-                    && (type == ImportContext2.Type.OTHER || !hasVisibleItemInRootScope(name, namespace))
+                    && (type == ImportContext.Type.OTHER || !hasVisibleItemInRootScope(name, namespace))
             }
             .map { ItemUsePath(modPath.path + name, modPath.crate, it, namespace, modPath.needExternCrate) }
     }
 
-private fun ImportContext2.hasVisibleItemInRootScope(name: String, namespace: Namespace): Boolean {
+private fun ImportContext.hasVisibleItemInRootScope(name: String, namespace: Namespace): Boolean {
     val perNs = rootDefMap.resolveNameInModule(rootModData, name, withLegacyMacros = true)
     return perNs.getVisItems(namespace).isNotEmpty()
 }
 
 /** Returns paths to [traits] in scope of [modPath] */
-private fun ImportContext2.getTraitsPathsInMod(modPath: ModUsePath, traits: Set<ModPath>): List<ItemUsePath> =
+private fun ImportContext.getTraitsPathsInMod(modPath: ModUsePath, traits: Set<ModPath>): List<ItemUsePath> =
     modPath.mod.visibleItems
         .flatMap { (name, perNs) ->
             perNs.types
@@ -367,9 +367,9 @@ private fun filterShortestPath(paths: List<ItemUsePath>): List<ItemUsePath> {
  * ~~~~~ this = [std::error, core::error]
  * ~~~~~~~~~~~~ root path - same item for both, so keep only `std::error`
  */
-private fun List<ItemUsePath>.filterForSingleRootItem(context: ImportContext2): List<ItemUsePath> {
+private fun List<ItemUsePath>.filterForSingleRootItem(context: ImportContext): List<ItemUsePath> {
     if (size <= 1 || !all { it.item.isModOrEnum }) return this
-    if (context.type == ImportContext2.Type.COMPLETION) return this
+    if (context.type == ImportContext.Type.COMPLETION) return this
     val segments = context.pathInfo?.nextSegments ?: return this
     return groupBy { resolveRootPath(context.rootDefMap, it, segments) ?: return this }
         .mapValues { (perNs, paths) ->
@@ -399,7 +399,7 @@ private fun resolveRootPath(defMap: CrateDefMap, path: ItemUsePath, segments: Li
     return perNs
 }
 
-private fun List<RsQualifiedNamedElement>.filterByNamespace(context: ImportContext2): List<RsQualifiedNamedElement> {
+private fun List<RsQualifiedNamedElement>.filterByNamespace(context: ImportContext): List<RsQualifiedNamedElement> {
     val pathInfo = context.pathInfo ?: return this
     return filter {
         pathInfo.namespaceFilter(it) && checkProcMacroType(it, pathInfo.parentIsMetaItem)
@@ -411,7 +411,7 @@ fun checkProcMacroType(element: RsQualifiedNamedElement, parentIsMetaItem: Boole
     return if (element is RsFunction && element.isProcMacroDef) element.isBangProcMacroDef else true
 }
 
-private fun ImportContext2.isUsefulTraitImport(usePath: String): Boolean {
+private fun ImportContext.isUsefulTraitImport(usePath: String): Boolean {
     if (pathInfo?.rootPathText == null) return true
     val path = createPathWithImportAdded(usePath) ?: return false
     val element = path.reference?.deepResolve() as? RsQualifiedNamedElement ?: return false
@@ -424,13 +424,13 @@ private fun ImportContext2.isUsefulTraitImport(usePath: String): Boolean {
         || element.canBeAccessedByTraitName
 }
 
-private fun ImportContext2.isRootPathResolved(usePath: String): Boolean {
-    if (type == ImportContext2.Type.COMPLETION) return true
+private fun ImportContext.isRootPathResolved(usePath: String): Boolean {
+    if (type == ImportContext.Type.COMPLETION) return true
     val path = createPathWithImportAdded(usePath) ?: return false
     return path.reference?.resolve() != null
 }
 
-private fun ImportContext2.createPathWithImportAdded(usePath: String): RsPath? {
+private fun ImportContext.createPathWithImportAdded(usePath: String): RsPath? {
     val rootPathText = pathInfo?.rootPathText ?: return null
     val rootPathParsingMode = pathInfo.rootPathParsingMode ?: return null
     val rootPathAllowedNamespaces = pathInfo.rootPathAllowedNamespaces ?: return null

--- a/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportContext.kt
@@ -17,7 +17,7 @@ import org.rust.lang.core.resolve2.ModData
 import org.rust.lang.core.resolve2.RsModInfo
 import org.rust.lang.core.resolve2.getModInfo
 
-class ImportContext2 private constructor(
+class ImportContext private constructor(
     /** Info of mod in which auto-import or completion is called */
     val rootInfo: RsModInfo,
     /** Mod in which auto-import or completion is called */
@@ -31,13 +31,13 @@ class ImportContext2 private constructor(
     val rootDefMap: CrateDefMap get() = rootInfo.defMap
 
     companion object {
-        fun from(path: RsPath, type: Type = Type.AUTO_IMPORT): ImportContext2? =
+        fun from(path: RsPath, type: Type = Type.AUTO_IMPORT): ImportContext? =
             from(path, type, PathInfo.from(path, type == Type.COMPLETION))
 
-        fun from(context: RsElement, type: Type = Type.AUTO_IMPORT, pathInfo: PathInfo? = null): ImportContext2? {
+        fun from(context: RsElement, type: Type = Type.AUTO_IMPORT, pathInfo: PathInfo? = null): ImportContext? {
             val rootMod = context.containingMod
             val info = getModInfo(rootMod) ?: return null
-            return ImportContext2(info, rootMod, type, pathInfo)
+            return ImportContext(info, rootMod, type, pathInfo)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -59,17 +59,17 @@ object RsImportHelper {
 
     fun importElements(context: RsElement, elements: Set<RsQualifiedNamedElement>) {
         if (!RsCodeInsightSettings.getInstance().importOutOfScopeItems) return
-        val importContext = ImportContext2.from(context, ImportContext2.Type.OTHER) ?: return
+        val importContext = ImportContext.from(context, ImportContext.Type.OTHER) ?: return
         for (element in elements) {
-            val candidate = ImportCandidatesCollector2.findImportCandidate(importContext, element)
+            val candidate = ImportCandidatesCollector.findImportCandidate(importContext, element)
             candidate?.import(context)
         }
     }
 
     // finds path to `element` from `context.containingMod`, taking into account reexports and glob imports
     fun findPath(context: RsElement, element: RsQualifiedNamedElement): String? {
-        val importContext = ImportContext2.from(context, ImportContext2.Type.OTHER) ?: return null
-        val candidate = ImportCandidatesCollector2.findImportCandidate(importContext, element)
+        val importContext = ImportContext.from(context, ImportContext.Type.OTHER) ?: return null
+        val candidate = ImportCandidatesCollector.findImportCandidate(importContext, element)
         return candidate?.info?.usePath
     }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -212,8 +212,8 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         Testmarks.OutOfScopeItemsCompletion.hit()
 
         val context = RsCompletionContext(path, expectedTy, isSimplePath = true)
-        val importContext = ImportContext2.from(path, ImportContext2.Type.COMPLETION) ?: return
-        val candidates = ImportCandidatesCollector2.getCompletionCandidates(importContext, result.prefixMatcher, processedPathElements)
+        val importContext = ImportContext.from(path, ImportContext.Type.COMPLETION) ?: return
+        val candidates = ImportCandidatesCollector.getCompletionCandidates(importContext, result.prefixMatcher, processedPathElements)
 
         for (candidate in candidates) {
             val item = candidate.qualifiedNamedItem.item
@@ -239,10 +239,10 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
 
         // We don't use `Type.COMPLETION` because we're importing the first segment of the 2-segment path,
         // so we don't want to relax the namespace filter
-        val importContext = ImportContext2.from(qualifier, ImportContext2.Type.AUTO_IMPORT) ?: return
+        val importContext = ImportContext.from(qualifier, ImportContext.Type.AUTO_IMPORT) ?: return
 
         val referenceName = qualifier.referenceName ?: return
-        val itemToCandidates = ImportCandidatesCollector2.getImportCandidates(importContext, referenceName)
+        val itemToCandidates = ImportCandidatesCollector.getImportCandidates(importContext, referenceName)
             .groupBy { it.qualifiedNamedItem.item }
         for ((_, candidates) in itemToCandidates) {
             // Here all use path resolves to the same item, so we can just use the first of them
@@ -482,7 +482,7 @@ private fun findTraitImportCandidate(methodOrField: RsMethodOrField, resolveVari
     val ancestor = PsiTreeUtil.getParentOfType(methodOrField, RsBlock::class.java, RsMod::class.java) ?: return null
     // `ImportCandidatesCollector.getImportCandidates` expects original scope element for correct item filtering
     val scope = CompletionUtil.getOriginalElement(ancestor) as? RsElement ?: return null
-    val candidates = ImportCandidatesCollector2.getImportCandidates(scope, listOf(resolveVariant))?.asSequence()
+    val candidates = ImportCandidatesCollector.getImportCandidates(scope, listOf(resolveVariant))?.asSequence()
     return candidates.orEmpty().singleOrNull()
 }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
@@ -16,8 +16,8 @@ import com.intellij.util.ProcessingContext
 import com.intellij.util.containers.MultiMap
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.utils.import.ImportCandidate
-import org.rust.ide.utils.import.ImportCandidatesCollector2
-import org.rust.ide.utils.import.ImportContext2
+import org.rust.ide.utils.import.ImportCandidatesCollector
+import org.rust.ide.utils.import.ImportContext
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.completion.RsLookupElementProperties.ElementKind
@@ -87,8 +87,8 @@ object RsDeriveCompletionProvider : RsCompletionProvider() {
     }
 
     private fun addCompletionsForOutOfScopeDerives(path: RsPath, result: CompletionResultSet, processedElements: MultiMap<String, RsElement>) {
-        val importContext = ImportContext2.from(path, ImportContext2.Type.COMPLETION) ?: return
-        val candidates = ImportCandidatesCollector2.getCompletionCandidates(importContext, result.prefixMatcher, processedElements)
+        val importContext = ImportContext.from(path, ImportContext.Type.COMPLETION) ?: return
+        val candidates = ImportCandidatesCollector.getCompletionCandidates(importContext, result.prefixMatcher, processedElements)
         for (candidate in candidates) {
             val item = candidate.qualifiedNamedItem.item
             if (item !is RsFunction || !item.isCustomDeriveProcMacroDef) continue


### PR DESCRIPTION
Related: #7558

I don't rename `QualifiedNamedItem2` since I will refactor it in follow-up PR