### PR TITLE
#9961: Support raw slice pointers in debugger pretty-printers

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -202,8 +202,8 @@ class RsDebugProcessConfigurationHelper(
         private val RUST_STD_TYPES: List<String> = listOf(
             "^(alloc::([a-z_]+::)+)String$",
             "^[&*]?(const |mut )?str\\*?$",
-            "^&(mut )?\\[.*\\]$",
-            "^(mut )?slice\\$<.+>$",
+            "^(&|&mut |\\*const |\\*mut )?\\[.*\\]$",
+            "^(slice\\$<.+>)|((ptr_const|ptr_mut)\\$<slice\\$<.+> >)$",
             "^(std::ffi::([a-z_]+::)+)OsString$",
             "^((&|&mut )?std::ffi::([a-z_]+::)+)OsStr( \\*)?$",
             "^(std::([a-z_]+::)+)PathBuf$",

--- a/prettyPrinters/rust_types.py
+++ b/prettyPrinters/rust_types.py
@@ -51,8 +51,10 @@ class RustType(object):
 STD_STRING_REGEX = re.compile(r"^(alloc::([a-z_]+::)+)String$")
 # str, mut str, const str*, mut str* (vanilla LLDB); &str, &mut str, *const str, *mut str (Rust-enabled LLDB)
 STD_STR_REGEX = re.compile(r"^[&*]?(const |mut )?str\*?$")
-STD_SLICE_REGEX = re.compile(r"^&(mut )?\[.*\]$")
-STD_MSVC_SLICE_REGEX = re.compile(r"^(mut )?slice\$<.+>$")
+# &[T], &mut [T], *const [T], *mut [T]
+STD_SLICE_REGEX = re.compile(r"^(&|&mut |\*const |\*mut )?\[.*]$")
+# slice$<T>, ptr_const$<slice$<T> >, ptr_mut$<slice$<T> >
+STD_MSVC_SLICE_REGEX = re.compile(r"^(slice\$<.+>)|((ptr_const|ptr_mut)\$<slice\$<.+> >)$")
 
 STD_OS_STRING_REGEX = re.compile(r"^(std::ffi::([a-z_]+::)+)OsString$")
 STD_OS_STR_REGEX = re.compile(r"^((&|&mut )?std::ffi::([a-z_]+::)+)OsStr( \*)?$")

--- a/pretty_printers_tests/tests/slice.rs
+++ b/pretty_printers_tests/tests/slice.rs
@@ -8,6 +8,12 @@
 // lldb-command:print slice_mut
 // lldbr-check:[...]slice_mut = size=2 { [0] = 1 [1] = 2 }
 // lldbg-check:[...]$1 = size=2 { [0] = 1 [1] = 2 }
+// lldb-command:print slice_ptr_const
+// lldbr-check:[...]slice_ptr_const = size=2 { [0] = 1 [1] = 2 }
+// lldbg-check:[...]$2 = size=2 { [0] = 1 [1] = 2 }
+// lldb-command:print slice_ptr_mut
+// lldbr-check:[...]slice_ptr_mut = size=2 { [0] = 1 [1] = 2 }
+// lldbg-check:[...]$3 = size=2 { [0] = 1 [1] = 2 }
 
 // === GDB TESTS ===================================================================================
 
@@ -17,10 +23,16 @@
 // gdb-check:[...]$1 = size=2 = {1, 2}
 // gdb-command:print slice_mut
 // gdb-check:[...]$2 = size=2 = {1, 2}
+// gdb-command:print slice_ptr_const
+// gdb-check:[...]$3 = size=2 = {1, 2}
+// gdb-command:print slice_ptr_mut
+// gdb-check:[...]$4 = size=2 = {1, 2}
 
 fn main() {
     let slice: &[i32] = &[1, 2];
     let slice_mut: &mut [i32] = &mut [1, 2];
+    let slice_ptr_const: *const [i32] = slice as *const [i32];
+    let slice_ptr_mut: *mut [i32] = slice_mut as *mut [i32];
 
     print!(""); // #break
 }


### PR DESCRIPTION
Fixes #9961.

In addition to `&[T]` and `&mut [T]` types, LLDB and GDB pretty-printers now render `*const [T]` and `*mut [T]` types on any supported OS.

<img width="692" alt="Screenshot 2023-01-12 at 15 43 16" src="https://user-images.githubusercontent.com/4854600/212096619-0e6da64b-3a74-4611-aa93-d61a048bc5ea.png">


Note, `mut slice<T>` is now excluded from `STD_MSVC_SLICE_REGEX` because rustc 1.56+ (IntelliJ Rust minimal supported Rust version) does not emit it anymore.

changelog: Show the contents of raw slice pointers (`*const [T]`, `*mut [T]`) in the debugger
