### PR TITLE
LI: allow injecting languages into macro calls

### DIFF
--- a/intelliLang/src/test/kotlin/org/rust/ide/intentions/InjectLanguageIntentionTest.kt
+++ b/intelliLang/src/test/kotlin/org/rust/ide/intentions/InjectLanguageIntentionTest.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.injection.Injectable
 import org.intellij.lang.annotations.Language
 import org.intellij.plugins.intelliLang.inject.InjectLanguageAction
 import org.intellij.plugins.intelliLang.inject.InjectedLanguage
+import org.intellij.plugins.intelliLang.inject.UnInjectLanguageAction
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 
 class InjectLanguageIntentionTest : RsIntentionTestBase(InjectLanguageAction::class) {
@@ -29,13 +30,37 @@ class InjectLanguageIntentionTest : RsIntentionTestBase(InjectLanguageAction::cl
         const C: i32 = /*caret*/123;
     """)
 
-    fun `test available in macro call bodies`() = checkAvailable("""
+    fun `test available string literals inside macro call bodies`() = checkAvailable("""
         foobar!(/*caret*/"abc(def)");
     """)
 
-    fun `test inject RegExp`() = doTest("RegExp", """
-        const C: &str = /*caret*/"abc(def)";
+    fun `test inject RegExp into string literal`() = doTest("RegExp", """
+        const C: &str = /*caret*/"<inject>abc(def)</inject>";
     """)
+
+    fun `test available inside a macro call body`() = checkAvailable("""
+        foo!(/*caret*/foo bar baz);
+    """)
+
+    fun `test available inside a macro call identifier`() = checkAvailable("""
+        foo/*caret*/!(foo bar baz);
+    """)
+
+    fun `test unavailable inside a macro call without a body`() = doUnavailableTest("""
+        foo/*caret*/!
+    """)
+
+    fun `test inject RegExp into macro call body 1`() = doTest("RegExp", """
+        |foo! {
+        |<inject>    /*caret*/abc(def)
+        |</inject>}
+    """.trimMargin())
+
+    fun `test inject RegExp into macro call body 2`() = doTest("RegExp", """
+        |    foo! {
+        |<inject>        /*caret*/abc(def)
+        |</inject>    }
+    """.trimMargin())
 
     private fun checkAvailable(@Language("Rust") code: String) {
         InlineFile(code.trimIndent()).withCaret()
@@ -49,13 +74,18 @@ class InjectLanguageIntentionTest : RsIntentionTestBase(InjectLanguageAction::cl
         val language = InjectedLanguage.findLanguageById(lang)
         val injectable = Injectable.fromLanguage(language)
         InjectLanguageAction.invokeImpl(project, myFixture.editor, myFixture.file, injectable)
-        val host = findInjectionHost(myFixture.editor, myFixture.file)
-            ?: error("InjectionHost not found")
-        val injectedList = InjectedLanguageManager.getInstance(project).getInjectedPsiFiles(host)
-            ?: error("Language injection failed")
-        assertEquals(injectedList.size, 1)
-        val injectedPsi = injectedList.first().first
-        assertEquals(injectedPsi.language, language)
+        try {
+            val host = findInjectionHost(myFixture.editor, myFixture.file)
+                ?: error("InjectionHost not found")
+            val injectedList = InjectedLanguageManager.getInstance(project).getInjectedPsiFiles(host)
+                ?: error("Language injection failed")
+            assertEquals(injectedList.size, 1)
+            val injectedPsi = injectedList.first().first
+            assertEquals(injectedPsi.language, language)
+            myFixture.checkHighlighting(false, true, false, false)
+        } finally {
+            UnInjectLanguageAction.invokeImpl(project, myFixture.editor, myFixture.file)
+        }
     }
 }
 

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1482,7 +1482,8 @@ fake MacroCall ::= AttrsAndVis PathWithoutTypeArgs '!' identifier? (
                  "org.rust.lang.core.macros.RsExpandedElement"
                  "org.rust.lang.core.psi.ext.RsPossibleMacroCall"
                  "org.rust.lang.core.psi.ext.RsAttrProcMacroOwner"
-                 "org.rust.lang.core.psi.ext.RsModificationTrackerOwner" ]
+                 "org.rust.lang.core.psi.ext.RsModificationTrackerOwner"
+                 "com.intellij.psi.PsiLanguageInjectionHost" ]
   mixin = "org.rust.lang.core.psi.ext.RsMacroCallImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsMacroCallStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/main/kotlin/org/rust/ide/injected/RsMacroCallManipulator.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsMacroCallManipulator.kt
@@ -1,0 +1,56 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.injected
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.AbstractElementManipulator
+import com.intellij.util.text.CharArrayUtil
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.bodyTextRange
+import org.rust.lang.core.psi.ext.macroBody
+import org.rust.lang.core.psi.ext.startOffset
+
+class RsMacroCallManipulator : AbstractElementManipulator<RsMacroCall>() {
+    override fun handleContentChange(element: RsMacroCall, range: TextRange, newContent: String): RsMacroCall {
+        val oldText = element.text
+        val newText = "${oldText.substring(0, range.startOffset)}$newContent${oldText.substring(range.endOffset)}"
+
+        val newMacroCall = RsPsiFactory(element.project).createFile("m!$newText").firstChild as? RsMacroCall
+            ?: error(newText)
+        return element.replace(newMacroCall) as RsMacroCall
+    }
+
+    /**
+     * Used in "Inject language or reference" intention action to find a text range for injection.
+     * See `InjectLanguageIntentionTest`.
+     */
+    override fun getRangeInElement(element: RsMacroCall): TextRange {
+        val bodyTextRange = element.bodyTextRange?.shiftLeft(element.startOffset) ?: return super.getRangeInElement(element)
+        val macroBody = element.macroBody ?: return bodyTextRange
+
+        var trimmedStart = bodyTextRange.startOffset
+        var trimmedEnd = bodyTextRange.endOffset
+
+        // Trim start
+        val firstNonSpaceIndex = CharArrayUtil.shiftForward(macroBody, 0, " \t")
+        if (firstNonSpaceIndex < macroBody.length && macroBody[firstNonSpaceIndex] == '\n') {
+            trimmedStart = bodyTextRange.startOffset + firstNonSpaceIndex + 1
+        }
+
+        // Trim end
+        val lastNonSpaceIndex = CharArrayUtil.shiftBackward(macroBody, firstNonSpaceIndex, macroBody.lastIndex, " \t")
+        if (lastNonSpaceIndex > firstNonSpaceIndex && macroBody[lastNonSpaceIndex] == '\n') {
+            trimmedEnd = bodyTextRange.endOffset - (macroBody.length - lastNonSpaceIndex) + 1
+        }
+
+        return if (trimmedStart < trimmedEnd) {
+            TextRange(trimmedStart, trimmedEnd)
+        } else {
+            bodyTextRange
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/injected/RsStringLiteralManipulator.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsStringLiteralManipulator.kt
@@ -26,6 +26,10 @@ class RsStringLiteralManipulator : AbstractElementManipulator<RsLitExpr>() {
         return element.replace(newLitExpr) as RsLitExpr
     }
 
+    /**
+     * Used in "Inject language or reference" intention action to find a text range for injection.
+     * See `InjectLanguageIntentionTest`.
+     */
     override fun getRangeInElement(element: RsLitExpr): TextRange {
         return (element.kind as? RsLiteralKind.String)?.offsets?.value ?: super.getRangeInElement(element)
     }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1159,6 +1159,8 @@
 
         <lang.elementManipulator forClass="org.rust.lang.core.psi.RsLitExpr"
                                  implementationClass="org.rust.ide.injected.RsStringLiteralManipulator"/>
+        <lang.elementManipulator forClass="org.rust.lang.core.psi.RsMacroCall"
+                                 implementationClass="org.rust.ide.injected.RsMacroCallManipulator"/>
         <multiHostInjector implementation="org.rust.ide.injected.RsRegExpInjector"/>
         <multiHostInjector implementation="org.rust.ide.injected.RsDoctestLanguageInjector"/>
 


### PR DESCRIPTION
Fixes #9943

1. It's now possible to use `Inject language or reference` intention to make a language injection into macro invocation body:

https://user-images.githubusercontent.com/3221931/212474368-9172849d-a25c-4a0d-98f1-17f4b0bea447.mp4

2. Plugin developers now can make automatic language injections into some macro invocation bodies.
Example of a language injector that injects JSON language into a macro call that refers to a macro "json" in crate "rs_test":
```kotlin
class RsMacroCallJsonInjector : MultiHostInjector {
    override fun elementsToInjectIn(): List<Class<out PsiElement>> =
        listOf(RsMacroCall::class.java)

    override fun getLanguagesToInject(registrar: MultiHostRegistrar, context: PsiElement) {
        if (context !is RsMacroCall || !context.isValidHost) return

        val macroArgumentRange = context.bodyTextRange?.shiftLeft(context.startOffset) ?: return
        val resolvedTo = context.path.reference?.resolve() ?: return

        val isAppropriateMacro = resolvedTo is RsMacro
            && resolvedTo.name == "json"
            && resolvedTo.containingCrate.normName == "rs_test"
        if (!isAppropriateMacro) return

        val inj = registrar.startInjecting(Json5Language.INSTANCE)
        inj.addPlace(null, null, context, macroArgumentRange)
        inj.doneInjecting()
    }
}
```
Result: 
![image](https://user-images.githubusercontent.com/3221931/212427260-06cfc008-00c2-4e81-9480-6bbf7f6344b5.png)

changelog: FEATURE: Provide `Inject language or reference` intention action inside macro invocation bodies (gif). INTERNAL: Plugin developers now can implement `MultiHostInjector`s to make language injections into some macro invocation bodies.