### PR TITLE
RES: fix namespace shadowing for a path in a type argument position

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -721,7 +721,7 @@ class ImportingPsiRenderer(
         val elementToName = mutableMapOf<RsElement, String>()
         processNestedScopesUpwards(context, TYPES_N_VALUES, createProcessor {
             val element = it.element as? RsNamedElement ?: return@createProcessor false
-            for (namespace in element.namespaces) {
+            for (namespace in it.namespaces) {
                 nameToElement[it.name to namespace] = element
                 if (it.name != "_" && element !in elementToName) {
                     elementToName[element] = it.name

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -209,7 +209,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
 
         for (candidate in candidates) {
             val item = candidate.item
-            val scopeEntry = SimpleScopeEntry(candidate.itemName, item)
+            val scopeEntry = SimpleScopeEntry(candidate.itemName, item, TYPES_N_VALUES_N_MACROS)
 
             if (item is RsEnumItem
                 && (context.expectedTy?.ty?.stripReferences() as? TyAdt)?.item == (item.declaredType as? TyAdt)?.item) {
@@ -529,7 +529,7 @@ fun collectVariantsForEnumCompletion(
         val variantName = enumVariant.name ?: return@mapNotNull null
 
         return@mapNotNull createLookupElement(
-            scopeEntry = SimpleScopeEntry("${enumName}::${variantName}", enumVariant, substitution),
+            scopeEntry = SimpleScopeEntry("${enumName}::${variantName}", enumVariant, ENUM_VARIANT_NS, substitution),
             context = context,
             null,
             object : RsDefaultInsertHandler() {

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -28,18 +28,18 @@ fun processItemOrEnumVariantDeclarations(
             val (item, subst) = (scope.typeReference?.skipParens() as? RsPathType)
                 ?.path?.reference?.advancedDeepResolve() ?: return false
             if (item is RsEnumItem) {
-                if (processAllWithSubst(item.variants, subst, processor)) return true
+                if (processAllWithSubst(item.variants, subst, ENUM_VARIANT_NS, processor)) return true
             }
         }
         is RsImplItem -> {
             val (item, subst) = (scope.typeReference?.skipParens() as? RsPathType)
                 ?.path?.reference?.advancedDeepResolve() ?: return false
             if (item is RsEnumItem) {
-                if (processAllWithSubst(item.variants, subst, processor)) return true
+                if (processAllWithSubst(item.variants, subst, ENUM_VARIANT_NS, processor)) return true
             }
         }
         is RsEnumItem -> {
-            if (processAll(scope.variants, processor)) return true
+            if (processor.processAll(scope.variants, ENUM_VARIANT_NS)) return true
         }
         is RsMod -> {
             val ipm = if (withPrivateImports()) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsPathResolveResult.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsPathResolveResult.kt
@@ -18,17 +18,9 @@ data class RsPathResolveResult<T : RsElement>(
     val element: T,
     val resolvedSubst: Substitution = emptySubstitution,
     val isVisible: Boolean,
+    val namespaces: Set<Namespace> = emptySet(),
 ) : ResolveResult {
     override fun getElement(): PsiElement = element
 
     override fun isValidResult(): Boolean = true
-
-    inline fun mapSubst(
-        f: (Substitution) -> Substitution
-    ): RsPathResolveResult<T> {
-        if (resolvedSubst === emptySubstitution) {
-            return this
-        }
-        return RsPathResolveResult(element, f(resolvedSubst), isVisible)
-    }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
@@ -71,6 +71,11 @@ interface DotExprResolveVariant : ScopeEntry {
     val selfTy: Ty
     /** The number of `*` dereferences should be performed on receiver to match `selfTy` */
     val derefCount: Int
+
+    override val namespaces: Set<Namespace>
+        get() = VALUES // Namespace does not matter in the case of dot expression
+
+    override fun doCopyWithNs(namespaces: Set<Namespace>): ScopeEntry = this
 }
 
 data class FieldResolveVariant(

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -395,8 +395,7 @@ private fun filterResolveResults(
             1 -> result
             else -> {
                 val types = result.filter {
-                    val element = it.element as? RsNamedElement ?: return@filter false
-                    Namespace.Types in element.namespaces
+                    Namespace.Types in it.namespaces
                 }
                 types.ifEmpty { result }
             }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
@@ -23,6 +23,8 @@ import org.rust.lang.core.psi.ext.RsMethodOrField
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.resolve.SimpleScopeEntry
+import org.rust.lang.core.resolve.TYPES
+import org.rust.lang.core.resolve.TYPES_N_VALUES
 
 class RsLookupElementTest : RsTestBase() {
     fun `test fn`() = check("""
@@ -157,7 +159,7 @@ class RsLookupElementTest : RsTestBase() {
     fun `test mod`() {
         myFixture.configureByText("foo.rs", "")
         val lookup = createLookupElement(
-            SimpleScopeEntry("foo", myFixture.file as RsFile),
+            SimpleScopeEntry("foo", myFixture.file as RsFile, TYPES),
             RsCompletionContext()
         )
         val presentation = LookupElementPresentation()
@@ -331,7 +333,7 @@ class RsLookupElementTest : RsTestBase() {
 
         val element = findElementInEditor<T>()
         val lookup = createLookupElement(
-            SimpleScopeEntry(element.name!!, element as RsElement),
+            SimpleScopeEntry(element.name!!, element as RsElement, TYPES_N_VALUES),
             RsCompletionContext()
         )
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsConstArgumentResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsConstArgumentResolveTest.kt
@@ -123,6 +123,29 @@ class RsConstArgumentResolveTest : RsResolveTestBase() {
         }       //^
     """)
 
+    fun `test type namespace is shadowed 1`() = checkByCode("""
+        mod a {
+            pub struct S;
+        }
+        use a::*;
+        struct S {}
+             //X
+        trait Trait<T> {}
+        impl Trait<S> for S {}
+                 //^
+    """)
+
+    fun `test type namespace is shadowed 2`() = checkByCode("""
+        pub struct S;
+        fn main() {
+            struct S {}
+                 //X
+            trait Trait<T> {}
+            impl Trait<S> for S {}
+                     //^
+        }
+    """)
+
     // Method call arguments:
 
     fun `test disambiguate type argument in method call`() = checkByCode("""


### PR DESCRIPTION
Fixes #9878

Also slightly speeds up name resolution because of less calls to `RsNamedElement.namespaces`