### PR TITLE
RES: Fix resolve of custom macros with same name as in prelude

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -138,8 +138,10 @@ private fun ModData.processMacros(
             if (processor.process(name, macro)) return true
         }
 
-        info.defMap.prelude?.let { prelude ->
-            if (prelude.processScopedMacros(processor, info)) return true
+        if (!isHanging) {
+            info.defMap.prelude?.let { prelude ->
+                if (prelude.processScopedMacros(processor, info)) return true
+            }
         }
     }
 

--- a/src/main/kotlin/org/rust/openapiext/psi.kt
+++ b/src/main/kotlin/org/rust/openapiext/psi.kt
@@ -135,9 +135,10 @@ private class RsWithMacrosRecursiveElementWalkingVisitor(
     }
 
     private fun processMacro(element: RsPossibleMacroCall, path: RsElement?) {
-        val expansion = element.expansion ?: return
         val visitor = RsWithMacrosRecursiveElementWalkingVisitor(processor)
         if (path != null) visitor.visitElement(path)
+
+        val expansion = element.expansion ?: return
         for (expandedElement in expansion.elements) {
             visitor.visitElement(expandedElement)
         }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -1080,4 +1080,17 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
             }
         }
     """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test custom column macro`() = checkByFileTree("""
+    //- lib.rs
+        #[macro_export]
+        macro_rules! column { () => {} }
+    //- main.rs
+        /*caret*/
+        use test_package::column;
+        fn main() {
+            column!();
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #9915

changelog: Fix resolve of custom macros with the same name as in prelude