### PR TITLE
Enable `function-like` and `derive` proc macro expansion by default

### DIFF
--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -12,10 +12,10 @@
         <experimentalFeature id="org.rust.macros.proc" percentOfUsers="0">
             <description>Enables all types of procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.macros.proc.function-like" percentOfUsers="0">
+        <experimentalFeature id="org.rust.macros.proc.function-like" percentOfUsers="100">
             <description>Enables function-like procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.macros.proc.derive" percentOfUsers="0">
+        <experimentalFeature id="org.rust.macros.proc.derive" percentOfUsers="100">
             <description>Enables derive procedural macro expansion</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.macros.proc.attr" percentOfUsers="0">


### PR DESCRIPTION
If you came to this PR because your issue just has been closed, note the plugin including PR will be released only in early December. If you can't wait to try it now, you can use the nightly IntelliJ Rust plugin channel (see [instructions](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-quick-start.html#install-nightly)).

Derive macros support:
Fixes #4629
Fixes #5468
Fixes #5478
Fixes #5728
Fixes #5954
Fixes #6036
Fixes #6489
Fixes #6880
Fixes #7158
Fixes #7848
Fixes #8193
Fixes #8415
Fixes #8581
Fixes #8610
Fixes #8847
Fixes #8856
Fixes #9133
Fixes #9216
Fixes #9226
Fixes #9682
Fixes #7707
Fixes #7365
Fixes #6482

Function-like macros support:
Fixes #4707
Fixes #6367
Fixes #6983
Fixes #7090
Fixes #7242
Fixes #7608
Fixes #7699
Fixes #8049
Fixes #8785
Fixes #9266

changelog: Enable [`function-like`](https://doc.rust-lang.org/reference/procedural-macros.html#function-like-procedural-macros)  and [`derive`](https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros) proc macro expansion by default.
Note that attribute procedural macro expansion is still disabled by default. If you want to try it, you can enable `org.rust.macros.proc.attr` [experimental feature](https://plugins.jetbrains.com/plugin/8182-rust/docs/#experimental-features).
