### PR TITLE
INSP: Optimize "Unused imports" inspection

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -494,6 +494,24 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test usage inside attribute proc macro expansion 2`() = checkByText("""
+        mod inner {
+            pub fn bar() {}
+        }
+        /*warning descr="Unused import: `inner::bar`"*/use inner::bar;/*warning**/
+
+        struct Foo {}
+        impl Foo {
+            #[test_proc_macros::attr_replace_with_attr]
+            fn foo() {
+                bar();
+            }
+        }
+    """)
+
     fun `test deny lint`() = checkByText("""
         #![deny(unused_imports)]
 


### PR DESCRIPTION
The main changes are:
* Ignore resolving `$crate` (turns out it is slow, probably need to optimize it)
* Fix `RsWithMacrosRecursiveElementWalkingVisitor` - previously in some cases it could traverse (unexpanded) body of attribute macro call

Meta: #2158

changelog: Slightly optimize `Unused imports` inspection