### PR TITLE
Respect #[allow(clippy::wrong_self_convention)]

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -38,7 +38,8 @@ enum class RsLint(
     UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
     // CLippy lints
     NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy")),
-    DoubleMustUse("clippy::double_must_use", listOf("clippy::style", "clippy::all", "clippy"));
+    DoubleMustUse("clippy::double_must_use", listOf("clippy::style", "clippy::all", "clippy")),
+    WrongSelfConvention("clippy::wrong_self_convention", listOf("clippy::style", "clippy::all", "clippy"));
 
     /**
      * Returns the level of the lint for the given PSI element.

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspection.kt
@@ -3,9 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.*
@@ -16,7 +17,10 @@ import org.rust.lang.core.types.selfType
 import org.rust.lang.core.types.ty.TyReference
 import org.rust.lang.core.types.ty.TyUnknown
 
-class RsSelfConventionInspection : RsLocalInspectionTool() {
+class RsSelfConventionInspection : RsLintInspection() {
+
+    override fun getLint(element: PsiElement): RsLint = RsLint.WrongSelfConvention
+
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitFunction(m: RsFunction) {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -433,7 +433,7 @@
         <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Self convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsSelfConventionInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsSelfConventionInspection"/>
 
         <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Struct naming convention"

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionSuppressorTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionSuppressorTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.inspections
 
+import org.rust.ide.inspections.lints.RsSelfConventionInspection
+
 /**
  * Tests for inspections suppression
  */

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspectionTest.kt
@@ -3,10 +3,12 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.lints.RsSelfConventionInspection
 
 class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionInspection::class) {
     fun `test from`() = checkByText("""
@@ -119,6 +121,46 @@ class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionIns
             fn into_foo(<warning descr="methods called `into_*` usually take self by value; consider choosing a less ambiguous name">self: &Self</warning>) -> u32 { 0 }
             fn into_foo_mut(<warning descr="methods called `into_*` usually take self by value; consider choosing a less ambiguous name">self: &mut Self</warning>) -> u32 { 0 }
             fn from_nothing(<warning descr="methods called `from_*` usually take no self; consider choosing a less ambiguous name">self: Self</warning>) -> u32 { 0 }
+        }
+    """)
+
+    fun `test allow`() = checkByText("""
+        struct Foo;
+        impl Foo {
+            #[allow(clippy::wrong_self_convention)]
+            fn to_f32<'a>(a: String) -> Foo {
+                Foo
+            }
+
+            #[allow(clippy::style)]
+            fn from_string<'a>(&self) -> String {
+                3.7
+            }
+
+            #[allow(clippy::all)]
+            fn to_foo(self) -> String {
+                String::new()
+            }
+
+            #[allow(clippy)]
+            fn from_feet<'a>(&self) -> i32 {
+                7
+            }
+        }
+    """)
+
+    fun `test global allow`() = checkByText("""
+        #![allow(clippy::wrong_self_convention)]
+
+        struct Foo;
+        impl Foo {
+            fn from_i32(self) -> i32 {
+                7
+            }
+
+            fn to_f32(self) -> Foo {
+                7.6
+            }
         }
     """)
 }


### PR DESCRIPTION
See here for description of attribute: https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

changelog:
  - Respect `#[allow(clippy::wrong_self_convention)]` attribute,
    avoiding the need to use `//noinspection RsSelfConvention` anymore
