### PR TITLE
HINT: Show type hints inside macro calls

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
@@ -16,6 +16,9 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.SyntaxTraverser
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.psi.util.parentOfTypes
 import org.rust.RsBundle
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.macros.*
@@ -28,6 +31,7 @@ import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.TyInfer
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
+import org.rust.openapiext.testAssert
 import javax.swing.JComponent
 import javax.swing.JPanel
 
@@ -87,44 +91,80 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
                 if (project.service<DumbService>().isDumb) return true
                 if (element !is RsElement) return true
 
+                if (element is RsMacroCall) {
+                    processMacroCall(element)
+                }
                 if (settings.showForVariables) {
-                    presentVariable(element)
+                    presentVariable(element, isExpanded = false)
                 }
                 if (settings.showForLambdas) {
-                    presentLambda(element)
+                    presentLambda(element, isExpanded = false)
                 }
                 if (settings.showForIterators) {
-                    presentIterator(element)
+                    presentIterator(element, isExpanded = false)
                 }
 
                 return true
             }
 
-            private fun presentVariable(element: RsElement) {
-                when (element) {
-                    is RsLetDecl -> {
-                        if (settings.showForPlaceholders) {
-                            presentTypePlaceholders(element)
+            private fun processMacroCall(call: RsMacroCall) {
+                if (call.getCodeStatus(crate) == RsCodeStatus.CFG_DISABLED) return
+                // continue if inside attribute macro
+
+                // Macros with hardcoded PSI don't need special handling and thus are ignored here
+                val macroBody = call.macroArgument ?: return
+                val traverser = SyntaxTraverser.psiTraverser(macroBody)
+                for (leaf in traverser.preOrderDfsTraversal()) {
+                    if (leaf !is LeafPsiElement) continue
+                    when (leaf.elementType) {
+                        RsElementTypes.LET, RsElementTypes.MATCH -> {
+                            if (!settings.showForVariables) continue
+                            val parentExpanded = leaf.findExpansionElements()?.singleOrNull()?.parent as? RsElement ?: continue
+                            presentVariable(parentExpanded, isExpanded = true)
                         }
-
-                        if (element.typeReference != null) return
-
-                        val pat = element.pat ?: return
-                        presentTypeForPat(pat, element.expr)
-                    }
-                    is RsLetExpr -> {
-                        val pat = element.pat ?: return
-                        presentTypeForPat(pat, element.expr)
-                    }
-                    is RsMatchExpr -> {
-                        for (arm in element.arms) {
-                            presentTypeForPat(arm.pat, element.expr)
+                        RsElementTypes.FOR -> {
+                            if (!settings.showForIterators) continue
+                            val parentExpanded = leaf.findExpansionElements()?.singleOrNull()?.parent as? RsForExpr ?: continue
+                            presentIterator(parentExpanded, isExpanded = true)
+                        }
+                        RsElementTypes.OR -> {
+                            if (!settings.showForLambdas) continue
+                            val leafExpanded = leaf.findExpansionElements()?.singleOrNull() ?: continue
+                            val valueParameterList = leafExpanded.parent as? RsValueParameterList ?: continue
+                            // Handle expansion only if `leaf` is first `|`
+                            if (valueParameterList.stubChildOfElementType(RsElementTypes.OR) != leafExpanded) continue
+                            val lambdaExpr = valueParameterList.parent as? RsLambdaExpr ?: continue
+                            presentLambda(lambdaExpr, isExpanded = true)
                         }
                     }
                 }
             }
 
-            private fun presentTypePlaceholders(declaration: RsLetDecl) {
+            private fun presentVariable(element: RsElement, isExpanded: Boolean) {
+                when (element) {
+                    is RsLetDecl -> {
+                        if (settings.showForPlaceholders) {
+                            presentTypePlaceholders(element, isExpanded)
+                        }
+
+                        if (element.typeReference != null) return
+
+                        val pat = element.pat ?: return
+                        presentTypeForPat(pat, element.expr, isExpanded)
+                    }
+                    is RsLetExpr -> {
+                        val pat = element.pat ?: return
+                        presentTypeForPat(pat, element.expr, isExpanded)
+                    }
+                    is RsMatchExpr -> {
+                        for (arm in element.arms) {
+                            presentTypeForPat(arm.pat, element.expr, isExpanded)
+                        }
+                    }
+                }
+            }
+
+            private fun presentTypePlaceholders(declaration: RsLetDecl, isExpanded: Boolean) {
                 run {
                     // optimization - skip processing if no type placeholders
                     val typeReference = declaration.typeReference ?: return
@@ -132,6 +172,7 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
                 }
 
                 val expandedDeclaration = declaration.getExpanded { it.let } ?: return
+                if (isExpanded) testAssert { declaration == expandedDeclaration }
                 val inferredType = expandedDeclaration.pat?.type ?: return
                 val formalType = expandedDeclaration.typeReference?.rawType ?: return
                 val placeholders = formalType.collectInferTys()
@@ -146,55 +187,63 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
                 val infer = expandedDeclaration.implLookup.ctx
                 infer.combineTypes(inferredType, formalType)
 
-                for ((rawType, expandedTypeElement) in placeholders) {
+                for ((rawType, typeElement) in placeholders) {
                     val type = infer.resolveTypeVarsIfPossible(rawType)
                     if (type is TyInfer || type is TyUnknown) continue
 
-                    val offset = if (declaration == expandedDeclaration) {
-                        expandedTypeElement.endOffset
-                    } else {
-                        expandedTypeElement.findElementExpandedFrom()?.endOffset ?: return
-                    }
+                    val offset = when {
+                        // hints inside attribute macro call
+                        declaration != expandedDeclaration -> typeElement.findElementExpandedFrom()?.endOffset
+                        // hints inside function-like macro call
+                        isExpanded -> findOriginalOffset(typeElement, file)
+                        else -> typeElement.endOffset
+                    } ?: return
                     val presentation = typeHintsFactory.typeHint(type)
                     val finalPresentation = presentation.withDisableAction(declaration.project)
                     sink.addInlineElement(offset, false, finalPresentation, false)
                 }
             }
 
-            private fun presentLambda(element: RsElement) {
+            private fun presentLambda(element: RsElement, isExpanded: Boolean) {
                 if (element !is RsLambdaExpr) return
 
                 for (parameter in element.valueParameterList.valueParameterList) {
                     if (parameter.typeReference != null) continue
                     val pat = parameter.pat ?: continue
-                    presentTypeForPat(pat)
+                    presentTypeForPat(pat, expr = null, isExpanded)
                 }
             }
 
-            private fun presentIterator(element: RsElement) {
+            private fun presentIterator(element: RsElement, isExpanded: Boolean) {
                 if (element !is RsForExpr) return
 
                 val pat = element.pat ?: return
-                presentTypeForPat(pat)
+                presentTypeForPat(pat, expr = null, isExpanded)
             }
 
-            private fun presentTypeForPat(pat: RsPat, expr: RsExpr? = null) {
+            private fun presentTypeForPat(pat: RsPat, expr: RsExpr?, isExpanded: Boolean) {
                 if (!settings.showObviousTypes && isObvious(pat, expr?.declaration)) return
 
                 for (binding in pat.descendantsOfType<RsPatBinding>()) {
                     if (binding.referenceName.startsWith("_")) continue
-                    presentTypeForBinding(binding)
+                    presentTypeForBinding(binding, isExpanded)
                 }
             }
 
-            private fun presentTypeForBinding(binding: RsPatBinding) {
+            private fun presentTypeForBinding(binding: RsPatBinding, isExpanded: Boolean) {
                 val bindingExpanded = binding.getExpanded { it.identifier } ?: return
                 if (bindingExpanded.reference.resolve()?.isConstantLike == true) return
                 if (bindingExpanded.type is TyUnknown) return
 
+                val offset = if (isExpanded) {
+                    testAssert { binding == bindingExpanded }
+                    findOriginalOffset(binding.identifier, file) ?: return
+                } else {
+                    binding.endOffset
+                }
                 val presentation = typeHintsFactory.typeHint(bindingExpanded.type)
                 val finalPresentation = presentation.withDisableAction(project)
-                sink.addInlineElement(binding.endOffset, false, finalPresentation, false)
+                sink.addInlineElement(offset, false, finalPresentation, false)
             }
 
             private inline fun <reified T : PsiElement> T.getExpanded(getLeaf: (T) -> PsiElement): T? =
@@ -239,3 +288,40 @@ private fun isObvious(pat: RsPat, declaration: RsElement?): Boolean =
         is RsStructItem, is RsEnumVariant -> pat is RsPatIdent
         else -> false
     }
+
+/**
+ * For [anchor] expanded from function-like macro call, finds corresponding offset in [originalFile],
+ * but only if macro body has enough context for showing hints:
+ *
+ * `foo1! { let x = 1; }` expanded to `let x = 1;` - show hints
+ * `foo2!(x, 1)` expanded to `let x = 1;` - don't show hints
+ */
+private fun findOriginalOffset(anchor: PsiElement, originalFile: PsiFile): Int? {
+    testAssert { anchor.containingFile != originalFile }  // [anchor] should be expanded
+
+    /*
+     * Expansion:
+     * ... let x = 1; ...
+     * ~~~~~~~~ offset2
+     *         ^ anchor
+     *     ~~~~~~~~~~ range2
+     *
+     * Original file:
+     * ... foo! { let x = 1; } ...
+     * ~~~~~~~~~~~~~~~ offset1
+     *            ~~~~~~~~~~ range1
+     *
+     */
+    val parent = anchor.parentOfTypes(RsLetDecl::class, RsLetExpr::class, RsMatchArm::class, RsForExpr::class, RsLambdaExpr::class) ?: return null
+    val offset2 = anchor.endOffset
+    val range2 = parent.textRange
+    testAssert { range2.contains(offset2) }
+
+    val call = anchor.findMacroCallExpandedFromNonRecursive() ?: return null
+    val range1 = call.mapRangeFromExpansionToCallBodyStrict(range2) ?: return null
+    val offset1 = range1.startOffset + (offset2 - range2.startOffset)
+    // Check that [offset1] is expanded only once.
+    // Ideally, we should check that [range1] is expanded only once.
+    if (originalFile.findElementAt(offset1)?.findExpansionElements()?.size != 1) return null
+    return offset1
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/RangeMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RangeMap.kt
@@ -106,6 +106,7 @@ val MappedTextRange.srcEndOffset: Int get() = srcOffset + length
 val MappedTextRange.dstEndOffset: Int get() = dstOffset + length
 
 val MappedTextRange.srcRange: TextRange get() = TextRange(srcOffset, srcOffset + length)
+val MappedTextRange.dstRange: TextRange get() = TextRange(dstOffset, dstOffset + length)
 
 fun MappedTextRange.srcShiftLeft(delta: Int) = copy(srcOffset = srcOffset - delta)
 fun MappedTextRange.dstShiftRight(delta: Int) = copy(dstOffset = dstOffset + delta)

--- a/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
@@ -553,4 +553,121 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
         $fnTypes
         fn consume(_: impl Fn(i32)) {}
     """)
+
+    fun `test inside macro call body`() = checkByText("""
+        macro_rules! as_is { ($($ t:tt)*) => {$($ t)*} }
+        fn main() {
+            as_is! {
+                let x1/*hint text="[:  i32]"*/ = 0;
+                let mut x2/*hint text="[:  i32]"*/ = 0;
+                let x3/*hint text="[:  i32]"*/ = bar();
+
+                let x4: Option<_/*hint text="[:  i32]"*/> = Option::Some(0);
+                match x4 {
+                    Option::Some(x5/*hint text="[:  i32]"*/) => {},
+                    Option::None => {},
+                }
+
+                consume(|x/*hint text="[:  i32]"*/| {});
+            }
+        }
+        fn bar() -> i32 { 0 }
+        enum Option<T> { Some(T), None }
+
+        $fnTypes
+        fn consume(_: impl Fn(i32)) {}
+    """)
+
+    fun `test inside macro call body (nested block)`() = checkByText("""
+        macro_rules! id { ($ t:block) => { $ t } }
+        fn main() {
+            id! {
+                {
+                    let x/*hint text="[:  i32]"*/ = 1;
+                }
+            }
+        }
+    """)
+
+    fun `test inside macro call body (nested macro call)`() = checkByText("""
+        macro_rules! as_is { ($($ t:tt)*) => {$($ t)*} }
+        macro_rules! gen {
+            ($($ t:tt)*) => {
+                println!();
+                as_is!($($ t)*);
+            }
+        }
+        fn main() {
+            gen! {
+                let x/*hint text="[:  i32]"*/ = 1;
+            }
+        }
+    """)
+
+    fun `test inside macro call body (only ident)`() = checkByText("""
+        macro_rules! gen { ($ t:ident) => { let $ t = 1; } }
+        fn main() {
+            gen!(X);
+        }
+    """)
+
+    fun `test inside macro call body (no hint if expanded twice 1)`() = checkByText("""
+        macro_rules! gen {
+            ($($ t:tt)*) => {
+                {
+                    fn foo() -> i32 { 0 }
+                    $($ t)*
+                }
+                {
+                    fn foo() -> u32 { 0 }
+                    $($ t)*
+                }
+            }
+        }
+        fn main() {
+            gen! {
+                let x = foo();
+            }
+        }
+    """)
+
+    fun `test inside macro call body (no hint if expanded twice 2)`() = checkByText("""
+        macro_rules! foo {
+            ($ t1:tt $ t2:tt $ t3:tt $ t4:tt $ t5:tt) => {
+                { $ t1$ t2$ t3$ t4$ t5 }
+                { let $ t2 = ""; }
+            };
+        }
+        fn main() {
+            foo! {
+                let x = 1;
+            }
+        }
+    """)
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test attribute macro inside function-like macro`() = checkByText("""
+        macro_rules! as_is { ($($ t:tt)*) => {$($ t)*} }
+        as_is! {
+            #[test_proc_macros::attr_as_is]
+            fn test() {
+                let x/*hint text="[:  i32]"*/ = 1;
+            }
+        }
+    """)
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test function-like macro inside attribute macro`() = checkByText("""
+        macro_rules! as_is { ($($ t:tt)*) => {$($ t)*} }
+        #[test_proc_macros::attr_as_is]
+        fn test() {
+            as_is! {
+                let x/*hint text="[:  i32]"*/ = 1;
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsTestBase.kt
@@ -30,7 +30,7 @@ abstract class RsInlayTypeHintsTestBase(
     }
 
     protected fun checkByText(@Language("Rust") code: String) {
-        InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))
+        InlineFile(code.trimIndent().replace(HINT_COMMENT_PATTERN, "<$1/>"))
         checkInlays()
     }
 


### PR DESCRIPTION
Fixes #8214
Fixes #8374
Related: #9803
Depends on #10095

Add type hints inside function-like macro calls:

<img src="https://user-images.githubusercontent.com/6505554/204094202-0dc51b3a-bb83-4222-ba2b-d9842a73b9a9.png" width="50%">

changelog: Show type hints inside macro calls
