### PR TITLE
Add configuration option for Run Targets to use the project path instead of a random directory

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfigurable.kt
@@ -9,10 +9,7 @@ import com.intellij.execution.target.getRuntimeType
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.dsl.builder.Cell
-import com.intellij.ui.dsl.builder.Row
-import com.intellij.ui.dsl.builder.bindText
-import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import org.rust.RsBundle
 
@@ -43,6 +40,12 @@ class RsLanguageRuntimeConfigurable(val config: RsLanguageRuntimeConfiguration) 
                 .comment(RsBundle.message("run.target.build.arguments.comment"))
                 .apply { component.emptyText.text = "e.g. --target=x86_64-unknown-linux-gnu" }
                 .bindText(config::localBuildArgs)
+        }
+        row {
+            checkBox(RsBundle.message("run.target.rustc.use_project_path.label"))
+                .bindSelected(config::useProjectPath)
+
+            contextHelp(RsBundle.message("run.target.rustc.use_project_path.comment"))
         }
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfiguration.kt
@@ -19,6 +19,8 @@ class RsLanguageRuntimeConfiguration : LanguageRuntimeConfiguration(RsLanguageRu
 
     var localBuildArgs: String = ""
 
+    var useProjectPath: Boolean = false
+
     override fun getState() = MyState().also {
         it.rustcPath = this.rustcPath
         it.rustcVersion = this.rustcVersion
@@ -27,6 +29,8 @@ class RsLanguageRuntimeConfiguration : LanguageRuntimeConfiguration(RsLanguageRu
         it.cargoVersion = this.cargoVersion
 
         it.localBuildArgs = this.localBuildArgs
+
+        it.useProjectPath = this.useProjectPath
     }
 
     override fun loadState(state: MyState) {
@@ -37,6 +41,8 @@ class RsLanguageRuntimeConfiguration : LanguageRuntimeConfiguration(RsLanguageRu
         this.cargoVersion = state.cargoVersion.orEmpty()
 
         this.localBuildArgs = state.localBuildArgs.orEmpty()
+
+        this.useProjectPath = state.useProjectPath.or(false)
     }
 
     class MyState : BaseState() {
@@ -47,5 +53,7 @@ class RsLanguageRuntimeConfiguration : LanguageRuntimeConfiguration(RsLanguageRu
         var cargoVersion by string()
 
         var localBuildArgs by string()
+
+        var useProjectPath by property(false)
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/Utils.kt
@@ -67,6 +67,11 @@ fun GeneralCommandLine.startProcess(
     }
 
     val request = config.createEnvironmentRequest(project)
+    val languageRuntime: RsLanguageRuntimeConfiguration? = request.configuration?.languageRuntime
+    if (languageRuntime?.useProjectPath == true) {
+        request.projectPathOnTarget = config.projectRootOnTarget;
+    }
+
     val setup = RsCommandLineSetup(request)
     val targetCommandLine = toTargeted(setup, uploadExecutable)
     val progressIndicator = ProgressManager.getInstance().progressIndicator ?: EmptyProgressIndicator()

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -106,6 +106,8 @@ run.target.cargo.executable.path.label=Cargo executable:
 run.target.cargo.executable.version.label=Cargo version:
 run.target.rustc.executable.path.label=Rustc executable:
 run.target.rustc.executable.version.label=Rustc version:
+run.target.rustc.use_project_path.label=Use working directory instead of temporary directory
+run.target.rustc.use_project_path.comment=Will use the <b<Project path on target</b> setting in the run target instead of creating a temporary directory
 
 settings.rust.auto.import.on.completion=Import out-of-scope items on completion
 settings.rust.auto.import.show.popup=Show import popup

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -106,7 +106,7 @@ run.target.cargo.executable.path.label=Cargo executable:
 run.target.cargo.executable.version.label=Cargo version:
 run.target.rustc.executable.path.label=Rustc executable:
 run.target.rustc.executable.version.label=Rustc version:
-run.target.rustc.use_project_path.label=Use working directory instead of temporary directory
+run.target.rustc.use_project_path.label=Use Project path for Run Configuration instead of creating a temporary directory
 run.target.rustc.use_project_path.comment=Will use the <b<Project path on target</b> setting in the run target instead of creating a temporary directory
 
 settings.rust.auto.import.on.completion=Import out-of-scope items on completion


### PR DESCRIPTION
When using Run Targets with SSH, a random directory is created inside the target, instead of creating the folder as the folder you set.

For example,

This allows setting an option in the run target to not create a random folder, which is what IntelliJ does by default.

For example, when creating a Run Target, my SSH Configuration looks like this:
![image](https://user-images.githubusercontent.com/225131/212524045-a25dc17b-d28c-45c9-89d4-8784976ee1c4.png)


And my Run Target looks like this:
![2023-01-15_11-27_1](https://user-images.githubusercontent.com/225131/212524087-6ba28928-fccb-4ad2-9f74-b5f1fa83f609.png)

I would expect my project to be in the root directory of my project path, not a random directory. Cargo DOES, however set the `target` directory to be here.

So if you have relative paths in your Cargo.toml files this will fail.

For example here I have "../../aya", and it fails.

![2023-01-15_11-29](https://user-images.githubusercontent.com/225131/212524135-3cdb2888-2ceb-483b-804e-57539f8e6542.png)

My proposal is to add a checkbox to the Rust configuration to allow using the project path instead of a random directory:
![image](https://user-images.githubusercontent.com/225131/212524236-5ed4ac29-214f-4c5e-b89a-3a73c6f76524.png)

This will allow the project to be in the root directory of the project path.

The `projectPathOnTarget` is set for the request here:
```rust
val languageRuntime: RsLanguageRuntimeConfiguration? = request.configuration?.languageRuntime
if (languageRuntime?.useProjectPath == true) {
    request.projectPathOnTarget = config.projectRootOnTarget;
}
```

Closes #9963

changelog:
Add configuration option for Run Targets to use the project path instead of a random directory