### PR TITLE
Don't remove unused imports marked with `#[allow(unused_imports)]`

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -46,7 +46,7 @@ enum class RsLint(
      */
     fun levelFor(el: PsiElement): RsLintLevel = explicitLevel(el) ?: superModsLevel(el) ?: defaultLevel
 
-    private fun explicitLevel(el: PsiElement): RsLintLevel? = el.ancestors
+    fun explicitLevel(el: PsiElement): RsLintLevel? = el.ancestors
         .filterIsInstance<RsDocAndAttributeOwner>()
         .flatMap { it.queryAttributes.metaItems.toList().asReversed().asSequence() }
         .filter { it.metaItemArgs?.metaItemList.orEmpty().any { item -> item.id == id || item.id in groupIds } }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -153,6 +153,7 @@ fun RsUseSpeck.isUsed(pathUsage: PathUsageMap): Boolean {
     val useItem = ancestorStrict<RsUseItem>() ?: return true
     if (!isApplicableForUseItem(useItem)) return true
     return isUseSpeckUsed(this, pathUsage)
+        || RsLint.UnusedImports.explicitLevel(useItem) == RsLintLevel.ALLOW
 }
 
 private fun isUseSpeckUsed(useSpeck: RsUseSpeck, usage: PathUsageMap): Boolean {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
@@ -660,6 +660,15 @@ class RsImportOptimizerTest: RsTestBase() {
         }
     """)
 
+    fun `test keep unused import with allow lint`() = checkNotChanged("""
+        #[allow(unused_imports)]
+        use foo::S;
+
+        mod foo {
+            pub struct S;
+        }
+    """)
+
     fun `test ignore reexport of legacy macro`() = checkNotChanged("""
         macro_rules! foo1 { () => {} }
         macro_rules! foo2 { () => {} }


### PR DESCRIPTION
Fixes #9857

changelog: Don't remove unused imports marked with `#[allow(unused_imports)]`