### PR TITLE
Fix `type info` action inside attribute procedural macro calls

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/type/RsExpressionTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsExpressionTypeProvider.kt
@@ -13,7 +13,10 @@ import org.rust.ide.presentation.render
 import org.rust.lang.core.macros.findExpansionElementOrSelf
 import org.rust.lang.core.macros.findMacroCallExpandedFromNonRecursive
 import org.rust.lang.core.macros.mapRangeFromExpansionToCallBodyStrict
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsPat
+import org.rust.lang.core.psi.RsPatField
+import org.rust.lang.core.psi.RsStructLiteralField
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.contexts
 import org.rust.lang.core.types.adjustments
@@ -126,7 +129,7 @@ class RsExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
 
 /** A hack around [ExpressionTypeProvider] to make it work inside macro calls (by following macro expansions) */
 private fun PsiElement.wrapExpandedElements(): PsiElement? {
-    val macroCall = findMacroCallExpandedFromNonRecursive() as? RsMacroCall
+    val macroCall = findMacroCallExpandedFromNonRecursive()
     return if (macroCall != null) {
         val rangeInExpansion = textRange
         val rangeInMacroCall = macroCall.mapRangeFromExpansionToCallBodyStrict(rangeInExpansion)

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -321,11 +321,11 @@ private fun MappedTextRange.fromBodyRelativeRange(call: RsPossibleMacroCall): Ma
     return MappedTextRange(newSrcOffset, dstOffset, length)
 }
 
-fun RsMacroCall.mapRangeFromExpansionToCallBodyStrict(range: TextRange): TextRange? {
+fun RsPossibleMacroCall.mapRangeFromExpansionToCallBodyStrict(range: TextRange): TextRange? {
     return mapRangeFromExpansionToCallBody(range).singleOrNull()?.takeIf { it.length == range.length }
 }
 
-private fun RsMacroCall.mapRangeFromExpansionToCallBody(range: TextRange): List<TextRange> {
+private fun RsPossibleMacroCall.mapRangeFromExpansionToCallBody(range: TextRange): List<TextRange> {
     val expansion = expansion ?: return emptyList()
     return mapRangeFromExpansionToCallBody(expansion, this, range)
 }

--- a/src/test/kotlin/org/rust/ide/hints/type/RsExpressionTypeProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsExpressionTypeProviderTest.kt
@@ -6,7 +6,9 @@
 package org.rust.ide.hints.type
 
 import org.intellij.lang.annotations.Language
-import org.rust.RsTestBase
+import org.rust.*
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.openapiext.escaped
 
 
@@ -80,6 +82,18 @@ class RsExpressionTypeProviderTest : RsTestBase() {
             };
         }
     """, "i32, S")
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test attr proc macro`() = doTest("""
+        use test_proc_macros::attr_add_to_fn_beginning;
+
+        #[attr_add_to_fn_beginning(let a = 0;)]
+        fn main() {
+            let _ = /*caret*/a;
+        }
+    """, "i32")
 
     private fun doTest(@Language("Rust") code: String, type: String) {
         InlineFile(code).withCaret()


### PR DESCRIPTION
Previously that action has never worked in attr proc macros before. A user always saw the message "Select an expression!":
![image](https://user-images.githubusercontent.com/3221931/205074580-381694c3-82c8-4386-b4d1-d9f891f72176.png)
Now it should work fine.

changelog: Fix `type info` action (`Ctrl`+`Shift`+`P`) inside attribute procedural macro calls
