### PR TITLE
Fix `CFG_UNKNOWN` vs `ATTR_PROC_MACRO_CALL` code status

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
@@ -49,12 +49,13 @@ val PsiElement.isCfgUnknown: Boolean
  * See tests in `RsCodeStatusTest`
  */
 fun PsiElement.getCodeStatus(crate: Crate?): RsCodeStatus {
+    var result = RsCodeStatus.CODE
     for ((it, cameFrom) in stubAncestors.withPrevious().toList().asReversed()) {
         when (it) {
             is RsDocAndAttributeOwner -> {
                 when (it.evaluateCfg(crate)) {
                     ThreeValuedLogic.False -> return RsCodeStatus.CFG_DISABLED
-                    ThreeValuedLogic.Unknown -> return RsCodeStatus.CFG_UNKNOWN
+                    ThreeValuedLogic.Unknown -> result = RsCodeStatus.CFG_UNKNOWN
                     ThreeValuedLogic.True -> Unit
                 }
                 if (it is RsAttrProcMacroOwner) {
@@ -76,7 +77,7 @@ fun PsiElement.getCodeStatus(crate: Crate?): RsCodeStatus {
         }
     }
 
-    return RsCodeStatus.CODE
+    return result
 }
 
 /**

--- a/src/test/kotlin/org/rust/lang/core/psi/RsCodeStatusTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsCodeStatusTest.kt
@@ -91,6 +91,17 @@ class RsCodeStatusTest : RsTestBase() {
         }
     """)
 
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test proc macro wins over cfg-unknown`() = doTest("""
+        #[cfg(test)]
+        mod tests {
+            #[attr]
+            fn bar () {
+               //^ ATTR_PROC_MACRO_CALL
+            }
+        }
+    """)
+
     private fun doTest(@Language("Rust") code: String) {
         InlineFile(code)
         val (element, data) = findElementAndDataInEditor<RsElement>()


### PR DESCRIPTION
Fixes #9855

changelog: I don't think it deserves to be included in the changelog, but it fixes issue #9855