### PR TITLE
IDE: add version control author Code Vision

### DIFF
--- a/src/223/test/kotlin/org/rust/ide/hints/codeVision/RsReferenceCodeVisionTest.kt
+++ b/src/223/test/kotlin/org/rust/ide/hints/codeVision/RsReferenceCodeVisionTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.codeVision
+
+import com.intellij.codeInsight.codeVision.CodeVisionTestCase
+import com.intellij.codeInsight.hints.VcsCodeVisionProvider
+import org.intellij.lang.annotations.Language
+
+@Suppress("UnstableApiUsage")
+class RsCodeVisionTestCase : CodeVisionTestCase() {
+    fun `test function`() = doTest("""
+        <# block [John Smith +2] #>
+        fn foo() {}
+    """)
+
+    fun `test struct`() = doTest("""
+        <# block [John Smith +2] #>
+        struct S;
+    """)
+
+    fun `test enum`() = doTest("""
+        <# block [John Smith +2] #>
+        enum E { V1 }
+    """)
+
+    fun `test impl`() = doTest("""
+        <# block [John Smith +2] #>
+        struct S;
+
+        <# block [John Smith +2] #>
+        impl S {}
+    """)
+
+    fun `test trait`() = doTest("""
+        <# block [John Smith +2] #>
+        trait Trait {}
+    """)
+
+    fun `test mod`() = doTest("""
+        <# block [John Smith +2] #>
+        mod foo {}
+    """)
+
+    fun `test macro`() = doTest("""
+        <# block [John Smith +2] #>
+        macro_rules! foo {}
+    """)
+
+    fun `test macro 2`() = doTest("""
+        <# block [John Smith +2] #>
+        macro foo() {}
+    """)
+
+    private fun doTest(@Language("Rust") text: String) {
+        testProviders(text.trimIndent(), "main.rs", VcsCodeVisionProvider.id)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/hints/codeVision/RsVcsCodeVisionContext.kt
+++ b/src/main/kotlin/org/rust/ide/hints/codeVision/RsVcsCodeVisionContext.kt
@@ -1,0 +1,36 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.codeVision
+
+import com.intellij.codeInsight.hints.VcsCodeVisionLanguageContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsModItem
+import org.rust.lang.core.psi.ext.RsMacroDefinitionBase
+import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
+import org.rust.lang.core.psi.ext.RsTraitOrImpl
+import org.rust.openapiext.isUnitTestMode
+import java.awt.event.MouseEvent
+
+@Suppress("UnstableApiUsage")
+class RsVcsCodeVisionContext : VcsCodeVisionLanguageContext {
+    override fun handleClick(mouseEvent: MouseEvent, editor: Editor, element: PsiElement) {}
+
+    override fun isAccepted(element: PsiElement): Boolean {
+        if (!isUnitTestMode && !Registry.`is`("org.rust.code.vision.author", false)) return false
+
+        return when (element) {
+            is RsFunction,
+            is RsStructOrEnumItemElement,
+            is RsTraitOrImpl,
+            is RsMacroDefinitionBase,
+            is RsModItem -> true
+            else -> false
+        }
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -101,6 +101,10 @@
         <lang.implementationTextSelectioner language="Rust"
                                             implementationClass="org.rust.ide.hints.RsImplementationTextSelectioner"/>
 
+        <!-- Code Vision -->
+        <vcs.codeVisionLanguageContext language="Rust"
+                                       implementationClass="org.rust.ide.hints.codeVision.RsVcsCodeVisionContext"/>
+
         <!-- Filters -->
 
         <analyzeStacktraceFilter implementation="org.rust.cargo.runconfig.filters.RsBacktraceFilter"/>
@@ -1216,6 +1220,9 @@
                      defaultValue="true"
                      description="Enable new Cargo project model reloading"
                      restartRequired="true"/>
+        <registryKey key="org.rust.code.vision.author"
+                     defaultValue="false"
+                     description="Enable version control author Code Vision hints for Rust" />
 
         <!-- Move refactoring -->
 


### PR DESCRIPTION
I looked into `intellij-community` implementation of author code vision for Kotlin and there don't seem to be any tests (and it would be probably quite complicated to test this), so there are no test here.

Relevant issue: https://github.com/intellij-rust/intellij-rust/issues/9427

changelog: Add support for displaying source control author Code Vision.