### PR TITLE
MACRO: enable derive proc macro expansion in nightly plugin

### DIFF
--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -15,7 +15,7 @@
         <experimentalFeature id="org.rust.macros.proc.function-like" percentOfUsers="100">
             <description>Enables function-like procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.macros.proc.derive" percentOfUsers="0">
+        <experimentalFeature id="org.rust.macros.proc.derive" percentOfUsers="100">
             <description>Enables derive procedural macro expansion</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.macros.proc.attr" percentOfUsers="0">

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -6,6 +6,8 @@
 package org.rust.lang.core.resolve
 
 import org.rust.MockRustcVersion
+import org.rust.WithoutExperimentalFeatures
+import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.ext.RsFieldDecl
 
@@ -1547,6 +1549,7 @@ class RsResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @WithoutExperimentalFeatures(RsExperiments.DERIVE_PROC_MACROS)
     fun `test derive serde Serialize`() = checkByCode("""
         #[lang = "serde::Serialize"]
         trait Serialize { fn serialize(&self); }


### PR DESCRIPTION
changelog: Enable [derive](https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros) procedural macro expansion in [nightly plugin builds](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-quick-start.html#install-nightly).