### PR TITLE
Don't pass `RUSTC_BOOTSTRAP` to rustc during build script evaluation

### DIFF
--- a/native-helper/src/rustc_wrapper.rs
+++ b/native-helper/src/rustc_wrapper.rs
@@ -33,11 +33,29 @@ pub fn run_rustc_skipping_cargo_checking(
 }
 
 fn run_rustc(rustc_executable: OsString, args: Vec<OsString>) -> io::Result<ExitCode> {
-    let mut child = Command::new(rustc_executable)
+    const RUSTC_BOOTSTRAP: &'static str = "RUSTC_BOOTSTRAP";
+    const ORIGINAL_RUSTC_BOOTSTRAP: &'static str = "INTELLIJ_ORIGINAL_RUSTC_BOOTSTRAP";
+
+    let mut command = Command::new(rustc_executable);
+    command
         .args(args)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    // IntelliJ Rust plugin may add `RUSTC_BOOTSTRAP=1` environment variable to `cargo check` call
+    // during build script execution.
+    // But we need it only to use experimental `cargo` feature
+    // and don't want to propagate it to `rustc` call because it may produce different results.
+    // So we use `INTELLIJ_ORIGINAL_RUSTC_BOOTSTRAP` environment variable to keep original value
+    // of `RUSTC_BOOTSTRAP` and restore it (if needed) for `rustc` call.
+    //
+    // See https://github.com/intellij-rust/intellij-rust/issues/9700
+    command.env_remove(RUSTC_BOOTSTRAP);
+    if let Some(original_rustc_bootstrap_value) = std::env::var_os(ORIGINAL_RUSTC_BOOTSTRAP) {
+        command.env(RUSTC_BOOTSTRAP, original_rustc_bootstrap_value);
+    }
+    let mut child = command
         .spawn()?;
     Ok(ExitCode(child.wait()?.code()))
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
@@ -127,6 +127,12 @@ abstract class RsToolchainBase(val location: Path) {
         const val RUSTC_BOOTSTRAP: String = "RUSTC_BOOTSTRAP"
         const val RUSTC_WRAPPER: String = "RUSTC_WRAPPER"
 
+        /**
+         * Environment variable used to keep original value of `RUSTC_BOOTSTRAP` variable
+         * to be able to restore original value for subprocesses if needed
+         */
+        const val ORIGINAL_RUSTC_BOOTSTRAP = "INTELLIJ_ORIGINAL_RUSTC_BOOTSTRAP"
+
         @JvmOverloads
         fun suggest(projectDir: Path? = null): RsToolchainBase? {
             val distribution = projectDir?.let { WslPath.getDistributionByWindowsUncPath(it.toString()) }


### PR DESCRIPTION
Since #9176 the plugin passes `RUSTC_BOOTSTRAP=1` environment variable to `cargo check` call to compiler and run as much as possible during build script evaluation phase (it's experimental feature of cargo that's why we need `RUSTC_BOOTSTRAP=1` here). But this variable also is passed to `rustc` calls launched by cargo during compilation. And it may affect compilation. For example, compilation and evaluation of `thiserror` crate produce different results with different value of `RUSTC_BOOTSTRAP`.

Actually, we don't want to provide `RUSTC_BOOTSTRAP` to `rustc` invocations. So now the plugin stores original value of `RUSTC_BOOTSTRAP` in `INTELLIJ_ORIGINAL_RUSTC_BOOTSTRAP` (if it existed) environment variable and native helper passes it to `rustc`. It allows us to avoid some unexpected circumstances of `RUSTC_BOOTSTRAP=1`

Fixes #9700
Fixes #9880

changelog: Fix broken compilation of some crates (for example, `thiserror`) after build script evaluation by the plugin
