### PR TITLE
UI: fix erratic jumps of linter icon during scan

### DIFF
--- a/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
@@ -15,7 +15,6 @@ import java.awt.Color
 import java.awt.Component
 import java.awt.Graphics
 import java.awt.Graphics2D
-import java.awt.geom.AffineTransform
 import java.awt.image.RGBImageFilter
 import javax.swing.Icon
 
@@ -111,7 +110,7 @@ object RsIcons {
 
     val GEAR = load("/icons/gear.svg")
     val GEAR_OFF = load("/icons/gear-off.svg")
-    val GEAR_ANIMATED = AnimatedIcon(AnimatedIcon.Default.DELAY, GEAR, GEAR.rotated(-45.0), GEAR.rotated(90.0), GEAR.rotated(45.0))
+    val GEAR_ANIMATED = AnimatedIcon(AnimatedIcon.Default.DELAY, GEAR, GEAR.rotated(15.0), GEAR.rotated(30.0), GEAR.rotated(45.0))
 
     private fun load(path: String): Icon = IconLoader.getIcon(path, RsIcons::class.java)
 }
@@ -139,16 +138,22 @@ fun Icon.grayed(): Icon =
         }
     }, null)
 
+/**
+ * Rotates the icon by the given angle, in degrees.
+ *
+ * **Important**: Do ***not*** rotate the icon by ±90 degrees (or any sufficiently close amount)!
+ * The implementation of rotation by that amount in AWT is broken, and results in erratic shifts for composed
+ * transformations. In other words, the (final) transformation matrix as a function of rotation angle
+ * is discontinuous at those points.
+ */
 fun Icon.rotated(angle: Double): Icon {
     val q = this
     return object : Icon by this {
         override fun paintIcon(c: Component, g: Graphics, x: Int, y: Int) {
             val g2d = g.create() as Graphics2D
             try {
-                val transform = AffineTransform.getTranslateInstance(x.toDouble(), y.toDouble())
-                transform.concatenate(AffineTransform.getRotateInstance(Math.toRadians(angle), iconWidth / 2.0, iconHeight / 2.0))
-                transform.preConcatenate(g2d.transform)
-                g2d.transform = transform
+                g2d.translate(x.toDouble(), y.toDouble())
+                g2d.rotate(Math.toRadians(angle), iconWidth / 2.0, iconHeight / 2.0)
                 q.paintIcon(c, g2d, 0, 0)
             } finally {
                 g2d.dispose()


### PR DESCRIPTION
Closes #9426

The icon rendering (or affine transformation implementation) in AWT is broken: they have tried to special-case ±90° turns (for performance), but ended up with erratic shifts in composed transformations, which lead to jumps of linter icon during its animation. Fortunately, since the gear icon is 6-fold symmetric, we can use only 0, 15, 30 and 45 degrees to reproduce the whole animation correctly.

I have fixed the animation and added a warning to the documentation of `Icon.rotated`.

changelog: fix flickering of external linter icon in the status bar during scans
