### PR TITLE
Don't show "File does not belong to Cargo project" for scratch files

### DIFF
--- a/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.notifications
 
 import com.intellij.ide.impl.isTrusted
+import com.intellij.ide.scratch.ScratchUtil
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.NlsContexts.LinkLabel
@@ -40,6 +41,7 @@ class NoCargoProjectNotificationProvider(project: Project) : RsNotificationProvi
     ): RsEditorNotificationPanel? {
         if (isUnitTestMode && !isDispatchThread) return null
         if (!(file.isRustFile || file.isCargoToml) || isNotificationDisabled(file)) return null
+        if (ScratchUtil.isScratch(file)) return null
         @Suppress("UnstableApiUsage")
         if (!project.isTrusted()) return null
 


### PR DESCRIPTION
changelog: Don't show `File does not belong to any known Cargo project` warning for scratch files
