### PR TITLE
ANN: Annotate range patterns

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -44,6 +44,7 @@ import org.rust.lang.core.CompilerFeature.Companion.EXTERN_CRATE_SELF
 import org.rust.lang.core.CompilerFeature.Companion.EXTERN_TYPES
 import org.rust.lang.core.CompilerFeature.Companion.GENERATORS
 import org.rust.lang.core.CompilerFeature.Companion.GENERIC_ASSOCIATED_TYPES
+import org.rust.lang.core.CompilerFeature.Companion.HALF_OPEN_RANGE_PATTERNS
 import org.rust.lang.core.CompilerFeature.Companion.IF_LET_GUARD
 import org.rust.lang.core.CompilerFeature.Companion.IF_WHILE_OR_PATTERNS
 import org.rust.lang.core.CompilerFeature.Companion.INHERENT_ASSOCIATED_TYPES
@@ -664,6 +665,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkPatRange(holder: RsAnnotationHolder, range: RsPatRange) {
+        if (range.start == null && range.end != null) {
+            HALF_OPEN_RANGE_PATTERNS.check(holder, range, "half-open range patterns")
+        }
+
         val op = range.op?.takeUnless { it == range.dotdot } ?: return
         if (range.start != null && range.end == null) {
             RsDiagnostic.InclusiveRangeWithNoEndError(op).addToHolder(holder)

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1433,18 +1433,15 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
     // E0586: inclusive range with no end
     private fun checkRangeExpr(holder: RsAnnotationHolder, range: RsRangeExpr) {
-        val dotdoteq = range.dotdoteq ?: range.dotdotdot ?: return
-        if (dotdoteq == range.dotdotdot) {
+        val op = range.dotdotdot ?: range.dotdoteq ?: return
+        if (op == range.dotdotdot) {
             // rustc doesn't have an error code for this ("error: unexpected token: `...`")
-            holder.createErrorAnnotation(
-                dotdoteq,
-                "`...` syntax is deprecated. Use `..` for an exclusive range or `..=` for an inclusive range"
-            )
+            holder.createErrorAnnotation(op, "`...` syntax is deprecated. Use `..` for an exclusive range or `..=` for an inclusive range")
             return
         }
-        val expr = range.exprList.singleOrNull() ?: return
-        if (expr.startOffsetInParent < dotdoteq.startOffsetInParent) {
-            RsDiagnostic.InclusiveRangeWithNoEndError(dotdoteq).addToHolder(holder)
+
+        if (range.end == null) {
+            RsDiagnostic.InclusiveRangeWithNoEndError(op).addToHolder(holder)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -118,6 +118,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             override fun visitPatField(o: RsPatField) = checkPatField(rsHolder, o)
             override fun visitPatBinding(o: RsPatBinding) = checkPatBinding(rsHolder, o)
             override fun visitPatRest(o: RsPatRest) = checkPatRest(rsHolder, o)
+            override fun visitPatRange(o: RsPatRange) = checkPatRange(rsHolder, o)
             override fun visitOrPat(o: RsOrPat) = checkOrPat(rsHolder, o)
             override fun visitPath(o: RsPath) = checkPath(rsHolder, o)
             override fun visitNamedFieldDecl(o: RsNamedFieldDecl) = checkDuplicates(rsHolder, o)
@@ -659,6 +660,13 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         val parent = patRest.parent
         if (parent is RsPatSlice || parent is RsPatIdent && parent.parent is RsPatSlice) {
             SLICE_PATTERNS.check(holder, patRest, "subslice patterns")
+        }
+    }
+
+    private fun checkPatRange(holder: RsAnnotationHolder, range: RsPatRange) {
+        val op = range.op?.takeUnless { it == range.dotdot } ?: return
+        if (range.start != null && range.end == null) {
+            RsDiagnostic.InclusiveRangeWithNoEndError(op).addToHolder(holder)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -49,6 +49,7 @@ class RsSyntaxErrorsAnnotator : AnnotatorBase() {
             is RsTypeParameterList -> checkTypeParameterList(holder, element)
             is RsTypeArgumentList -> checkTypeArgumentList(holder, element)
             is RsLetExpr -> checkLetExpr(holder, element)
+            is RsPatRange -> checkPatRange(holder, element)
         }
     }
 }
@@ -350,6 +351,23 @@ private fun checkLetExpr(holder: AnnotationHolder, element: RsLetExpr) {
         ancestor = ancestor.parent
     }
     deny(element, holder, "`let` expressions are not supported here")
+}
+
+private fun checkPatRange(holder: AnnotationHolder, element: RsPatRange) {
+    val start = element.start
+    val end = element.end
+    when {
+        element.dotdot != null -> when {
+            start == null && end == null -> deny(element.dotdot, holder, "Unexpected `..`")
+        }
+        element.dotdoteq != null -> when {
+            start == null && end == null -> deny(element.dotdoteq, holder, "Unexpected `..=`")
+        }
+        element.dotdotdot != null -> when {
+            start == null && end == null -> deny(element.dotdotdot, holder, "Unexpected `...`")
+            start == null -> deny(element.dotdotdot, holder, "Range-to patterns with `...` are not allowed")
+        }
+    }
 }
 
 private enum class TypeKind {

--- a/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
+++ b/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
@@ -210,6 +210,7 @@ class CompilerFeature(
         val START: CompilerFeature get() = get("start")
         val UNBOXED_CLOSURES: CompilerFeature get() = get("unboxed_closures")
         val WASM_ABI: CompilerFeature get() = get("wasm_abi")
+        val HALF_OPEN_RANGE_PATTERNS: CompilerFeature get() = get("half_open_range_patterns")
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatRange.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatRange.kt
@@ -5,7 +5,24 @@
 
 package org.rust.lang.core.psi.ext
 
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsPatConst
 import org.rust.lang.core.psi.RsPatRange
 
 val RsPatRange.isInclusive: Boolean
     get() = dotdotdot != null || dotdoteq != null
+
+val RsPatRange.op: PsiElement?
+    get() = dotdot ?: dotdotdot ?: dotdoteq
+
+val RsPatRange.start: RsPatConst?
+    get() {
+        val op = op ?: return null
+        return patConstList.firstOrNull()?.takeIf { it.endOffset <= op.startOffset }
+    }
+
+val RsPatRange.end: RsPatConst?
+    get() {
+        val op = op ?: return null
+        return patConstList.lastOrNull()?.takeIf { it.startOffset >= op.endOffset }
+    }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsRangeExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsRangeExpr.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsRangeExpr
+
+val RsRangeExpr.op: PsiElement?
+    get() = dotdot ?: dotdotdot ?: dotdoteq
+
+val RsRangeExpr.start: RsExpr?
+    get() {
+        val op = op ?: return null
+        return exprList.firstOrNull()?.takeIf { it.endOffset <= op.startOffset }
+    }
+
+val RsRangeExpr.end: RsExpr?
+    get() {
+        val op = op ?: return null
+        return exprList.lastOrNull()?.takeIf { it.startOffset >= op.endOffset }
+    }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3462,6 +3462,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    @MockRustcVersion("1.66.0")
     fun `test inclusive range pat with no end E0586`() = checkErrors("""
         fn foo() {
             match 0 {
@@ -3480,6 +3481,48 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             }
         }
     """)
+
+    @MockRustcVersion("1.65.0")
+    fun `test half open range patterns E0658 1`() = checkErrors("""
+        fn foo() {
+            match 0 {
+                 ..   => {},
+                1..   => {},
+                 <error descr="half-open range patterns is experimental [E0658]">..2</error>  => {},
+                1..2  => {},
+                 ..=  => {},
+                1<error>..=</error>  => {},
+                 <error descr="half-open range patterns is experimental [E0658]">..=2</error> => {},
+                1..=2 => {},
+                 ...  => {},
+                1<error>...</error>  => {},
+                 <error descr="half-open range patterns is experimental [E0658]">...2</error> => {},
+                1...2 => {},
+            }
+        }
+    """)
+
+    @MockRustcVersion("1.65.0-nightly")
+    fun `test half open range patterns E0658 2`() = checkErrors("""
+        #![feature(half_open_range_patterns)]
+        fn foo() {
+            match 0 {
+                 ..   => {},
+                1..   => {},
+                 ..2  => {},
+                1..2  => {},
+                 ..=  => {},
+                1<error>..=</error>  => {},
+                 ..=2 => {},
+                1..=2 => {},
+                 ...  => {},
+                1<error>...</error>  => {},
+                 ...2 => {},
+                1...2 => {},
+            }
+        }
+    """)
+
 
     fun `test arbitrary enum discriminant without repr E0732`() = checkErrors("""
         #![feature(arbitrary_enum_discriminant)]

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3462,6 +3462,25 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    fun `test inclusive range pat with no end E0586`() = checkErrors("""
+        fn foo() {
+            match 0 {
+                 ..   => {},
+                1..   => {},
+                 ..2  => {},
+                1..2  => {},
+                 ..=  => {},
+                1<error descr="inclusive ranges must be bounded at the end (`..=b` or `a..=b`) [E0586]">..=</error>  => {},
+                 ..=2 => {},
+                1..=2 => {},
+                 ...  => {},
+                1<error descr="inclusive ranges must be bounded at the end (`..=b` or `a..=b`) [E0586]">...</error>  => {},
+                 ...2 => {},
+                1...2 => {},
+            }
+        }
+    """)
+
     fun `test arbitrary enum discriminant without repr E0732`() = checkErrors("""
         #![feature(arbitrary_enum_discriminant)]
         enum <error descr="`#[repr(inttype)]` must be specified [E0732]">Enum</error> {

--- a/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
@@ -460,4 +460,23 @@ class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator:
             };
         }
     """)
+    fun `test range pats`() = checkErrors("""
+        fn foo() {
+            match 0 {
+                 ..   => {}, // `..` patterns are not allowed here
+                1..   => {},
+                 ..2  => {},
+                1..2  => {},
+                 <error descr="Unexpected `..=`">..=</error>  => {},
+                1..=  => {},
+                 ..=2 => {},
+                1..=2 => {},
+                 <error descr="Unexpected `...`">...</error>  => {},
+                1...  => {},
+                 <error descr="Range-to patterns with `...` are not allowed">...</error>2 => {},
+                1...2 => {}, // `...` range patterns are deprecated
+            }
+        }
+    """)
+
 }


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/9824.
Closes https://github.com/intellij-rust/intellij-rust/issues/9780.

Includes:
- Annotate half-open ranges patterns as experimental before 1.66
- Annotate inclusive ranges without end for range patterns
- Annotate syntactically invalid range patterns

changelog: Annotate syntactically invalid range patterns / Annotate half-open ranges patterns as experimental before 1.66 / Annotate inclusive ranges without end for range patterns
