### PR TITLE
ANN: Add support for E0130, E0642

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -16,8 +16,10 @@ import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.annotator.fixes.AddTypeFix
 import org.rust.ide.inspections.fixes.SubstituteTextFix
 import org.rust.lang.core.CompilerFeature.Companion.C_VARIADIC
+import org.rust.lang.core.macros.MacroExpansion
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.Mutability
 import org.rust.lang.core.types.type
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
@@ -234,17 +236,43 @@ private fun checkDot3Parameter(holder: AnnotationHolder, dot3: PsiElement?) {
         }
 }
 
+private fun isComplexPattern(pat: RsPat?): Boolean {
+    return when (pat) {
+        null, is RsPatWild -> false
+        is RsPatIdent -> {
+            val binding = pat.patBinding
+            binding.mutability == Mutability.MUTABLE || binding.kind is RsBindingModeKind.BindByReference || pat.at != null
+        }
+
+        is RsPatMacro -> {
+            val expansion = pat.macroCall.expansion
+            return expansion != null && expansion is MacroExpansion.Pat && isComplexPattern(expansion.pat)
+        }
+
+        else -> true
+    }
+}
+
 private fun checkValueParameter(holder: AnnotationHolder, param: RsValueParameter) {
     val fn = param.parent.parent as? RsFunction ?: return
+    val pat = param.pat
+    val isComplexPattern = isComplexPattern(pat)
     when (fn.owner) {
         is RsAbstractableOwner.Free,
-        is RsAbstractableOwner.Impl,
+        is RsAbstractableOwner.Impl -> {
+            require(pat, holder, "${fn.title} cannot have anonymous parameters", param)
+        }
         is RsAbstractableOwner.Foreign -> {
-            require(param.pat, holder, "${fn.title} cannot have anonymous parameters", param)
+            require(pat, holder, "${fn.title} cannot have anonymous parameters", param)
+            if (isComplexPattern) {
+                RsDiagnostic.PatternArgumentInForeignFunctionError(param).addToHolder(holder)
+            }
         }
         is RsAbstractableOwner.Trait -> {
-            denyType<RsPatTup>(param.pat, holder, "${fn.title} cannot have tuple parameters", param)
-            if (param.pat == null) {
+            if (isComplexPattern && fn.block == null) {
+                RsDiagnostic.PatternArgumentInFunctionWithoutBodyError(param).addToHolder(holder)
+            }
+            if (pat == null) {
                 val message = "Anonymous functions parameters are deprecated (RFC 1685)"
                 val annotation = holder.newAnnotation(HighlightSeverity.WARNING, message)
 

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1602,19 +1602,39 @@ sealed class RsDiagnostic(
         override fun prepare() = PreparedAnnotation(
             ERROR,
             E0044,
-            "Foreign items may not have $kinds parameters"
+            "Foreign items may not have $kinds parameters",
+        )
+    }
+
+    class PatternArgumentInForeignFunctionError (
+        element: PsiElement
+    ) : RsDiagnostic(element) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            E0130,
+            "Patterns aren't allowed in foreign function declarations",
+        )
+    }
+
+    class PatternArgumentInFunctionWithoutBodyError (
+        element: PsiElement
+    ) : RsDiagnostic(element) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            E0642,
+            "Patterns aren't allowed in functions without bodies",
         )
     }
 }
 
 enum class RsErrorCode {
     E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
-    E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0191, E0198, E0199,
+    E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0130, E0132, E0133, E0184, E0185, E0186, E0191, E0198, E0199,
     E0200, E0201, E0220, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0364, E0365, E0379, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0437, E0438, E0449, E0451, E0463,
     E0517, E0518, E0537, E0552, E0554, E0562, E0569, E0583, E0586, E0594,
-    E0601, E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0695,
+    E0601, E0603, E0614, E0616, E0618, E0624, E0642, E0658, E0666, E0667, E0695,
     E0703, E0704, E0728, E0732, E0733, E0741, E0742, E0747, E0774;
 
     val code: String

--- a/src/test/kotlin/org/rust/ide/annotator/RsPatternArgumentInForeignFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsPatternArgumentInForeignFunctionTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+class RsPatternArgumentInForeignFunctionTest: RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
+    fun `test E0130 tuple struct pattern`() = checkByText("""
+        struct MyInt(i32);
+
+        extern "C" {
+            fn foo(<error descr="Patterns aren't allowed in foreign function declarations [E0130]">MyInt(x): MyInt</error>);
+        }
+    """)
+
+    fun `test E0130 array pattern`() = checkByText("""
+        extern "C" {
+            fn foo(<error descr="Patterns aren't allowed in foreign function declarations [E0130]">[x, ..]: [i32; 3]</error>);
+        }
+    """)
+
+    fun `test E0130 allow all cases without extern`() = checkByText("""
+        struct MyInt(i32);
+
+        fn foo(MyInt(x): MyInt) {}
+
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        fn bar(Point { x, y }: Point) {}
+
+        fn baz([x, ..]: [i32; 3]) {}
+
+        fn qux(a: i32) {}
+    """)
+
+    fun `test E0130 compiler test -- no-patterns-in-args`() = checkByText("""
+        extern "C" {
+            fn f1(<error descr="Patterns aren't allowed in foreign function declarations [E0130]">mut arg: u8</error>);
+            fn f2(<error descr="Patterns aren't allowed in foreign function declarations [E0130]">&arg: u8</error>);
+            fn f3(<error descr="Patterns aren't allowed in foreign function declarations [E0130]">arg @ _: u8</error>);
+        }
+    """)
+
+    fun `test E0130 compiler test -- issue-10877`() = checkByText("""
+        extern "C" {
+            fn foo(<error descr="Patterns aren't allowed in foreign function declarations [E0130]">1: ()</error>);
+            fn bar(<error descr="Patterns aren't allowed in foreign function declarations [E0130]">(): isize</error>);
+            fn baz(<error descr="Patterns aren't allowed in foreign function declarations [E0130]">Foo { x }: isize</error>);
+            fn qux(<error descr="Patterns aren't allowed in foreign function declarations [E0130]">(x, y): ()</error>);
+            fn this_is_actually_ok(a: usize);
+            fn and_so_is_this(_: usize);
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/annotator/RsPatternArgumentInFunctionWithoutBodyTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsPatternArgumentInFunctionWithoutBodyTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+class RsPatternArgumentInFunctionWithoutBodyTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
+    fun `test E0642 compiler test -- E0642`() = checkByText("""
+        struct S;
+
+        trait T {
+            fn foo(<error descr="Patterns aren't allowed in functions without bodies [E0642]">(x, y): (i32, i32)</error>);
+            fn bar(<error descr="Patterns aren't allowed in functions without bodies [E0642]">(x, y): (i32, i32)</error>);
+            fn method(<error descr="Patterns aren't allowed in functions without bodies [E0642]">S { .. }: S</error>);
+
+            fn f(&ident: &S) {} // ok
+            fn g(&&ident: &&S) {} // ok
+            fn h(mut ident: S) {} // ok
+        }
+    """)
+
+    fun `test E0642 compiler test -- issue-50571`() = checkByText("""
+        trait Foo {
+            fn foo(<error descr="Patterns aren't allowed in functions without bodies [E0642]">[a, b]: [i32; 2]</error>);
+        }
+    """)
+
+    fun `test E0642 compiler test -- no-patterns-in-args-2`() = checkByText("""
+        trait Tr {
+            fn f1(<error descr="Patterns aren't allowed in functions without bodies [E0642]">mut arg: u8</error>);
+            fn f2(<error descr="Patterns aren't allowed in functions without bodies [E0642]">&arg: u8</error>);
+            fn g1(arg: u8);
+            fn g2(_: u8);
+        }
+    """)
+
+    fun `test E0642 macros`() = checkByText("""
+        macro_rules! foo {
+            () => { _ };
+        }
+
+        macro_rules! proxy_foo {
+            () => { foo!() };
+        }
+
+        macro_rules! bad {
+            () => { (a, b) };
+        }
+
+        macro_rules! proxy_bad {
+            () => { bad!() };
+        }
+
+        trait A {
+            fn foo(foo!(): (i32, i32)); // OK
+            fn proxy_foo(proxy_foo!(): (i32, i32)); // OK
+            fn bad(<error descr="Patterns aren't allowed in functions without bodies [E0642]">bad!(): (i32, i32)</error>);
+            fn proxy_bad(<error descr="Patterns aren't allowed in functions without bodies [E0642]">proxy_bad!(): (i32, i32)</error>);
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
@@ -60,7 +60,7 @@ class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator:
 
             <error descr="Associated function `default_foo` cannot have the `default` qualifier">default</error> fn default_foo();
             <error descr="Associated function `pub_foo` cannot have the `pub` qualifier">pub</error> fn pub_foo();
-            fn tup_param(<error descr="Associated function `tup_param` cannot have tuple parameters">(x, y): (u8, u8)</error>, a: bool);
+            fn tup_param(<error descr="Patterns aren't allowed in functions without bodies [E0642]">(x, y): (u8, u8)</error>, a: bool);
             fn var_foo(a: bool, <error descr="Associated function `var_foo` cannot be variadic">...</error>);
         }
     """)
@@ -76,7 +76,7 @@ class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator:
 
             <error descr="Method `default_foo` cannot have the `default` qualifier">default</error> fn default_foo(&self);
             <error descr="Method `pub_foo` cannot have the `pub` qualifier">pub</error> fn pub_foo(&mut self);
-            fn tup_param(&self, <error descr="Method `tup_param` cannot have tuple parameters">(x, y): (u8, u8)</error>, a: bool);
+            fn tup_param(&self, <error descr="Patterns aren't allowed in functions without bodies [E0642]">(x, y): (u8, u8)</error>, a: bool);
             fn var_foo(&self, a: bool, <error descr="Method `var_foo` cannot be variadic">...</error>);
         }
     """)


### PR DESCRIPTION
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

changelog:
Add support for E0130, and E0642.
Replace the old code for E0642, since it catches only tuple destructions and doesn't consider whether a function has a body or not:
```[rust]
denyType<RsPatTup>(param.pat, holder, "${fn.title} cannot have tuple parameters", param)
```
This approach might lead to a false positive, for example, the next code compiles, but we got an error from IDE: 
```
trait Foo {
    fn baz((a, b): (i32, i32)) {}
}
```

E0130 reference: https://doc.rust-lang.org/error_codes/E0130.html
E0642 reference: https://doc.rust-lang.org/beta/error_codes/E0642.html
Compiler reference: https://github.com/rust-lang/rust/blob/30117a1dbb843da1d5ab1258e89a3ed0b1940475/compiler/rustc_ast_passes/src/ast_validation.rs#L1471
