### PR TITLE
MACRO: fix find usages for pat bindings defined by macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatBinding.kt
@@ -74,7 +74,7 @@ abstract class RsPatBindingImplMixin(node: ASTNode) : RsNamedElementImpl(node),
     }
 
     override fun getUseScope(): SearchScope {
-        val owner = PsiTreeUtil.getParentOfType(this,
+        val owner = PsiTreeUtil.getContextOfType(this,
             RsBlock::class.java,
             RsFunction::class.java,
             RsLambdaExpr::class.java

--- a/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
+++ b/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
@@ -206,6 +206,16 @@ class RsFindUsagesTest : RsTestBase() {
         }
     """)
 
+    fun `test variable defined by a macro`() = doTestByText("""
+        macro_rules! foo { ($($ t:tt)*) => { $($ t)* }; }
+        fn main() {
+            foo! {
+                let a = 2;
+            }     //^
+            let _ = a; // - null
+        }
+    """)
+
     fun `test method from trait`() = doTestByText("""
         struct B1; struct B2;
         trait A { fn foo(self, x: i32); }


### PR DESCRIPTION
Now find usages work in such cases:
```rust
macro_rules! foo { ($($ t:tt)*) => { $($ t)* }; }
fn main() {
    foo! {
        let a = 2;
    }     //^ invoke find usages here
    let _ = a; // - this should be found
}
```

changelog: fix find usages for variables defined by macros
