### PR TITLE
IDE: add implementations Code Vision hint

### DIFF
--- a/src/232/test/kotlin/org/rust/ide/hints/codeVision/RsImplementationsCodeVisionTest.kt
+++ b/src/232/test/kotlin/org/rust/ide/hints/codeVision/RsImplementationsCodeVisionTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.codeVision
+
+import com.intellij.testFramework.utils.codeVision.CodeVisionTestCase
+import org.intellij.lang.annotations.Language
+
+class RsImplementationsCodeVisionTest : CodeVisionTestCase() {
+    override val onlyCodeVisionHintsAllowed: Boolean = false
+
+    fun `test no implementations`() = doTest("""
+        trait Trait {
+            fn foo();
+            fn bar() {}
+
+            const FOO: u32 = 0;
+            type BAR;
+        }
+    """)
+
+    fun `test trait single implementation`() = doTest("""
+        <# block [1 usage   1 implementation] #>
+        trait Trait {}
+        impl Trait for () {}
+    """)
+
+    fun `test trait multiple implementations`() = doTest("""
+        <# block [2 usages   2 implementations] #>
+        trait Trait {}
+        impl Trait for () {}
+        impl Trait for u32 {}
+    """)
+
+    fun `test function single implementation`() = doTest("""
+        <# block [1 usage   1 implementation] #>
+        trait Trait {
+        <# block [1 implementation] #>
+            fn foo();
+        }
+        impl Trait for () {
+            fn foo() {}
+        }
+    """)
+
+    fun `test function multiple implementations`() = doTest("""
+        <# block [2 usages   2 implementations] #>
+        trait Trait {
+        <# block [2 implementations] #>
+            fn foo();
+        }
+        impl Trait for () {
+            fn foo() {}
+        }
+        impl Trait for u32 {
+            fn foo() {}
+        }
+    """)
+
+    fun `test function single override`() = doTest("""
+        <# block [1 usage   1 implementation] #>
+        trait Trait {
+        <# block [1 override] #>
+            fn foo() {}
+        }
+        impl Trait for () {
+            fn foo() {}
+        }
+    """)
+
+    fun `test function multiple overrides`() = doTest("""
+        <# block [2 usages   2 implementations] #>
+        trait Trait {
+        <# block [2 overrides] #>
+            fn foo() {}
+        }
+        impl Trait for () {
+            fn foo() {}
+        }
+        impl Trait for u32 {
+            fn foo() {}
+        }
+    """)
+
+    fun `test constant implementation`() = doTest("""
+        <# block [1 usage   1 implementation] #>
+        trait Trait {
+        <# block [1 implementation] #>
+            const FOO: u32;
+        }
+        impl Trait for () {
+            const FOO: u32 = 5;
+        }
+    """)
+
+    fun `test function override`() = doTest("""
+        <# block [1 usage   1 implementation] #>
+        trait Trait {
+        <# block [1 override] #>
+            const FOO: u32 = 0;
+        }
+        impl Trait for () {
+            const FOO: u32 = 5;
+        }
+    """)
+
+    fun `test type alias implementation`() = doTest("""
+        <# block [1 usage   1 implementation] #>
+        trait Trait {
+        <# block [1 implementation] #>
+            type TYPE;
+        }
+        impl Trait for () {
+            type TYPE = ();
+        }
+    """)
+
+    fun `test type alias override`() = doTest("""
+        <# block [1 usage   1 implementation] #>
+        trait Trait {
+        <# block [1 override] #>
+            type TYPE = ();
+        }
+        impl Trait for () {
+            type TYPE = u32;
+        }
+    """)
+
+    private fun doTest(@Language("Rust") text: String) {
+        testProviders(text.trimIndent(), "main.rs", RsImplementationsCodeVisionProvider.ID)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/hints/codeVision/RsImplementationsCodeVisionProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/codeVision/RsImplementationsCodeVisionProvider.kt
@@ -1,0 +1,121 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.codeVision
+
+import com.intellij.codeInsight.CodeInsightBundle
+import com.intellij.codeInsight.codeVision.CodeVisionRelativeOrdering
+import com.intellij.codeInsight.daemon.impl.PsiElementListNavigator
+import com.intellij.codeInsight.hints.codeVision.InheritorsCodeVisionProvider
+import com.intellij.ide.util.DefaultPsiElementCellRenderer
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.util.EmptyQuery
+import com.intellij.util.Query
+import org.rust.RsBundle
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.rustStructureModificationTracker
+import org.rust.openapiext.isUnitTestMode
+import java.awt.event.MouseEvent
+
+class RsImplementationsCodeVisionProvider : InheritorsCodeVisionProvider() {
+    override fun acceptsFile(file: PsiFile): Boolean = file is RsFile
+
+    override fun acceptsElement(element: PsiElement): Boolean {
+        if (!isUnitTestMode && !Registry.`is`("org.rust.code.vision.implementation", false)) return false
+
+        return when (element) {
+            is RsTraitItem -> true
+            is RsAbstractable -> element.owner is RsAbstractableOwner.Trait
+            else -> false
+        }
+    }
+
+    override fun getHint(element: PsiElement, file: PsiFile): String? {
+        // The following check is required to smart cast `element` to `RsElement`
+        if (element !is RsElement) return null
+        if (element !is RsTraitItem && element !is RsAbstractable) return null
+
+        val implementationCount = element.implementationCount
+        if (implementationCount == 0) return null
+
+        return when (element) {
+            is RsTraitItem -> {
+                return RsBundle.message("rust.code.vision.implementation.hint", implementationCount)
+            }
+
+            is RsAbstractable -> {
+                return if (element.isAbstract) {
+                    RsBundle.message("rust.code.vision.implementation.hint", implementationCount)
+                } else {
+                    RsBundle.message("rust.code.vision.overrides.hint", implementationCount)
+                }
+            }
+
+            else -> null
+        }
+    }
+
+    override fun handleClick(editor: Editor, element: PsiElement, event: MouseEvent?) {
+        // copied from ImplsNavigationGutterIconRenderer::navigateToItems
+        if (event == null) return
+
+        val namedElement = element as? RsNamedElement ?: return
+        val elementName = namedElement.name ?: return
+
+        val targets = getImplementations(element).filterIsInstance<NavigatablePsiElement>().toTypedArray()
+        if (targets.isEmpty()) return
+
+        val escapedName = StringUtil.escapeXmlEntities(elementName)
+
+        PsiElementListNavigator.openTargets(
+            event,
+            targets,
+            CodeInsightBundle.message("goto.implementation.chooserTitle", escapedName, targets.size, ""),
+            CodeInsightBundle.message("goto.implementation.findUsages.title", escapedName, targets.size),
+            DefaultPsiElementCellRenderer()
+        )
+    }
+
+    override val relativeOrderings: List<CodeVisionRelativeOrdering>
+        get() = listOf(CodeVisionRelativeOrdering.CodeVisionRelativeOrderingAfter(RsReferenceCodeVisionProvider.ID))
+
+    override val id: String = ID
+
+    companion object {
+        const val ID = "rust.inheritors"
+    }
+}
+
+private fun getImplementationsQuery(element: PsiElement): Query<out PsiElement> {
+    return when (element) {
+        is RsTraitItem -> element.searchForImplementations()
+        is RsAbstractable -> element.searchForImplementations()
+        else -> EmptyQuery()
+    }
+}
+
+private fun countImplementations(element: PsiElement): Int = getImplementations(element).size
+
+private fun getImplementations(element: PsiElement): List<PsiElement> =
+    getImplementationsQuery(element).findAll().toList()
+
+private val IMPL_CACHE_KEY: Key<CachedValue<Int>> = Key.create("IMPL_CACHE_KEY")
+
+private val RsElement.implementationCount: Int
+    get() = CachedValuesManager.getCachedValue(this, IMPL_CACHE_KEY) {
+        val usages = countImplementations(this)
+        CachedValueProvider.Result.create(usages, project.rustStructureModificationTracker)
+    }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -112,6 +112,8 @@
                                        implementationClass="org.rust.ide.hints.codeVision.RsVcsCodeVisionContext"/>
         <codeInsight.daemonBoundCodeVisionProvider
             implementation="org.rust.ide.hints.codeVision.RsReferenceCodeVisionProvider"/>
+        <codeInsight.daemonBoundCodeVisionProvider
+            implementation="org.rust.ide.hints.codeVision.RsImplementationsCodeVisionProvider"/>
 
         <!-- Filters -->
 
@@ -1385,10 +1387,12 @@
         <registryKey key="org.rust.code.vision.usage"
                      defaultValue="false"
                      description="Enable reference usage Code Vision hints for Rust" />
+        <registryKey key="org.rust.code.vision.implementation"
+                     defaultValue="false"
+                     description="Enable implementation Code Vision hints for rust"/>
         <registryKey key="org.rust.insp.unresolved.reference.type.independent"
                      defaultValue="true"
                      description="Enable Unresolved Reference inspection for type-independent paths" />
-
         <!-- Move refactoring -->
 
         <!--

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -292,6 +292,8 @@ inspection.PathStatementsInspection.description.no.effect=Path statement with no
 inspection.PathStatementsInspection.description.drops.value=Path statement drops value
 
 rust.code.vision.usage.hint={0,choice, 0#no usages|1#1 usage|2#{0,number} usages}
+rust.code.vision.implementation.hint={0,choice, 1#1 implementation|2#{0,number} implementations}
+rust.code.vision.overrides.hint={0,choice, 1#1 override|2#{0,number} overrides}
 
 rust.checkin.factory.fmt.commit.anyway.question=Would you like to commit anyway?
 rust.checkin.factory.fmt.failed.message=Failed to run rusfmt.


### PR DESCRIPTION
The `handleClick` implementation is copied from `ImplsNavigationGutterIconRenderer::navigateToItems`. It should probably be placed into some unified location, but I'm not sure where does it belong.

Relevant issue: https://github.com/intellij-rust/intellij-rust/issues/9427

changelog: Add support for showing implementations (inheritors) Code Vision. Note, these hints are available starting with 2022.3 and are currently disabled by default. You can turn it on via `Registry... | org.rust.code.vision.implementation`.