### PR TITLE
Optimize `Insert imports on paste`

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMovePathHelper.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMovePathHelper.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.parentOfType
-import org.rust.ide.refactoring.move.common.RsMoveUtil.containingModOrSelf
 import org.rust.ide.refactoring.move.common.RsMoveUtil.resolvesToAndAccessible
 import org.rust.ide.utils.import.RsImportHelper
 import org.rust.lang.core.psi.RsCodeFragmentFactory

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
@@ -200,8 +200,6 @@ object RsMoveUtil {
         return true
     }
 
-    val RsElement.containingModOrSelf: RsMod get() = (this as? RsMod) ?: containingMod
-
     /**
      * @return `super` instead of `this` for [RsFile]
      *

--- a/src/main/kotlin/org/rust/ide/typing/paste/RsImportCopyPasteProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/typing/paste/RsImportCopyPasteProcessor.kt
@@ -22,7 +22,10 @@ import com.intellij.psi.impl.source.tree.injected.changesHandler.range
 import org.rust.ide.inspections.fixes.QualifyPathFix
 import org.rust.ide.inspections.import.AutoImportFix
 import org.rust.ide.settings.RsCodeInsightSettings
-import org.rust.ide.utils.import.*
+import org.rust.ide.utils.import.ImportCandidate
+import org.rust.ide.utils.import.ImportContext
+import org.rust.ide.utils.import.ImportInfo
+import org.rust.ide.utils.import.import
 import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -113,23 +116,23 @@ class RsImportCopyPasteProcessor : CopyPastePostProcessor<RsTextBlockTransferabl
         val data = values.getOrNull(0) ?: return
         val file = editor.document.toPsiFile(project) as? RsFile ?: return
 
-        val elements = gatherElements(file, bounds.range)
-        val importCtx = elements.firstOrNull { it is RsElement } as? RsElement ?: return
+        val containingMod = CollectHighlightsUtil.findCommonParent(file, bounds.startOffset, bounds.endOffset)
+            ?.ancestorOrSelf<RsElement>()
+            ?.containingModOrSelf ?: return
+        val importCtx = containingMod.firstItem ?: return
 
         val importOffset = bounds.range.startOffset
 
-        val visitor = ImportingVisitor(importOffset, data.importMap)
+        val processor = ImportingProcessor(importOffset, data.importMap)
 
         runWriteAction {
-            for (element in elements) {
-                element.accept(visitor)
-            }
+            processElementsInRange(file, bounds.range, processor)
             // We need to import the candidates after visiting all elements, otherwise the relative offsets could be
             // invalidated after an import has been added
-            for (candidate in visitor.importCandidates) {
+            for (candidate in processor.importCandidates) {
                 candidate.import(importCtx)
             }
-            for ((element, importInfo) in visitor.qualifyCandidates) {
+            for ((element, importInfo) in processor.qualifyCandidates) {
                 QualifyPathFix.qualify(element, importInfo)
             }
         }
@@ -155,29 +158,26 @@ class RsImportCopyPasteProcessor : CopyPastePostProcessor<RsTextBlockTransferabl
 
 private class RsReferenceData
 
-private class ImportingVisitor(private val importOffset: Int, private val importMap: ImportMap) : RsRecursiveVisitor() {
+private class ImportingProcessor(private val importOffset: Int, private val importMap: ImportMap) : Processor {
     private val importCandidatesInner: MutableList<ImportCandidate> = mutableListOf()
     private val qualifyCandidatesInner: MutableList<Pair<RsPath, ImportInfo>> = mutableListOf()
 
     val importCandidates: List<ImportCandidate> = importCandidatesInner
     val qualifyCandidates: List<Pair<RsPath, ImportInfo>> = qualifyCandidatesInner
 
-    override fun visitPath(path: RsPath) {
+    override fun processPath(path: RsPath) {
         val ctx = AutoImportFix.findApplicableContext(path)
         handleImport(path, ctx)
-        super.visitPath(path)
     }
 
-    override fun visitMethodCall(methodCall: RsMethodCall) {
+    override fun processMethodCall(methodCall: RsMethodCall) {
         val ctx = AutoImportFix.findApplicableContext(methodCall)
         handleImport(methodCall, ctx)
-        super.visitMethodCall(methodCall)
     }
 
-    override fun visitPatBinding(binding: RsPatBinding) {
+    override fun processPatBinding(binding: RsPatBinding) {
         val ctx = AutoImportFix.findApplicableContext(binding)
         handleImport(binding, ctx)
-        super.visitPatBinding(binding)
     }
 
     private fun handleImport(element: RsElement, ctx: AutoImportFix.Context?) {
@@ -220,13 +220,10 @@ private fun AutoImportFix.Context?.getCandidate(originalItem: QualifiedItemPath)
  * from paths and method calls.
  */
 private fun createFqnMap(file: RsFile, range: TextRange): ImportMap {
-    val elements = gatherElements(file, range)
     val fqnMap = hashMapOf<RelativeEndOffset, QualifiedItemPath>()
 
-    val visitor = object : RsRecursiveVisitor() {
-        override fun visitPath(path: RsPath) {
-            super.visitPath(path)
-
+    val processor = object : Processor {
+        override fun processPath(path: RsPath) {
             // We only want to record the start of the path that can be imported (e.g. `a` in `a::b::c`).
             if (path.qualifier != null) return
 
@@ -236,7 +233,7 @@ private fun createFqnMap(file: RsFile, range: TextRange): ImportMap {
             }
         }
 
-        override fun visitMethodCall(methodCall: RsMethodCall) {
+        override fun processMethodCall(methodCall: RsMethodCall) {
             val methods = methodCall.inference?.getResolvedMethod(methodCall)
             val target = methods?.firstNotNullOfOrNull {
                 it.source.implementedTrait?.element
@@ -245,16 +242,13 @@ private fun createFqnMap(file: RsFile, range: TextRange): ImportMap {
             if (target != null) {
                 storeMapping(methodCall, target)
             }
-
-            super.visitMethodCall(methodCall)
         }
 
-        override fun visitPatBinding(binding: RsPatBinding) {
+        override fun processPatBinding(binding: RsPatBinding) {
             val target = binding.reference.resolve() as? RsQualifiedNamedElement
             if (target != null) {
                 storeMapping(binding, target)
             }
-            super.visitPatBinding(binding)
         }
 
         fun storeMapping(element: RsElement, target: RsQualifiedNamedElement) {
@@ -264,11 +258,39 @@ private fun createFqnMap(file: RsFile, range: TextRange): ImportMap {
             )
         }
     }
+
+    processElementsInRange(file, range, processor)
+    return ImportMap(fqnMap)
+}
+
+private interface Processor {
+    fun processPath(path: RsPath)
+    fun processMethodCall(methodCall: RsMethodCall)
+    fun processPatBinding(binding: RsPatBinding)
+}
+
+private fun processElementsInRange(file: RsFile, range: TextRange, processor: Processor) {
+    val visitor = object : RsRecursiveVisitor() {
+        override fun visitPath(path: RsPath) {
+            super.visitPath(path)
+            processor.processPath(path)
+        }
+
+        override fun visitMethodCall(methodCall: RsMethodCall) {
+            super.visitMethodCall(methodCall)
+            processor.processMethodCall(methodCall)
+        }
+
+        override fun visitPatBinding(binding: RsPatBinding) {
+            super.visitPatBinding(binding)
+            processor.processPatBinding(binding)
+        }
+    }
+
+    val elements = gatherElements(file, range)
     for (element in elements) {
         element.accept(visitor)
     }
-
-    return ImportMap(fqnMap)
 }
 
 private fun gatherElements(file: RsFile, range: TextRange): List<PsiElement> =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -66,6 +66,8 @@ val RsElement.containingCrate: Crate
 
 val RsElement.containingCargoPackage: CargoWorkspace.Package? get() = containingCargoTarget?.pkg
 
+val RsElement.containingModOrSelf: RsMod get() = (this as? RsMod) ?: containingMod
+
 val PsiElement.edition: Edition?
     get() = contextOrSelf<RsElement>()?.containingCrate?.edition
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -14,7 +14,6 @@ import com.intellij.psi.StubBasedPsiElement
 import org.jetbrains.annotations.VisibleForTesting
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.PackageOrigin
-import org.rust.ide.refactoring.move.common.RsMoveUtil.containingModOrSelf
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.crate.crateGraph


### PR DESCRIPTION
Related: #9664
Closes #9768
Fixes performance issue that we can process the same `PsiElement` multiple times.

No changelog since this is the first optimization step before the feature can be enabled by default