### PR TITLE
Ty: infer const arguments in a path qualifier type arguments

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -192,7 +192,9 @@ private PathIdent ::= <<parsePathIdent>>
 
 fake Path ::= (Path '::' | '::' | TypeQual)? (identifier | self | super | 'Self' | crate) PathTypeArguments? {
   implements = [ "org.rust.lang.core.psi.ext.RsPathReferenceElement"
-                 "org.rust.lang.core.psi.ext.RsMethodOrPath" ]
+                 "org.rust.lang.core.psi.ext.RsMethodOrPath"
+                 "org.rust.lang.core.psi.ext.RsInferenceContextOwner" ]
+
   mixin = "org.rust.lang.core.psi.ext.RsPathImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsPathStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
@@ -281,7 +283,6 @@ ValuePathGenericArgsNoTypeQual ::= <<pathMode 'VALUE' 'TypeQualsMode.OFF' PathIm
 
 // Path semantically constrained to resolve to a trait
 TraitRef ::= TypePathGenericArgsNoTypeQual {
-  implements = "org.rust.lang.core.psi.ext.RsInferenceContextOwner"
   extends = "org.rust.lang.core.psi.ext.RsStubbedElementImpl<?>"
   stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub<?>"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
@@ -1000,7 +1001,6 @@ ForInType ::= ForLifetimes (FnPointerType | TraitRef) {
 }
 
 PathType ::= TypePathGenericArgs {
-  implements = [ "org.rust.lang.core.psi.ext.RsInferenceContextOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
@@ -1194,8 +1194,7 @@ LambdaExpr ::= OuterAttr* [asyncBlock | static] move? LambdaParameters RetType? 
 }
 
 StructLiteral ::= <<checkStructAllowed>> OuterAttr* ValuePathGenericArgsNoTypeQual StructLiteralBody {
-  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
-                 "org.rust.lang.core.psi.ext.RsInferenceContextOwner" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1243,7 +1243,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun collectDiagnostics(holder: RsAnnotationHolder, element: RsInferenceContextOwner) {
-        for (it in element.inference.diagnostics) {
+        for (it in element.selfInferenceResult.diagnostics) {
             if (it.inspectionClass == javaClass) it.addToHolder(holder)
         }
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
@@ -7,7 +7,7 @@ package org.rust.ide.inspections
 
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsInferenceContextOwner
-import org.rust.lang.core.types.inference
+import org.rust.lang.core.types.selfInferenceResult
 import org.rust.lang.utils.addToHolder
 
 abstract class RsDiagnosticBasedInspection : RsLocalInspectionTool() {
@@ -22,7 +22,7 @@ abstract class RsDiagnosticBasedInspection : RsLocalInspectionTool() {
     }
 
     private fun collectDiagnostics(holder: RsProblemsHolder, element: RsInferenceContextOwner) {
-        for (it in element.inference.diagnostics) {
+        for (it in element.selfInferenceResult.diagnostics) {
             if (it.inspectionClass == javaClass) it.addToHolder(holder)
         }
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
@@ -16,8 +16,7 @@ abstract class RsDiagnosticBasedInspection : RsLocalInspectionTool() {
         override fun visitConstant(o: RsConstant) = collectDiagnostics(holder, o)
         override fun visitConstParameter(o: RsConstParameter) = collectDiagnostics(holder, o)
         override fun visitArrayType(o: RsArrayType) = collectDiagnostics(holder, o)
-        override fun visitPathType(o: RsPathType) = collectDiagnostics(holder, o)
-        override fun visitTraitRef(o: RsTraitRef) = collectDiagnostics(holder, o)
+        override fun visitPath(o: RsPath) = collectDiagnostics(holder, o)
         override fun visitVariantDiscriminant(o: RsVariantDiscriminant) = collectDiagnostics(holder, o)
     }
 

--- a/src/main/kotlin/org/rust/lang/core/dfa/borrowck/BorrowChecker.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/borrowck/BorrowChecker.kt
@@ -15,7 +15,7 @@ import org.rust.lang.core.psi.ext.body
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.types.controlFlowGraph
 import org.rust.lang.core.types.infer.RsInferenceResult
-import org.rust.lang.core.types.inference
+import org.rust.lang.core.types.selfInferenceResult
 
 class BorrowCheckContext private constructor(
     val inference: RsInferenceResult,
@@ -31,7 +31,7 @@ class BorrowCheckContext private constructor(
             // TODO: handle body represented by RsExpr
             val body = owner.body as? RsBlock ?: return null
             val cfg = owner.controlFlowGraph ?: return null
-            return BorrowCheckContext(owner.inference, body, cfg)
+            return BorrowCheckContext(owner.selfInferenceResult, body, cfg)
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/dfa/liveness/Liveness.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/liveness/Liveness.kt
@@ -12,7 +12,7 @@ import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.types.controlFlowGraph
 import org.rust.lang.core.types.declaration
 import org.rust.lang.core.types.infer.RsInferenceResult
-import org.rust.lang.core.types.inference
+import org.rust.lang.core.types.selfInferenceResult
 
 enum class DeclarationKind { Parameter, Variable }
 
@@ -58,7 +58,7 @@ class LivenessContext private constructor(
         fun buildFor(owner: RsInferenceContextOwner): LivenessContext? {
             val body = owner.body as? RsBlock ?: return null
             val cfg = owner.controlFlowGraph ?: return null
-            return LivenessContext(owner.inference, body, cfg)
+            return LivenessContext(owner.selfInferenceResult, body, cfg)
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsInferenceContextOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsInferenceContextOwner.kt
@@ -25,8 +25,6 @@ val RsInferenceContextOwner.body: RsElement?
         is RsExpressionCodeFragment -> expr
         is RsReplCodeFragment -> this
         is RsPathCodeFragment -> this
-        is RsPathType -> path.typeArgumentList
-        is RsTraitRef -> path.typeArgumentList
-        is RsStructLiteral -> path.typeArgumentList
+        is RsPath -> typeArgumentList
         else -> null
     }

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -107,7 +107,7 @@ val RsTypeReference.lifetimeElidable: Boolean
 
 private val TYPE_INFERENCE_KEY: Key<CachedValue<RsInferenceResult>> = Key.create("TYPE_INFERENCE_KEY")
 
-val RsInferenceContextOwner.inference: RsInferenceResult
+val RsInferenceContextOwner.selfInferenceResult: RsInferenceResult
     get() = CachedValuesManager.getCachedValue(this, TYPE_INFERENCE_KEY) {
         val inferred = inferTypesIn(this)
 
@@ -123,7 +123,7 @@ val PsiElement.inferenceContextOwner: RsInferenceContextOwner?
         }?.first as? RsInferenceContextOwner
 
 val PsiElement.inference: RsInferenceResult?
-    get() = inferenceContextOwner?.inference
+    get() = inferenceContextOwner?.selfInferenceResult
 
 val RsPatBinding.type: Ty
     get() = inference?.getBindingType(this) ?: TyUnknown

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -29,7 +29,7 @@ import org.rust.lang.core.types.regions.getRegionScopeTree
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTypeParameter
 import org.rust.lang.core.types.ty.TyUnknown
-import org.rust.stdext.withPrevious
+import org.rust.stdext.withNext
 
 
 private fun <T> RsInferenceContextOwner.createResult(value: T): Result<T> {
@@ -108,19 +108,30 @@ val RsTypeReference.lifetimeElidable: Boolean
 private val TYPE_INFERENCE_KEY: Key<CachedValue<RsInferenceResult>> = Key.create("TYPE_INFERENCE_KEY")
 
 val RsInferenceContextOwner.selfInferenceResult: RsInferenceResult
-    get() = CachedValuesManager.getCachedValue(this, TYPE_INFERENCE_KEY) {
-        val inferred = inferTypesIn(this)
+    get() {
+        if (this is RsPath) {
+            val parent = parent
+            if (parent != null && !parent.isAllowedPathParent()) {
+                return RsInferenceResult.EMPTY
+            }
+        }
+        return CachedValuesManager.getCachedValue(this, TYPE_INFERENCE_KEY) {
+            val inferred = inferTypesIn(this)
 
-        createResult(inferred)
+            createResult(inferred)
+        }
     }
 
 val PsiElement.inferenceContextOwner: RsInferenceContextOwner?
     get() = contexts
-        .withPrevious()
-        .find { (it, prev) ->
+        .withNext()
+        .find { (it, next) ->
             if (it !is RsInferenceContextOwner) return@find false
-            it !is RsStructLiteral || prev is RsPath
+            it !is RsPath || next != null && next.isAllowedPathParent()
         }?.first as? RsInferenceContextOwner
+
+private fun PsiElement.isAllowedPathParent() =
+    this is RsPathType || this is RsTraitRef || this is RsStructLiteral || this is RsPath
 
 val PsiElement.inference: RsInferenceResult?
     get() = inferenceContextOwner?.selfInferenceResult

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -154,6 +154,22 @@ class RsInferenceResult(
 
     @TestOnly
     fun getTimestamp(): Long = timestamp
+
+    companion object {
+        @JvmStatic
+        val EMPTY: RsInferenceResult = RsInferenceResult(
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptySet(),
+            emptyList(),
+        )
+    }
 }
 
 /**
@@ -224,18 +240,12 @@ class RsInferenceContext(
                 }
                 RsTypeInferenceWalker(this, TyUnknown).inferReplCodeFragment(element)
             }
-            is RsPathType, is RsTraitRef, is RsStructLiteral -> {
-                val path = when (element) {
-                    is RsPathType -> element.path
-                    is RsTraitRef -> element.path
-                    is RsStructLiteral -> element.path
-                    else -> null
-                }
-                val declaration = path?.let { resolvePathRaw(it, lookup) }?.singleOrNull()?.element as? RsGenericDeclaration
-                if (path != null && declaration != null) {
+            is RsPath -> {
+                val declaration = resolvePathRaw(element, lookup).singleOrNull()?.element as? RsGenericDeclaration
+                if (declaration != null) {
                     val constParameters = mutableListOf<RsConstParameter>()
                     val constArguments = mutableListOf<RsElement>()
-                    for ((param, value) in pathPsiSubst(path, declaration).constSubst) {
+                    for ((param, value) in pathPsiSubst(element, declaration).constSubst) {
                         if (value is RsPsiSubstitution.Value.Present) {
                             constParameters += param
                             constArguments += value.value

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -416,7 +416,7 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
         }
 
         fn main() {
-            S::<"">::foo(); // TODO: issue https://github.com/intellij-rust/intellij-rust/issues/8150
+            S::<<error descr="mismatched types [E0308]expected `usize`, found `&str`">""</error>>::foo();
             S::<<error descr="mismatched types [E0308]expected `usize`, found `&str`">""</error>>.bar();
         }
     """)

--- a/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
@@ -329,4 +329,21 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ S<42>
     """)
+
+    fun `test const argument in a path qualifier type parameter list`() = stubOnlyTypeInfer("""
+    //- foo.rs
+        pub struct S<const A: i32>;
+        impl<const B: i32> S<B> {
+            fn foo() -> Self { todo!() }
+        }
+        pub const C: i32 = 1;
+    //- lib.rs
+        mod foo;
+        use foo::*;
+
+        fn main() {
+            let a = S::<{ C }>::foo();
+            a;
+        } //^ S<1>
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeInferenceCachingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeInferenceCachingTest.kt
@@ -10,14 +10,14 @@ import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.childrenOfType
-import org.rust.lang.core.types.inference
+import org.rust.lang.core.types.selfInferenceResult
 
 class RsTypeInferenceCachingTest : RsTestBase() {
     private val complete: () -> Unit = { myFixture.completeBasic() }
     private fun type(text: String = "a"): () -> Unit = { myFixture.type(text) }
 
     private fun List<RsFunction>.collectStamps(): Map<String, Long> =
-        associate { it.name!! to it.inference.getTimestamp() }
+        associate { it.name!! to it.selfInferenceResult.getTimestamp() }
 
 
     private fun checkReinferred(action: () -> Unit, @Language("Rust") code: String, vararg names: String) {

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
@@ -17,6 +17,7 @@ import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.lang.core.psi.ext.descendantsWithMacrosOfType
 import org.rust.lang.core.psi.ext.macroName
 import org.rust.lang.core.types.inference
+import org.rust.lang.core.types.selfInferenceResult
 import org.rust.lang.core.types.type
 import org.rust.lang.utils.Severity
 
@@ -53,7 +54,7 @@ abstract class RsTypificationTestBase : RsTestBase() {
 
     private fun checkNoInferenceErrors() {
         val errors = myFixture.file.descendantsOfType<RsInferenceContextOwner>().asSequence()
-            .flatMap { it.inference.diagnostics.asSequence() }
+            .flatMap { it.selfInferenceResult.diagnostics.asSequence() }
             .map { it.element to it.prepare() }
             .filter { it.second.severity == Severity.ERROR }
             .toList()


### PR DESCRIPTION
Fixes #9685, fixes #8150

changelog: fix type inference of const arguments in a path qualifier type arguments