### PR TITLE
INSP: Fix handling reference-like `self` parameter in `Needless lifetimes`

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/ElideLifetimesFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/ElideLifetimesFix.kt
@@ -62,7 +62,7 @@ private class LifetimeRemover : RsVisitor() {
             val newSelfParameter = RsPsiFactory(selfParameter.project).createSelfReference(selfParameter.mutability.isMut)
             selfParameter.replace(newSelfParameter)
         }
-        selfParameter.typeReference?.let { visitTypeReference(it) }
+        selfParameter.typeReference?.accept(this)
     }
 
     override fun visitRefLikeType(refLike: RsRefLikeType) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -85,7 +85,7 @@ private fun couldUseElision(fn: RsFunction): Boolean {
 
     return when {
         outputLifetimes.distinct().size > 1 -> false
-        inputLifetimes.size == 1 || fn.selfParameter?.isRef == true && areInputsDistinct -> {
+        inputLifetimes.size == 1 || fn.selfParameter?.isRefLike == true && areInputsDistinct -> {
             val input = inputLifetimes.first()
             val output = outputLifetimes.first()
             when {
@@ -262,4 +262,20 @@ private fun LifetimeName.toReferenceLifetime(): ReferenceLifetime =
         is LifetimeName.Parameter -> Named(name)
         LifetimeName.Static -> Static
         LifetimeName.Implicit, LifetimeName.Underscore -> Unnamed
+    }
+
+/**
+ * Includes:
+ * - `&self` and `&mut self` (see [isRef])
+ * - `self: &Self` and `self: &mut Self`
+ * - `self: Box<&Self>`, `self: Rc<&Self>`, `self: Arc<&Self>`, `self: Pin<&Self>`
+ * - `self: Rc<Box<&Self>>` and other combinations
+ */
+val RsSelfParameter.isRefLike: Boolean
+    get() {
+        if (isRef) return true
+        // Ideally, we should check the presence of `&Self` possible wrapped in `Box`, `Arc`, etc,
+        // But anything else is anyway not allowed - https://doc.rust-lang.org/error_codes/E0307.html,
+        val typeReference = typeReference ?: return false
+        return typeReference.descendantsOfTypeOrSelf<RsRefLikeType>().any { it.and != null }
     }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
@@ -182,6 +182,30 @@ class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifeti
         }
     """)
 
+    fun `test self 7 (&Self)`() = doTest("""
+        struct S;
+        impl S {
+            /*weak_warning*/fn /*caret*/foo<'a, 'b>(self: &'a Self, _: &'b i32) -> &'a i32/*weak_warning**/ { &0 }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(self: &Self, _: &i32) -> &i32 { &0 }
+        }
+    """)
+
+    fun `test self 8 (Box)`() = doTest("""
+        struct S;
+        impl S {
+            /*weak_warning*/fn /*caret*/foo<'a, 'b>(self: Box<&'a Self>, _: &'b i32) -> &'a i32/*weak_warning**/ { &0 }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(self: Box<&Self>, _: &i32) -> &i32 { &0 }
+        }
+    """)
+
     fun `test inside impl`() = doTest("""
         struct S<'a>(&'a str);
         <weak_warning>fn <caret>foo<'a>(x: &'a mut [u8]) -> S<'a></weak_warning> { unimplemented!() }


### PR DESCRIPTION
changelog: Suggest `Elide lifetimes` fix in case `self` parameter has reference type like `Box<&Self>`