### PR TITLE
ANN: Annotate exclusive range patterns as experimental

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -40,6 +40,7 @@ import org.rust.lang.core.CompilerFeature.Companion.CONST_TRAIT_IMPL
 import org.rust.lang.core.CompilerFeature.Companion.CRATE_IN_PATHS
 import org.rust.lang.core.CompilerFeature.Companion.CRATE_VISIBILITY_MODIFIER
 import org.rust.lang.core.CompilerFeature.Companion.DECL_MACRO
+import org.rust.lang.core.CompilerFeature.Companion.EXCLUSIVE_RANGE_PATTERN
 import org.rust.lang.core.CompilerFeature.Companion.EXTERN_CRATE_SELF
 import org.rust.lang.core.CompilerFeature.Companion.EXTERN_TYPES
 import org.rust.lang.core.CompilerFeature.Companion.GENERATORS
@@ -665,6 +666,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkPatRange(holder: RsAnnotationHolder, range: RsPatRange) {
+        if (range.isExclusive && range.start == null) {
+            EXCLUSIVE_RANGE_PATTERN.check(holder, range, "exclusive range patterns")
+        }
+
         if (range.start == null && range.end != null) {
             HALF_OPEN_RANGE_PATTERNS.check(holder, range, "half-open range patterns")
         }

--- a/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
+++ b/src/main/kotlin/org/rust/lang/core/CompilerFeature.kt
@@ -184,6 +184,7 @@ class CompilerFeature(
         val C_UNWIND: CompilerFeature get() = get("c_unwind")
         val C_VARIADIC: CompilerFeature get() = get("c_variadic")
         val DECL_MACRO: CompilerFeature get() = get("decl_macro")
+        val EXCLUSIVE_RANGE_PATTERN: CompilerFeature get() = get("exclusive_range_pattern")
         val EXTERN_CRATE_SELF: CompilerFeature get() = get("extern_crate_self")
         val EXTERN_TYPES: CompilerFeature get() = get("extern_types")
         val FORMAT_ARGS_CAPTURE: CompilerFeature get() = get("format_args_capture")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatRange.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatRange.kt
@@ -12,6 +12,9 @@ import org.rust.lang.core.psi.RsPatRange
 val RsPatRange.isInclusive: Boolean
     get() = dotdotdot != null || dotdoteq != null
 
+val RsPatRange.isExclusive: Boolean
+    get() = dotdot != null
+
 val RsPatRange.op: PsiElement?
     get() = dotdot ?: dotdotdot ?: dotdoteq
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3486,7 +3486,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             match 0 {
                  ..   => {},
                 1..   => {},
-                 ..2  => {},
+                 <error>..2</error>  => {},
                 1..2  => {},
                  ..=  => {},
                 1<error descr="inclusive ranges must be bounded at the end (`..=b` or `a..=b`) [E0586]">..=</error>  => {},
@@ -3506,7 +3506,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             match 0 {
                  ..   => {},
                 1..   => {},
-                 <error descr="half-open range patterns is experimental [E0658]">..2</error>  => {},
+                 <error descr="half-open range patterns is experimental [E0658]"><error>..2</error></error>  => {},
                 1..2  => {},
                  ..=  => {},
                 1<error>..=</error>  => {},
@@ -3527,7 +3527,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             match 0 {
                  ..   => {},
                 1..   => {},
-                 ..2  => {},
+                 <error>..2</error>  => {},
                 1..2  => {},
                  ..=  => {},
                 1<error>..=</error>  => {},
@@ -3541,6 +3541,46 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    @MockRustcVersion("1.11.0")
+    fun `test exclusive range patterns E0658 1`() = checkErrors("""
+        fn foo() {
+            match 0 {
+                 ..   => {},
+                1..   => {},
+                 <error descr="exclusive range patterns is experimental [E0658]"><error>..2</error></error>  => {},
+                1..2  => {},
+                 ..=  => {},
+                1<error>..=</error>  => {},
+                 <error>..=2</error> => {},
+                1..=2 => {},
+                 ...  => {},
+                1<error>...</error>  => {},
+                 <error>...2</error> => {},
+                1...2 => {},
+            }
+        }
+    """)
+
+    @MockRustcVersion("1.11.0-nightly")
+    fun `test exclusive range patterns E0658 2`() = checkErrors("""
+        #![feature(exclusive_range_pattern)]
+        fn foo() {
+            match 0 {
+                 ..   => {},
+                1..   => {},
+                 <error>..2</error>  => {},
+                1..2  => {},
+                 ..=  => {},
+                1<error>..=</error>  => {},
+                 <error>..=2</error> => {},
+                1..=2 => {},
+                 ...  => {},
+                1<error>...</error>  => {},
+                 <error>...2</error> => {},
+                1...2 => {},
+            }
+        }
+    """)
 
     fun `test arbitrary enum discriminant without repr E0732`() = checkErrors("""
         #![feature(arbitrary_enum_discriminant)]


### PR DESCRIPTION
Closes https://github.com/intellij-rust/intellij-rust/issues/9873.

changelog: Annotate exclusive range patterns as experimental
