### PR TITLE
CARGO: log any failure during build script evaluation

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -295,10 +295,13 @@ class Cargo(
         val envs = EnvironmentVariablesData.create(envMap, true)
         val commandLine = CargoCommandLine("check", projectDirectory, additionalArgs, environmentVariables = envs)
 
-        val processOutput = commandLine.execute(owner, listener = listener)
+        val processResult = commandLine.execute(owner, listener = listener)
+        if (processResult is Err) {
+            LOG.warn("Build script evaluation failed", processResult.err)
+        }
+        val processOutput = processResult
             .ignoreExitCode()
             .unwrapOrElse {
-                LOG.warn(it)
                 return BuildMessages.FAILED
             }
 


### PR DESCRIPTION
Previously, the plugin logged only if `cargo check` couldn't be launched at all and ignored all other errors. I made investigation of problems related to building script evaluation difficult.

Now the plugin writes a warning for any failure