### PR TITLE
INSP: Fix handling fn pointer in `Needless lifetimes`

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -144,7 +144,10 @@ private class LifetimesCollector(val isForInputParams: Boolean = false) : RsRecu
     override fun visitLifetime(lifetime: RsLifetime) = record(lifetime)
 
     override fun visitElement(element: RsElement) {
-        if (abort || element is RsItemElement /* ignore nested items */) return
+        if (abort) return
+        if (element is RsItemElement) return  // ignore nested items
+        if (element is RsFnPointerType) return  // ignore `fn(&i32)`
+        if (element is RsPath && element.valueParameterList != null) return  // ignore `Fn(&i32)`
         element.forEachChild { it.accept(this) }
     }
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
@@ -44,6 +44,18 @@ class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifeti
         fn <caret>foo(x: &str) -> Box<&str> { unimplemented!() }
     """)
 
+    fun `test one input lifetime 4 (fn pointer)`() = doTest("""
+        /*weak_warning*/fn /*caret*/foo<'a>(s: &'a str, b: fn(&'a i32)) -> &'a i32/*weak_warning**/ { unimplemented!() }
+    """, """
+        fn foo(s: &str, b: fn(&i32)) -> &i32 { unimplemented!() }
+    """)
+
+    fun `test one input lifetime 5 (Fn trait)`() = doTest("""
+        /*weak_warning*/fn /*caret*/foo<'a>(s: &'a str, b: impl Fn(&'a i32)) -> &'a i32/*weak_warning**/ { unimplemented!() }
+    """, """
+        fn foo(s: &str, b: impl Fn(&i32)) -> &i32 { unimplemented!() }
+    """)
+
     fun `test no input lifetimes`() = doTest("""
         fn foo() -> &str { unimplemented!() }
     """)


### PR DESCRIPTION
changelog: Suggest `Elide lifetimes` fix in cases when a function has `fn` pointer parameters