### PR TITLE
INSP: Annotate missing lifetimes in function signature

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -282,3 +282,10 @@ val RsSelfParameter.isRefLike: Boolean
         val typeReference = typeReference ?: return false
         return typeReference.descendantsOfTypeOrSelf<RsRefLikeType>().any { it.and != null }
     }
+
+fun RsFunction.hasMissingLifetimes(): Boolean {
+    if (retType == null) return false
+    if (selfParameter?.isRefLike == true) return false
+    val (inputLifetimes, outputLifetimes) = collectLifetimesFromFnSignature(this) ?: return false
+    return outputLifetimes.any { it is Unnamed } && inputLifetimes.size != 1
+}

--- a/src/test/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberTest.kt
@@ -105,6 +105,26 @@ class RsWrongLifetimeParametersNumberInspectionTest : RsInspectionsTestBase(RsWr
 
     """)
 
+    fun `test E0106 missing lifetime in function`() = checkByText("""
+        fn func1() {}
+        fn func2(a: &i32) -> &i32 { unimplemented!() }
+        fn func3(a: &i32, b: &i32) {}
+        fn func4() -> fn(&i32) { |_| {} }
+        fn func5() -> impl Fn(&i32) { |_| {} }
+
+        fn func6() -> /*error descr="Missing lifetime specifier [E0106]"*/&/*error**/i32 { unimplemented!() }
+        fn func7(a: &i32, b: &i32) -> /*error descr="Missing lifetime specifier [E0106]"*/&/*error**/i32 { unimplemented!() }
+
+        struct Foo {}
+        impl Foo {
+            fn method1(&self, a: &i32, b: &i32) -> &i32 { &0 }
+            fn method2(self: &Self, a: &i32, b: &i32) -> &i32 { &0 }
+            fn method3(self: Box<&Self>, a: &i32, b: &i32) -> &i32 { &0 }
+
+            fn method4(self, a: &i32, b: &i32) -> /*error descr="Missing lifetime specifier [E0106]"*/&/*error**/i32 { &0 }
+        }
+    """)
+
     fun `test E0107 wrong number of lifetime parameters`() = checkByText("""
         struct Foo0;
         struct Foo1<'a>(&'a str);


### PR DESCRIPTION
Fixes #2767

changelog: Annotate missing lifetimes in function signature