### PR TITLE
Revert "UI: add marker to icons of unsafe items"

### DIFF
--- a/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
@@ -39,7 +39,6 @@ object RsIcons {
 
     val FINAL_MARK = AllIcons.Nodes.FinalMark
     val STATIC_MARK = AllIcons.Nodes.StaticMark
-    val UNSAFE_MARK = load("/icons/unsafeMark.svg")
     val TEST_MARK = AllIcons.Nodes.JunitTestMark
     val DOCS_MARK = load("/icons/docsrs.svg")
     val FEATURE_CHECKED_MARK = AllIcons.Diff.GutterCheckBoxSelected
@@ -64,9 +63,8 @@ object RsIcons {
     val MACRO2 = load("/icons/nodes/macro2.0.svg")
 
     val CONSTANT = load("/icons/nodes/constant.svg")
-    private val STATIC_BASE = load("/icons/nodes/static.svg")
-    val STATIC = STATIC_BASE.addFinalMark()
-    val MUT_STATIC = STATIC_BASE.addUnsafeMark()
+    val MUT_STATIC = load("/icons/nodes/static.svg")
+    val STATIC = MUT_STATIC.addFinalMark()
 
     val METHOD = load("/icons/nodes/method.svg")
     val ASSOC_FUNCTION = FUNCTION.addStaticMark()
@@ -118,8 +116,6 @@ object RsIcons {
 fun Icon.addFinalMark(): Icon = LayeredIcon(this, RsIcons.FINAL_MARK)
 
 fun Icon.addStaticMark(): Icon = LayeredIcon(this, RsIcons.STATIC_MARK)
-
-fun Icon.addUnsafeMark(): Icon = LayeredIcon(this, RsIcons.UNSAFE_MARK)
 
 fun Icon.addTestMark(): Icon = LayeredIcon(this, RsIcons.TEST_MARK)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -14,7 +14,6 @@ import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.CachedValueImpl
 import org.rust.ide.icons.RsIcons
-import org.rust.ide.icons.addUnsafeMark
 import org.rust.ide.presentation.getPresentation
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsElementTypes.DEFAULT
@@ -52,7 +51,7 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
     constructor(node: ASTNode) : super(node)
     constructor(stub: RsImplItemStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getIcon(flags: Int) = if (isUnsafe) RsIcons.IMPL.addUnsafeMark() else RsIcons.IMPL
+    override fun getIcon(flags: Int) = RsIcons.IMPL
 
     override val isPublic: Boolean get() = false // pub does not affect impls at all
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -12,7 +12,6 @@ import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.util.Query
 import org.rust.ide.icons.RsIcons
-import org.rust.ide.icons.addUnsafeMark
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.KNOWN_DERIVABLE_TRAITS
@@ -125,10 +124,8 @@ abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>
 
     constructor(stub: RsTraitItemStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getIcon(flags: Int): Icon {
-        val icon = if (isUnsafe) RsIcons.TRAIT.addUnsafeMark() else RsIcons.TRAIT
-        return iconWithVisibility(flags, icon)
-    }
+    override fun getIcon(flags: Int): Icon =
+        iconWithVisibility(flags, RsIcons.TRAIT)
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 

--- a/src/main/resources/icons/unsafeMark.svg
+++ b/src/main/resources/icons/unsafeMark.svg
@@ -1,7 +1,0 @@
-<!-- Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <g fill="none" fill-rule="evenodd">
-    <polygon fill="#F4AF3D" stroke = "black" stroke-width="0.4px" points="11.5 8.5 16 16 7 16"/>
-    <path fill="#000" d="M12,14 L12,15 L11,15 L11,14 L12,14 Z M12,10.5 L12,13 L11,13 L11,10.5 L12,10.5 Z"/>
-  </g>
-</svg>


### PR DESCRIPTION
Reverts #9802.

#9802 was accidentally merged without a proper discussion with the rest of the IntelliJ Rust team. @afetisov, we're sorry for that.

After the discussion we came to the conclusion that we have complaints about this design and decided to revert the PR.

1. The icon looks similar to a well-known warning sign, which can make users think something is wrong somewhere.
2. The new UI does not use icon marks at all, so we will likely drop all the marks in the new UI in the future.


But note that I think highlighting unsafe items is very important at least in the completion list, so we just need to come up with a better UI solution. This can be not only playing with icons, but also playing with text style and in general with `LookupElementPresentation`. I'll try to ask JetBrains' UX team to suggest some ideas.