### PR TITLE
COMP: improve completion in incomplete function-like macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -194,8 +194,9 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         run {
             val originalFile = position.containingFile.originalFile
             // true if delegated from RsPartialMacroArgumentCompletionProvider
-            val ignoreCodeFragment = originalFile is RsExpressionCodeFragment
-                && originalFile.getUserData(FORCE_OUT_OF_SCOPE_COMPLETION) != true
+            val ignoreCodeFragment = (originalFile is RsExpressionCodeFragment
+                && originalFile.getUserData(FORCE_OUT_OF_SCOPE_COMPLETION) != true)
+                || originalFile.getUserData(FORCE_OUT_OF_SCOPE_COMPLETION) == false
             if (ignoreCodeFragment) return
 
             // Not null if delegated from RsMacroCallBodyCompletionProvider

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
@@ -135,6 +135,39 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
         }
     """, setOf("iii", "i32"))
 
+    fun `test last resort completion with mismatched input`() = doTest("""
+        macro_rules! my_macro {
+            (#[foo] fn $ i:ident () $ b:block ) => ( fn $ i () $ b );
+        }
+
+        struct Baz;
+
+        my_macro! {
+            #[test] // expected #[foo]
+            fn foo() {
+                let a: Ba/*caret*/
+            }
+        }
+
+        pub mod other {
+            pub struct BazOutOfScope;
+        }
+    """, setOf("Baz"), setOf("BazOutOfScope"))
+
+    fun `test last resort completion with unresolved macro`() = doTest("""
+        struct Baz;
+
+        unresolved_macro! {
+            fn foo() {
+                let a: Ba/*caret*/
+            }
+        }
+
+        pub mod other {
+            pub struct BazOutOfScope;
+        }
+    """, setOf("Baz"), setOf("BazOutOfScope"))
+
     private fun doTest(@Language("Rust") code: String, contains: Set<String>, notContains: Set<String> = emptySet()) {
         RsPartialMacroArgumentCompletionProvider.Testmarks.Touched.checkHit {
             RsFullMacroArgumentCompletionProvider.Testmarks.Touched.checkNotHit {


### PR DESCRIPTION
This PR implements the idea from https://github.com/intellij-rust/intellij-rust/issues/2755#issuecomment-994768022. 

Now when a user invokes completion in a (declarative or procedural) function-like macro that can't be expanded right now for some reason (for example, because of incomplete code inside the macro body), the plugin tries to parse the entire macro body like a plain Rust code, that is like there isn't a macro invocation around it.

```rust
foobar_macro! { // unresolved macro
    fn foo() {
        let a = /*invoke completion here*/
    }
}
```

In such cases, the plugin will try parsing the macro body like a usual Rust code and perform completion there:

```rust
fn foo() {
    let a = /*invoke completion here*/
}
```

But this mechanism work *only during completion*. From the perspective of other IDE features such a code is still considered as nonsense since macro has not been expanded successfully.

Also this is a kind of continuation of #4001.
