### PR TITLE
TY: take into account `impl`s expanded from macro calls inside function bodies and `impl`s from doctests

### DIFF
--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -367,3 +367,6 @@ val RsFile.isDoctestInjection: Boolean
 
 val RsElement.isDoctestInjection: Boolean
     get() = (contextualFile as? RsFile)?.isDoctestInjection == true
+
+val RsElement.isInsideInjection: Boolean
+    get() = (contextualFile as? RsFile)?.virtualFile is VirtualFileWindow

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -42,7 +42,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         result: CompletionResultSet
     ) {
         // Use original position if possible to re-use caches of the real file
-        val position = parameters.position.safeGetOriginalOrSelf()
+        val position = parameters.position
         val element = position.parent as RsReferenceElement
         if (position !== element.referenceNameElement) return
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -13,13 +13,15 @@ import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.CachedValueImpl
-import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.presentation.getPresentation
 import org.rust.lang.core.macros.RsExpandedElement
-import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.DEFAULT
 import org.rust.lang.core.psi.RsElementTypes.EXCL
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.psi.rustStructureOrAnyPsiModificationTracker
 import org.rust.lang.core.resolve.RsCachedImplItem
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.stubs.RsImplItemStub
@@ -84,12 +86,7 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
 
     val cachedImplItem: CachedValue<RsCachedImplItem> = CachedValueImpl {
         val cachedImpl = RsCachedImplItem(this)
-        val modTracker = if (cachedImpl.containingCrate?.origin == PackageOrigin.WORKSPACE) {
-            project.rustStructureModificationTracker
-        } else {
-            project.rustPsiManager.rustStructureModificationTrackerInDependencies
-        }
-        CachedValueProvider.Result(cachedImpl, modTracker)
+        RsCachedImplItem.toCachedResult(this, containingCrate, cachedImpl)
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -10,16 +10,13 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.CachedValue
-import com.intellij.psi.util.CachedValueProvider
 import com.intellij.util.CachedValueImpl
-import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsElementTypes.DEFAULT
 import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.psi.RsTypeAlias
-import org.rust.lang.core.psi.rustPsiManager
-import org.rust.lang.core.psi.rustStructureModificationTracker
+import org.rust.lang.core.resolve.RsCachedImplItem
 import org.rust.lang.core.resolve.RsCachedTypeAlias
 import org.rust.lang.core.stubs.RsTypeAliasStub
 import org.rust.lang.core.types.RsPsiTypeImplUtil
@@ -57,11 +54,6 @@ abstract class RsTypeAliasImplMixin : RsStubbedNamedElementImpl<RsTypeAliasStub>
 
     val cachedImplItem: CachedValue<RsCachedTypeAlias> = CachedValueImpl {
         val cachedTypeAlias = RsCachedTypeAlias(this)
-        val modTracker = if (cachedTypeAlias.containingCrate?.origin == PackageOrigin.WORKSPACE) {
-            project.rustStructureModificationTracker
-        } else {
-            project.rustPsiManager.rustStructureModificationTrackerInDependencies
-        }
-        CachedValueProvider.Result(cachedTypeAlias, modTracker)
+        RsCachedImplItem.toCachedResult(this, containingCrate, cachedTypeAlias)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -36,7 +36,7 @@ import org.rust.stdext.RsResult.Ok
 fun inferTypesIn(element: RsInferenceContextOwner): RsInferenceResult {
     val items = element.knownItems
     val paramEnv = if (element is RsItemElement) ParamEnv.buildFor(element) else ParamEnv.EMPTY
-    val lookup = ImplLookup(element.project, element.containingCrate, items, paramEnv)
+    val lookup = ImplLookup(element.project, element.containingCrate, items, paramEnv, element)
     return recursionGuard(element, { lookup.ctx.infer(element) }, memoize = false)
         ?: error("Can not run nested type inference")
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
@@ -21,13 +21,12 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
          //X
     """, "lib.rs")
 
-    // BACKCOMPAT: Rust 1.50. Vec struct was moved into `vec/mod.rs` since Rust 1.51
     @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
     fun `test resolve std element`() = stubOnlyResolve("""
     //- lib.rs
         /// ```
         /// Vec::new()
-        /// //^ ...vec.rs|...vec/mod.rs
+        /// //^ ...vec/mod.rs
         /// ```
         pub fn foo() {}
     """)
@@ -191,4 +190,40 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
         /// ```
         fn foo() {}
     """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test impl`() = checkByCode("""
+        /// ```
+        /// use test_package::Bar;
+        /// struct Foo;
+        /// impl Foo {
+        ///      fn foo(&self) -> Bar {}
+        /// }
+        /// Foo.foo().bar();
+        ///         //^
+        /// ```
+        pub struct Bar;
+        impl Bar {
+            pub fn bar(&self) {}
+        }        //X
+    """, "lib.rs")
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test impl outside of main`() = checkByCode("""
+        /// ```
+        /// use test_package::Bar;
+        /// struct Foo;
+        /// impl Foo {
+        ///      fn foo(&self) -> Bar {}
+        /// }
+        /// fn main() {
+        ///     Foo.foo().bar();
+        ///             //^
+        /// }
+        /// ```
+        pub struct Bar;
+        impl Bar {
+            pub fn bar(&self) {}
+        }        //X
+    """, "lib.rs")
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -666,6 +666,46 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         }           //^
     """)
 
+    fun `test impl defined by macro inside a function body`() = checkByCode("""
+        macro_rules! foo {
+            ($ i:ident) => {
+                impl $ i {
+                    fn foo(&self) -> Bar {}
+                }
+            }
+        }
+
+        struct Foo;
+        struct Bar;
+        fn main() {
+            foo!(Foo);
+            impl Bar { fn bar(&self) {} }
+                        //X
+            Foo.foo().bar();
+        }           //^
+    """)
+
+    fun `test impl defined by macro inside a parent function body`() = checkByCode("""
+        macro_rules! foo {
+            ($ i:ident) => {
+                impl $ i {
+                    fn foo(&self) -> Bar {}
+                }
+            }
+        }
+
+        struct Foo;
+        struct Bar;
+        fn main() {
+            foo!(Foo);
+            fn bar() {
+                impl Bar { fn bar(&self) {} }
+                            //X
+                Foo.foo().bar();
+            }           //^
+        }
+    """)
+
     fun `test mod declared with macro`() = stubOnlyResolve("""
     //- main.rs
         macro_rules! foo {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -579,7 +579,7 @@ class RsProcMacroExpansionResolveTest : RsResolveTestBase() {
         }     //X
     """)
 
-    fun `test custom derive inside a function body`() = checkByCode("""
+    fun `test custom derive expanding to a struct inside a function body`() = checkByCode("""
         use test_proc_macros::DeriveStructFooDeclaration;
 
         fn main() {
@@ -592,6 +592,37 @@ class RsProcMacroExpansionResolveTest : RsResolveTestBase() {
 
             Foo.bar()
         }     //^
+    """)
+
+    fun `test custom derive expanding to an impl inside a function body`() = checkByCode("""
+        use test_proc_macros::DeriveImplForFoo;
+
+        fn main() {
+            #[derive(DeriveImplForFoo)] // impl Foo { fn foo(&self) -> Bar {} }
+            struct Foo;
+            struct Bar;
+            impl Bar {
+                fn bar(&self) {}
+            }     //X
+
+            Foo.foo().bar()
+        }           //^
+    """)
+
+    fun `test attr expanded to an impl inside a function body`() = checkByCode("""
+        use test_proc_macros::attr_replace_with_attr;
+
+        fn main() {
+            #[attr_replace_with_attr(impl Foo { fn foo(&self) -> Bar {} })]
+            foobar!();
+            struct Foo;
+            struct Bar;
+            impl Bar {
+                fn bar(&self) {}
+            }     //X
+
+            Foo.foo().bar()
+        }           //^
     """)
 
     // Issue https://github.com/intellij-rust/intellij-rust/issues/9531


### PR DESCRIPTION
Fixes #6164

Note that because of technical limitations `impl`s are accounted only when performing type inference within the same function

changelog: 1. Take into account `impl`s expanded from macro calls inside function bodies. 2. Take into account `impl`s located in doctests

