### PR TITLE
PERF: speed up syntax highlighting in macro calls

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/AnnotationSessionEx.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/AnnotationSessionEx.kt
@@ -11,11 +11,13 @@ import com.intellij.openapi.util.Key
 import com.intellij.util.containers.orNull
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.asNotFake
+import org.rust.lang.core.psi.AttrCache
 import org.rust.lang.core.psi.RsFile
 import org.rust.openapiext.getOrPut
 import java.util.*
 
 private val CRATE_KEY = Key<Optional<Crate>>("org.rust.ide.annotator.currentCrate")
+private val ATTR_CACHE_KEY = Key<AttrCache>("org.rust.ide.annotator.attrCache")
 
 fun AnnotationSession.currentCrate(): Crate? {
     return getOrPut(CRATE_KEY) {
@@ -28,3 +30,10 @@ fun AnnotationSession.setCurrentCrate(crate: Crate?) {
 }
 
 fun AnnotationHolder.currentCrate(): Crate? = currentAnnotationSession.currentCrate()
+
+fun AnnotationHolder.attrCache(): AttrCache {
+    val session = currentAnnotationSession
+    return session.getOrPut(ATTR_CACHE_KEY) {
+        AttrCache.HashMapCache(session.currentCrate())
+    }
+}

--- a/src/main/kotlin/org/rust/ide/annotator/RsAttrHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsAttrHighlightingAnnotator.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.psi.PsiElement
+import org.rust.ide.colors.RsColor
+import org.rust.lang.core.psi.ext.RsAttr
+import org.rust.lang.core.psi.ext.existsAfterExpansion
+import org.rust.openapiext.isUnitTestMode
+
+class RsAttrHighlightingAnnotator : AnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        if (holder.isBatchMode) return
+        val color = when (element) {
+            is RsAttr -> RsColor.ATTRIBUTE
+            else -> null
+        } ?: return
+
+        if (!element.existsAfterExpansion) return
+
+        val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
+
+        holder.newSilentAnnotation(severity).textAttributes(color.textAttributesKey).create()
+    }
+}

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -45,7 +45,7 @@ class RsHighlightingAnnotator : AnnotatorBase() {
     }
 
     private fun highlightLeafInMacroCallBody(element: PsiElement, holder: AnnotationHolder): RsColor? {
-        val expansionElements = element.findExpansionElements()
+        val expansionElements = element.findExpansionElements(holder.attrCache())
             ?.filterIsInstance<LeafPsiElement>()
             ?: return null
 
@@ -69,11 +69,11 @@ class RsHighlightingAnnotator : AnnotatorBase() {
     }
 
     private fun shouldHighlightElement(element: PsiElement, holder: AnnotationHolder): Boolean {
-        val crate = holder.currentCrate()
-        if (crate != null && !element.existsAfterExpansion(crate)) {
+        val crate = holder.currentCrate() ?: return true
+        if (!element.existsAfterExpansion(crate)) {
             return false
         }
-        if (crate != null && element.ancestors.any { it is RsAttr && it.isDisabledCfgAttrAttribute(crate) }) {
+        if (element.ancestors.any { it is RsAttr && it.isDisabledCfgAttrAttribute(crate) }) {
             return false
         }
         return true

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -14,9 +14,12 @@ import com.intellij.psi.impl.cache.impl.IndexPatternUtil
 import com.intellij.psi.impl.search.PsiTodoSearchHelperImpl
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.search.PsiTodoSearchHelper
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.TokenSet
 import org.rust.ide.colors.RsColor
 import org.rust.ide.highlight.RsHighlighter
 import org.rust.ide.todo.isTodoPattern
+import org.rust.lang.core.macros.findExpansionElements
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.ext.*
@@ -28,29 +31,58 @@ class RsHighlightingAnnotator : AnnotatorBase() {
 
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         if (holder.isBatchMode) return
-        val color = when (element) {
-            is LeafPsiElement -> highlightLeaf(element, holder)
-            is RsAttr -> RsColor.ATTRIBUTE
-            else -> null
-        } ?: return
+        if (element !is LeafPsiElement) return
+        val elementType = element.elementType
+        if (elementType !in HIGHLIGHTED_ELEMENTS) return
 
-        val crate = holder.currentCrate()
-        if (crate != null && !element.existsAfterExpansion(crate)) return
-        if (crate != null && element.ancestors.any { it is RsAttr && it.isDisabledCfgAttrAttribute(crate) }) return
+        val color = highlightLeafInMacroCallBody(element, holder)
+            ?: highlightLeafOutsideOfMacroCallBody(element, elementType, holder)
+            ?: return
 
         val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
 
         holder.newSilentAnnotation(severity).textAttributes(color.textAttributesKey).create()
     }
 
-    private fun macroGroupColor(parent: RsElement): RsColor? {
-        return if (parent is RsMacroExpansionReferenceGroup || parent is RsMacroBindingGroup) RsColor.MACRO else null
+    private fun highlightLeafInMacroCallBody(element: PsiElement, holder: AnnotationHolder): RsColor? {
+        val expansionElements = element.findExpansionElements()
+            ?.filterIsInstance<LeafPsiElement>()
+            ?: return null
+
+        for (expansionElement in expansionElements) {
+            val color = highlightLeaf(expansionElement, expansionElement.elementType, holder) ?: continue
+            if (!shouldHighlightElement(expansionElement, holder)) continue
+
+            return color
+        }
+        return null
     }
 
-    private fun highlightLeaf(element: PsiElement, holder: AnnotationHolder): RsColor? {
+    private fun highlightLeafOutsideOfMacroCallBody(
+        element: PsiElement,
+        elementType: IElementType,
+        holder: AnnotationHolder
+    ): RsColor? {
+        val color = highlightLeaf(element, elementType, holder) ?: return null
+        if (!shouldHighlightElement(element, holder)) return null
+        return color
+    }
+
+    private fun shouldHighlightElement(element: PsiElement, holder: AnnotationHolder): Boolean {
+        val crate = holder.currentCrate()
+        if (crate != null && !element.existsAfterExpansion(crate)) {
+            return false
+        }
+        if (crate != null && element.ancestors.any { it is RsAttr && it.isDisabledCfgAttrAttribute(crate) }) {
+            return false
+        }
+        return true
+    }
+
+    private fun highlightLeaf(element: PsiElement, elementType: IElementType, holder: AnnotationHolder): RsColor? {
         val parent = element.parent as? RsElement ?: return null
 
-        return when (element.elementType) {
+        return when (elementType) {
             DOLLAR -> RsColor.MACRO
             IDENTIFIER, QUOTE_IDENTIFIER, SELF -> highlightIdentifier(element, parent, holder)
             // Although we remap tokens from identifier to keyword, this happens in the
@@ -67,7 +99,7 @@ class RsHighlightingAnnotator : AnnotatorBase() {
             }
             in RS_LITERALS -> if (parent is RsLitExpr) {
                 when (parent.parent) {
-                    is RsMetaItem, is RsMetaItemArgs -> RsHighlighter.map(element.elementType)
+                    is RsMetaItem, is RsMetaItemArgs -> RsHighlighter.map(elementType)
                     else -> null
                 }
             } else {
@@ -157,8 +189,19 @@ class RsHighlightingAnnotator : AnnotatorBase() {
         }
     }
 
+    private fun macroGroupColor(parent: RsElement): RsColor? {
+        return if (parent is RsMacroExpansionReferenceGroup || parent is RsMacroBindingGroup) RsColor.MACRO else null
+    }
+
     companion object {
         private val IS_TODO_HIGHLIGHTING_ENABLED: Key<Boolean> = Key.create("IS_TODO_HIGHLIGHTING_ENABLED")
+        private val HIGHLIGHTED_ELEMENTS = TokenSet.orSet(
+            tokenSetOf(
+                DOLLAR, IDENTIFIER, QUOTE_IDENTIFIER, SELF, FLOAT_LITERAL, Q, COLON, MUL, PLUS, LPAREN, LBRACE,
+                RPAREN, RBRACE, EXCL
+            ),
+            RS_CONTEXTUAL_KEYWORDS, RS_LITERALS
+        )
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
@@ -70,7 +70,7 @@ class RsMacroExpansionHighlightingPass(
 
     private fun createAnnotators(): List<Annotator> = listOf(
         RsEdition2018KeywordsAnnotator(),
-        RsHighlightingAnnotator(),
+        RsAttrHighlightingAnnotator(),
         RsHighlightingMutableAnnotator(),
         RsCfgDisabledCodeAnnotator(),
         RsFormatMacroAnnotator(),

--- a/src/main/kotlin/org/rust/lang/core/psi/AttrCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/AttrCache.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.psi.ext.RsAttrProcMacroOwner
+
+/**
+ * A simple single-thread cache used for caching of attribute macros
+ * during per-file operations like highlighting
+ */
+sealed class AttrCache {
+    abstract fun cachedGetProcMacroAttribute(owner: RsAttrProcMacroOwner): RsMetaItem?
+
+    object NoCache : AttrCache() {
+        override fun cachedGetProcMacroAttribute(owner: RsAttrProcMacroOwner): RsMetaItem? =
+            owner.procMacroAttribute.attr
+    }
+
+    class HashMapCache(
+        private val crate: Crate?
+    ): AttrCache() {
+        private val cache: MutableMap<RsAttrProcMacroOwner, ProcMacroAttribute<RsMetaItem>> = hashMapOf()
+
+        override fun cachedGetProcMacroAttribute(owner: RsAttrProcMacroOwner): RsMetaItem? {
+            return cache.getOrPut(owner) {
+                ProcMacroAttribute.getProcMacroAttribute(owner, explicitCrate = crate)
+            }.attr
+        }
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -203,6 +203,7 @@
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsEdition2018KeywordsAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsLiteralAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.format.RsFormatMacroAnnotator"/>
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsAttrHighlightingAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsHighlightingAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsHighlightingMutableAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsExpressionAnnotator"/>

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -13,7 +13,7 @@ import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.colors.RsColor
 
 @ExpandMacros
-class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator::class) {
+class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator::class, RsAttrHighlightingAnnotator::class) {
 
     override fun setUp() {
         super.setUp()

--- a/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
@@ -88,6 +88,10 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
         RsAnnotationTestFixture(
             this,
             myFixture,
-            annotatorClasses = listOf(RsHighlightingAnnotator::class, RsCfgDisabledCodeAnnotator::class)
+            annotatorClasses = listOf(
+                RsHighlightingAnnotator::class,
+                RsAttrHighlightingAnnotator::class,
+                RsCfgDisabledCodeAnnotator::class
+            )
         )
 }


### PR DESCRIPTION
Previously we highlighted macro expansion and then mapped annotations to a macro call body. It was slow due to several reasons:
1. macro expansions are usually larger than macro calls (in terms of tokens);
2. In general, Annotators are more lazy - they first highlight a visible part of the code and then the rest of the file. On the opposite, `RsMacroExpansionHighlightingPass` is not lazy - it highlights the entire file and only then shows highlighting.

Now we do the same for most of the annotators except `RsHighlightingAnnotator` which now uses a reverse approach - it maps a token from a macro call to a macro expansion and then figures out how they should be highlighted there.