### PR TITLE
MACRO: properly limit max depth of im-memory macro expansions

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
@@ -117,11 +117,8 @@ private fun getMacroExpansions(macroToExpand: RsPossibleMacroCall, expandRecursi
         return singleStepExpansion
     }
 
-    val expansionText = if (expandRecursively) {
-        macroToExpand.expandMacrosRecursively(replaceDollarCrate = true)
-    } else {
-        macroToExpand.expandMacrosRecursively(depthLimit = 1, replaceDollarCrate = true)
-    }
+    val depthLimit = if (expandRecursively) Int.MAX_VALUE else 1
+    val expansionText = macroToExpand.expandMacrosRecursively(depthLimit, replaceDollarCrate = true)
 
     return parseExpandedTextWithContext(
         macroToExpand.expansionContext,

--- a/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
@@ -17,7 +17,6 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.ext.RsBindingModeKind.BindByReference
 import org.rust.lang.core.psi.ext.RsBindingModeKind.BindByValue
-import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.lang.core.resolve.VALUES
 import org.rust.lang.core.types.infer.substituteOrUnknown
 import org.rust.lang.core.types.normType
@@ -111,8 +110,6 @@ enum class MutateMode {
 }
 
 class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCategorizationContext) {
-    private var nestedMacroCallsCount: Int = 0
-
     fun consumeBody(body: RsBlock) {
         val function = body.parent as? RsFunction ?: return
 
@@ -313,11 +310,6 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
     }
 
     private fun walkMacroCall(macroCall: RsMacroCall) {
-        if (nestedMacroCallsCount > DEFAULT_RECURSION_LIMIT) {
-            return
-        }
-        nestedMacroCallsCount++
-
         when (val argument = macroCall.macroArgumentElement) {
             is RsExprMacroArgument -> argument.expr?.let(::walkExpr)
             is RsIncludeMacroArgument -> argument.expr?.let(::walkExpr)
@@ -360,7 +352,6 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
 
             else -> error("unreachable")
         }
-        nestedMacroCallsCount--
     }
 
     private fun walkStmt(stmt: RsStmt) {

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -100,16 +100,6 @@ fun PsiElement.findMacroCallExpandedFrom(): RsPossibleMacroCall? {
     return found?.findMacroCallExpandedFrom() ?: found
 }
 
-fun PsiElement.calculateMacroExpansionDepth(): Int {
-    var macroCall = findMacroCallExpandedFromNonRecursive() ?: return 0
-    var counter = 1
-    while (true) {
-        macroCall = macroCall.findMacroCallExpandedFromNonRecursive() ?: break
-        counter++
-    }
-    return counter
-}
-
 fun PsiElement.findMacroCallExpandedFromNonRecursive(): RsPossibleMacroCall? {
     return stubAncestors
         .filterIsInstance<RsExpandedElement>()

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -44,7 +44,7 @@ interface RsExpandedElement : RsElement {
 }
 
 fun RsExpandedElement.setContext(context: RsElement) {
-    (containingFile as? RsFile)?.setRsFileContext(context, lazy = true)
+    (containingFile as? RsFile)?.setRsFileContext(context, isInMemoryMacroExpansion = false)
     setExpandedElementContext(context)
 }
 
@@ -54,10 +54,10 @@ fun RsExpandedElement.setExpandedElementContext(context: RsElement) {
 }
 
 /** Internal. Use [setContext] */
-fun RsFile.setRsFileContext(context: RsElement, lazy: Boolean) {
+fun RsFile.setRsFileContext(context: RsElement, isInMemoryMacroExpansion: Boolean) {
     val contextContainingFile = context.containingRsFileSkippingCodeFragments
     if (contextContainingFile != null) {
-        inheritCachedDataFrom(contextContainingFile, lazy)
+        inheritCachedDataFrom(contextContainingFile, isInMemoryMacroExpansion)
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
@@ -28,6 +28,7 @@ sealed class GetMacroExpansionError {
 
     object ModDataNotFound : GetMacroExpansionError()
     object InconsistentExpansionExpandedFrom : GetMacroExpansionError()
+    object TooDeepExpansion : GetMacroExpansionError()
     object NoMacroIndex : GetMacroExpansionError()
     object ExpansionNameNotFound : GetMacroExpansionError()
     object ExpansionFileNotFound : GetMacroExpansionError()
@@ -85,6 +86,8 @@ sealed class GetMacroExpansionError {
         ModDataNotFound -> "internal error: can't find ModData for containing mod of the macro call"
         InconsistentExpansionExpandedFrom -> "internal error: `macro.expansion.expandedFrom != macro`; " +
             "maybe the macro invocation is inside a module that conflicts with another module name?"
+        ModDataNotFound -> "can't find ModData for containing mod of the macro call"
+        TooDeepExpansion -> "recursion limit reached"
         NoMacroIndex -> "can't find macro index of the macro call"
         ExpansionNameNotFound -> "internal error: expansion name not found"
         ExpansionFileNotFound -> "the macro is not yet expanded"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -23,7 +23,6 @@ import org.rust.lang.core.macros.expansionContext
 import org.rust.lang.core.macros.findMacroCallExpandedFrom
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
-import org.rust.lang.core.resolve2.getRecursionLimit
 import org.rust.lang.core.stubs.RsMacroCallStub
 import org.rust.openapiext.findFileByMaybeRelativePath
 import org.rust.openapiext.isUnitTestMode
@@ -169,20 +168,13 @@ val RsMacroCall.expansionFlatten: List<RsExpandedElement>
         return list
     }
 
-fun RsMacroCall.processExpansionRecursively(recursionLimit: Int, processor: (RsExpandedElement) -> Boolean): Boolean =
-    processExpansionRecursively(processor, recursionLimit)
-
-fun RsMacroCall.processExpansionRecursively(processor: (RsExpandedElement) -> Boolean): Boolean =
-    processExpansionRecursively(processor, getRecursionLimit(this))
-
-private fun RsMacroCall.processExpansionRecursively(processor: (RsExpandedElement) -> Boolean, recursionLimit: Int): Boolean {
-    if (recursionLimit == 0) return true
-    return expansion?.elements.orEmpty().any { it.processRecursively(processor, recursionLimit) }
+fun RsMacroCall.processExpansionRecursively(processor: (RsExpandedElement) -> Boolean): Boolean {
+    return expansion?.elements.orEmpty().any { it.processRecursively(processor) }
 }
 
-private fun RsExpandedElement.processRecursively(processor: (RsExpandedElement) -> Boolean, recursionLimit: Int): Boolean {
+private fun RsExpandedElement.processRecursively(processor: (RsExpandedElement) -> Boolean): Boolean {
     return when (this) {
-        is RsMacroCall -> existsAfterExpansionSelf && processExpansionRecursively(processor, recursionLimit - 1)
+        is RsMacroCall -> existsAfterExpansionSelf && processExpansionRecursively(processor)
         else -> processor(this)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
@@ -28,7 +28,6 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsPossibleMacroCallKind.MacroCall
 import org.rust.lang.core.psi.ext.RsPossibleMacroCallKind.MetaItem
 import org.rust.lang.core.resolve.resolveDollarCrateIdentifier
-import org.rust.lang.core.resolve2.getRecursionLimit
 import org.rust.lang.core.resolve2.resolveToMacroWithoutPsi
 import org.rust.lang.core.resolve2.resolveToProcMacroWithoutPsi
 import org.rust.lang.core.stubs.RsAttrProcMacroOwnerStub
@@ -465,7 +464,7 @@ val RS_MACRO_CALL_EXPANSION_RESULT: Key<CachedValue<RsResult<MacroExpansion, Get
     Key("org.rust.lang.core.psi.ext.RS_MACRO_CALL_EXPANSION_RESULT")
 
 fun RsPossibleMacroCall.expandMacrosRecursively(
-    depthLimit: Int = getRecursionLimit(this),
+    depthLimit: Int = Int.MAX_VALUE,
     replaceDollarCrate: Boolean = true,
     expander: (RsPossibleMacroCall) -> MacroExpansion? = RsPossibleMacroCall::expansion
 ): String {

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeMetaInfo.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeMetaInfo.kt
@@ -58,6 +58,7 @@ fun CrateDefMap.hasTransitiveGlobImport(source: RsMod, target: RsMod): Boolean {
     return globImportGraph.hasTransitiveGlobImport(sourceModData, targetModData)
 }
 
+@Suppress("unused") // May be useful for type inference
 fun getRecursionLimit(element: PsiElement): Int {
     val mod = element.ancestorOrSelf<RsElement>()?.containingMod ?: return DEFAULT_RECURSION_LIMIT
     val (_, defMap, _) = getModInfo(mod) ?: return DEFAULT_RECURSION_LIMIT

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TyLowering.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TyLowering.kt
@@ -9,10 +9,8 @@ import com.intellij.openapi.util.RecursionGuard
 import com.intellij.openapi.util.RecursionManager
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.macros.MacroExpansion
-import org.rust.lang.core.macros.calculateMacroExpansionDepth
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.lang.core.resolve.RsPathResolveResult
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.resolve.ref.RsPathReferenceImpl
@@ -166,7 +164,6 @@ class TyLowering private constructor(
             }
 
             is RsMacroType -> {
-                if (type.calculateMacroExpansionDepth() >= DEFAULT_RECURSION_LIMIT) return TyUnknown
                 val expansion = type.macroCall.expansion as? MacroExpansion.Type ?: return TyUnknown
                 lowerTy(expansion.type, null)
             }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1455,7 +1455,6 @@ object TypeInferenceMarks {
     object WinnowParamCandidateLoses : Testmark()
     object WinnowObjectOrProjectionCandidateWins : Testmark()
     object TraitSelectionOverflow : Testmark()
-    object MacroExprDepthLimitReached : Testmark()
     object UnsizeToTraitObject : Testmark()
     object UnsizeArrayToSlice : Testmark()
     object UnsizeStruct : Testmark()

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -47,7 +47,6 @@ class RsTypeInferenceWalker(
 ) {
     private var tryTy: Ty? = returnTy
     private var yieldTy: Ty? = null
-    private var macroExprDepth: Int = 0
     private val lookup get() = ctx.lookup
     private val items get() = ctx.items
     private val fulfill get() = ctx.fulfill
@@ -1228,19 +1227,6 @@ class RsTypeInferenceWalker(
     }
 
     private fun inferMacroExprType(macroExpr: RsMacroExpr, expected: Expectation): Ty {
-        if (macroExprDepth > DEFAULT_RECURSION_LIMIT) {
-            TypeInferenceMarks.MacroExprDepthLimitReached.hit()
-            return TyUnknown
-        }
-        macroExprDepth++
-        try {
-            return inferMacroExprType0(macroExpr, expected)
-        } finally {
-            macroExprDepth--
-        }
-    }
-
-    private fun inferMacroExprType0(macroExpr: RsMacroExpr, expected: Expectation): Ty {
         val macroCall = macroExpr.macroCall
 
         val definition = macroCall.resolveToMacro()

--- a/src/main/kotlin/org/rust/openapiext/psi.kt
+++ b/src/main/kotlin/org/rust/openapiext/psi.kt
@@ -19,7 +19,6 @@ import org.rust.lang.core.psi.ext.RsAttrProcMacroOwner
 import org.rust.lang.core.psi.ext.RsPossibleMacroCall
 import org.rust.lang.core.psi.ext.expansion
 import org.rust.lang.core.psi.ext.macroName
-import org.rust.lang.core.resolve2.getRecursionLimit
 import org.rust.stdext.exhaustive
 
 
@@ -91,7 +90,7 @@ fun processElementsWithMacros(element: PsiElement, processor: PsiTreeProcessor):
         return true
     }
 
-    val visitor = RsWithMacrosRecursiveElementWalkingVisitor(processor, getRecursionLimit(element))
+    val visitor = RsWithMacrosRecursiveElementWalkingVisitor(processor)
     element.accept(visitor)
 
     return visitor.result
@@ -99,7 +98,6 @@ fun processElementsWithMacros(element: PsiElement, processor: PsiTreeProcessor):
 
 private class RsWithMacrosRecursiveElementWalkingVisitor(
     private val processor: PsiTreeProcessor,
-    private val recursionLimit: Int,
 ) : PsiRecursiveElementWalkingVisitor() {
 
     var result: Boolean = true
@@ -135,12 +133,9 @@ private class RsWithMacrosRecursiveElementWalkingVisitor(
     }
 
     private fun processMacro(element: RsPossibleMacroCall) {
-        if (recursionLimit == 0) {
-            return
-        }
         val expansion = element.expansion ?: return
         for (expandedElement in expansion.elements) {
-            val visitor = RsWithMacrosRecursiveElementWalkingVisitor(processor, recursionLimit - 1)
+            val visitor = RsWithMacrosRecursiveElementWalkingVisitor(processor)
             expandedElement.accept(visitor)
         }
     }

--- a/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
@@ -9,6 +9,7 @@ import org.intellij.lang.annotations.Language
 import org.rust.*
 import org.rust.ide.colors.RsColor
 import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.macros.MacroExpansionManager
 
 // More tests are located in `RsHighlightingAnnotatorTest` (most of those tests are executed
 // in both plain and macro context)
@@ -54,6 +55,16 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
         <ATTRIBUTE>#</ATTRIBUTE><ATTRIBUTE>[allow</ATTRIBUTE><ATTRIBUTE>(foo</ATTRIBUTE><ATTRIBUTE>)]</ATTRIBUTE>
         fn <FUNCTION>main</FUNCTION>() {
             <ATTRIBUTE>#!</ATTRIBUTE><ATTRIBUTE>[crate_type = <STRING>"lib"</STRING></ATTRIBUTE><ATTRIBUTE>]</ATTRIBUTE>
+        }
+    """)
+
+    @CheckTestmarkHit(MacroExpansionManager.Testmarks.TooDeepExpansion::class)
+    fun `test infinite recursive macro`() = checkHighlighting("""
+        macro_rules! foo {
+            ($ i:ident) => { foo!($ i) };
+        }
+        fn main() {
+            let _ = foo!(a);
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -5,12 +5,10 @@
 
 package org.rust.ide.inspections.borrowck
 
-import org.rust.ExpandMacros
-import org.rust.MockAdditionalCfgOptions
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.*
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.lang.core.macros.MacroExpansionManager
 import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection::class) {
@@ -733,6 +731,8 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
         }
     """, checkWarn = false)
 
+    @ExpandMacros
+    @CheckTestmarkHit(MacroExpansionManager.Testmarks.TooDeepExpansion::class)
     fun `test infinitely recursive macro call`() = checkByText("""
         macro_rules! infinite_macro {
             ($ e:expr) => { infinite_macro!($ e) };

--- a/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.dfa
 
 import org.intellij.lang.annotations.Language
 import org.rust.*
+import org.rust.lang.core.macros.MacroExpansionManager
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.block
 import org.rust.lang.core.psi.ext.descendantsOfType
@@ -1347,6 +1348,8 @@ class RsControlFlowGraphTest : RsTestBase() {
         }
     """)
 
+    @ExpandMacros
+    @CheckTestmarkHit(MacroExpansionManager.Testmarks.TooDeepExpansion::class)
     fun `test infinitely recursive macro call`() = testCFG("""
         macro_rules! infinite_macro {
             () => { infinite_macro!() };
@@ -1361,8 +1364,8 @@ class RsControlFlowGraphTest : RsTestBase() {
             "0: Entry" -> "3: 1";
             "3: 1" -> "4: 1;";
             "4: 1;" -> "5: infinite_macro ! ( )";
-            "5: infinite_macro ! ( )" -> "2: Termination";
-            "6: Unreachable" -> "7: infinite_macro ! ( )";
+            "5: infinite_macro ! ( )" -> "6: infinite_macro ! ( )";
+            "6: infinite_macro ! ( )" -> "7: infinite_macro ! ( )";
             "7: infinite_macro ! ( )" -> "8: infinite_macro ! ( )";
             "8: infinite_macro ! ( )" -> "9: infinite_macro ! ( )";
             "9: infinite_macro ! ( )" -> "10: infinite_macro ! ( )";
@@ -1488,14 +1491,11 @@ class RsControlFlowGraphTest : RsTestBase() {
             "129: infinite_macro ! ( )" -> "130: infinite_macro ! ( )";
             "130: infinite_macro ! ( )" -> "131: infinite_macro ! ( )";
             "131: infinite_macro ! ( )" -> "132: infinite_macro ! ( )";
-            "132: infinite_macro ! ( )" -> "133: infinite_macro ! ( )";
-            "133: infinite_macro ! ( )" -> "134: infinite_macro ! ( )";
-            "134: infinite_macro ! ( )" -> "135: infinite_macro ! ( )";
-            "135: infinite_macro ! ( )" -> "136: infinite_macro ! ( );";
-            "136: infinite_macro ! ( );" -> "137: 2";
-            "137: 2" -> "138: 2;";
-            "138: 2;" -> "139: BLOCK";
-            "139: BLOCK" -> "1: Exit";
+            "132: infinite_macro ! ( )" -> "133: infinite_macro ! ( );";
+            "133: infinite_macro ! ( );" -> "134: 2";
+            "134: 2" -> "135: 2;";
+            "135: 2;" -> "136: BLOCK";
+            "136: BLOCK" -> "1: Exit";
             "1: Exit" -> "2: Termination";
         }
     """)

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -5,10 +5,9 @@
 
 package org.rust.lang.core.type
 
-import org.rust.MockEdition
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
+import org.rust.lang.core.macros.MacroExpansionManager
 
 class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
     fun `test function call`() = testExpr("""
@@ -1755,6 +1754,8 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ i32
     """)
 
+    @ExpandMacros
+    @CheckTestmarkHit(MacroExpansionManager.Testmarks.TooDeepExpansion::class)
     fun `test infinite macro type`() = testExpr("""
         fn main() {
           macro_rules! infinite {

--- a/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
@@ -6,7 +6,8 @@
 package org.rust.lang.core.type
 
 import org.rust.CheckTestmarkHit
-import org.rust.lang.core.types.infer.TypeInferenceMarks
+import org.rust.ExpandMacros
+import org.rust.lang.core.macros.MacroExpansionManager
 
 class RsMacroTypeInferenceTest : RsTypificationTestBase() {
     override val followMacroExpansions: Boolean get() = true
@@ -128,7 +129,8 @@ class RsMacroTypeInferenceTest : RsTypificationTestBase() {
         } //^ <unknown>
     """)
 
-    @CheckTestmarkHit(TypeInferenceMarks.MacroExprDepthLimitReached::class)
+    @ExpandMacros
+    @CheckTestmarkHit(MacroExpansionManager.Testmarks.TooDeepExpansion::class)
     fun `test infinite recursion`() = testExpr("""
         macro_rules! foo { () => { foo!(); }; }
         fn main() {


### PR DESCRIPTION
Previously, this code immediately triggered a stack overflow exception:
```rust
macro_rules! foo {
    ($ i:ident) => { foo!($ i) };
}
fn main() {
    let _ = foo!(a);
}
```