### PR TITLE
Refactor resolve processors more

### DIFF
--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.psi.ext.childOfType
 import org.rust.lang.core.psi.ext.expandedTailExpr
 import org.rust.lang.core.resolve.ItemProcessingMode
 import org.rust.lang.core.resolve.TYPES_N_VALUES_N_MACROS
-import org.rust.lang.core.resolve.createProcessor
+import org.rust.lang.core.resolve.collectNames
 import org.rust.lang.core.resolve.findPrelude
 import org.rust.lang.core.resolve2.processItemDeclarations
 import org.rust.openapiext.toPsiFile
@@ -43,12 +43,9 @@ class RsConsoleCodeFragmentContext(codeFragment: RsReplCodeFragment?) {
     private fun addItemsNamesFromPrelude(codeFragment: RsReplCodeFragment) {
         val prelude = findPrelude(codeFragment) ?: return
 
-        val preludeItemsNames = mutableListOf<String>()
-        val processor = createProcessor {
-            preludeItemsNames += it.name
-            false
+        val preludeItemsNames = collectNames {
+            processItemDeclarations(prelude, TYPES_N_VALUES_N_MACROS, it, ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS)
         }
-        processItemDeclarations(prelude, TYPES_N_VALUES_N_MACROS, processor, ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS)
         itemsNames += preludeItemsNames
         hasAddedNamesFromPrelude = true
     }

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -720,14 +720,13 @@ class ImportingPsiRenderer(
         val nameToElement = mutableMapOf<Pair<String, Namespace>, RsElement>()
         val elementToName = mutableMapOf<RsElement, String>()
         processNestedScopesUpwards(context, TYPES_N_VALUES, createProcessor {
-            val element = it.element as? RsNamedElement ?: return@createProcessor false
+            val element = it.element as? RsNamedElement ?: return@createProcessor
             for (namespace in it.namespaces) {
                 nameToElement[it.name to namespace] = element
                 if (it.name != "_" && element !in elementToName) {
                     elementToName[element] = it.name
                 }
             }
-            false
         })
         nameToElement to elementToName
     }

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -176,7 +176,7 @@ object RsImportHelper {
         rawImportSubjects: Set<RsQualifiedNamedElement>
     ): TypeReferencesInfo {
         val subjectsWithName = rawImportSubjects.associateWithTo(hashMapOf()) { it.name }
-        val processor = createProcessor { entry ->
+        val processor = createStoppableProcessor { entry ->
             val element = entry.element
             if (subjectsWithName[element] == entry.name) {
                 subjectsWithName.remove(element)

--- a/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
@@ -80,7 +80,6 @@ object RsDeriveCompletionProvider : RsCompletionProvider() {
         val processor = createProcessor { e ->
             result.addElement(createLookupElement(e.name))
             processedElements.putValue(e.name, e.element)
-            false
         }
         val filtered = filterDeriveProcMacros(processor)
         processProcMacroResolveVariants(path, filtered, isCompletion = true)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -144,17 +144,9 @@ abstract class RsStubbedElementImpl<StubT : StubElement<*>> : StubBasedPsiElemen
 }
 
 fun RsElement.findInScope(name: String, ns: Set<Namespace>): PsiElement? {
-    var resolved: PsiElement? = null
-    val processor = createProcessor(name) { entry ->
-        if (entry.name == name) {
-            resolved = entry.element
-            true
-        } else {
-            false
-        }
+    return pickFirstResolveVariant(name) {
+        processNestedScopesUpwards(this, ns, it)
     }
-    processNestedScopesUpwards(this, ns, processor)
-    return resolved
 }
 
 fun RsElement.getLocalVariableVisibleBindings(): Map<String, RsPatBinding> {
@@ -168,15 +160,9 @@ fun RsElement.getLocalVariableVisibleBindings(): Map<String, RsPatBinding> {
 }
 
 fun RsElement.getAllVisibleBindings(): Set<String> {
-    val bindings = mutableSetOf<String>()
-    val processor = createProcessor { entry ->
-        val element = entry.element as? RsNameIdentifierOwner ?: return@createProcessor false
-        val name = element.name ?: return@createProcessor false
-        bindings.add(name)
-        false
+    return collectNames {
+        processNestedScopesUpwards(this, VALUES, it)
     }
-    processNestedScopesUpwards(this, VALUES, processor)
-    return bindings
 }
 
 /**

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemElement.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.TYPES
-import org.rust.lang.core.resolve.createProcessor
+import org.rust.lang.core.resolve.createStoppableProcessor
 import org.rust.lang.core.resolve.processNestedScopesUpwards
 
 /**
@@ -20,7 +20,7 @@ interface RsItemElement : RsVisibilityOwner, RsOuterAttributeOwner, RsExpandedEl
 
 fun <T : RsItemElement> Iterable<T>.filterInScope(scope: RsElement): List<T> {
     val set = toMutableSet()
-    val processor = createProcessor {
+    val processor = createStoppableProcessor {
         set.remove(it.element)
         set.isEmpty()
     }


### PR DESCRIPTION
Continuation of #9879

Replace most of the lambda-based `RsResolveProcessorBase` implementation to named classes