### PR TITLE
DBG: Update MSVC pretty-printers and type name decorators to Rust 1.67

### DIFF
--- a/.github/workflows/get-rust-versions.yml
+++ b/.github/workflows/get-rust-versions.yml
@@ -19,7 +19,7 @@ on:
 
 env:
     STABLE: "1.66.1"
-    NIGHTLY: "nightly-2022-11-05"
+    NIGHTLY: "nightly-2022-11-12"
     OLD: "1.56.0"
 
 jobs:

--- a/debugger/src/main/antlr/RsTypeName.g4
+++ b/debugger/src/main/antlr/RsTypeName.g4
@@ -21,6 +21,7 @@ typeName
 
 msvcTypeName
     : msvcStr
+    | msvcStrDollar
     | msvcNever
     | msvcTuple
     | msvcPtr_const
@@ -29,11 +30,15 @@ msvcTypeName
     | msvcRef_mut
     | msvcArray
     | msvcSlice
+    | msvcSlice2
     | msvcEnum
     | msvcEnum2
     ;
 
+//BACKCOMPAT: Rust 1.66
 msvcStr: STR ;
+
+msvcStrDollar: STR_DOLLAR ;
 
 msvcNever: NEVER ;
 
@@ -61,8 +66,13 @@ msvcArray
     : ARRAY LT type=typeName COMMA length=WORD GT
     ;
 
+//BACKCOMPAT: Rust 1.66
 msvcSlice
     : SLICE LT type=typeName GT
+    ;
+
+msvcSlice2
+    : SLICE2 LT type=typeName GT
     ;
 
 //BACKCOMPAT: Rust 1.64
@@ -136,6 +146,7 @@ commaSeparatedList
     ;
 
 STR : 'str' ;
+STR_DOLLAR : 'str$' ;
 NEVER: 'never$' ;
 TUPLE : 'tuple$' ;
 PTR_CONST: 'ptr_const$' ;
@@ -144,6 +155,7 @@ REF: 'ref$' ;
 REF_MUT: 'ref_mut$' ;
 ARRAY : 'array$' ;
 SLICE : 'slice$' ;
+SLICE2 : 'slice2$' ;
 ENUM: 'enum$' ;
 ENUM2: 'enum2$' ;
 

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -177,9 +177,12 @@ class RsDebugProcessConfigurationHelper(
          */
         private val RUST_STD_TYPES: List<String> = listOf(
             "^(alloc::([a-z_]+::)+)String$",
-            "^[&*]?(const |mut )?str\\*?$",
+            "^(&|&mut |\\*const |\\*mut )str$",
+            "^(str)|((ptr_const|ptr_mut)\\$<str>)$",
+            "^(str\\$)|((ref|ref_mut|ptr_const|ptr_mut)\\$<str\\$>)$",
             "^(&|&mut |\\*const |\\*mut )?\\[.*\\]$",
             "^(slice\\$<.+>)|((ptr_const|ptr_mut)\\$<slice\\$<.+> >)$",
+            "^(slice2\\$<.+>)|((ref|ref_mut|ptr_const|ptr_mut)\\$<slice2\\$<.+> >)$",
             "^(std::ffi::([a-z_]+::)+)OsString$",
             "^((&|&mut )?std::ffi::([a-z_]+::)+)OsStr( \\*)?$",
             "^(std::([a-z_]+::)+)PathBuf$",

--- a/debugger/src/test/kotlin/org/rust/debugger/lang/RsFrameTypeDecoratorTest.kt
+++ b/debugger/src/test/kotlin/org/rust/debugger/lang/RsFrameTypeDecoratorTest.kt
@@ -19,6 +19,42 @@ class RsFrameTypeDecoratorTest {
     )
 
     @Test
+    fun `test decorate msvc ptr_const str`() = checkDecorate(
+        "ptr_const$<str>",
+        "*const str"
+    )
+
+    @Test
+    fun `test decorate msvc ptr_mut str`() = checkDecorate(
+        "ptr_mut$<str>",
+        "*mut str"
+    )
+
+    @Test
+    fun `test decorate msvc ref str$`() = checkDecorate(
+        "ref$<str$>",
+        "&str"
+    )
+
+    @Test
+    fun `test decorate msvc ref_mut str$`() = checkDecorate(
+        "ref_mut$<str$>",
+        "&mut str"
+    )
+
+    @Test
+    fun `test decorate msvc ptr_const str$`() = checkDecorate(
+        "ptr_const$<str$>",
+        "*const str"
+    )
+
+    @Test
+    fun `test decorate msvc ptr_mut str$`() = checkDecorate(
+        "ptr_mut$<str$>",
+        "*mut str"
+    )
+
+    @Test
     fun `test decorate msvc str in generics`() = checkDecorate(
         "Foo<str>",
         "Foo<&str>"
@@ -87,6 +123,42 @@ class RsFrameTypeDecoratorTest {
     fun `test decorate msvc slice`() = checkDecorate(
         "slice$<Foo>",
         "&[Foo]"
+    )
+
+    @Test
+    fun `test decorate msvc ptr_const slice`() = checkDecorate(
+        "ptr_const$<slice$<Foo> >",
+        "*const [Foo]"
+    )
+
+    @Test
+    fun `test decorate msvc ptr_mut slice`() = checkDecorate(
+        "ptr_mut$<slice$<Foo> >",
+        "*mut [Foo]"
+    )
+
+    @Test
+    fun `test decorate msvc ref slice2`() = checkDecorate(
+        "ref$<slice2$<Foo> >",
+        "&[Foo]"
+    )
+
+    @Test
+    fun `test decorate msvc ref_mut slice2`() = checkDecorate(
+        "ref_mut$<slice2$<Foo> >",
+        "&mut [Foo]"
+    )
+
+    @Test
+    fun `test decorate msvc ptr_const slice2`() = checkDecorate(
+        "ptr_const$<slice2$<Foo> >",
+        "*const [Foo]"
+    )
+
+    @Test
+    fun `test decorate msvc ptr_mut slice2`() = checkDecorate(
+        "ptr_mut$<slice2$<Foo> >",
+        "*mut [Foo]"
     )
 
     @Test

--- a/debugger/src/test/kotlin/org/rust/debugger/lang/RsTypeNameParserTest.kt
+++ b/debugger/src/test/kotlin/org/rust/debugger/lang/RsTypeNameParserTest.kt
@@ -19,6 +19,12 @@ class RsTypeNameParserTest {
     )
 
     @Test
+    fun `test parse msvc str$`() = checkParse(
+        "str$",
+        "(typeName (msvcTypeName (msvcStrDollar str$)))"
+    )
+
+    @Test
     fun `test parse msvc never`() = checkParse(
         "never$",
         "(typeName (msvcTypeName (msvcNever never$)))"
@@ -70,6 +76,12 @@ class RsTypeNameParserTest {
     fun `test parse msvc slice`() = checkParse(
         "slice$<Foo>",
         "(typeName (msvcTypeName (msvcSlice slice$ < (typeName (commonTypeName (qualifiedName (qualifiedNameSegment Foo)))) >)))"
+    )
+
+    @Test
+    fun `test parse msvc slice2`() = checkParse(
+        "slice2$<Foo>",
+        "(typeName (msvcTypeName (msvcSlice2 slice2$ < (typeName (commonTypeName (qualifiedName (qualifiedNameSegment Foo)))) >)))"
     )
 
     @Test

--- a/prettyPrinters/lldb_lookup.py
+++ b/prettyPrinters/lldb_lookup.py
@@ -30,7 +30,7 @@ def summary_lookup(valobj, dict):
         return StdOsStringSummaryProvider(valobj, dict)
     if rust_type == RustType.STD_PATH_BUF:
         return StdOsStringSummaryProvider(valobj.GetChildAtIndex(0), dict)
-    if rust_type == RustType.STD_STR:
+    if rust_type in RustType.ANY_STR:
         return StdStrSummaryProvider(valobj, dict)
     if rust_type == RustType.STD_OS_STR:
         return StdFFIStrSummaryProvider(valobj, dict)
@@ -41,7 +41,7 @@ def summary_lookup(valobj, dict):
     if rust_type == RustType.STD_CSTR:
         return StdFFIStrSummaryProvider(valobj, dict, is_null_terminated=True)
 
-    if rust_type == RustType.STD_SLICE or rust_type == RustType.STD_MSVC_SLICE:
+    if rust_type in RustType.ANY_SLICE:
         return SizeSummaryProvider(valobj, dict)
 
     if rust_type == RustType.STD_VEC:
@@ -104,7 +104,7 @@ def synthetic_lookup(valobj, dict):
     if rust_type == RustType.SINGLETON_ENUM:
         return synthetic_lookup(valobj.GetChildAtIndex(0), dict)
 
-    if rust_type == RustType.STD_SLICE or rust_type == RustType.STD_MSVC_SLICE:
+    if rust_type in RustType.ANY_SLICE:
         return StdSliceSyntheticProvider(valobj, dict)
 
     if rust_type == RustType.STD_VEC:

--- a/prettyPrinters/rust_types.py
+++ b/prettyPrinters/rust_types.py
@@ -19,8 +19,11 @@ class RustType(object):
     STD_OS_STRING = "StdOsString"
     STD_PATH_BUF = "StdPathBuf"
     STD_STR = "StdStr"
+    STD_MSVC_STR = "StdMsvcStr"
+    STD_MSVC_STR_DOLLAR = "StdMsvcStrDollar"
     STD_SLICE = "StdSlice"
     STD_MSVC_SLICE = "StdMsvcSlice"
+    STD_MSVC_SLICE2 = "StdMsvcSlice2"
     STD_OS_STR = "StdOsStr"
     STD_PATH = "StdPath"
     STD_CSTRING = "StdCString"
@@ -46,15 +49,37 @@ class RustType(object):
     STD_RANGE_TO = "StdRangeTo"
     STD_RANGE_TO_INCLUSIVE = "StdRangeToInclusive"
 
+    ANY_STR = [STD_STR, STD_MSVC_STR, STD_MSVC_STR_DOLLAR]
+    ANY_SLICE = [STD_SLICE, STD_MSVC_SLICE, STD_MSVC_SLICE2]
 
+
+#################################################################################################################
 # Should be synchronized with `RsDebugProcessConfigurationHelper.RUST_STD_TYPES`
+################################################################################################################
+
 STD_STRING_REGEX = re.compile(r"^(alloc::([a-z_]+::)+)String$")
-# str, mut str, const str*, mut str* (vanilla LLDB); &str, &mut str, *const str, *mut str (Rust-enabled LLDB)
-STD_STR_REGEX = re.compile(r"^[&*]?(const |mut )?str\*?$")
+
+# &str, &mut str, *const str, *mut str
+STD_STR_REGEX = re.compile(r"^(&|&mut |\*const |\*mut )str$")
+
+# BACKCOMPAT: Rust 1.66
+# str, ptr_const$<str>, ptr_mut$<str>
+STD_MSVC_STR_REGEX = re.compile(r"^(str)|((ptr_const|ptr_mut)\$<str>)$")
+
+# Since Rust 1.67 https://github.com/rust-lang/rust/pull/103691
+# str$, ref$<str$>, ref_mut$<str$>, ptr_const$<str$>, ptr_mut$<str$>
+STD_MSVC_STR_DOLLAR_REGEX = re.compile(r"^(str\$)|((ref|ref_mut|ptr_const|ptr_mut)\$<str\$>)$")
+
 # &[T], &mut [T], *const [T], *mut [T]
 STD_SLICE_REGEX = re.compile(r"^(&|&mut |\*const |\*mut )?\[.*]$")
+
+# BACKCOMPAT: Rust 1.66
 # slice$<T>, ptr_const$<slice$<T> >, ptr_mut$<slice$<T> >
 STD_MSVC_SLICE_REGEX = re.compile(r"^(slice\$<.+>)|((ptr_const|ptr_mut)\$<slice\$<.+> >)$")
+
+# Since Rust 1.67 https://github.com/rust-lang/rust/pull/103691
+# slice2$<T>, ref$<slice2$<T> >, ref_mut$<slice2$<T> >, ptr_const$<slice2$<T> >, ptr_mut$<slice2$<T> >
+STD_MSVC_SLICE2_REGEX = re.compile(r"^(slice2\$<.+>)|((ref|ref_mut|ptr_const|ptr_mut)\$\<slice2\$<.+> \>?)$")
 
 STD_OS_STRING_REGEX = re.compile(r"^(std::ffi::([a-z_]+::)+)OsString$")
 STD_OS_STR_REGEX = re.compile(r"^((&|&mut )?std::ffi::([a-z_]+::)+)OsStr( \*)?$")
@@ -94,8 +119,11 @@ STD_TYPE_TO_REGEX = {
     RustType.STD_PATH_BUF: STD_PATH_BUF_REGEX,
     RustType.STD_PATH: STD_PATH_REGEX,
     RustType.STD_STR: STD_STR_REGEX,
+    RustType.STD_MSVC_STR: STD_MSVC_STR_REGEX,
+    RustType.STD_MSVC_STR_DOLLAR: STD_MSVC_STR_DOLLAR_REGEX,
     RustType.STD_SLICE: STD_SLICE_REGEX,
     RustType.STD_MSVC_SLICE: STD_MSVC_SLICE_REGEX,
+    RustType.STD_MSVC_SLICE2: STD_MSVC_SLICE2_REGEX,
     RustType.STD_OS_STR: STD_OS_STR_REGEX,
     RustType.STD_CSTRING: STD_CSTRING_REGEX,
     RustType.STD_CSTR: STD_CSTR_REGEX,

--- a/pretty_printers_tests/tests/string.rs
+++ b/pretty_printers_tests/tests/string.rs
@@ -13,10 +13,10 @@
 // lldbg-check:[...]$2 = "A∆й中" [...]
 // lldb-command:print s4
 // lldbr-check:[...]s4 = "A∆й中" [...]
-// TODO: update pretty-printer (does not work since Rust 1.55) and add `lldbg-check`
+// lldbg-check:[...]$3 = "A∆й中" [...]
 // lldb-command:print s5
 // lldbr-check:[...]s5 = "A∆й中" [...]
-// TODO: update pretty-printer (does not work since Rust 1.55) and add `lldbg-check`
+// lldbg-check:[...]$4 = "A∆й中" [...]
 // lldb-command:print empty_s1
 // lldbr-check:[...]empty_s1 = "" [...]
 // lldbg-check:[...]$5 = "" [...]
@@ -28,10 +28,10 @@
 // lldbg-check:[...]$7 = "" [...]
 // lldb-command:print empty_s4
 // lldbr-check:[...]empty_s4 = "" [...]
-// TODO: update pretty-printer (does not work since Rust 1.55) and add `lldbg-check`
+// lldbg-check:[...]$8 = "" [...]
 // lldb-command:print empty_s5
 // lldbr-check:[...]empty_s5 = "" [...]
-// TODO: update pretty-printer (does not work since Rust 1.55) and add `lldbg-check`
+// lldbg-check:[...]$9 = "" [...]
 
 // === GDB TESTS ==================================================================================
 


### PR DESCRIPTION
Depends on #9962.

Fixes #7935.
Fixes #9769.

changelog: Update debugger pretty-printers and type name decorators for MSVC to Rust 1.67. Now the debugger renders `str` and slice types properly
