### PR TITLE
MACRO&COMP: let a proc macro know if it is invoked during completion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroCallData.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroCallData.kt
@@ -5,21 +5,33 @@
 
 package org.rust.lang.core.macros
 
+import com.intellij.codeInsight.completion.CompletionInitializationContext.DUMMY_IDENTIFIER_TRIMMED
+import com.intellij.codeInsight.completion.CompletionUtil
 import org.rust.lang.core.psi.ext.RsPossibleMacroCall
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.psi.ext.macroBody
 
 class RsMacroCallData(
     val macroBody: MacroCallBody,
-    val packageEnv: Map<String, String>
+    val env: Map<String, String>,
 ) {
 
     companion object {
         fun fromPsi(call: RsPossibleMacroCall): RsMacroCallData? {
             val macroBody = call.macroBody ?: return null
+            val isCompletion = CompletionUtil.getOriginalElement(call) != null
+            val packageEnv = call.containingCargoPackage?.env.orEmpty()
+            val env = if (isCompletion) {
+                packageEnv + mapOf(
+                    "RUST_IDE_PROC_MACRO_COMPLETION" to "1",
+                    "RUST_IDE_PROC_MACRO_COMPLETION_DUMMY_IDENTIFIER" to DUMMY_IDENTIFIER_TRIMMED,
+                )
+            } else {
+                packageEnv
+            }
             return RsMacroCallData(
                 macroBody,
-                call.containingCargoPackage?.env.orEmpty()
+                env,
             )
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroCallDataWithHash.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroCallDataWithHash.kt
@@ -13,7 +13,7 @@ class RsMacroCallDataWithHash(
 ) {
     fun hashWithEnv(): HashCode? {
         val bodyHash = bodyHash ?: return null
-        val env = data.packageEnv
+        val env = data.env
             .entries
             .sortedBy { it.key }
             .joinToString(separator = ";") { it.key + "=" + it.value }

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -87,7 +87,7 @@ class ProcMacroExpander private constructor(
             Triple(null, macroCallBodyTokenMap, loweredMacroCallBodyRanges)
         }
         val lib = def.artifact.path.toString()
-        val env = call.packageEnv
+        val env = call.env
         return expandMacroAsTtWithErrInternal(server, macroCallBodyTt, attrSubtree, def.name, lib, env).map {
             val (text, ranges) = MappedSubtree(it, mergedTokenMap).toMappedText()
             text to mergedRanges.mapAll(ranges)


### PR DESCRIPTION
Now the plugin sets these environment variables when expands a proc macro during completion: `RUST_IDE_PROC_MACRO_COMPLETION=1`
`RUST_IDE_PROC_MACRO_COMPLETION_DUMMY_IDENTIFIER=IntellijIdeaRulezzz`

changelog: Experimentally set `RUST_IDE_PROC_MACRO_COMPLETION` and `RUST_IDE_PROC_MACRO_COMPLETION_DUMMY_IDENTIFIER` environment variables for procedural macro when invoking them during completion. The idea is that authors of proc macros could use these variables and based on them change behavior of the macro to provide a better (possible custom) completion for IDE users
