### PR TITLE
TYPE: fix unavailable move item action

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt
@@ -19,8 +19,8 @@ import org.rust.openapiext.Testmark
 
 abstract class RsLineMover : LineMover() {
     override fun checkAvailable(editor: Editor, file: PsiFile, info: MoveInfo, down: Boolean): Boolean {
-        if (file !is RsFile && super.checkAvailable(editor, file, info, down)) return false
-        @Suppress("USELESS_ELVIS") // NotNull annotation is wrong :(
+        if (file !is RsFile) return false
+        if (!super.checkAvailable(editor, file, info, down)) return false
         val originalRange = info.toMove ?: return false
         val psiRange = StatementUpDownMover.getElementRange(editor, file, originalRange) ?: return false
         if (psiRange.first == null || psiRange.second == null) return false


### PR DESCRIPTION
Closes #9668

changelog: fix move item/statement/etc editor action being incorrectly disabled with some IDE configurations
