### PR TITLE
INSP: properly process items by `Main function not found`

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
@@ -13,9 +13,7 @@ import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsVisitor
-import org.rust.lang.core.psi.ext.childOfType
-import org.rust.lang.core.psi.ext.childrenOfType
-import org.rust.lang.core.psi.ext.queryAttributes
+import org.rust.lang.core.psi.ext.*
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
 
@@ -33,9 +31,10 @@ class RsMainFunctionNotFoundInspection : RsLocalInspectionTool() {
 
                     if (file.queryAttributes.hasAttribute("no_main")) return
                     if (START.availability(file) == FeatureAvailability.AVAILABLE) return
-                    if (file.childrenOfType<RsFunction>().lastOrNull { fn -> "main" == fn.name } != null) return
-
-                    RsDiagnostic.MainFunctionNotFound(file, crate.presentableName).addToHolder(holder)
+                    val hasMainFunction = file.processExpandedItemsExceptImplsAndUses { it is RsFunction && "main" == it.name }
+                    if (!hasMainFunction) {
+                        RsDiagnostic.MainFunctionNotFound(file, crate.presentableName).addToHolder(holder)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, the inspection didn't take into account cfg-disabled items as well as items expanded from macros. After this change, it does

Fixes false positive described in #5975 only if `org.rust.macros.proc.attr` [experimental feature](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features) is enabled

changelog: Properly process top-level items by `Main function not found` inspection. Now it takes into account `cfg` attributes and items expanded from macros. Note, you need to enable attribute macro expansion via `org.rust.macros.proc.attr` [experimental feature](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features) to fix false positive `Main function not found` with [rocket](https://rocket.rs/) library
