### PR TITLE
UI: add marker to icons of unsafe items

### DIFF
--- a/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
@@ -39,6 +39,7 @@ object RsIcons {
 
     val FINAL_MARK = AllIcons.Nodes.FinalMark
     val STATIC_MARK = AllIcons.Nodes.StaticMark
+    val UNSAFE_MARK = load("/icons/unsafeMark.svg")
     val TEST_MARK = AllIcons.Nodes.JunitTestMark
     val DOCS_MARK = load("/icons/docsrs.svg")
     val FEATURE_CHECKED_MARK = AllIcons.Diff.GutterCheckBoxSelected
@@ -63,8 +64,9 @@ object RsIcons {
     val MACRO2 = load("/icons/nodes/macro2.0.svg")
 
     val CONSTANT = load("/icons/nodes/constant.svg")
-    val MUT_STATIC = load("/icons/nodes/static.svg")
-    val STATIC = MUT_STATIC.addFinalMark()
+    private val STATIC_BASE = load("/icons/nodes/static.svg")
+    val STATIC = STATIC_BASE.addFinalMark()
+    val MUT_STATIC = STATIC_BASE.addUnsafeMark()
 
     val METHOD = load("/icons/nodes/method.svg")
     val ASSOC_FUNCTION = FUNCTION.addStaticMark()
@@ -116,6 +118,8 @@ object RsIcons {
 fun Icon.addFinalMark(): Icon = LayeredIcon(this, RsIcons.FINAL_MARK)
 
 fun Icon.addStaticMark(): Icon = LayeredIcon(this, RsIcons.STATIC_MARK)
+
+fun Icon.addUnsafeMark(): Icon = LayeredIcon(this, RsIcons.UNSAFE_MARK)
 
 fun Icon.addTestMark(): Icon = LayeredIcon(this, RsIcons.TEST_MARK)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
@@ -21,5 +21,7 @@ abstract class RsForeignModItemImplMixin : RsStubbedElementImpl<RsForeignModStub
 
     override val visibility: RsVisibility get() = RsVisibility.Private // visibility does not affect foreign mods
 
+    val abi: String = greenStub?.abi ?: "C"
+
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.icons.addTestMark
+import org.rust.ide.icons.addUnsafeMark
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsFunctionStub
@@ -160,7 +161,7 @@ val RsFunction.isActuallyUnsafe: Boolean
                 // See https://github.com/rustwasm/wasm-bindgen
                 context.queryAttributes.hasAttribute("wasm_bindgen") -> false
                 // Some Rust intrinsics are safe. This info is hardcoded in compiler
-                context.externAbi.litExpr?.stringValue == "rust-intrinsic" -> name !in SAFE_INTRINSICS
+                (context as? RsForeignModItemImplMixin)?.abi == "rust-intrinsic" -> name !in SAFE_INTRINSICS
                 else -> true
             }
         } else {
@@ -306,6 +307,7 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 
     override fun getIcon(flags: Int): Icon {
+        var hasVisibility = true
         val baseIcon = when (val owner = owner) {
             is RsAbstractableOwner.Free, is RsAbstractableOwner.Foreign ->
                 when {
@@ -315,17 +317,19 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
                 }
 
             is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl -> {
-                val icon = when {
+                if (!owner.isInherentImpl) {
+                    hasVisibility = false
+                }
+                when {
                     isAssocFn && isAbstract -> RsIcons.ABSTRACT_ASSOC_FUNCTION
                     isAssocFn -> RsIcons.ASSOC_FUNCTION
                     isAbstract -> RsIcons.ABSTRACT_METHOD
                     else -> RsIcons.METHOD
                 }
-                if (!owner.isInherentImpl) return icon
-                icon
             }
         }
-        return iconWithVisibility(flags, baseIcon)
+        val icon = if (isActuallyUnsafe) baseIcon.addUnsafeMark() else baseIcon
+        return if (hasVisibility) iconWithVisibility(flags, icon) else icon
     }
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.CachedValueImpl
 import org.rust.ide.icons.RsIcons
+import org.rust.ide.icons.addUnsafeMark
 import org.rust.ide.presentation.getPresentation
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsElementTypes.DEFAULT
@@ -51,7 +52,7 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
     constructor(node: ASTNode) : super(node)
     constructor(stub: RsImplItemStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getIcon(flags: Int) = RsIcons.IMPL
+    override fun getIcon(flags: Int) = if (isUnsafe) RsIcons.IMPL.addUnsafeMark() else RsIcons.IMPL
 
     override val isPublic: Boolean get() = false // pub does not affect impls at all
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.util.Query
 import org.rust.ide.icons.RsIcons
+import org.rust.ide.icons.addUnsafeMark
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.KNOWN_DERIVABLE_TRAITS
@@ -124,8 +125,10 @@ abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>
 
     constructor(stub: RsTraitItemStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getIcon(flags: Int): Icon =
-        iconWithVisibility(flags, RsIcons.TRAIT)
+    override fun getIcon(flags: Int): Icon {
+        val icon = if (isUnsafe) RsIcons.TRAIT.addUnsafeMark() else RsIcons.TRAIT
+        return iconWithVisibility(flags, icon)
+    }
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 

--- a/src/main/resources/icons/unsafeMark.svg
+++ b/src/main/resources/icons/unsafeMark.svg
@@ -1,0 +1,7 @@
+<!-- Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <g fill="none" fill-rule="evenodd">
+    <polygon fill="#F4AF3D" stroke = "black" stroke-width="0.4px" points="11.5 8.5 16 16 7 16"/>
+    <path fill="#000" d="M12,14 L12,15 L11,15 L11,14 L12,14 Z M12,10.5 L12,13 L11,13 L11,10.5 L12,10.5 Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
Mark all icons of unsafe items (including functions in `extern` blocks) with the unsafety marker. This allows to easily see unsafe methods (which are usually avoided) in autocomplete popup and symbol search.

changelog: changed icons for unsafe items, in Structure View and search.
