### PR TITLE
PRJ: Trim template name and URL when creating new project

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/ui/CargoNewCrateDialog.kt
+++ b/src/main/kotlin/org/rust/ide/actions/ui/CargoNewCrateDialog.kt
@@ -15,6 +15,7 @@ import com.intellij.ui.dsl.builder.panel
 import org.jetbrains.annotations.TestOnly
 import org.rust.ide.newProject.RsPackageNameValidator
 import org.rust.openapiext.isUnitTestMode
+import org.rust.openapiext.trimmedText
 import javax.swing.JComponent
 
 data class CargoNewCrateSettings(val binary: Boolean, val crateName: String)
@@ -51,7 +52,7 @@ class CargoNewCrateDialog(project: Project, private val root: VirtualFile) : Dia
     private val name = JBTextField(20)
 
     val binary get() = this.typeCombobox.selectedIndex == 0
-    val crateName get() = name.text.trim()
+    val crateName get() = name.trimmedText
 
     init {
         title = "New Cargo Crate"

--- a/src/main/kotlin/org/rust/openapiext/ui.kt
+++ b/src/main/kotlin/org/rust/openapiext/ui.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.NlsContexts.DialogTitle
 import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.Row
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
@@ -117,3 +118,6 @@ fun <T : JComponent> Row.fullWidthCell(component: T): Cell<T> {
     return cell(component)
         .horizontalAlign(HorizontalAlign.FILL)
 }
+
+val JBTextField.trimmedText: String
+    get() = text.trim()


### PR DESCRIPTION
Fixes #9968.

changelog: Trim template name and URL when creating a new project using a [custom cargo-generate template](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-new-cargo-projects.html#cargo-generate)