### PR TITLE
IDE: add references Code Vision hint

### DIFF
--- a/src/223/main/kotlin/org/rust/ide/hints/codeVision/RsReferenceCodeVisionProvider.kt
+++ b/src/223/main/kotlin/org/rust/ide/hints/codeVision/RsReferenceCodeVisionProvider.kt
@@ -1,0 +1,74 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.codeVision
+
+import com.intellij.codeInsight.codeVision.CodeVisionRelativeOrdering
+import com.intellij.codeInsight.hints.codeVision.ReferencesCodeVisionProvider
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiSearchHelper
+import org.rust.RsBundle
+import org.rust.lang.core.psi.RsConstant
+import org.rust.lang.core.psi.RsEnumVariant
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsModItem
+import org.rust.lang.core.psi.RsNamedFieldDecl
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.isUnitTestMode
+
+class RsReferenceCodeVisionProvider : ReferencesCodeVisionProvider() {
+    override fun acceptsFile(file: PsiFile): Boolean = file is RsFile
+
+    override fun acceptsElement(element: PsiElement): Boolean {
+        if (!isUnitTestMode && !Registry.`is`("org.rust.code.vision.usage", false)) return false
+
+        return when (element) {
+            is RsFunction,
+            is RsStructOrEnumItemElement,
+            is RsEnumVariant,
+            is RsNamedFieldDecl,
+            is RsTraitItem,
+            is RsTypeAlias,
+            is RsConstant,
+            is RsMacroDefinitionBase,
+            is RsModItem -> true
+            else -> false
+        }
+    }
+
+    override fun getHint(element: PsiElement, file: PsiFile): String? {
+        val namedElement = element as? RsNamedElement ?: return null
+        val name = namedElement.name ?: return null
+
+        val searchHelper = PsiSearchHelper.getInstance(namedElement.project)
+        val useScope = searchHelper.getUseScope(namedElement)
+        if (useScope is GlobalSearchScope) {
+            val searchCost = searchHelper.isCheapEnoughToSearch(name, useScope, file, null)
+            if (searchCost == PsiSearchHelper.SearchCostResult.TOO_MANY_OCCURRENCES) {
+                // Don't show the usages count in case of too many occurrences
+                return null
+            }
+        }
+
+        val usageCount = namedElement.searchReferences(useScope).count()
+        if (usageCount == 0) return null
+
+        return RsBundle.message("rust.code.vision.usage.hint", usageCount)
+    }
+
+    override val relativeOrderings: List<CodeVisionRelativeOrdering> = emptyList()
+
+    override val id: String = ID
+
+    companion object {
+        const val ID = "rust.references"
+    }
+}

--- a/src/223/main/resources/META-INF/platform-rust-core.xml
+++ b/src/223/main/resources/META-INF/platform-rust-core.xml
@@ -2,5 +2,11 @@
     <extensions defaultExtensionNs="com.intellij">
         <registryKey key="org.rust.debugger.lldb.rust.msvc" defaultValue="true" restartRequired="false"
                      description="Enable Rust MSVC support in LLDB (Windows-only)"/>
+        <registryKey key="org.rust.code.vision.usage"
+                     defaultValue="false"
+                     description="Enable reference usage Code Vision hints for Rust" />
+
+        <codeInsight.daemonBoundCodeVisionProvider
+            implementation="org.rust.ide.hints.codeVision.RsReferenceCodeVisionProvider"/>
     </extensions>
 </idea-plugin>

--- a/src/223/test/kotlin/org/rust/ide/hints/codeVision/RsVcsCodeVisionTestCase.kt
+++ b/src/223/test/kotlin/org/rust/ide/hints/codeVision/RsVcsCodeVisionTestCase.kt
@@ -1,0 +1,60 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.codeVision
+
+import com.intellij.codeInsight.codeVision.CodeVisionTestCase
+import com.intellij.codeInsight.hints.VcsCodeVisionProvider
+import org.intellij.lang.annotations.Language
+
+@Suppress("UnstableApiUsage")
+class RsVcsCodeVisionTestCase : CodeVisionTestCase() {
+    fun `test function`() = doTest("""
+        <# block [John Smith +2] #>
+        fn foo() {}
+    """)
+
+    fun `test struct`() = doTest("""
+        <# block [John Smith +2] #>
+        struct S;
+    """)
+
+    fun `test enum`() = doTest("""
+        <# block [John Smith +2] #>
+        enum E { V1 }
+    """)
+
+    fun `test impl`() = doTest("""
+        <# block [1 usage   John Smith +2] #>
+        struct S;
+
+        <# block [John Smith +2] #>
+        impl S {}
+    """)
+
+    fun `test trait`() = doTest("""
+        <# block [John Smith +2] #>
+        trait Trait {}
+    """)
+
+    fun `test mod`() = doTest("""
+        <# block [John Smith +2] #>
+        mod foo {}
+    """)
+
+    fun `test macro`() = doTest("""
+        <# block [John Smith +2] #>
+        macro_rules! foo {}
+    """)
+
+    fun `test macro 2`() = doTest("""
+        <# block [John Smith +2] #>
+        macro foo() {}
+    """)
+
+    private fun doTest(@Language("Rust") text: String) {
+        testProviders(text.trimIndent(), "main.rs", VcsCodeVisionProvider.id)
+    }
+}

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -257,3 +257,5 @@ inspection.RedundantSemicolons.fix.name=Remove unnecessary trailing semicolons
 
 inspection.DoubleMustUse.description=This function has a `#[must_use]` attribute, but returns a type already marked as `#[must_use]`
 inspection.DoubleMustUse.FixRemoveMustUseAttr.name=Remove `#[must_use]` from the function
+
+rust.code.vision.usage.hint={0,choice, 0#no usages|1#1 usage|2#{0,number} usages}


### PR DESCRIPTION
Inspired by the corresponding Java implementation.

Relevant issue: https://github.com/intellij-rust/intellij-rust/issues/9427

changelog: Add support for showing reference usages Code Vision. Note, these hints are available starting with 2022.3 and are currently disabled by default. You can turn it on via `Registry... | org.rust.code.vision.usage`