### PR TITLE
ACT: use background thread for Rust action `update`

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectActionBase.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectActionBase.kt
@@ -5,6 +5,9 @@
 
 package org.rust.cargo.project.model
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.project.DumbAwareAction
 
-abstract class CargoProjectActionBase : DumbAwareAction()
+abstract class CargoProjectActionBase : DumbAwareAction() {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt
@@ -5,11 +5,13 @@
 
 package org.rust.cargo.runconfig.command
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import org.rust.cargo.runconfig.hasCargoProject
 
 abstract class RunCargoCommandActionBase : DumbAwareAction() {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
     override fun update(e: AnActionEvent) {
         val hasCargoProject = e.project?.hasCargoProject == true
         e.presentation.isEnabledAndVisible = hasCargoProject

--- a/src/main/kotlin/org/rust/ide/actions/CargoEditSettingsAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/CargoEditSettingsAction.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
@@ -12,6 +13,8 @@ import org.rust.cargo.project.configurable.CargoConfigurable
 import org.rust.openapiext.showSettingsDialog
 
 class CargoEditSettingsAction : AnAction(), DumbAware {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.actions
 
 import com.google.common.annotations.VisibleForTesting
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
@@ -31,6 +32,8 @@ class RsBuildAction : AnAction() {
             project.buildProject()
         }
     }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/src/main/kotlin/org/rust/ide/actions/RsToolsActionGroup.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsToolsActionGroup.kt
@@ -5,12 +5,15 @@
 
 package org.rust.ide.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.project.DumbAware
 import org.rust.cargo.runconfig.hasCargoProject
 
 class RsToolsActionGroup : DefaultActionGroup(), DumbAware {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         val project = e.project ?: return

--- a/src/main/kotlin/org/rust/ide/actions/RustfmtCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RustfmtCargoProjectAction.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.vfs.VfsUtil
@@ -20,6 +21,8 @@ import org.rust.openapiext.saveAllDocumentsAsTheyAre
 import org.rust.stdext.unwrapOrElse
 
 class RustfmtCargoProjectAction : DumbAwareAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
@@ -6,13 +6,11 @@
 package org.rust.ide.actions
 
 import com.intellij.execution.ExecutionException
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.DumbAwareAction
-import com.intellij.openapi.project.Project
 import org.rust.RsBundle
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
@@ -25,6 +23,8 @@ import org.rust.lang.core.psi.isRustFile
 import org.rust.openapiext.*
 
 class RustfmtFileAction : DumbAwareAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         super.update(e)
@@ -63,14 +63,11 @@ class RustfmtFileAction : DumbAwareAction() {
     private fun getContext(e: AnActionEvent): Triple<CargoProject, Rustfmt, Document>? {
         val project = e.project ?: return null
         val rustfmt = project.toolchain?.rustfmt() ?: return null
-        val editor = e.getData(CommonDataKeys.EDITOR_EVEN_IF_INACTIVE) ?: getSelectedEditor(project) ?: return null
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return null
         val document = editor.document
         val file = document.virtualFile ?: return null
         if (!(file.isInLocalFileSystem && file.isRustFile)) return null
         val cargoProject = project.cargoProjects.findProjectForFile(file) ?: return null
         return Triple(cargoProject, rustfmt, document)
     }
-
-    private fun getSelectedEditor(project: Project): Editor? =
-        FileEditorManager.getInstance(project).selectedTextEditor
 }

--- a/src/main/kotlin/org/rust/ide/actions/ShareInPlaygroundAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/ShareInPlaygroundAction.kt
@@ -12,6 +12,7 @@ import com.intellij.ide.util.PropertiesComponent
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.runReadAction
@@ -41,6 +42,8 @@ import java.net.http.HttpResponse.BodyHandlers
 import java.time.Duration
 
 class ShareInPlaygroundAction : DumbAwareAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.PSI_FILE) as? RsFile

--- a/src/main/kotlin/org/rust/ide/actions/ToggleExternalLinterOnTheFlyAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/ToggleExternalLinterOnTheFlyAction.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import org.rust.cargo.project.settings.rustSettings
@@ -20,6 +21,8 @@ class ToggleExternalLinterOnTheFlyAction : ToggleAction() {
         val project = e.project ?: return
         project.rustSettings.modify { it.runExternalLinterOnTheFly = state }
     }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/src/main/kotlin/org/rust/ide/actions/diagnostic/CreateNewGithubIssue.kt
+++ b/src/main/kotlin/org/rust/ide/actions/diagnostic/CreateNewGithubIssue.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.actions.diagnostic
 
 import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.ApplicationInfo
@@ -29,6 +30,8 @@ import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.memberProperties
 
 class CreateNewGithubIssue : DumbAwareAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = e.project?.hasCargoProject == true

--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActions.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActions.kt
@@ -7,6 +7,7 @@ package org.rust.ide.actions.macroExpansion
 
 import com.google.common.annotations.VisibleForTesting
 import com.intellij.codeInsight.hint.HintManager
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
@@ -23,6 +24,8 @@ import org.rust.stdext.RsResult.Err
 import org.rust.stdext.RsResult.Ok
 
 abstract class RsShowMacroExpansionActionBase(private val expandRecursively: Boolean) : AnAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = getMacroUnderCaret(e.dataContext) != null

--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionGroup.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionGroup.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.actions.macroExpansion
 
 import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import org.rust.lang.core.psi.RsMacroCall
@@ -16,6 +17,9 @@ import org.rust.lang.core.psi.RsMacroCall
  * It is required to show those actions only on certain elements (like [RsMacroCall]s).
  */
 class RsShowMacroExpansionGroup : DefaultActionGroup() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
     override fun update(event: AnActionEvent) {
         val inEditorPopupMenu = event.place == ActionPlaces.EDITOR_POPUP
         event.presentation.isEnabledAndVisible = inEditorPopupMenu && getMacroUnderCaret(event.dataContext) != null

--- a/src/main/kotlin/org/rust/ide/console/RunRustConsoleAction.kt
+++ b/src/main/kotlin/org/rust/ide/console/RunRustConsoleAction.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.console
 
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.TransactionGuard
 import com.intellij.openapi.project.DumbAwareAction
@@ -13,6 +14,9 @@ import org.rust.cargo.runconfig.hasCargoProject
 import org.rust.ide.notifications.showBalloonWithoutProject
 
 class RunRustConsoleAction : DumbAwareAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabled = e.project?.hasCargoProject == true
     }

--- a/src/main/kotlin/org/rust/ide/spelling/RsSpellCheckerGenerateDictionariesAction.kt
+++ b/src/main/kotlin/org/rust/ide/spelling/RsSpellCheckerGenerateDictionariesAction.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.spelling
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
@@ -32,6 +33,8 @@ class RsSpellCheckerGenerateDictionariesAction : AnAction() {
         }
         generator.generate()
     }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = e.project?.cargoProjects?.hasAtLeastOneValidProject == true

--- a/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
@@ -6,9 +6,7 @@
 package org.rust.cargo.commands
 
 import com.intellij.codeInsight.actions.ReformatCodeProcessor
-import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.command.WriteCommandAction
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleManager
@@ -99,7 +97,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
         fn main() {
             println!("Hello, ΣΠ∫!");
         }
-    """) { reformatFile(myFixture.editor) }
+    """) { reformatFile() }
 
     fun `test rustfmt file action ignores emit option 1`() = doTest({
         toml("Cargo.toml", """
@@ -124,7 +122,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
         project.rustfmtSettings.modifyTemporary(testRootDisposable) {
             it.additionalArguments = "--emit files"
         }
-        reformatFile(myFixture.editor)
+        reformatFile()
     }
 
     fun `test rustfmt file action ignores emit option 2`() = doTest({
@@ -150,7 +148,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
         project.rustfmtSettings.modifyTemporary(testRootDisposable) {
             it.additionalArguments = "--emit=files"
         }
-        reformatFile(myFixture.editor)
+        reformatFile()
     }
 
     fun `test rustfmt file action with edited configuration 1`() = doTest({
@@ -177,7 +175,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
             it.additionalArguments = "--unstable-features"
             it.channel = RustChannel.NIGHTLY
         }
-        reformatFile(myFixture.editor)
+        reformatFile()
     }
 
     fun `test rustfmt file action with edited configuration 2`() = doTest({
@@ -205,7 +203,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
             it.channel = RustChannel.STABLE
         }
         assertThrows(RsProcessExecutionException::class.java) {
-            reformatFile(myFixture.editor)
+            reformatFile()
         }
     }
 
@@ -232,7 +230,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
         project.rustfmtSettings.modifyTemporary(testRootDisposable) {
             it.additionalArguments = "+nightly --unstable-features"
         }
-        reformatFile(myFixture.editor)
+        reformatFile()
     }
 
     fun `test rustfmt file action edition 2018`() = doTest({
@@ -255,7 +253,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
         async fn foo() {
             println!("Hello, ΣΠ∫!");
         }
-    """) { reformatFile(myFixture.editor) }
+    """) { reformatFile() }
 
     fun `test rustfmt cargo project action`() = doTest({
         toml("Cargo.toml", """
@@ -531,8 +529,8 @@ class RustfmtTest : RsWithToolchainTestBase() {
         }
     }
 
-    private fun reformatFile(editor: Editor) {
-        myFixture.launchAction("Cargo.RustfmtFile", CommonDataKeys.EDITOR_EVEN_IF_INACTIVE to editor)
+    private fun reformatFile() {
+        myFixture.launchAction("Cargo.RustfmtFile")
     }
 
     private fun reformatCargoProject() {


### PR DESCRIPTION
Also simplify `RustfmtFileAction`. Now it looks for editor using only `AnActionEvent.getData(CommonDataKeys.EDITOR)` (like common refactor action does). More complex search was introduced when Cargo toolwindow contained this action. But it was replaced with `RustfmtCargoProjectAction` action there long ago, so we don't need such complex logic anymore

Fixes #8720
Closes #8752


changelog: Check if any plugin action is available in the current context in background thread to prevent possible UI freezes in some cases
