### PR TITLE
CARGO: fallback to hardcoded stdlib structure if fetching metadata fails

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
@@ -309,8 +309,7 @@ class StdlibDataFetcher private constructor(
             listener = listener
         ).unwrapOrElse {
             listener?.error("Failed to fetch stdlib package info", it.message.orEmpty())
-            LOG.error(it)
-            return
+            throw it
         }
 
         val rootPackageId = metadataProject.workspace_members.first()


### PR DESCRIPTION
Previously, exceptions occurred during fetching were suppressed by accident

It should help in cases like #7912 or #9414 to continue to work instead of breaking the whole analysis with stdlib

changelog: Fallback to hardcoded stdlib structure if fetching of stdlib structure failed for some reason
