### PR TITLE
T: Check type names in pretty-printers tests

### DIFF
--- a/pretty_printers_tests/Settings_linux.toml
+++ b/pretty_printers_tests/Settings_linux.toml
@@ -5,4 +5,3 @@ print_stdout = true
 [lldb]
 python = "python3"
 lldb_batchmode = "./lldb_batchmode.py"
-native_rust = true

--- a/pretty_printers_tests/Settings_macos.toml
+++ b/pretty_printers_tests/Settings_macos.toml
@@ -5,4 +5,3 @@ print_stdout = true
 [lldb]
 python = "python"
 lldb_batchmode = "./lldb_batchmode.py"
-native_rust = false

--- a/pretty_printers_tests/Settings_windows.toml
+++ b/pretty_printers_tests/Settings_windows.toml
@@ -5,4 +5,3 @@ print_stdout = true
 [lldb]
 # Note, `python` property is intentionally missing here. See `runPrettyPrintersTests` gradle task
 lldb_batchmode = "./lldb_batchmode.py"
-native_rust = false

--- a/pretty_printers_tests/src/main.rs
+++ b/pretty_printers_tests/src/main.rs
@@ -35,7 +35,6 @@ struct Settings {
 struct LLDBSettings {
     python: String,
     lldb_batchmode: String,
-    native_rust: bool
 }
 
 /// Expects "lldb" or "gdb as the first argument
@@ -69,7 +68,6 @@ fn test(debugger: Debugger, path: String) -> Result<(), ()> {
                 lldb_python: path,
                 lldb_batchmode: lldb_settings.lldb_batchmode,
                 python: lldb_settings.python,
-                native_rust: lldb_settings.native_rust,
             })
         },
 

--- a/pretty_printers_tests/src/test_runner.rs
+++ b/pretty_printers_tests/src/test_runner.rs
@@ -29,7 +29,6 @@ pub struct LLDBConfig {
     pub lldb_python: String,
     pub lldb_batchmode: String,
     pub python: String,
-    pub native_rust: bool,
 }
 
 #[derive(Clone)]
@@ -211,15 +210,15 @@ impl<'test> LLDBTestRunner<'test> {
 
 impl<'test> TestRunner<'test> for LLDBTestRunner<'test> {
     fn run(&self) -> TestResult {
-        // If `native_rust = true` in the `Settings_%os%.toml` configuration file,
-        // the test runner will execute all commands that start with `lldb` or `lldbr`.
-        // Otherwise, the test runner will execute commands that start with `lldb` or `lldbg`.
-        let prefixes = if self.config.native_rust {
-            static PREFIXES: &'static [&'static str] = &["lldb", "lldbr"];
+        // Test runner can run commands depending on the target's platform
+        let prefixes = if cfg!(unix) {
+            static PREFIXES: &'static [&'static str] = &["lldb", "lldb-unix"];
+            PREFIXES
+        } else if cfg!(windows) {
+            static PREFIXES: &'static [&'static str] = &["lldb", "lldb-windows"];
             PREFIXES
         } else {
-            static PREFIXES: &'static [&'static str] = &["lldb", "lldbg"];
-            PREFIXES
+            panic!("Unsupported platform");
         };
 
         // Parse debugger commands etc from test files

--- a/pretty_printers_tests/tests/cell.rs
+++ b/pretty_printers_tests/tests/cell.rs
@@ -2,18 +2,17 @@
 
 // lldb-command:run
 
-// lldb-command:print cell
-// lldbr-check:[...]cell = (value = 42)
-// lldbg-check:[...]$0 = (value = 42)
-// lldb-command:print ref_cell1
-// lldbr-check:[...]ref_cell1 = borrow=1 { value = 42 }
-// lldbg-check:[...]$1 = borrow=1 { value = 42 }
-// lldb-command:print ref1
-// lldbr-check:[...]ref1 = borrow=1 { [...] = 42 }
-// lldbg-check:[...]$2 = borrow=1 { [...] = 42 }
-// lldb-command:print ref_mut2
-// lldbr-check:[...]ref_mut2 = borrow_mut=1 { [...] = 42 }
-// lldbg-check:[...]$3 = borrow_mut=1 { [...] = 42 }
+// lldb-command:frame variable cell
+// lldb-check:(core::cell::Cell<i32>) cell = (value = 42)
+
+// lldb-command:frame variable ref_cell1
+// lldb-check:(core::cell::RefCell<i32>) ref_cell1 = borrow=1 { value = 42 }
+
+// lldb-command:frame variable ref1
+// lldb-check:(core::cell::Ref<i32>) ref1 = borrow=1 { [...] = 42 }
+
+// lldb-command:frame variable ref_mut2
+// lldb-check:(core::cell::RefMut<i32>) ref_mut2 = borrow_mut=1 { [...] = 42 }
 
 // === GDB TESTS ==================================================================================
 

--- a/pretty_printers_tests/tests/ffi_strings.rs
+++ b/pretty_printers_tests/tests/ffi_strings.rs
@@ -4,81 +4,72 @@
 
 // lldb-command:run
 
-// lldb-command:print os_string
-// lldbr-check:[...]os_string = "abc" [...]
-// lldbg-check:[...]$0 = "abc" [...]
+// lldb-command:frame variable os_string
+// lldb-check:(std::ffi::os_str::OsString) os_string = "abc" [...]
 
-// lldb-command:print os_string_empty
-// lldbr-check:[...]os_string_empty = "" [...]
-// lldbg-check:[...]$1 = "" [...]
+// lldb-command:frame variable os_string_empty
+// lldb-check:(std::ffi::os_str::OsString) os_string_empty = "" [...]
 
-// lldb-command:print os_string_unicode
-// lldbr-check:[...]os_string_unicode = "A∆й中" [...]
+// lldb-command:frame variable os_string_unicode
+// lldb-unix-check:(std::ffi::os_str::OsString) os_string_unicode = "A∆й中" [...]
 // TODO: support WTF-8 on Windows
 
-
-// lldb-command:print os_str
-// lldbr-check:[...]os_str = "abc" { data_ptr = [...] length = 3 }
+// lldb-command:frame variable os_str
+// lldb-unix-check:(&mut std::ffi::os_str::OsStr) os_str = "abc" { data_ptr = [...] length = 3 }
 // TODO: support `ref$<...>` and `ref_mut$<...>` type wrappings on Windows
 
-// lldb-command:print os_str_empty
-// lldbr-check:[...]os_str_empty = "" { data_ptr = [...] length = 0 }
+// lldb-command:frame variable os_str_empty
+// lldb-unix-check:(&std::ffi::os_str::OsStr) os_str_empty = "" { data_ptr = [...] length = 0 }
 // TODO: support `ref$<...>` and `ref_mut$<...>` type wrappings on Windows
 
-// lldb-command:print os_str_unicode
-// lldbr-check:[...]os_str_unicode = "A∆й中" { data_ptr = [...] length = 9 }
+// lldb-command:frame variable os_str_unicode
+// lldb-unix-check:(&mut std::ffi::os_str::OsStr) os_str_unicode = "A∆й中" { data_ptr = [...] length = 9 }
 // TODO: support `ref$<...>` and `ref_mut$<...>` type wrappings and WTF-8 on Windows
 
+// lldb-command:frame variable c_string
+// lldb-unix-check:(alloc::ffi::c_str::CString) c_string = "abc" [...]
+// MSVC LLDB without Rust support fails to frame variable `CString` in the console (but CLion renders it fine)
 
-// lldb-command:print c_string
-// lldbr-check:[...]c_string = "abc" [...]
+// lldb-command:frame variable c_string_empty
+// lldb-unix-check:(alloc::ffi::c_str::CString) c_string_empty = "" [...]
 // MSVC LLDB without Rust support fails to print `CString` in the console (but CLion renders it fine)
 
-// lldb-command:print c_string_empty
-// lldbr-check:[...]c_string_empty = "" [...]
+// lldb-command:frame variable c_string_unicode
+// lldb-unix-check:(alloc::ffi::c_str::CString) c_string_unicode = "A∆й中" [...]
 // MSVC LLDB without Rust support fails to print `CString` in the console (but CLion renders it fine)
 
-// lldb-command:print c_string_unicode
-// lldbr-check:[...]c_string_unicode = "A∆й中" [...]
-// MSVC LLDB without Rust support fails to print `CString` in the console (but CLion renders it fine)
-
-
-// lldb-command:print c_str
-// lldbr-check:[...]c_str = "abcd" { data_ptr = [...] length = 5 }
+// lldb-command:frame variable c_str
+// lldb-unix-check:(&core::ffi::c_str::CStr) c_str = "abcd" { data_ptr = [...] length = 5 }
 // TODO: support `ref$<...>` and `ref_mut$<...>` type wrappings on Windows
 
-// lldb-command:print c_str_empty
-// lldbr-check:[...]c_str_empty = "" { data_ptr = [...] length = 1 }
+// lldb-command:frame variable c_str_empty
+// lldb-unix-check:(&core::ffi::c_str::CStr) c_str_empty = "" { data_ptr = [...] length = 1 }
 // TODO: support `ref$<...>` and `ref_mut$<...>` type wrappings on Windows
 
-// lldb-command:print c_str_unicode
-// lldbr-check:[...]c_str_unicode = "A∆й中" { data_ptr = [...] length = 10 }
+// lldb-command:frame variable c_str_unicode
+// lldb-unix-check:(&core::ffi::c_str::CStr) c_str_unicode = "A∆й中" { data_ptr = [...] length = 10 }
 // TODO: support `ref$<...>` and `ref_mut$<...>` type wrappings on Windows
 
+// lldb-command:frame variable path_buf
+// lldb-check:(std::path::PathBuf) path_buf = "/a/b/c" [...]
 
-// lldb-command:print path_buf
-// lldbr-check:[...]path_buf = "/a/b/c" [...]
-// lldbg-check:[...]$12 = "/a/b/c" [...]
+// lldb-command:frame variable path_buf_empty
+// lldb-check:(std::path::PathBuf) path_buf_empty = "" [...]
 
-// lldb-command:print path_buf_empty
-// lldbr-check:[...]path_buf_empty = "" [...]
-// lldbg-check:[...]$13 = "" [...]
-
-// lldb-command:print path_buf_unicode
-// lldbr-check:[...]path_buf_unicode = "/a/b/∂" [...]
+// lldb-command:frame variable path_buf_unicode
+// lldb-unix-check:(std::path::PathBuf) path_buf_unicode = "/a/b/∂" [...]
 // TODO: support WTF-8 on Windows
 
-
-// lldb-command:print path
-// lldbr-check:[...]path = "/a/b/c" { data_ptr = [...] length = 6 }
+// lldb-command:frame variable path
+// lldb-unix-check:(&std::path::Path) path = "/a/b/c" { data_ptr = [...] length = 6 }
 // TODO: support `ref$<...>` and `ref_mut$<...>` type wrappings on Windows
 
-// lldb-command:print path_empty
-// lldbr-check:[...]path_empty = "" { data_ptr = [...] length = 0 }
+// lldb-command:frame variable path_empty
+// lldb-unix-check:(&std::path::Path) path_empty = "" { data_ptr = [...] length = 0 }
 // TODO: support `ref$<...>` and `ref_mut$<...>` type wrappings on Windows
 
-// lldb-command:print path_unicode
-// lldbr-check:[...]path_unicode = "/a/b/∂" { data_ptr = [...] length = 8 }
+// lldb-command:frame variable path_unicode
+// lldb-unix-check:(&std::path::Path) path_unicode = "/a/b/∂" { data_ptr = [...] length = 8 }
 // TODO: support `ref$<...>` and `ref_mut$<...>` type wrappings on Windows
 
 

--- a/pretty_printers_tests/tests/hash_map.rs
+++ b/pretty_printers_tests/tests/hash_map.rs
@@ -2,12 +2,12 @@
 
 // lldb-command:run
 
-// lldb-command:print xs
-// lldbr-check:[...]xs = size=4 { [0] = (0 = 1, 1 = 10) [1] = (0 = 2, 1 = 20) [2] = (0 = 3, 1 = 30) [3] = (0 = 4, 1 = 40) }
-// lldbg-check:[...]$0 = size=4 { [0] = (__0 = 1, __1 = 10) [1] = (__0 = 2, __1 = 20) [2] = (__0 = 3, __1 = 30) [3] = (__0 = 4, __1 = 40) }
-// lldb-command:print ys
-// lldbr-check:[...]ys = size=4 { [0] = 1 [1] = 2 [2] = 3 [3] = 4 }
-// lldbg-check:[...]$1 = size=4 { [0] = 1 [1] = 2 [2] = 3 [3] = 4 }
+// lldb-command:frame variable xs
+// lldb-unix-check:(std::collections::hash::map::HashMap<u64, u64, [...]>) xs = size=4 { [0] = (0 = 1, 1 = 10) [1] = (0 = 2, 1 = 20) [2] = (0 = 3, 1 = 30) [3] = (0 = 4, 1 = 40) }
+// lldb-windows-check:(std::collections::hash::map::HashMap<u64,u64,[...]>) xs = size=4 { [0] = (__0 = 1, __1 = 10) [1] = (__0 = 2, __1 = 20) [2] = (__0 = 3, __1 = 30) [3] = (__0 = 4, __1 = 40) }
+
+// lldb-command:frame variable ys
+// lldb-check:(std::collections::hash::set::HashSet<u64,[...]>) ys = size=4 { [0] = 1 [1] = 2 [2] = 3 [3] = 4 }
 
 // === GDB TESTS ===================================================================================
 

--- a/pretty_printers_tests/tests/nonzero.rs
+++ b/pretty_printers_tests/tests/nonzero.rs
@@ -2,12 +2,11 @@
 
 // lldb-command:run
 
-// lldb-command:print a
-// lldbr-check:[...]a = -1 [...]
-// lldbg-check:[...]$0 = -1 [...]
-// lldb-command:print b
-// lldbr-check:[...]b = 1024 [...]
-// lldbg-check:[...]$1 = 1024 [...]
+// lldb-command:frame variable a
+// lldb-check:(core::num::nonzero::NonZeroI32) a = -1 [...]
+
+// lldb-command:frame variable b
+// lldb-check:(core::num::nonzero::NonZeroUsize) b = 1024 [...]
 
 // === GDB TESTS ===================================================================================
 

--- a/pretty_printers_tests/tests/range.rs
+++ b/pretty_printers_tests/tests/range.rs
@@ -2,25 +2,20 @@
 
 // lldb-command:run
 
-// lldb-command:print range
-// lldbr-check:[...]range = 1..12 [...]
-// lldbg-check:[...]$0 = 1..12 [...]
+// lldb-command:frame variable range
+// lldb-check:(core::ops::range::Range<i32>) range = 1..12 [...]
 
-// lldb-command:print range_from
-// lldbr-check:[...]range_from = 9.. [...]
-// lldbg-check:[...]$1 = 9.. [...]
+// lldb-command:frame variable range_from
+// lldb-check:(core::ops::range::RangeFrom<i32>) range_from = 9.. [...]
 
-// lldb-command:print range_inclusive
-// lldbr-check:[...]range_inclusive = 32..=80 [...]
-// lldbg-check:[...]$2 = 32..=80 [...]
+// lldb-command:frame variable range_inclusive
+// lldb-check:(core::ops::range::RangeInclusive<i32>) range_inclusive = 32..=80 [...]
 
-// lldb-command:print range_to
-// lldbr-check:[...]range_to = ..42 [...]
-// lldbg-check:[...]$3 = ..42 [...]
+// lldb-command:frame variable range_to
+// lldb-check:(core::ops::range::RangeTo<i32>) range_to = ..42 [...]
 
-// lldb-command:print range_to_inclusive
-// lldbr-check:[...]range_to_inclusive = ..=120 [...]
-// lldbg-check:[...]$4 = ..=120 [...]
+// lldb-command:frame variable range_to_inclusive
+// lldb-check:(core::ops::range::RangeToInclusive<i32>) range_to_inclusive = ..=120 [...]
 
 // === GDB TESTS ===================================================================================
 

--- a/pretty_printers_tests/tests/rc_arc.rs
+++ b/pretty_printers_tests/tests/rc_arc.rs
@@ -2,19 +2,17 @@
 
 // lldb-command:run
 
-// lldb-command:print r
-// lldbr-check:[...]r = strong=2, weak=1 { value = 42 }
-// lldbg-check:[...]$0 = strong=2, weak=1 { value = 42 }
-// lldb-command:print r_weak
-// lldbr-check:[...]r_weak = strong=2, weak=1 { value = 42 }
-// lldbg-check:[...]$1 = strong=2, weak=1 { value = 42 }
+// lldb-command:frame variable r
+// lldb-check:(alloc::rc::Rc<i32>) r = strong=2, weak=1 { value = 42 }
 
-// lldb-command:print a
-// lldbr-check:[...]a = strong=2, weak=1 { data = 42 }
-// lldbg-check:[...]$2 = strong=2, weak=1 { data = 42 }
-// lldb-command:print a_weak
-// lldbr-check:[...]a_weak = strong=2, weak=1 { data = 42 }
-// lldbg-check:[...]$3 = strong=2, weak=1 { data = 42 }
+// lldb-command:frame variable r_weak
+// lldb-check:(alloc::rc::Weak<i32>) r_weak = strong=2, weak=1 { value = 42 }
+
+// lldb-command:frame variable a
+// lldb-check:(alloc::sync::Arc<i32>) a = strong=2, weak=1 { data = 42 }
+
+// lldb-command:frame variable a_weak
+// lldb-check:(alloc::sync::Weak<i32>) a_weak = strong=2, weak=1 { data = 42 }
 
 // === GDB TESTS ==================================================================================
 

--- a/pretty_printers_tests/tests/slice.rs
+++ b/pretty_printers_tests/tests/slice.rs
@@ -2,20 +2,25 @@
 
 // lldb-command:run
 
-// lldb-command:print slice
-// lldbr-check:[...]slice = size=2 { [0] = 1 [1] = 2 }
-// lldbg-check:[...]$0 = size=2 { [0] = 1 [1] = 2 }
-// lldb-command:print slice_mut
-// lldbr-check:[...]slice_mut = size=2 { [0] = 1 [1] = 2 }
-// lldbg-check:[...]$1 = size=2 { [0] = 1 [1] = 2 }
-// lldb-command:print slice_ptr_const
-// lldbr-check:[...]slice_ptr_const = size=2 { [0] = 1 [1] = 2 }
-// lldbg-check:[...]$2 = size=2 { [0] = 1 [1] = 2 }
-// lldb-command:print slice_ptr_mut
-// lldbr-check:[...]slice_ptr_mut = size=2 { [0] = 1 [1] = 2 }
-// lldbg-check:[...]$3 = size=2 { [0] = 1 [1] = 2 }
+// lldb-command:frame variable slice
+// lldb-unix-check:(&[i32]) slice = size=2 { [0] = 1 [1] = 2 }
+// lldb-windows-check:[...] slice = size=2 { [0] = 1 [1] = 2 }
+
+// lldb-command:frame variable slice_mut
+// lldb-unix-check:(&mut [i32]) slice_mut = size=2 { [0] = 1 [1] = 2 }
+// lldb-windows-check:[...] slice_mut = size=2 { [0] = 1 [1] = 2 }
+
+// lldb-command:frame variable slice_ptr_const
+// lldb-unix-check:(*const [i32]) slice_ptr_const = size=2 { [0] = 1 [1] = 2 }
+// lldb-windows-check:[...] slice_ptr_const = size=2 { [0] = 1 [1] = 2 }
+
+// lldb-command:frame variable slice_ptr_mut
+// lldb-unix-check:(*mut [i32]) slice_ptr_mut = size=2 { [0] = 1 [1] = 2 }
+// lldb-windows-check:[...] slice_ptr_mut = size=2 { [0] = 1 [1] = 2 }
+
 // lldb-command:frame variable --ptr-depth 1 slice_fixed_sized
-// lldb-check:[...]slice_fixed_sized = 0x[...] { [0] = 1 [1] = 2 }
+// lldb-unix-check:(&[i32; 2]) slice_fixed_sized = 0x[...] { [0] = 1 [1] = 2 }
+// lldb-windows-check:[...] slice_fixed_sized = 0x[...] { [0] = 1 [1] = 2 }
 
 // === GDB TESTS ===================================================================================
 

--- a/pretty_printers_tests/tests/string.rs
+++ b/pretty_printers_tests/tests/string.rs
@@ -2,36 +2,43 @@
 
 // lldb-command:run
 
-// lldb-command:print s1
-// lldbr-check:[...]s1 = "A∆й中" [...]
-// lldbg-check:[...]$0 = "A∆й中" [...]
-// lldb-command:print s2
-// lldbr-check:[...]s2 = "A∆й中" [...]
-// lldbg-check:[...]$1 = "A∆й中" [...]
-// lldb-command:print s3
-// lldbr-check:[...]s3 = "A∆й中" [...]
-// lldbg-check:[...]$2 = "A∆й中" [...]
-// lldb-command:print s4
-// lldbr-check:[...]s4 = "A∆й中" [...]
-// lldbg-check:[...]$3 = "A∆й中" [...]
-// lldb-command:print s5
-// lldbr-check:[...]s5 = "A∆й中" [...]
-// lldbg-check:[...]$4 = "A∆й中" [...]
-// lldb-command:print empty_s1
-// lldbr-check:[...]empty_s1 = "" [...]
-// lldbg-check:[...]$5 = "" [...]
-// lldb-command:print empty_s2
-// lldbr-check:[...]empty_s2 = "" [...]
-// lldbg-check:[...]$6 = "" [...]
-// lldb-command:print empty_s3
-// lldbr-check:[...]empty_s3 = "" [...]
-// lldbg-check:[...]$7 = "" [...]
-// lldb-command:print empty_s4
-// lldbr-check:[...]empty_s4 = "" [...]
-// lldbg-check:[...]$8 = "" [...]
-// lldb-command:print empty_s5
-// lldbr-check:[...]empty_s5 = "" [...]
-// lldbg-check:[...]$9 = "" [...]
+// lldb-command:frame variable s1
+// lldb-unix-check:(&str) s1 = "A∆й中" [...]
+// lldb-windows-check:[...] s1 = "A∆й中" [...]
+
+// lldb-command:frame variable s2
+// lldb-check:(alloc::string::String) s2 = "A∆й中" [...]
+
+// lldb-command:frame variable s3
+// lldb-unix-check:(&mut str) s3 = "A∆й中" [...]
+// lldb-windows-check:[...] s3 = "A∆й中" [...]
+
+// lldb-command:frame variable s4
+// lldb-unix-check:(*mut str) s4 = "A∆й中" [...]
+// lldb-windows-check:[...] s4 = "A∆й中" [...]
+
+// lldb-command:frame variable s5
+// lldb-unix-check:(*const str) s5 = "A∆й中" [...]
+// lldb-windows-check:[...] s5 = "A∆й中" [...]
+
+// lldb-command:frame variable empty_s1
+// lldb-unix-check:(&str) empty_s1 = "" [...]
+// lldb-windows-check:[...] empty_s1 = "" [...]
+
+// lldb-command:frame variable empty_s2
+// lldb-check:(alloc::string::String) empty_s2 = "" [...]
+
+// lldb-command:frame variable empty_s3
+// lldb-unix-check:(&mut str) empty_s3 = "" [...]
+// lldb-windows-check:[...] empty_s3 = "" [...]
+
+// lldb-command:frame variable empty_s4
+// lldb-unix-check:(*mut str) empty_s4 = "" [...]
+// lldb-windows-check:[...] empty_s4 = "" [...]
+
+// lldb-command:frame variable empty_s5
+// lldb-unix-check:(*const str) empty_s5 = "" [...]
+// lldb-windows-check:[...] empty_s5 = "" [...]
 
 // === GDB TESTS ==================================================================================
 

--- a/pretty_printers_tests/tests/tuple.rs
+++ b/pretty_printers_tests/tests/tuple.rs
@@ -2,13 +2,13 @@
 
 // lldb-command:run
 
-// lldb-command:print t1
-// lldbr-check:[...]t1 = { 0 = (0 = 1, 1 = 2) 1 = 3 }
-// lldbg-check:[...]$0 = { __0 = (__0 = 1, __1 = 2) __1 = 3 }
+// lldb-command:frame variable t1
+// lldb-unix-check:(((i32, i32), i32)) t1 = { 0 = (0 = 1, 1 = 2) 1 = 3 }
+// lldb-windows-check:(tuple$<tuple$<i32,i32>,i32>) t1 = { __0 = (__0 = 1, __1 = 2) __1 = 3 }
 
-// lldb-command:print t2
-// lldbr-check:[...]t2 = { 0 = "abc" [...] 1 = 42 }
-// lldbg-check:[...]$1 = { __0 = "abc" [...] __1 = 42 }
+// lldb-command:frame variable t2
+// lldb-unix-check:((&str, i32)) t2 = { 0 = "abc" [...] 1 = 42 }
+// lldb-windows-check:(tuple$<[...],i32>) t2 = { __0 = "abc" [...] __1 = 42 }
 
 // === GDB TESTS ==================================================================================
 

--- a/pretty_printers_tests/tests/vec.rs
+++ b/pretty_printers_tests/tests/vec.rs
@@ -2,12 +2,11 @@
 
 // lldb-command:run
 
-// lldb-command:print v
-// lldbr-check:[...]v = size=2 { [0] = size=2 { [0] = 1 [1] = 2 } [1] = size=1 { [0] = 3 } }
-// lldbg-check:[...]$0 = size=2 { [0] = size=2 { [0] = 1 [1] = 2 } [1] = size=1 { [0] = 3 } }
-// lldb-command:print empty_v
-// lldbr-check:[...]empty_v = size=0
-// lldbg-check:[...]$1 = size=0
+// lldb-command:frame variable v
+// lldb-check:(alloc::vec::Vec<alloc::vec::Vec<i32,[...]>,[...]>) v = size=2 { [0] = size=2 { [0] = 1 [1] = 2 } [1] = size=1 { [0] = 3 } }
+
+// lldb-command:frame variable empty_v
+// lldb-check:(alloc::vec::Vec<i32,[...]>) empty_v = size=0
 
 // === GDB TESTS ===================================================================================
 

--- a/pretty_printers_tests/tests/vec_deque.rs
+++ b/pretty_printers_tests/tests/vec_deque.rs
@@ -4,14 +4,13 @@
 
 // lldb-command:run
 
-// lldb-command:print d
-// lldbr-check:[...]d = size=7 { [0] = 2 [1] = 3 [2] = 4 [3] = 5 [4] = 6 [5] = 7 [6] = 8 }
-// lldbg-check:[...]$0 = size=7 { [0] = 2 [1] = 3 [2] = 4 [3] = 5 [4] = 6 [5] = 7 [6] = 8 }
-// lldb-command:print empty_d
-// lldbr-check:[...]empty_d = size=0
-// lldbg-check:[...]$1 = size=0
+// lldb-command:frame variable d
+// lldb-check:(alloc::collections::vec_deque::VecDeque<i32,[...]>) d = size=7 { [0] = 2 [1] = 3 [2] = 4 [3] = 5 [4] = 6 [5] = 7 [6] = 8 }
 
-// === LLDB TESTS ==================================================================================
+// lldb-command:frame variable empty_d
+// lldb-check:(alloc::collections::vec_deque::VecDeque<i32,[...]>) empty_d = size=0
+
+// === GDB TESTS ==================================================================================
 
 // gdb-command:run
 


### PR DESCRIPTION
Previously, the pretty-printers tests only checked how the variables' values were rendered. Now, pretty-printers tests for LLDB also check the variables' types according to the debugger. This aims to help us catch specific changes in the Rust debug information that can break pretty-printers and MSVC type decorators.

Currently, the pretty-printers test runner cannot check the output depending on the Rust version, so the types that have different names on Rust stable and Rust nightly are not being checked yet (`[...]` wildcard is used instead).

In addition, now the LLDB pretty-printers tests use `frame variable` command instead of the previously used `print` command. This allows removing Windows-specific checks written only because `print` outputs an index instead of a variable name.
