### PR TITLE
T: add test for line markers (gutter icons) inside attr proc macros

### DIFF
--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
@@ -5,8 +5,9 @@
 
 package org.rust.ide.lineMarkers
 
-import org.rust.MockAdditionalCfgOptions
-import org.rust.fileTree
+import org.rust.*
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.macros.MacroExpansionScope
 
 /**
  * Tests for Bench Function Line Marker.
@@ -87,5 +88,15 @@ class CargoBenchRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         fn has_icon() { assert(true) } // - Bench has_icon
         #[cfg_attr(not(intellij_rust), bench)]
         fn no_icon() { assert(true) }
+    """)
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test bench function under a proc macro attribute`() = doTestByText("""
+        use test_proc_macros::attr_as_is;
+        #[attr_as_is]
+        #[bench]
+        fn has_icon() { assert(true) } // - Bench has_icon
     """)
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoExecutableRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoExecutableRunLineMarkerContributorTest.kt
@@ -9,6 +9,12 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.util.PathUtil
 import org.intellij.lang.annotations.Language
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithExperimentalFeatures
+import org.rust.WithProcMacroRustProjectDescriptor
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.macros.MacroExpansionScope
 
 class CargoExecutableRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
 
@@ -42,6 +48,15 @@ class CargoExecutableRunLineMarkerContributorTest : RsLineMarkerProviderTestBase
         #![no_main]
 
         fn main() {}
+    """)
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test main expanded from a attribute macro call`() = doTest("main.rs", """
+        use test_proc_macros::attr_as_is;
+        #[attr_as_is]
+        fn main() {} // - Run 'Run test-package'
     """)
 
     private fun doTest(filePath: String, @Language("Rust") text: String) {

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -7,12 +7,11 @@ package org.rust.ide.lineMarkers
 
 import com.intellij.psi.PsiFileFactory
 import org.intellij.lang.annotations.Language
-import org.rust.MockAdditionalCfgOptions
-import org.rust.ProjectDescriptor
-import org.rust.WithDependencyRustProjectDescriptor
+import org.rust.*
 import org.rust.cargo.icons.CargoIcons
-import org.rust.fileTree
+import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.RsFileType
+import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsMod
@@ -146,6 +145,16 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         fn has_icon() { assert(true) } // - Test has_icon
         #[cfg_attr(not(intellij_rust), test)]
         fn no_icon() { assert(true) }
+    """)
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test test function under a proc macro attribute`() = doTestByText("""
+        use test_proc_macros::attr_as_is;
+        #[attr_as_is]
+        #[test]
+        fn has_icon() { assert(true) } // - Test has_icon
     """)
 
     fun `test function doctest`() = doTestByText("""

--- a/src/test/kotlin/org/rust/ide/lineMarkers/LineMarkerTestHelper.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/LineMarkerTestHelper.kt
@@ -17,6 +17,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import org.rust.lang.core.macros.macroExpansionManagerIfCreated
 import java.awt.event.MouseEvent
 import javax.swing.JLabel
 
@@ -33,6 +34,7 @@ class LineMarkerTestHelper(private val fixture: CodeInsightTestFixture) {
     }
 
     private fun doTest() {
+        fixture.project.macroExpansionManagerIfCreated?.updateInUnitTestMode()
         fixture.doHighlighting()
         val expected = markersFrom(fixture.editor.document.text)
         val actual = markersFrom(fixture.editor, fixture.project)

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
@@ -8,6 +8,12 @@ package org.rust.ide.lineMarkers
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithExperimentalFeatures
+import org.rust.WithProcMacroRustProjectDescriptor
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
 
@@ -70,6 +76,18 @@ class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         "Bar for FooBar",
         "Foo for FooBar"
     )
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test struct an trait under a proc macro attribute`() = doTestByText("""
+        use test_proc_macros::attr_as_is;
+        #[attr_as_is]
+        trait Foo {}  // - Has implementations
+        #[attr_as_is]
+        struct Bar {} // - Has implementations
+        impl Foo for Bar {}
+    """)
 
     private fun doPopupTest(@Language("Rust") code: String, vararg expectedItems: String) {
         InlineFile(code)

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProviderTest.kt
@@ -5,6 +5,13 @@
 
 package org.rust.ide.lineMarkers
 
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithExperimentalFeatures
+import org.rust.WithProcMacroRustProjectDescriptor
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.macros.MacroExpansionScope
+
 /**
  * Tests for Rust Recursive Call Line Marker Provider
  */
@@ -58,4 +65,18 @@ class RsRecursiveCallLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
             increment(increment(1))     // - Recursive call
         }
     """)
+
+    // TODO support attribute macros in `RsRecursiveCallLineMarkerProvider`
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test function under a proc macro attribute`() = expect<Throwable> {
+    doTestByText("""
+        use test_proc_macros::attr_as_is;
+        #[attr_as_is]
+        fn foo() {
+            foo();      // - Recursive call
+        }
+    """)
+    }
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt
@@ -5,6 +5,13 @@
 
 package org.rust.ide.lineMarkers
 
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithExperimentalFeatures
+import org.rust.WithProcMacroRustProjectDescriptor
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.macros.MacroExpansionScope
+
 /**
  * Tests for Trait member (const, fn, type) Implementation Line Marker
  */
@@ -21,6 +28,36 @@ class RsTraitItemImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
             const C2: u32 = 1;  // - Has implementations
         }
         struct Bar {} // - Has implementations
+        impl Foo for Bar {
+            fn foo(&self) { // - Implements method in `Foo`
+            }
+            fn bar(&self) { // - Overrides method in `Foo`
+            }
+            type T1 = (); // - Implements type in `Foo`
+            type T2 = (); // - Overrides type in `Foo`
+            const C1: u32 = 1; // - Implements constant in `Foo`
+            const C2: u32 = 1; // - Overrides constant in `Foo`
+        }
+    """)
+
+    @ExpandMacros(MacroExpansionScope.WORKSPACE)
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+    fun `test trait and impl under a proc macro attribute`() = doTestByText("""
+        use test_proc_macros::attr_as_is;
+        #[attr_as_is]
+        trait Foo {         // - Has implementations
+            fn foo(&self);  // - Has implementations
+            fn bar(&self) { // - Has implementations
+                self.foo();
+            }
+            type T1;        // - Has implementations
+            type T2 = ();   // - Has implementations
+            const C1: u32;  // - Has implementations
+            const C2: u32 = 1;  // - Has implementations
+        }
+        struct Bar {} // - Has implementations
+        #[attr_as_is]
         impl Foo for Bar {
             fn foo(&self) { // - Implements method in `Foo`
             }


### PR DESCRIPTION
Interesting that most of line markers providers work with attribute macros because they just ignore the existence of a proc macro attribute (as well as `cfg` attributes)