### PR TITLE
Mark `org.rust.macros.proc.function-like` and `org.rust.macros.proc.derive` enabled in stable

### DIFF
--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -18,7 +18,9 @@ object RsExperiments {
     const val CARGO_FEATURES_SETTINGS_GUTTER = "org.rust.cargo.features.settings.gutter"
 
     const val PROC_MACROS = "org.rust.macros.proc"
+    @EnabledInStable
     const val FN_LIKE_PROC_MACROS = "org.rust.macros.proc.function-like"
+    @EnabledInStable
     const val DERIVE_PROC_MACROS = "org.rust.macros.proc.derive"
     const val ATTR_PROC_MACROS = "org.rust.macros.proc.attr"
 


### PR DESCRIPTION
It's a follow-up change to enabling procedural macro support for function-like and derive macros (#9729). Now, `Create New Issue` action doesn't add these features into issue description if they are enabled
