### PR TITLE
Support smart enter for more items

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessor.kt
@@ -39,13 +39,15 @@ class RsSmartEnterProcessor : SmartEnterProcessorWithFixers() {
     override fun getStatementAtCaret(editor: Editor, psiFile: PsiFile): PsiElement? {
         val atCaret = super.getStatementAtCaret(editor, psiFile) ?: return null
         if (atCaret is PsiWhiteSpace) return null
-        loop@ for (each in atCaret.ancestors) {
-            val elementType = each.node.elementType
-            when {
-                elementType == LBRACE || elementType == RBRACE -> continue@loop
-                each is RsMatchArm || each.parent is RsBlock
-                    || each.parent is RsFunction || each.parent is RsStructItem -> return each
-            }
+        for (element in atCaret.ancestors) {
+            val elementType = element.node.elementType
+            if (elementType == LBRACE || elementType == RBRACE) continue
+
+            val isSuitableElement = element is RsMatchArm || element is RsTypeAlias || element is RsTraitAlias
+                || element is RsConstant || element is RsExternCrateItem
+            val parent = element.parent
+            val stopAtParent = parent is RsBlock || parent is RsFunction || parent is RsStructItem
+            if (isSuitableElement || stopAtParent) return element
         }
         return null
     }

--- a/src/main/kotlin/org/rust/ide/typing/assist/SemicolonFixer.kt
+++ b/src/main/kotlin/org/rust/ide/typing/assist/SemicolonFixer.kt
@@ -9,7 +9,9 @@ import com.intellij.lang.SmartEnterProcessorWithFixers
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsBlock
-import org.rust.lang.core.psi.RsStmt
+import org.rust.lang.core.psi.RsElementTypes.SEMICOLON
+import org.rust.lang.core.psi.RsMembers
+import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.endOffset
 
 /**
@@ -17,7 +19,9 @@ import org.rust.lang.core.psi.ext.endOffset
  */
 class SemicolonFixer : SmartEnterProcessorWithFixers.Fixer<RsSmartEnterProcessor>() {
     override fun apply(editor: Editor, processor: RsSmartEnterProcessor, element: PsiElement) {
-        if (element.parent !is RsBlock || (element as? RsStmt)?.semicolon != null) return
+        val parent = element.parent
+        if (parent !is RsBlock && parent !is RsMod && parent !is RsMembers) return
+        if (element.node.findChildByType(SEMICOLON) != null) return
         editor.document.insertString(element.endOffset, ";")
     }
 }

--- a/src/test/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessorTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessorTest.kt
@@ -371,6 +371,87 @@ class RsSmartEnterProcessorTest : RsTestBase() {
         }
     """)
 
+    fun `test top-level type alias`() = doTest("""
+        type Foo = /*caret*/i32
+    """, """
+        type Foo = i32;
+        /*caret*/
+    """)
+
+    fun `test top-level type alias with semicolon`() = doTest("""
+        type Foo = /*caret*/i32;
+    """, """
+        type Foo = i32;
+        /*caret*/
+    """)
+
+    fun `test top-level trait alias`() = doTest("""
+        trait Foo = /*caret*/Bar
+    """, """
+        trait Foo = Bar;
+        /*caret*/
+    """)
+
+    fun `test type alias inside trait (no default value)`() = doTest("""
+        trait Trait {
+            type /*caret*/Foo
+        }
+    """, """
+        trait Trait {
+            type Foo;
+            /*caret*/
+        }
+    """)
+
+    fun `test type alias inside trait (with default value)`() = doTest("""
+        trait Trait {
+            type Foo = /*caret*/i32
+        }
+    """, """
+        trait Trait {
+            type Foo = i32;
+            /*caret*/
+        }
+    """)
+
+    fun `test type alias inside trait (with where clause)`() = doTest("""
+        trait Iterable {
+            type Iter<'a> where /*caret*/Self: 'a
+        }
+    """, """
+        trait Iterable {
+            type Iter<'a> where Self: 'a;
+            /*caret*/
+        }
+    """)
+
+    fun `test top-level constant`() = doTest("""
+        const C: i32 = /*caret*/0
+    """, """
+        const C: i32 = 0;
+        /*caret*/
+    """)
+
+    fun `test top-level constant (with block expr) 1`() = doTest("""
+        const C: i32 = /*caret*/{ 0 }
+    """, """
+        const C: i32 = { 0 };
+        /*caret*/
+    """)
+
+    fun `test top-level constant (with block expr) 2`() = doTest("""
+        const C: i32 = { 0/*caret*/ }
+    """, """
+        const C: i32 = { 0;/*caret*/ }
+    """)
+
+    fun `test top-level extern crate`() = doTest("""
+        extern crate /*caret*/std
+    """, """
+        extern crate std;
+        /*caret*/
+    """)
+
     private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) =
         checkEditorAction(before, after, IdeActions.ACTION_EDITOR_COMPLETE_STATEMENT)
 }


### PR DESCRIPTION
Fixes #9736

Now smart enter will add a semicolon for type aliases, trait aliases, extern crates and constants

changelog: Support smart enter for type aliases