### PR TITLE
INT: Don't offer `Un-elide lifetimes` intention when no input lifetimes

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
@@ -33,8 +33,8 @@ class UnElideLifetimesIntention : RsElementBaseIntentionAction<LifetimeContext>(
             if (outputLifetimes.any { it != null } || outputLifetimes.size > 1) return null
         }
 
-        val refArgs = ctx.inputs + listOfNotNull(ctx.self)
-        if (refArgs.isEmpty() || refArgs.any { it.lifetimes.any { lifetime -> lifetime != null } }) return null
+        val inputLifetimes = ctx.inputs.flatMap { it.lifetimes } + ctx.self?.lifetimes.orEmpty()
+        if (inputLifetimes.isEmpty() || inputLifetimes.any { it != null }) return null
 
         return ctx
     }

--- a/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
@@ -8,8 +8,13 @@ package org.rust.ide.intentions
 import org.rust.MockAdditionalCfgOptions
 
 class UnElideLifetimesIntentionTest : RsIntentionTestBase(UnElideLifetimesIntention::class) {
-    fun `test unavailable without references`() = doUnavailableTest("""
+    fun `test unavailable without references 1`() = doUnavailableTest("""
         fn bar/*caret*/(x: i32) -> i32 {}
+    """)
+
+    fun `test unavailable without references 2`() = doUnavailableTest("""
+        fn bar/*caret*/(x: T) -> T {}
+        struct T;
     """)
 
     fun `test unavailable in block body`() = doUnavailableTest("""


### PR DESCRIPTION
Fixes #9734

changelog: Don't offer `Un-elide lifetimes` intention when there is no input lifetimes