### PR TITLE
Fix double space on autocomplete-with-space

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
@@ -107,6 +107,10 @@ class RsKeywordCompletionContributor : CompletionContributor(), DumbAware {
                 if (isLetExpr && !hasSemicolon) tail += ';'
                 context.document.insertString(context.selectionEndOffset, tail)
                 EditorModificationUtil.moveCaretRelatively(context.editor, 1)
+
+                if (context.completionChar == ' ') {
+                    context.setAddCompletionChar(false)
+                }
             }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
@@ -49,5 +49,5 @@ private fun addInsertionHandler(keyword: String, builder: LookupElementBuilder, 
         else -> return builder
     }
 
-    return builder.withInsertHandler { ctx, _ -> ctx.addSuffix(suffix) }
+    return builder.withInsertHandler { ctx, _ -> if (ctx.completionChar.toString() != suffix) ctx.addSuffix(suffix) }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsVisibilityCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsVisibilityCompletionProvider.kt
@@ -29,7 +29,9 @@ class RsVisibilityCompletionProvider : CompletionProvider<CompletionParameters>(
                 LookupElementBuilder.create(name)
                     .bold()
                     .withInsertHandler { ctx, _ ->
-                        insertSpaceIfNeeded(ctx)
+                        if (ctx.completionChar != ' ') {
+                            insertSpaceIfNeeded(ctx)
+                        }
                         ctx.editor.caretModel.moveToOffset(ctx.selectionEndOffset)
                     }
                     .toKeywordElement(priority)


### PR DESCRIPTION
Fixes #8999.

changelog: Fix insertion of unnecessary spaces when _Insert selected suggestion by pressing space_ is enabled.