### PR TITLE
Fix a UI freeze caused by navbar

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
@@ -17,9 +17,11 @@ import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTypeParameter
 import org.rust.openapiext.filterQuery
 import org.rust.openapiext.mapQuery
+import javax.swing.Icon
 
 interface RsAbstractable : RsNameIdentifierOwner, RsExpandedElement, RsVisible, RsDocAndAttributeOwner {
     val isAbstract: Boolean
+    fun getIcon(flags: Int, allowNameResolution: Boolean): Icon
 }
 
 sealed class RsAbstractableOwner {
@@ -34,8 +36,9 @@ sealed class RsAbstractableOwner {
 }
 
 val RsAbstractable.owner: RsAbstractableOwner get() = getOwner(PsiElement::getContext)
+val RsAbstractable.ownerBySyntaxOnly: RsAbstractableOwner get() = getOwner(PsiElement::stubParent)
 
-inline fun RsAbstractable.getOwner(getAncestor: PsiElement.() -> PsiElement?): RsAbstractableOwner {
+private inline fun RsAbstractable.getOwner(getAncestor: PsiElement.() -> PsiElement?): RsAbstractableOwner {
     return when (val ancestor = getAncestor()) {
         is RsForeignModItem -> RsAbstractableOwner.Foreign
         is RsMembers -> {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -47,10 +47,12 @@ abstract class RsConstantImplMixin : RsStubbedNamedElementImpl<RsConstantStub>, 
 
     constructor(stub: RsConstantStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getIcon(flags: Int): Icon {
+    override fun getIcon(flags: Int): Icon = getIcon(flags, allowNameResolution = true)
+
+    override fun getIcon(flags: Int, allowNameResolution: Boolean): Icon {
         val baseIcon = when (kind) {
             RsConstantKind.CONST -> {
-                val owner = owner
+                val owner = if (allowNameResolution) owner else ownerBySyntaxOnly
                 val icon = when (owner) {
                     is RsAbstractableOwner.Trait -> if (isAbstract) RsIcons.ABSTRACT_ASSOC_CONSTANT else RsIcons.ASSOC_CONSTANT
                     is RsAbstractableOwner.Impl -> RsIcons.ASSOC_CONSTANT

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -306,9 +306,11 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 
-    override fun getIcon(flags: Int): Icon {
+    override fun getIcon(flags: Int): Icon = getIcon(flags, allowNameResolution = true)
+
+    override fun getIcon(flags: Int, allowNameResolution: Boolean): Icon {
         var hasVisibility = true
-        val baseIcon = when (val owner = owner) {
+        val baseIcon = when (val owner = if (allowNameResolution) owner else ownerBySyntaxOnly) {
             is RsAbstractableOwner.Free, is RsAbstractableOwner.Foreign ->
                 when {
                     isTest -> RsIcons.FUNCTION.addTestMark()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -32,8 +32,10 @@ abstract class RsTypeAliasImplMixin : RsStubbedNamedElementImpl<RsTypeAliasStub>
 
     constructor(stub: RsTypeAliasStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getIcon(flags: Int): Icon? {
-        val owner = owner
+    override fun getIcon(flags: Int): Icon = getIcon(flags, allowNameResolution = true)
+
+    override fun getIcon(flags: Int, allowNameResolution: Boolean): Icon {
+        val owner = if (allowNameResolution) owner else ownerBySyntaxOnly
         val baseIcon = when (owner) {
             RsAbstractableOwner.Free, RsAbstractableOwner.Foreign -> RsIcons.TYPE_ALIAS
             is RsAbstractableOwner.Trait -> if (isAbstract) RsIcons.ABSTRACT_ASSOC_TYPE_ALIAS else RsIcons.ASSOC_TYPE_ALIAS

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
@@ -5,11 +5,9 @@
 
 package org.rust.lang.core.stubs
 
-import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IndexSink
 import org.rust.lang.core.psi.ext.RsAbstractableOwner
-import org.rust.lang.core.psi.ext.getOwner
-import org.rust.lang.core.psi.ext.stubParent
+import org.rust.lang.core.psi.ext.ownerBySyntaxOnly
 import org.rust.lang.core.resolve.indexes.RsImplIndex
 import org.rust.lang.core.resolve.indexes.RsLangItemIndex
 import org.rust.lang.core.resolve.indexes.RsMacroIndex
@@ -70,7 +68,7 @@ fun IndexSink.indexConstant(stub: RsConstantStub) {
 
 fun IndexSink.indexTypeAlias(stub: RsTypeAliasStub) {
     indexNamedStub(stub)
-    if (stub.psi.getOwner(PsiElement::stubParent) !is RsAbstractableOwner.Impl) {
+    if (stub.psi.ownerBySyntaxOnly !is RsAbstractableOwner.Impl) {
         indexGotoClass(stub)
         RsTypeAliasIndex.index(stub, this)
     }


### PR DESCRIPTION
Fixes #10011

The bug was initially introduced by #6581. It seems like a default navbar implementation retrieves an icon for a PSI element from EDT without a cancellable progress indicator. At the same time, `getIcon()` implementations of PSI element that can be trait/impl members (function, constant, type alias) access a `DefMap` of their crate in order to handle a specific case where an item is inside a file included to a trait/impl body via include macro (and hence such item should have icon marks about being trait/impl members). Accessing `DefMap` without a cancellable progress may lead to a UI freeze for the duration of `DefMap` building.

I decided to ignore this specific case and don't use such icons marker in the navbar in the case of a included file. This fixes the freeze.

changelog: Fix a UI freeze caused by navbar
