### PR TITLE
MACRO: fix `getContext()` for elements expanded from macros in pat ctx

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -543,6 +543,7 @@ private TopPat ::= &'|' OrPat | Pat { name = "pattern" }
 
 Pat ::= SimplePat OrPatLeft? {
   implements = "org.rust.lang.core.macros.RsExpandedElement"
+  mixin = "org.rust.lang.core.psi.ext.RsPatImplMixin"
   name = "pattern"
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
@@ -5,6 +5,9 @@
 
 package org.rust.lang.core.psi.ext
 
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.ref.deepResolve
 
@@ -62,4 +65,8 @@ fun RsPat.skipUnnecessaryTupDown(): RsPat {
         pat = pat.patList.singleOrNull() ?: return pat
     }
     return pat
+}
+
+abstract class RsPatImplMixin(node: ASTNode) : RsElementImpl(node), RsPat {
+    override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
@@ -53,10 +53,8 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
                     //^
     """)
 
-    // TODO implement `getContext()` in all RsPat PSI elements
     @CheckTestmarkHit(Testmarks.Touched::class)
-    fun `test pattern context`() = expect<IllegalStateException> {
-        checkByCode("""
+    fun `test pattern context`() = checkByCode("""
         const X: i32 = 0;
             //X
         macro_rules! foo { ($($ i:tt)*) => { $( $ i )* }; }
@@ -68,7 +66,6 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
             }
         }
     """)
-    }
 
     @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test lifetime`() = checkByCode("""


### PR DESCRIPTION
Fixes go-to-declaration, highlighting, completion and other features in function-like macros used in the pattern context:
```rust
const X: i32 = 0;
    //X
macro_rules! foo {
    ($($ i:tt)*) => { $( $ i )* };
}
fn main() {
    match 0 {
        foo!(X) => {}
           //^ this
        _ => {}
    }
}
```

changelog: Fixes `Go To Declaration`, highlighting, completion and other features in function-like macros used in the pattern context
