### PR TITLE
MACRO: highlight errors in attribute macros

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
@@ -13,7 +13,7 @@ import org.rust.lang.core.psi.kind
 import kotlin.math.*
 
 class RsApproxConstantInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
         override fun visitLitExpr(o: RsLitExpr) {
             val literal = o.kind
             if (literal is RsLiteralKind.Float) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
@@ -19,9 +19,9 @@ import org.rust.lang.core.types.type
 import org.rust.openapiext.Testmark
 
 class RsAssertEqualInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
 
-        override fun visitMacroCall(o: RsMacroCall) {
+        override fun visitMacroCall2(o: RsMacroCall) {
             if (o.macroName != "assert") return
             val assertMacroArg = o.assertMacroArgument ?: return
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
@@ -21,7 +21,7 @@ import org.rust.lang.utils.addToHolder
 class RsAssignToImmutableInspection : RsLocalInspectionTool() {
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 if (expr.isAssignBinaryExpr) checkAssignment(expr, holder)
             }

--- a/src/main/kotlin/org/rust/ide/inspections/RsAttrWithoutParenthesesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAttrWithoutParenthesesInspection.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.inspections
 
 import org.rust.lang.core.psi.RsMetaItem
-import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.isRootMetaItem
 import org.rust.lang.core.psi.ext.name
 import org.rust.lang.utils.RsDiagnostic
@@ -14,7 +13,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsAttrWithoutParenthesesInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
         override fun visitMetaItem(metaItem: RsMetaItem) {
             if (!metaItem.isRootMetaItem()) return
             val name = metaItem.name ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspection.kt
@@ -19,7 +19,7 @@ import org.rust.lang.core.types.type
 class RsBorrowCheckerInspection : RsLocalInspectionTool() {
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitMethodCall(o: RsMethodCall) {
                 val fn = o.reference.resolve() as? RsFunction ?: return
                 val receiver = o.receiver
@@ -36,7 +36,8 @@ class RsBorrowCheckerInspection : RsLocalInspectionTool() {
                 }
             }
 
-            override fun visitFunction(func: RsFunction) {
+            @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+            override fun visitFunction2(func: RsFunction) {
                 val borrowCheckResult = func.borrowCheckResult ?: return
 
                 // TODO: Remove this check when type inference is implemented for `asm!` macro calls

--- a/src/main/kotlin/org/rust/ide/inspections/RsCStringPointerInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsCStringPointerInspection.kt
@@ -12,7 +12,7 @@ class RsCStringPointerInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Unsafe CString pointer"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitMethodCall(asPtrCall: RsMethodCall) {
                 if (asPtrCall.referenceName != "as_ptr") return
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsCastToBoolInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsCastToBoolInspection.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.inspections
 
 import org.rust.lang.core.psi.RsCastExpr
-import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.types.normType
 import org.rust.lang.core.types.ty.TyBool
 import org.rust.lang.core.types.ty.TyPrimitive
@@ -17,7 +16,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsCastToBoolInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
         override fun visitCastExpr(castExpr: RsCastExpr) {
             // It is allowed to cast a bool to a bool, so if the expression's type is of bool, ignore this cast.
             // Casts from non-primitive types (and the unit type) emit another error, so we ignore those as well.

--- a/src/main/kotlin/org/rust/ide/inspections/RsConstReferStaticInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsConstReferStaticInspection.kt
@@ -5,7 +5,10 @@
 
 package org.rust.ide.inspections
 
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsConstant
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsPathExpr
+import org.rust.lang.core.psi.RsPathType
 import org.rust.lang.core.psi.ext.RsConstContextKind
 import org.rust.lang.core.psi.ext.classifyConstContext
 import org.rust.lang.core.psi.ext.isConst
@@ -16,7 +19,7 @@ import org.rust.lang.utils.addToHolder
  * Inspection that detects the E0013 error.
  */
 class RsConstReferStaticInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
         override fun visitPathExpr(pathExpr: RsPathExpr) {
             val constContext = pathExpr.classifyConstContext
             if (constContext != null) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsConstantConditionIfInspection.kt
@@ -19,7 +19,7 @@ import org.rust.lang.utils.evaluation.evaluate
 /** See also [RsRedundantElseInspection]. */
 class RsConstantConditionIfInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitIfExpr(ifExpr: RsIfExpr) {
                 val condition = ifExpr.condition ?: return
                 if (condition.expr?.descendantOfTypeOrSelf<RsLetExpr>() != null) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
@@ -27,7 +27,7 @@ class RsDanglingElseInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Dangling else"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitElseBranch(expr: RsElseBranch) {
                 val elseEl = expr.`else`
                 val breakEl = elseEl.rightSiblings

--- a/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
@@ -11,9 +11,9 @@ import org.rust.lang.core.types.selfInferenceResult
 import org.rust.lang.utils.addToHolder
 
 abstract class RsDiagnosticBasedInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
-        override fun visitFunction(o: RsFunction) = collectDiagnostics(holder, o)
-        override fun visitConstant(o: RsConstant) = collectDiagnostics(holder, o)
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
+        override fun visitFunction2(o: RsFunction) = collectDiagnostics(holder, o)
+        override fun visitConstant2(o: RsConstant) = collectDiagnostics(holder, o)
         override fun visitConstParameter(o: RsConstParameter) = collectDiagnostics(holder, o)
         override fun visitArrayType(o: RsArrayType) = collectDiagnostics(holder, o)
         override fun visitPath(o: RsPath) = collectDiagnostics(holder, o)

--- a/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt
@@ -19,7 +19,7 @@ class RsDoubleNegInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Double negation"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitUnaryExpr(expr: RsUnaryExpr) {
                 if (expr.isNegation && expr.expr.isNegation) {
                     holder.registerProblem(expr, "--x could be misinterpreted as a pre-decrement, but effectively is a no-op")

--- a/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt
@@ -22,7 +22,7 @@ class RsDropRefInspection : RsLocalInspectionTool() {
     override fun getDisplayName(): String = "Drop reference"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitCallExpr(expr: RsCallExpr) = inspectExpr(expr, holder)
         }
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsDuplicatedTraitMethodBindingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDuplicatedTraitMethodBindingInspection.kt
@@ -16,8 +16,9 @@ class RsDuplicatedTraitMethodBindingInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Duplicated trait method parameter binding"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitFunction(function: RsFunction) {
+        object : RsWithMacrosInspectionVisitor() {
+            @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+            override fun visitFunction2(function: RsFunction) {
                 if (function.owner !is RsAbstractableOwner.Trait) return
                 if (!function.isAbstract) return
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
@@ -26,8 +26,8 @@ class RsExtraSemicolonInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Extra semicolon"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitFunction(o: RsFunction) = inspect(holder, o)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitFunction2(o: RsFunction) = inspect(holder, o)
         }
 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
@@ -15,7 +15,7 @@ import org.rust.lang.core.psi.RsVisitor
 
 
 class RsFieldInitShorthandInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
         override fun visitStructLiteralField(o: RsStructLiteralField) {
             val init = o.expr ?: return
             if (!(init is RsPathExpr && init.text == o.identifier?.text)) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsLiftInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLiftInspection.kt
@@ -19,7 +19,7 @@ import org.rust.openapiext.Testmark
 class RsLiftInspection : RsLocalInspectionTool() {
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor {
-        return object : RsVisitor() {
+        return object : RsWithMacrosInspectionVisitor() {
             override fun visitIfExpr(o: RsIfExpr) {
                 if (o.parent is RsElseBranch) return
                 checkExpr(o, o.`if`)

--- a/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
@@ -25,7 +25,7 @@ class RsMissingElseInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Missing else"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitExprStmt(expr: RsExprStmt) {
                 val firstIf = expr.extractIf() ?: return
                 val nextIf = expr.rightSiblings

--- a/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
@@ -17,7 +17,7 @@ import org.rust.lang.utils.addToHolder
 class RsReassignImmutableInspection : RsLocalInspectionTool() {
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 val left = expr.left.takeIf { it.isImmutable } ?: return
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
@@ -23,7 +23,7 @@ class RsRedundantElseInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Redundant else"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
 
             override fun visitElseBranch(expr: RsElseBranch) {
                 if (expr.isRedundant) registerProblem(expr, expr.`else`.textRangeInParent)

--- a/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt
@@ -17,7 +17,7 @@ import org.rust.lang.core.psi.RsVisitor
 class RsSimplifyBooleanExpressionInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Simplify boolean expression"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
 
         override fun visitExpr(expr: RsExpr) {
             if (expr.isPure() == true && BooleanExprSimplifier.canBeSimplified(expr)) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt
@@ -22,9 +22,9 @@ class RsSimplifyPrintInspection : RsLocalInspectionTool() {
     @Suppress("DialogTitleCapitalization")
     override fun getDisplayName(): String = "println!(\"\") usage"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
 
-        override fun visitMacroCall(o: RsMacroCall) {
+        override fun visitMacroCall2(o: RsMacroCall) {
             val macroName = o.macroName
             val formatMacroArg = o.formatMacroArgument ?: return
             if (!(macroName.endsWith("println"))) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -16,8 +16,9 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.Testmark
 
 class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
-        override fun visitImplItem(impl: RsImplItem) {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
+        @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+        override fun visitImplItem2(impl: RsImplItem) {
             val trait = impl.traitRef?.resolveToTrait() ?: return
             val typeRef = impl.typeReference ?: return
             if (sortedImplItems(impl.explicitMembers, trait.explicitMembers) == null) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
@@ -26,7 +26,7 @@ class RsSuspiciousAssignmentInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Suspicious assignment"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 if (expr.operator.text != "=") return
                 val unaryExpr = findUnaryExpr(expr.right)

--- a/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
@@ -14,8 +14,9 @@ import org.rust.lang.utils.addToHolder
 
 class RsTraitImplementationInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
-        override fun visitImplItem(impl: RsImplItem) {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
+        @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+        override fun visitImplItem2(impl: RsImplItem) {
             val traitRef = impl.traitRef ?: return
             val trait = traitRef.resolveToTrait() ?: return
             val traitName = trait.name ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt
@@ -25,8 +25,8 @@ class RsTryMacroInspection : RsLocalInspectionTool() {
     @Suppress("DialogTitleCapitalization")
     override fun getDisplayName(): String = "try! macro usage"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
-        override fun visitMacroCall(o: RsMacroCall) {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
+        override fun visitMacroCall2(o: RsMacroCall) {
             val isApplicable = o.isExprOrStmtContext && o.isStdTryMacro
             if (!isApplicable) return
             holder.registerProblem(

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -26,7 +26,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Unresolved reference"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
 
             override fun visitPath(path: RsPath) {
                 val (isPathUnresolved, context) = processPath(path) ?: return
@@ -44,7 +44,8 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
                 }
             }
 
-            override fun visitExternCrateItem(externCrate: RsExternCrateItem) {
+            @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+            override fun visitExternCrateItem2(externCrate: RsExternCrateItem) {
                 if (externCrate.reference.multiResolve().isEmpty() &&
                     externCrate.containingCrate.origin == PackageOrigin.WORKSPACE) {
                     RsDiagnostic.CrateNotFoundError(externCrate.referenceNameElement, externCrate.referenceName)

--- a/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
@@ -19,7 +19,7 @@ class RsVariableMutableInspection : RsLocalInspectionTool() {
     override fun getDisplayName(): String = "No mutable required"
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitPatBinding(o: RsPatBinding) {
                 if (!o.mutability.isMut) return
                 val block = o.ancestorStrict<RsBlock>() ?: o.ancestorStrict<RsFunction>() ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsWithMacrosInspectionVisitor.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWithMacrosInspectionVisitor.kt
@@ -1,0 +1,175 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.rust.lang.core.macros.prepareForExpansionHighlighting
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsAttrProcMacroOwner
+import org.rust.stdext.removeLast
+
+/**
+ * This is a non-recursive element visitor, but if it faces a macro invocation, it accepts all elements
+ * expanded from the macro. This visitor is intended to be used in [RsLocalInspectionTool] implementations.
+ */
+abstract class RsWithMacrosInspectionVisitor : RsVisitor() {
+    private var processingMacros: Boolean = false
+
+    final override fun visitConstant(o: RsConstant) {
+        visitConstant2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitConstant2(o: RsConstant) {
+        super.visitConstant(o)
+    }
+
+    final override fun visitEnumItem(o: RsEnumItem) {
+        visitEnumItem2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitEnumItem2(o: RsEnumItem) {
+        super.visitEnumItem(o)
+    }
+
+    final override fun visitExternCrateItem(o: RsExternCrateItem) {
+        visitExternCrateItem2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitExternCrateItem2(o: RsExternCrateItem) {
+        super.visitExternCrateItem(o)
+    }
+
+    final override fun visitForeignModItem(o: RsForeignModItem) {
+        visitForeignModItem2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitForeignModItem2(o: RsForeignModItem) {
+        super.visitForeignModItem(o)
+    }
+
+    final override fun visitFunction(o: RsFunction) {
+        visitFunction2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitFunction2(o: RsFunction) {
+        super.visitFunction(o)
+    }
+
+    final override fun visitImplItem(o: RsImplItem) {
+        visitImplItem2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitImplItem2(o: RsImplItem) {
+        super.visitImplItem(o)
+    }
+
+    final override fun visitMacro(o: RsMacro) {
+        visitMacro2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitMacro2(o: RsMacro) {
+        super.visitMacro(o)
+    }
+
+    final override fun visitMacro2(o: RsMacro2) {
+        visitMacro22(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitMacro22(o: RsMacro2) {
+        super.visitMacro2(o)
+    }
+
+    final override fun visitMacroCall(o: RsMacroCall) {
+        visitMacroCall2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitMacroCall2(o: RsMacroCall) {
+        super.visitMacroCall(o)
+    }
+
+    final override fun visitModItem(o: RsModItem) {
+        visitModItem2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitModItem2(o: RsModItem) {
+        super.visitModItem(o)
+    }
+
+    final override fun visitStructItem(o: RsStructItem) {
+        visitStructItem2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitStructItem2(o: RsStructItem) {
+        super.visitStructItem(o)
+    }
+
+    final override fun visitTraitAlias(o: RsTraitAlias) {
+        visitTraitAlias2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitTraitAlias2(o: RsTraitAlias) {
+        super.visitTraitAlias(o)
+    }
+
+    final override fun visitTraitItem(o: RsTraitItem) {
+        visitTraitItem2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitTraitItem2(o: RsTraitItem) {
+        super.visitTraitItem(o)
+    }
+
+    final override fun visitTypeAlias(o: RsTypeAlias) {
+        visitTypeAlias2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitTypeAlias2(o: RsTypeAlias) {
+        super.visitTypeAlias(o)
+    }
+
+    final override fun visitUseItem(o: RsUseItem) {
+        visitUseItem2(o)
+        visitMacroExpansion(o)
+    }
+
+    open fun visitUseItem2(o: RsUseItem) {
+        super.visitUseItem(o)
+    }
+
+    private fun visitMacroExpansion(item: RsAttrProcMacroOwner) {
+        if (processingMacros) return
+
+        val preparedMacro = item.procMacroAttribute.attr?.prepareForExpansionHighlighting() ?: return
+        val macros = mutableListOf(preparedMacro)
+
+        processingMacros = true
+
+        while (macros.isNotEmpty()) {
+            val macro = macros.removeLast()
+            for (element in macro.elementsForHighlighting) {
+                element.accept(this)
+                if (element is RsAttrProcMacroOwner) {
+                    macros += element.procMacroAttribute.attr?.prepareForExpansionHighlighting(macro) ?: continue
+                }
+            }
+        }
+
+        processingMacros = false
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongAssocTypeArgumentsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongAssocTypeArgumentsInspection.kt
@@ -20,7 +20,7 @@ import org.rust.lang.utils.addToHolder
  */
 class RsWrongAssocTypeArgumentsInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitTraitRef(trait: RsTraitRef) {
                 checkAssocTypes(holder, trait, trait.path)
             }

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
@@ -19,7 +19,7 @@ import org.rust.openapiext.createSmartPointer
  */
 class RsWrongGenericArgumentsNumberInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitMethodCall(methodCall: RsMethodCall) = checkTypeArguments(holder, methodCall)
             override fun visitPath(path: RsPath) {
                 if (!isPathValid(path)) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsOrderInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsOrderInspection.kt
@@ -16,7 +16,7 @@ import org.rust.lang.utils.addToHolder
  */
 class RsWrongGenericArgumentsOrderInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitMethodCall(methodCall: RsMethodCall) = checkGenericArguments(holder, methodCall)
             override fun visitPath(path: RsPath) {
                 if (!isPathValid(path)) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericParametersNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericParametersNumberInspection.kt
@@ -17,13 +17,15 @@ import org.rust.lang.utils.addToHolder
  * Inspection that detects the E0049 error.
  */
 class RsWrongGenericParametersNumberInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
-        override fun visitFunction(function: RsFunction) {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
+        @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+        override fun visitFunction2(function: RsFunction) {
             checkParameters(holder, function, "type") { typeParameters }
             checkParameters(holder, function, "const") { constParameters }
         }
 
-        override fun visitTypeAlias(alias: RsTypeAlias) {
+        @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+        override fun visitTypeAlias2(alias: RsTypeAlias) {
             checkParameters(holder, alias, "type") { typeParameters }
             checkParameters(holder, alias, "const") { constParameters }
         }

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt
@@ -18,7 +18,7 @@ import org.rust.lang.utils.addToHolder
 class RsWrongLifetimeParametersNumberInspection : RsLocalInspectionTool() {
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitPathType(type: RsPathType) {
                 val path = type.path
 
@@ -44,7 +44,8 @@ class RsWrongLifetimeParametersNumberInspection : RsLocalInspectionTool() {
                 }
             }
 
-            override fun visitFunction(fn: RsFunction) {
+            @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+            override fun visitFunction2(fn: RsFunction) {
                 // https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-elision
                 if (!fn.hasMissingLifetimes()) return
 

--- a/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsNonExhaustiveMatchInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsNonExhaustiveMatchInspection.kt
@@ -7,16 +7,16 @@ package org.rust.ide.inspections.checkMatch
 
 import org.rust.ide.inspections.RsLocalInspectionTool
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.utils.checkMatch.checkExhaustive
 import org.rust.lang.core.psi.RsMatchExpr
-import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
 
 class RsNonExhaustiveMatchInspection : RsLocalInspectionTool() {
     override fun getDisplayName(): String = "Non-exhaustive match"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
         override fun visitMatchExpr(matchExpr: RsMatchExpr) {
             val patterns = matchExpr.checkExhaustive() ?: return
             RsDiagnostic.NonExhaustiveMatch(matchExpr, patterns).addToHolder(holder)

--- a/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsUnreachablePatternsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsUnreachablePatternsInspection.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.inspections.fixes.SubstituteTextFix
 import org.rust.ide.inspections.lints.RsLint
 import org.rust.ide.inspections.lints.RsLintInspection
@@ -16,7 +17,6 @@ import org.rust.ide.utils.checkMatch.*
 import org.rust.lang.core.psi.RsElementTypes.OR
 import org.rust.lang.core.psi.RsMatchArm
 import org.rust.lang.core.psi.RsMatchExpr
-import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.infer.containsTyOfClass
 import org.rust.lang.core.types.ty.TyUnknown
@@ -27,7 +27,7 @@ class RsUnreachablePatternsInspection : RsLintInspection() {
 
     override fun getLint(element: PsiElement): RsLint = RsLint.UnreachablePattern
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
         override fun visitMatchExpr(matchExpr: RsMatchExpr) {
             val exprType = matchExpr.expr?.type ?: return
             if (exprType.containsTyOfClass(TyUnknown::class.java)) return

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
@@ -10,6 +10,7 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.dyn
 import org.rust.lang.core.psi.ext.isAtLeastEdition2018
@@ -20,7 +21,7 @@ class RsBareTraitObjectsInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.BareTraitObjects
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitTypeReference(typeReference: RsTypeReference) {
                 if (!typeReference.isAtLeastEdition2018) return
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
@@ -8,6 +8,7 @@ package org.rust.ide.inspections.lints
 import com.intellij.psi.PsiElement
 import io.github.z4kn4fein.semver.toVersionOrNull
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.RsElementTypes.CSELF
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMetaItem
@@ -20,7 +21,7 @@ class RsDeprecationInspection : RsLintInspection() {
 
     override fun getLint(element: PsiElement): RsLint = RsLint.Deprecated
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
         override fun visitElement(ref: RsElement) {
             // item is non-inline module declaration or not reference element
             if (ref is RsModDeclItem || ref !is RsReferenceElement) return

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDoubleMustUseInspection.kt
@@ -11,8 +11,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.rust.RsBundle
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.findFirstMetaItem
 import org.rust.lang.core.psi.ext.normReturnType
 import org.rust.lang.core.types.ty.TyAdt
@@ -29,10 +29,8 @@ private class FixRemoveMustUseAttr : LocalQuickFix {
 class RsDoubleMustUseInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.DoubleMustUse
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
-        override fun visitFunction(o: RsFunction) {
-            super.visitFunction(o)
-
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
+        override fun visitFunction2(o: RsFunction) {
             val mustUseAttrName = "must_use"
             val attrFunc = o.findFirstMetaItem(mustUseAttrName)
             val type = o.normReturnType as? TyAdt

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.psi.PsiElement
 import org.rust.ide.injected.isDoctestInjection
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.inspections.fixes.RemoveParameterFix
 import org.rust.ide.inspections.fixes.RemoveVariableFix
 import org.rust.ide.inspections.fixes.RenameFix
@@ -24,8 +25,9 @@ class RsLivenessInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.UnusedVariables
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitFunction(func: RsFunction) {
+        object : RsWithMacrosInspectionVisitor() {
+            @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+            override fun visitFunction2(func: RsFunction) {
                 // Disable inside doc tests
                 if (func.isDoctestInjection) return
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.inspections.fixes.RenameFix
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -175,7 +176,7 @@ fun String.toSnakeCase(upper: Boolean): String {
 
 class RsArgumentNamingInspection : RsSnakeCaseNamingInspection("Argument") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitPatBinding(el: RsPatBinding) {
                 if (el.parent?.parent is RsValueParameter) {
                     inspect(el.identifier, holder)
@@ -186,10 +187,10 @@ class RsArgumentNamingInspection : RsSnakeCaseNamingInspection("Argument") {
 
 class RsConstNamingInspection : RsUpperCaseNamingInspection("Constant") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitConstant(el: RsConstant) {
-                if (el.kind == RsConstantKind.CONST) {
-                    inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitConstant2(o: RsConstant) {
+                if (o.kind == RsConstantKind.CONST) {
+                    inspect(o.identifier, holder)
                 }
             }
         }
@@ -197,10 +198,10 @@ class RsConstNamingInspection : RsUpperCaseNamingInspection("Constant") {
 
 class RsStaticConstNamingInspection : RsUpperCaseNamingInspection("Static constant") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitConstant(el: RsConstant) {
-                if (el.kind != RsConstantKind.CONST && el.owner is RsAbstractableOwner.Free) {
-                    inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitConstant2(o: RsConstant) {
+                if (o.kind != RsConstantKind.CONST && o.owner is RsAbstractableOwner.Free) {
+                    inspect(o.identifier, holder)
                 }
             }
         }
@@ -208,24 +209,24 @@ class RsStaticConstNamingInspection : RsUpperCaseNamingInspection("Static consta
 
 class RsEnumNamingInspection : RsCamelCaseNamingInspection("Type", "Enum") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitEnumItem(el: RsEnumItem) = inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitEnumItem2(o: RsEnumItem) = inspect(o.identifier, holder)
         }
 }
 
 class RsEnumVariantNamingInspection : RsCamelCaseNamingInspection("Enum variant") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitEnumVariant(el: RsEnumVariant) = inspect(el.identifier, holder)
         }
 }
 
 class RsFunctionNamingInspection : RsSnakeCaseNamingInspection("Function") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitFunction(el: RsFunction) {
-                if (el.owner is RsAbstractableOwner.Free) {
-                    inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitFunction2(o: RsFunction) {
+                if (o.owner is RsAbstractableOwner.Free) {
+                    inspect(o.identifier, holder)
                 }
             }
         }
@@ -240,9 +241,9 @@ class RsFunctionNamingInspection : RsSnakeCaseNamingInspection("Function") {
 
 class RsMethodNamingInspection : RsSnakeCaseNamingInspection("Method") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitFunction(el: RsFunction) = when (el.owner) {
-                is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl -> inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitFunction2(o: RsFunction) = when (o.owner) {
+                is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl -> inspect(o.identifier, holder)
                 else -> Unit
             }
         }
@@ -250,53 +251,53 @@ class RsMethodNamingInspection : RsSnakeCaseNamingInspection("Method") {
 
 class RsLifetimeNamingInspection : RsSnakeCaseNamingInspection("Lifetime") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitLifetimeParameter(el: RsLifetimeParameter) = inspect(el.quoteIdentifier, holder)
         }
 }
 
 class RsMacroNamingInspection : RsSnakeCaseNamingInspection("Macro") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitMacro(el: RsMacro) = inspect(el.nameIdentifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitMacro2(o: RsMacro) = inspect(o.nameIdentifier, holder)
         }
 }
 
 class RsModuleNamingInspection : RsSnakeCaseNamingInspection("Module") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitModDeclItem(el: RsModDeclItem) = inspect(el.identifier, holder)
-            override fun visitModItem(el: RsModItem) = inspect(el.identifier, holder)
+            override fun visitModItem2(o: RsModItem) = inspect(o.identifier, holder)
         }
 }
 
 class RsStructNamingInspection : RsCamelCaseNamingInspection("Type", "Struct") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitStructItem(el: RsStructItem) = inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitStructItem2(o: RsStructItem) = inspect(o.identifier, holder)
         }
 }
 
 class RsFieldNamingInspection : RsSnakeCaseNamingInspection("Field") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitNamedFieldDecl(el: RsNamedFieldDecl) = inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitNamedFieldDecl(o: RsNamedFieldDecl) = inspect(o.identifier, holder)
         }
 }
 
 class RsTraitNamingInspection : RsCamelCaseNamingInspection("Trait") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitTraitItem(el: RsTraitItem) = inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitTraitItem2(o: RsTraitItem) = inspect(o.identifier, holder)
         }
 }
 
 class RsTypeAliasNamingInspection : RsCamelCaseNamingInspection("Type", "Type alias") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitTypeAlias(el: RsTypeAlias) {
-                if (el.owner is RsAbstractableOwner.Free) {
-                    inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitTypeAlias2(o: RsTypeAlias) {
+                if (o.owner is RsAbstractableOwner.Free) {
+                    inspect(o.identifier, holder)
                 }
             }
         }
@@ -304,10 +305,10 @@ class RsTypeAliasNamingInspection : RsCamelCaseNamingInspection("Type", "Type al
 
 class RsAssocTypeNamingInspection : RsCamelCaseNamingInspection("Type", "Associated type") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitTypeAlias(el: RsTypeAlias) {
-                if (el.owner is RsAbstractableOwner.Trait) {
-                    inspect(el.identifier, holder)
+        object : RsWithMacrosInspectionVisitor() {
+            override fun visitTypeAlias2(o: RsTypeAlias) {
+                if (o.owner is RsAbstractableOwner.Trait) {
+                    inspect(o.identifier, holder)
                 }
             }
         }
@@ -316,14 +317,14 @@ class RsAssocTypeNamingInspection : RsCamelCaseNamingInspection("Type", "Associa
 
 class RsTypeParameterNamingInspection : RsCamelCaseNamingInspection("Type parameter") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitTypeParameter(el: RsTypeParameter) = inspect(el.identifier, holder)
         }
 }
 
 class RsVariableNamingInspection : RsSnakeCaseNamingInspection("Variable") {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitPatBinding(el: RsPatBinding) {
                 if (el.isReferenceToConstant) return
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -8,6 +8,7 @@ package org.rust.ide.inspections.lints
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.inspections.fixes.ElideLifetimesFix
 import org.rust.ide.inspections.lints.ReferenceLifetime.*
 import org.rust.lang.core.psi.*
@@ -27,8 +28,9 @@ class RsNeedlessLifetimesInspection : RsLintInspection() {
 
     override fun getLint(element: PsiElement): RsLint = RsLint.NeedlessLifetimes
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
-        override fun visitFunction(fn: RsFunction) {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
+        @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+        override fun visitFunction2(fn: RsFunction) {
             if (couldUseElision(fn)) {
                 registerProblem(holder, fn)
             }
@@ -180,7 +182,7 @@ private class LifetimesCollector(val isForInputParams: Boolean = false) : RsRecu
     }
 }
 
-private class BodyLifetimeChecker : RsVisitor() {
+private class BodyLifetimeChecker : RsWithMacrosInspectionVisitor() {
     var lifetimesUsedInBody: Boolean = false
         private set
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspection.kt
@@ -10,6 +10,7 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.RsPatFieldFull
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsVisitor
@@ -17,7 +18,7 @@ import org.rust.lang.core.psi.RsVisitor
 class RsNonShorthandFieldPatternsInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.NonShorthandFieldPatterns
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
         override fun visitPatFieldFull(o: RsPatFieldFull) {
             val identifier = o.identifier?.text ?: return
             val binding = o.pat.text

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspection.kt
@@ -13,10 +13,10 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.RsBundle
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.RsBlock
 import org.rust.lang.core.psi.RsEmptyStmt
 import org.rust.lang.core.psi.RsStmt
-import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.endOffsetInParent
 
@@ -36,7 +36,7 @@ private class FixRedundantSemicolons(start: PsiElement, end: PsiElement = start)
 class RsRedundantSemicolonsInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.RedundantSemicolons
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
         override fun visitBlock(block: RsBlock) {
             super.visitBlock(block)
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspection.kt
@@ -7,6 +7,7 @@ package org.rust.ide.inspections.lints
 
 import com.intellij.psi.PsiElement
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.*
@@ -22,8 +23,9 @@ class RsSelfConventionInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.WrongSelfConvention
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
-            override fun visitFunction(m: RsFunction) {
+        object : RsWithMacrosInspectionVisitor() {
+            @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+            override fun visitFunction2(m: RsFunction) {
                 val traitOrImpl = when (val owner = m.owner) {
                     is RsAbstractableOwner.Trait -> owner.trait
                     is RsAbstractableOwner.Impl -> owner.impl.takeIf { owner.isInherent }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
@@ -8,6 +8,7 @@ package org.rust.ide.inspections.lints
 import com.intellij.psi.PsiElement
 import org.rust.ide.annotator.fixes.NameSuggestionFix
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.psi.RsLitExpr
 import org.rust.lang.core.psi.RsPsiFactory
@@ -18,7 +19,7 @@ class RsUnknownCrateTypesInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.UnknownCrateTypes
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
-        object : RsVisitor() {
+        object : RsWithMacrosInspectionVisitor() {
             override fun visitLitExpr(element: RsLitExpr) {
                 if (!RsPsiPattern.insideCrateTypeAttrValue.accepts(element)) return
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspection.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.parentOfType
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.inspections.fixes.SubstituteTextFix
 import org.rust.lang.core.parser.RustParserUtil
 import org.rust.lang.core.psi.*
@@ -18,7 +19,7 @@ import org.rust.lang.core.resolve.TYPES_N_VALUES_N_MACROS
 class RsUnnecessaryQualificationsInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.UnusedQualifications
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
         override fun visitPath(path: RsPath) {
             val shouldCheckPath = path.parentOfType<RsUseItem>() == null
                 && path.parentOfType<RsVisRestriction>() == null

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspection.kt
@@ -11,9 +11,9 @@ import com.intellij.psi.PsiElement
 import com.intellij.refactoring.suggested.stripWhitespace
 import org.rust.ide.injected.isDoctestInjection
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.inspections.fixes.SubstituteTextFix
 import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.rangeWithPrevSpace
 import org.rust.lang.core.psi.ext.startOffset
 import org.rust.lang.core.types.controlFlowGraph
@@ -26,8 +26,9 @@ class RsUnreachableCodeInspection : RsLintInspection() {
 
     override fun getLint(element: PsiElement): RsLint = RsLint.UnreachableCode
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
-        override fun visitFunction(func: RsFunction) {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
+        @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+        override fun visitFunction2(func: RsFunction) {
             if (func.isDoctestInjection) return
             val controlFlowGraph = func.controlFlowGraph ?: return
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -17,6 +17,7 @@ import com.intellij.psi.search.SearchScope
 import com.intellij.psi.search.UsageSearchContext
 import org.rust.ide.injected.isDoctestInjection
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.inspections.fixes.RemoveImportFix
 import org.rust.lang.core.crate.asNotFake
 import org.rust.lang.core.crate.impl.DoctestCrate
@@ -37,8 +38,9 @@ class RsUnusedImportInspection : RsLintInspection() {
 
     override fun getShortName(): String = SHORT_NAME
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
-        override fun visitUseItem(item: RsUseItem) {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
+        @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+        override fun visitUseItem2(item: RsUseItem) {
             if (!isApplicableForUseItem(item)) return
 
             // It's common to include more imports than needed in doctest sample code

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
@@ -16,6 +16,7 @@ import com.intellij.psi.PsiFile
 import org.rust.RsBundle
 import org.rust.ide.annotator.getFunctionCallContext
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.utils.template.newTemplateBuilder
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.expandedStmtsAndTailExpr
@@ -99,7 +100,7 @@ private fun inspectAndProposeFixes(expr: RsExpr): InspectionResult? {
 class RsUnusedMustUseInspection : RsLintInspection() {
     override fun getLint(element: PsiElement) = RsLint.UnusedMustUse
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
         override fun visitExprStmt(o: RsExprStmt) {
             super.visitExprStmt(o)
             val parent = o.parent

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.utils.skipParenExprDown
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.endOffsetInParent
@@ -22,7 +23,7 @@ class RsWhileTrueLoopInspection : RsLintInspection() {
     override fun getDisplayName(): String = "While true loop"
     override fun getLint(element: PsiElement): RsLint = RsLint.WhileTrue
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
         override fun visitWhileExpr(o: RsWhileExpr) {
             val condition = o.condition ?: return
             val expr = condition.skipParenExprDown() as? RsLitExpr ?: return

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroHighlightingUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroHighlightingUtil.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.codeInsight.daemon.impl.CollectHighlightsUtil
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.ext.RsPossibleMacroCall
+import org.rust.lang.core.psi.ext.existsAfterExpansion
+import org.rust.lang.core.psi.ext.expansion
+
+fun RsPossibleMacroCall.prepareForExpansionHighlighting(
+    ancestorMacro: MacroCallPreparedForHighlighting? = null
+): MacroCallPreparedForHighlighting? {
+    if (this is RsMacroCall && macroArgument == null) return null // special macros should not be highlighted
+    if (!existsAfterExpansion) return null
+    val expansion = expansion ?: return null
+    val isDeeplyAttrMacro = (ancestorMacro == null || ancestorMacro.isDeeplyAttrMacro) && this is RsMetaItem
+    return MacroCallPreparedForHighlighting(this, expansion, isDeeplyAttrMacro)
+}
+
+data class MacroCallPreparedForHighlighting(
+    val macroCall: RsPossibleMacroCall,
+    val expansion: MacroExpansion,
+    val isDeeplyAttrMacro: Boolean,
+) {
+    val elementsForHighlighting: List<PsiElement>
+        get() {
+            if (expansion.ranges.isEmpty()) return emptyList()
+            // Don't try to restrict range by `getElementsInRange`: it does not return all ancestors
+            // even if `includeAllParents = true`
+            return CollectHighlightsUtil.getElementsInRange(expansion.file, 0, expansion.file.textLength)
+        }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1753,15 +1753,13 @@ fun RsDiagnostic.addToHolder(holder: AnnotationHolder) {
 
 fun RsDiagnostic.addToHolder(holder: RsProblemsHolder) {
     val prepared = prepare()
-    val descriptor = holder.manager.createProblemDescriptor(
+    holder.registerProblem(
         element,
         endElement ?: element,
         prepared.fullDescription,
         prepared.severity.toProblemHighlightType(),
-        holder.isOnTheFly,
         *prepared.fixes.toTypedArray()
     )
-    holder.registerProblem(descriptor)
 }
 
 private val PreparedAnnotation.fullDescription: String


### PR DESCRIPTION
Currently we don't highlight any errors in any macros using our analysis. Errors in macros can only be highlighted by an external linter (`Cargo check`/`Clippy`). 

This PR enables error highlighting in items with successfully expanded attribute macros. This includes `RsErrorAnnotator` and all inspections. Quick fixes for such errors doesn't supported for now.
An error is only highlighted if the annotation text range can be mapped to the macro call body.

The PR does not contain any tests. I'm going to support quick-fixes first (in a separate PR) and then make all our annotator/inspection tests to run again with a test snippet wrapped into an attribute macro.
I suppose many errors implemented incorrectly using `.parent`, instead of `.context`, so they will not work in macros in some cases, but I expect they will be fine with most of the attribute macros.

changelog: Provide error highlighting in attribute macros. Note that attribute macro expansion is not enabled by default.
