### PR TITLE
MACRO: Don't add whitespace between tokens adjacent in macro call body

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -209,7 +209,7 @@ class ProcMacroExpander private constructor(
         psi !is RsDotExpr && psi.childrenWithLeaves.any { it is PsiErrorElement || it !is RsExpr && hasErrorToHandle(it) }
 
     companion object {
-        const val EXPANDER_VERSION: Int = 6
+        const val EXPANDER_VERSION: Int = 7
 
         fun forCrate(crate: Crate): ProcMacroExpander {
             val project = crate.project

--- a/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
@@ -16,7 +16,7 @@ import org.rust.ide.experiments.RsExperiments
 class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
 
     fun `test attributes inside macro call`() = checkHighlightingInsideMacro("""
-        <ATTRIBUTE>#</ATTRIBUTE><ATTRIBUTE>[foo(foo)]</ATTRIBUTE>
+        <ATTRIBUTE>#[foo(foo)]</ATTRIBUTE>
         fn <FUNCTION>main</FUNCTION>() {
             <ATTRIBUTE>#![crate_type = <STRING>"lib"</STRING>]</ATTRIBUTE>
         }
@@ -24,8 +24,8 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
 
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test disabled function`() = checkHighlightingInsideMacro("""
-        <CFG_DISABLED_CODE>#</CFG_DISABLED_CODE><CFG_DISABLED_CODE>[cfg(not(intellij_rust))]
-        fn foo</CFG_DISABLED_CODE><CFG_DISABLED_CODE>() {
+        <CFG_DISABLED_CODE>#[cfg(not(intellij_rust))]
+        fn foo() {
             let x = 1;
         }</CFG_DISABLED_CODE>
     """)
@@ -37,9 +37,9 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
         use <CRATE>test_proc_macros</CRATE>::<FUNCTION>attr_as_is</FUNCTION>;
 
         <ATTRIBUTE>#[<FUNCTION>attr_as_is</FUNCTION>]</ATTRIBUTE>
-        <ATTRIBUTE>#</ATTRIBUTE><ATTRIBUTE>[allow</ATTRIBUTE><ATTRIBUTE>(foo</ATTRIBUTE><ATTRIBUTE>)]</ATTRIBUTE>
+        <ATTRIBUTE>#[allow(foo)]</ATTRIBUTE>
         fn <FUNCTION>main</FUNCTION>() {
-            <ATTRIBUTE>#!</ATTRIBUTE><ATTRIBUTE>[crate_type = <STRING>"lib"</STRING></ATTRIBUTE><ATTRIBUTE>]</ATTRIBUTE>
+            <ATTRIBUTE>#![crate_type = <STRING>"lib"</STRING>]</ATTRIBUTE>
         }
     """)
 
@@ -50,10 +50,10 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
         use <CRATE>test_proc_macros</CRATE>::<FUNCTION>attr_as_is</FUNCTION>;
 
         <ATTRIBUTE>#[<FUNCTION>attr_as_is</FUNCTION>]</ATTRIBUTE>
-        <ATTRIBUTE>#</ATTRIBUTE><ATTRIBUTE>[<FUNCTION>attr_as_is</FUNCTION></ATTRIBUTE><ATTRIBUTE>]</ATTRIBUTE>
-        <ATTRIBUTE>#</ATTRIBUTE><ATTRIBUTE>[allow</ATTRIBUTE><ATTRIBUTE>(foo</ATTRIBUTE><ATTRIBUTE>)]</ATTRIBUTE>
+        <ATTRIBUTE>#[<FUNCTION>attr_as_is</FUNCTION>]</ATTRIBUTE>
+        <ATTRIBUTE>#[allow(foo)]</ATTRIBUTE>
         fn <FUNCTION>main</FUNCTION>() {
-            <ATTRIBUTE>#!</ATTRIBUTE><ATTRIBUTE>[crate_type = <STRING>"lib"</STRING></ATTRIBUTE><ATTRIBUTE>]</ATTRIBUTE>
+            <ATTRIBUTE>#![crate_type = <STRING>"lib"</STRING>]</ATTRIBUTE>
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/hints/type/RsExpressionTypeProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsExpressionTypeProviderTest.kt
@@ -95,6 +95,30 @@ class RsExpressionTypeProviderTest : RsTestBase() {
         }
     """, "i32")
 
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test attr proc macro 2`() = doTest("""
+        fn foo(x: i32) -> i32 { x }
+
+        #[test_proc_macros::attr_as_is]
+        fn main() {
+            let _ = /*caret*/foo(0);
+        }
+    """, "fn(i32) -> i32, i32")
+
+    fun `test inside macro call`() = doTest("""
+        macro_rules! as_is { ($($ t:tt)*) => { $($ t)* } }
+
+        fn foo() -> i32 { 0 }
+
+        fn main() {
+            as_is! {
+                /*caret*/foo();
+            }
+        }
+    """, "fn() -> i32, i32")
+
     private fun doTest(@Language("Rust") code: String, type: String) {
         InlineFile(code).withCaret()
 


### PR DESCRIPTION
changelog: Improve [Extend selection](https://www.jetbrains.com/idea/guide/tips/extend-selection/) and [Type info](https://www.jetbrains.com/help/idea/viewing-reference-information.html#type-info) actions inside macro calls