### PR TITLE
Support "Create field" quick-fix for struct literals with `Self`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFix.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsVisibility
 import org.rust.lang.core.psi.ext.parentStructLiteral
+import org.rust.lang.core.resolve.ref.deepResolve
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.regions.ReStatic
 import org.rust.lang.core.types.regions.Region
@@ -71,7 +72,7 @@ class CreateStructFieldFromConstructorFix private constructor(
         }
 
         private fun RsStructLiteralField.resolveToStructItem(): RsStructItem? {
-            return parentStructLiteral.path.reference?.resolve() as? RsStructItem
+            return parentStructLiteral.path.reference?.deepResolve() as? RsStructItem
         }
 
         private fun canUse(ty: Ty): Boolean {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFixTest.kt
@@ -94,6 +94,27 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
         }
     """)
 
+    fun `test struct referenced via Self`() = checkFixByTextWithoutHighlighting("Create field", """
+        struct Foo {}
+        impl Foo {
+            fn new() -> Foo {
+                Self {
+                    /*caret*/field: 0,
+                }
+            }
+        }
+    """, """
+        struct Foo {
+            field: i32,
+        }
+        impl Foo {
+            fn new() -> Foo {
+                Self {
+                    /*caret*/field: 0,
+                }
+            }
+        }
+    """)
 
     fun `test no block`() = checkFixByText("Create field", """
         struct S;


### PR DESCRIPTION
Fixes #9651

changelog: Support `Create field` quick-fix for struct literals with `Self`