### PR TITLE
TYPE: fix overwriting of operators on completion of associated items.

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
@@ -5,9 +5,11 @@
 
 package org.rust.ide.navigation.goto
 
+import com.intellij.codeInsight.TargetElementEvaluatorEx
 import com.intellij.codeInsight.TargetElementEvaluatorEx2
 import com.intellij.codeInsight.TargetElementUtil
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiReference
 import com.intellij.util.BitUtil
 import org.rust.lang.core.macros.findExpansionElements
@@ -17,7 +19,7 @@ import org.rust.lang.core.resolve.ref.*
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.type
 
-class RsTargetElementEvaluator : TargetElementEvaluatorEx2() {
+class RsTargetElementEvaluator : TargetElementEvaluatorEx, TargetElementEvaluatorEx2() {
     /**
      * Allows to intercept platform calls to [PsiReference.resolve]
      *
@@ -81,5 +83,21 @@ class RsTargetElementEvaluator : TargetElementEvaluatorEx2() {
         }
 
         return null
+    }
+
+    // TODO: this override exists only as a hack to solve issue #8309. Remove this if a better solution is found.
+    //      Ideally the platform would add a proper extension point to customize text replacement logic.
+    override fun isIdentifierPart(element: PsiFile, text: CharSequence, offset: Int): Boolean {
+        val charAt = text[offset]
+        if (charAt.isJavaIdentifierPart()) return true
+        if (charAt != ':') return false
+        val prev = text.elementAtOrNull(offset - 1)
+        val next = text.elementAtOrNull(offset + 1)
+        // We consider the path part separator `::` to be a part of identifier.
+        // This is used in completion of associated items, because the built-in symbol insertion algorithm
+        // has annoying behaviour otherwise. See https://github.com/intellij-rust/intellij-rust/issues/8309
+        // We do not allow 3 or more consecutive `:` to be part of identifiers.
+        return (next != ':' && prev == ':' && text.elementAtOrNull(offset - 2) != ':')
+            || (prev != ':' && next == ':' && text.elementAtOrNull(offset + 2) != ':')
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -481,13 +481,243 @@ class RsCompletionTest : RsCompletionTestBase() {
         trait Foo {
             type Bar;
             fn foo(bar: Self::Ba/*caret*/);
+            fn bar(bar: &[Self::Ba/*caret*/]);
         }
     """, """
         trait Foo {
             type Bar;
             fn foo(bar: Self::Bar/*caret*/);
+            fn bar(bar: &[Self::Bar/*caret*/]);
         }
     """)
+
+    fun `test associated const completion 1`() = doSingleCompletion("""
+        struct Foo;
+
+        impl Foo {
+            const FOO: usize = 3;
+        }
+
+        fn f(_: usize) {
+            let x = [1, 2, 3];
+            let _ = x[Foo::/*caret*/];
+            foo(Foo::/*caret*/);
+            vec![Foo::/*caret*/];
+            vec!{Foo::/*caret*/};
+            let _ = x[Foo::/*caret*/];
+            foo(Foo::/*caret*/);
+            vec![Foo::/*caret*/];
+            vec!{Foo::/*caret*/};
+        }
+    """, """
+        struct Foo;
+
+        impl Foo {
+            const FOO: usize = 3;
+        }
+
+        fn f(_: usize) {
+            let x = [1, 2, 3];
+            let _ = x[Foo::FOO/*caret*/];
+            foo(Foo::FOO/*caret*/);
+            vec![Foo::FOO/*caret*/];
+            vec!{Foo::FOO/*caret*/};
+            let _ = x[Foo::FOO/*caret*/];
+            foo(Foo::FOO/*caret*/);
+            vec![Foo::FOO/*caret*/];
+            vec!{Foo::FOO/*caret*/};
+        }
+    """)
+
+    fun `test associated const completion 2`() = doSingleCompletion("""
+        trait T {
+            const CONST: usize;
+        }
+
+        struct Foo;
+
+        impl T for Foo {
+            const CONST: usize = 1;
+        }
+
+        fn f(_: usize) {
+            let x = [1, 2, 3];
+            let _ = x[<Foo as T>::/*caret*/];
+            foo(<Foo as T>::/*caret*/);
+            vec![<Foo as T>::/*caret*/];
+            vec!{<Foo as T>::/*caret*/};
+            let _ = x[<Foo as T>::/*caret*/];
+            foo(<Foo as T>::/*caret*/);
+            vec![<Foo as T>::/*caret*/];
+            vec!{<Foo as T>::/*caret*/};
+
+            let _ = x[Foo::/*caret*/];
+            foo(Foo::/*caret*/);
+            vec![Foo::/*caret*/];
+            vec!{Foo::/*caret*/};
+            let _ = x[Foo::/*caret*/];
+            foo(Foo::/*caret*/);
+            vec![Foo::/*caret*/];
+            vec!{Foo::/*caret*/};
+        }
+    """, """
+        trait T {
+            const CONST: usize;
+        }
+
+        struct Foo;
+
+        impl T for Foo {
+            const CONST: usize = 1;
+        }
+
+        fn f(_: usize) {
+            let x = [1, 2, 3];
+            let _ = x[<Foo as T>::CONST/*caret*/];
+            foo(<Foo as T>::CONST/*caret*/);
+            vec![<Foo as T>::CONST/*caret*/];
+            vec!{<Foo as T>::CONST/*caret*/};
+            let _ = x[<Foo as T>::CONST/*caret*/];
+            foo(<Foo as T>::CONST/*caret*/);
+            vec![<Foo as T>::CONST/*caret*/];
+            vec!{<Foo as T>::CONST/*caret*/};
+
+            let _ = x[Foo::CONST/*caret*/];
+            foo(Foo::CONST/*caret*/);
+            vec![Foo::CONST/*caret*/];
+            vec!{Foo::CONST/*caret*/};
+            let _ = x[Foo::CONST/*caret*/];
+            foo(Foo::CONST/*caret*/);
+            vec![Foo::CONST/*caret*/];
+            vec!{Foo::CONST/*caret*/};
+        }
+    """)
+
+    fun `test no overwrite of brackets`() = checkCompletion("FOO", """
+        struct Foo;
+
+        impl Foo {
+            const FOO: usize = 0;
+        }
+
+        fn main() {
+            [0][Foo::/*caret*/];
+            mac![Foo::/*caret*/];
+            mac!(Foo::/*caret*/);
+            mac!{Foo::/*caret*/};
+            func(Foo::/*caret*/);
+            if true {Foo::/*caret*/};
+            Foo::/*caret*/+1;
+            Foo::/*caret*/-1;
+            Foo::/*caret*/*1;
+            Foo::/*caret*//1;
+            Foo::/*caret*/+=1;
+            Foo::/*caret*/-=1;
+            Foo::/*caret*/*=1;
+            Foo::/*caret*//=1;
+            Foo::/*caret*/;
+            Foo::/*caret*/.bar;
+        }
+    """, """
+        struct Foo;
+
+        impl Foo {
+            const FOO: usize = 0;
+        }
+
+        fn main() {
+            [0][Foo::FOO/*caret*/];
+            mac![Foo::FOO/*caret*/];
+            mac!(Foo::FOO/*caret*/);
+            mac!{Foo::FOO/*caret*/};
+            func(Foo::FOO/*caret*/);
+            if true {Foo::FOO/*caret*/};
+            Foo::FOO/*caret*/+1;
+            Foo::FOO/*caret*/-1;
+            Foo::FOO/*caret*/*1;
+            Foo::FOO/*caret*//1;
+            Foo::FOO/*caret*/+=1;
+            Foo::FOO/*caret*/-=1;
+            Foo::FOO/*caret*/*=1;
+            Foo::FOO/*caret*//=1;
+            Foo::FOO/*caret*/;
+            Foo::FOO/*caret*/.bar;
+        }
+    """, '\t')
+
+    fun `test tab completion overwrites identifiers`() = checkCompletion("FOO", """
+        struct Foo;
+
+        impl Foo {
+            const FOO: usize = 0;
+        }
+
+        fn main() {
+            [0][Foo::F/*caret*/Bar];
+            mac![Foo::F/*caret*/Bar];
+            mac!(Foo::F/*caret*/Bar);
+            mac!{Foo::F/*caret*/Bar};
+            func(Foo::F/*caret*/Bar);
+            if true {Foo::F/*caret*/Bar};
+            Foo::F/*caret*/Bar+1;
+            Foo::F/*caret*/Bar-1;
+            Foo::F/*caret*/Bar*1;
+            Foo::F/*caret*/Bar/1;
+            Foo::F/*caret*/Bar+=1;
+            Foo::F/*caret*/Bar-=1;
+            Foo::F/*caret*/Bar*=1;
+            Foo::F/*caret*/Bar/=1;
+            Foo::F/*caret*/Bar;
+            Foo::F/*caret*/Bar.bar;
+        }
+    """, """
+        struct Foo;
+
+        impl Foo {
+            const FOO: usize = 0;
+        }
+
+        fn main() {
+            [0][Foo::FOO/*caret*/];
+            mac![Foo::FOO/*caret*/];
+            mac!(Foo::FOO/*caret*/);
+            mac!{Foo::FOO/*caret*/};
+            func(Foo::FOO/*caret*/);
+            if true {Foo::FOO/*caret*/};
+            Foo::FOO/*caret*/+1;
+            Foo::FOO/*caret*/-1;
+            Foo::FOO/*caret*/*1;
+            Foo::FOO/*caret*//1;
+            Foo::FOO/*caret*/+=1;
+            Foo::FOO/*caret*/-=1;
+            Foo::FOO/*caret*/*=1;
+            Foo::FOO/*caret*//=1;
+            Foo::FOO/*caret*/;
+            Foo::FOO/*caret*/.bar;
+        }
+    """, '\t')
+
+    fun `test no overwrite of brackets short`() = checkCompletion("FOO", """
+        struct Foo;
+
+        impl Foo {
+            const FOO: usize = 0;
+        }
+
+        fn main() {
+            [0][Foo::F/*caret*/];
+        }
+    """, """
+        struct Foo;
+
+        impl Foo {
+            const FOO: usize = 0;
+        }
+
+        fn main() {
+            [0][Foo::FOO/*caret*/];
+        }
+    """, '\t')
 
     fun `test complete enum variants 1`() = doSingleCompletion("""
         enum Expr { Unit, BinOp(Box<Expr>, Box<Expr>) }


### PR DESCRIPTION
Closes #8309

The solution is, unfortunately, a hack. The overwriting happens due to hardwired platform's completion insertion logic in `CompletionProgressIndicator.duringCompletion`. Specifically, this code block:
```java
final int selectionEndOffset = initContext.getSelectionEndOffset();
final PsiReference reference = TargetElementUtil.findReference(myEditor, selectionEndOffset);
if (reference != null) {
  final int replacementOffset = findReplacementOffset(selectionEndOffset, reference);
  if (replacementOffset > document.getTextLength()) {
    LOG.error("Invalid replacementOffset: " + replacementOffset + " returned by reference " + reference + " of " + reference.getClass() +
              "; doc=" + document +
              "; doc actual=" + (document == initContext.getFile().getViewProvider().getDocument()) +
              "; doc committed=" + PsiDocumentManager.getInstance(getProject()).isCommitted(document));
  } else {
    initContext.setReplacementOffset(replacementOffset);
  }
}
```

The final `setReplacementOffset` call sets the replacement range (i.e. overwritten on text insertion) to `selectionEndOffset..replacementOffset`, which later in `CodeCompletionHandlerBase.insertItem` results in removed text if `replacementOffset > selectionEndOffset`:
```java
if (document.getRangeGuard(caretOffset, idEndOffset) == null) {
  document.deleteString(caretOffset, idEndOffset);
}
```

All of this happens before any of the expected plugin's custom insertion logic (i.e. `LookupElement.handleInsert`) has a chance to fire. In fact, the replacement range is determined before the completion popup is even invoked. When you type `[/*caret*/]`, the plugin has already determined that the replacement will happen between the brackets, and typing the identifier will just shift the upper bound of that range accordingly.

Ideally, the platform should provide some extension point which would allow us to modify the default text insertion handler. At the very least we should be able to customize the replacement range. Unfortunately, no such extension point exists, and the logic is quite Java-centric. 

This line determines the upper replacement bound:
```java
final int replacementOffset = findReplacementOffset(selectionEndOffset, reference);
```

It sets the `replacementOffset ` to the end of the replaceable text corresponding to `reference`. The idea is that if the caret is followed by a (broken, but technically possible) identifier, then we want to overwrite it. Unfortunately, references exist not only for simple variables, like in Java, but also for operators, since those operators may be overloaded and we want a mechanism to find that overload. This means that an operator right after the caret is treated just like a variable, and is overwritten.

However, this happens only for associated items, and not for simple identifiers. I.e. this `fo/*caret*/+` is completed to `foo+`, without overwriting the operator. This is because the `findReference` function actually fudges the detected following reference, specifically to avoid overwriting (some, but not all) operators and brackets.

The part which is responsible for that logic is the transitively called `TargetElementUtilBase.adjustOffset` function:
```java
  public static int adjustOffset(@Nullable PsiFile file, @NotNull Document document, final int offset) {
    CharSequence text = document.getCharsSequence();
    int correctedOffset = offset;
    int textLength = text.length();
    if (offset >= textLength) {
      correctedOffset = textLength - 1;
    }
    else if (!isIdentifierPart(file, text, offset)) {
      correctedOffset--;
    }
    if (correctedOffset >= 0) {
      char charAt = text.charAt(correctedOffset);
      if (charAt == '\'' || charAt == '"' || charAt == ')' || charAt == ']' ||
          isIdentifierPart(file, text, correctedOffset)) {
        return correctedOffset;
      }
    }
    return offset;
  }
```

We see that if the `offset` corresponds to a non-identifier (which is the case for our overwritten operators), the function takes a step back, but it stays there only if it hits `'`, `"`, `)`, `]` or an identifier.

Thus the only way to hack around wrong replacement behaviour that I can see is to change the logic of `isIdentifierPart` to consider `::` as part of an identifier. Fortunately, we can do that by implementing `TargetElementEvaluatorEx` for `RsTargetElementEvaluator`. Unfortunately, this changes isn't restricted just to the completion replacement, and can have unexpected effects in some other code which deals with language-defined identifiers.

Running the test suite shows that there are no current errors cause by this change, but you'll never know what can happen in the future. Ideally we should use a proper extension point, but none currently exists.

-------------

changelog: fixed completion of associated items (consts, types, functions) overwriting immediately following operators, including index brackets.
