### PR TITLE
Added links to docs for IJ Rust features in readme.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ The plugin is compatible with all IntelliJ-based IDEs starting from the version 
 
 |                        | Open-source and Educational IDEs<sup>*</sup> | [CLion] | [IntelliJ IDEA] Ultimate, [GoLand] | [PyCharm] Professional | [WebStorm], [PhpStorm], other commercial IDEs |
 |------------------------|----------------------------------------------|---------|------------------------------------|------------------------|-----------------------------------------------|
-| Language support       | +                                            | +       | +                                  | +                      | +                                             |
-| Cargo support          | +                                            | +       | +                                  | +                      | +                                             |
-| Code coverage          | +                                            | +       | +                                  | +                      | +                                             |
+| [Language support]     | +                                            | +       | +                                  | +                      | +                                             |
+| [Cargo support]        | +                                            | +       | +                                  | +                      | +                                             |
+| [Code coverage]        | +                                            | +       | +                                  | +                      | +                                             |
 | [Detecting duplicates] | -                                            | +       | +                                  | +                      | +                                             |
-| Debugger               | -                                            | +       | +**                                | +**                    | -                                             |
-| Run targets            | -                                            | +       | +                                  | -                      | -                                             |
-| Profiler               | -                                            | +       | -                                  | -                      | -                                             |
-| Valgrind Memcheck      | -                                            | +       | -                                  | -                      | -                                             |
+| [Debugger]             | -                                            | +       | +**                                | +**                    | -                                             |
+| [Run targets]          | -                                            | +       | +                                  | -                      | -                                             |
+| [Profiler]             | -                                            | +       | -                                  | -                      | -                                             |
+| [Valgrind Memcheck]    | -                                            | +       | -                                  | -                      | -                                             |
 
 
-\* [IntelliJ IDEA] Community Edition, [PyCharm] Community Edition, [PyCharm Edu and IntelliJ IDEA Edu].
+\* [IntelliJ IDEA] Community Edition, [PyCharm] Community Edition, [PyCharm Edu], [IntelliJ IDEA Edu], and third-party IntelliJ-based IDEs.
 
 \** Requires the
 [Native Debugging Support](https://plugins.jetbrains.com/plugin/12775-native-debugging-support) plugin. 
@@ -91,5 +91,13 @@ understand the high-level structure of the codebase. If you are not sure where t
 [GoLand]: https://www.jetbrains.com/go/
 [WebStorm]: https://www.jetbrains.com/webstorm/
 [PhpStorm]: https://www.jetbrains.com/phpstorm/
-[PyCharm Edu and IntelliJ IDEA Edu]: https://www.jetbrains.com/education
+[PyCharm Edu]: https://www.jetbrains.com/pycharm-edu/
+[IntelliJ IDEA Edu]: https://www.jetbrains.com/idea-edu/
 [Detecting duplicates]: https://www.jetbrains.com/help/idea/analyzing-duplicates.html
+[Language support]: https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-syntax-highlighting.html
+[Cargo support]: https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-new-cargo-projects.html
+[Code coverage]: https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-code-coverage.html
+[Debugger]: https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-debugging.html
+[Run targets]: https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-run-targets.html
+[Profiler]: https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-profiler.html
+[Valgrind Memcheck]: https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-valgrind.html


### PR DESCRIPTION
Hi! I added links to the IJ Rust features listed in the table in readme.txt. @Undin  Please take a look.
I also mentioned IJ-based IDEs in the footnote. Is it ok? I think, when it comes to footnotes, we really must be precise.
Once we merge this, I'll update the Marketplace docs accordingly.


changelog: Added links to docs for IJ Rust features in readme.txt.