### PR TITLE
Fix rename of paths inside doc links

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -839,6 +839,22 @@ class RenameTest : RsTestBase() {
         struct Struct {}
     """)
 
+    fun `test path inside doc link`() = doTest("bar", """
+        /// 1 [link1](foo)
+        /// 2 [link2]
+        ///
+        /// [link2]: foo
+        fn test() {}
+        fn foo/*caret*/() {}
+    """, """
+        /// 1 [link1](bar)
+        /// 2 [link2]
+        ///
+        /// [link2]: bar
+        fn test() {}
+        fn bar() {}
+    """)
+
     private fun doTest(
         newName: String,
         @Language("Rust") before: String,


### PR DESCRIPTION
This is a fix for #7353

Currently rename adds unnecessary newlines and whitespace for paths in doc links, thus breaking the doc comment