### PR TITLE
INSP: Add support for E0044

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1626,10 +1626,21 @@ sealed class RsDiagnostic(
             fixes = listOf(AddAssocTypeBindingsFix(element, missingTypes.map { it.name }))
         )
     }
+
+    class ConstOrTypeParamsInExternError(
+        element: PsiElement,
+        private val kinds: String
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0044,
+            "Foreign items may not have $kinds parameters"
+        )
+    }
 }
 
 enum class RsErrorCode {
-    E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
+    E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0191, E0198, E0199,
     E0200, E0201, E0220, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0364, E0365, E0379, E0384,

--- a/src/test/kotlin/org/rust/ide/annotator/RsTypeParamsInExternAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsTypeParamsInExternAnnotatorTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+class RsTypeParamsInExternAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
+    fun `test E0044 type param`() = checkByText("""
+        extern "C" {
+            fn foo<error descr="Foreign items may not have type parameters [E0044]"><T></error>();
+        }
+    """)
+
+    fun `test E0044 const type param`() = checkByText("""
+        extern "C" {
+            fn foo<error descr="Foreign items may not have const parameters [E0044]"><const X: usize></error>();
+        }
+    """)
+
+    fun `test E0044 type and const type params`() = checkByText("""
+        extern "C" {
+            fn foo<error descr="Foreign items may not have type or const parameters [E0044]"><T, const X: usize></error>();
+        }
+    """)
+
+    fun `test E0044 allow lifetime param`() = checkByText("""
+        extern "C" {
+            fn foo<'a>();
+        }
+    """)
+}


### PR DESCRIPTION
reference: [implementation in the compiler](https://github.com/rust-lang/rust/blob/30117a1dbb843da1d5ab1258e89a3ed0b1940475/compiler/rustc_hir_analysis/src/check/check.rs#L618)

changelog: Add support for [E0044](https://doc.rust-lang.org/error_codes/E0044.html)