### PR TITLE
GRD: make 2022.3 platform default for development

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
 # Supported platforms: 222, 223
-platformVersion=222
+platformVersion=223
 # Supported IDEs: idea, clion
 baseIDE=idea
 


### PR DESCRIPTION
changelog: Make 2022.3 platform default for development
