### PR TITLE
TY: fix impl search when there are multiple type aliases with same name

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -359,11 +359,11 @@ class ImplLookup(
             val result = aliases.any {
                 val name = it.name ?: return@any false
                 val aliasFingerprint = TyFingerprint(name)
-                val isAppropriateAlias = set.add(aliasFingerprint) && run {
+                val isAppropriateAlias = run {
                     val (declaredType, generics, constGenerics) = it.typeAndGenerics
                     canCombineTypes(selfTy, declaredType, generics, constGenerics)
                 }
-                isAppropriateAlias && processor(aliasFingerprint)
+                isAppropriateAlias && set.add(aliasFingerprint) && processor(aliasFingerprint)
             }
             if (result) return true
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -840,6 +840,28 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
+    fun `test impl for alias with multiple aliases with the same name`() = checkByCode("""
+        mod a {
+            pub struct X;
+            pub type Y = X;
+            impl Y { pub fn foo(&self) {} }
+        }
+        mod b {
+            pub struct X;
+            pub type Y = X;
+            impl Y { pub fn foo(&self) {} }
+                          //X
+        }
+        mod c {
+            pub struct X;
+            pub type Y = X;
+            impl Y { pub fn foo(&self) {} }
+        }
+        fn main() {
+            b::X.foo();
+        }      //^
+    """)
+
     fun `test primitive vs mod`() = checkByCode("""
         mod impls {
             #[lang = "str"]


### PR DESCRIPTION
Fixes this case:
```rust
mod a {
    pub struct X;
    pub type Y = X;
    impl Y { pub fn foo(&self) {} }
}
mod b {
    pub struct X;
    pub type Y = X;
    impl Y { pub fn foo(&self) {} }
                  //X
}
mod c {
    pub struct X;
    pub type Y = X;
    impl Y { pub fn foo(&self) {} }
}
fn main() {
    b::X.foo();
}      //^
```
Previously, `foo` was unresolved

changelog: fix impl search when there are multiple type aliases with same names
