### PR TITLE
CI: add Slack notification about release branch

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -25,7 +25,7 @@ jobs:
 
             - name: Make release branch
               if: github.event_name != 'schedule' || fromJSON(steps.check-date.outputs.result).create_release_branch
-              run: python scripts/make_release_branch.py
+              run: python scripts/make_release_branch.py --slack_webhook ${{ secrets.SLACK_WEBHOOK_URL }} --slack_ids ${{ secrets.SLACK_USERNAMES}}
 
             - name: Create new milestone
               if: github.event_name != 'schedule' || fromJSON(steps.check-date.outputs.result).create_release_branch

--- a/scripts/make_next_milestone.py
+++ b/scripts/make_next_milestone.py
@@ -4,8 +4,7 @@ from datetime import datetime, timedelta
 
 from common import env, get_patch_version
 from github_connect import get_latest_milestones, create_milestone
-
-RELEASE_MANAGER_RE = re.compile("Release manager: @(\\w+)")
+from release_managers_common import release_managers, RELEASE_MANAGER_RE
 
 
 def main():
@@ -31,13 +30,6 @@ def main():
     if prev_milestone is not None and prev_milestone["due_on"] is not None:
         date = datetime.strptime(prev_milestone["due_on"], "%Y-%m-%dT%H:%M:%SZ") + timedelta(weeks=2)
         due_on = "%04d-%02d-%02dT%02d:%02d:%02dZ" % (date.year, date.month, date.day, date.hour, date.minute, date.second)
-
-    release_managers = [
-        "mchernyavsky",
-        "vlad20012",
-        "dima74",
-        "ozkriff"
-    ]
 
     for m in milestones:
         if len(release_managers) == 1:

--- a/scripts/make_release_branch.py
+++ b/scripts/make_release_branch.py
@@ -1,7 +1,58 @@
-from common import get_patch_version, inc_patch_version, GRADLE_PROPERTIES
+import argparse
+import json
+import re
+import traceback
+from datetime import datetime
+from urllib.request import urlopen
+
+import github_connect
+from common import get_patch_version, inc_patch_version, GRADLE_PROPERTIES, env
 from git import git_command
+from release_managers_common import RELEASE_MANAGER_RE
+
+
+def send_slack_message(slack_ids, version, webhook):
+    repository = env("GITHUB_REPOSITORY")
+    milestone = github_connect.get_current_milestone(repo=repository, patch_version=version)
+
+    release_version = milestone["title"]
+    release_manager = re.search(RELEASE_MANAGER_RE, milestone['description']).group(1)
+    link = milestone['html_url']
+    date = datetime.strptime(milestone["due_on"], "%Y-%m-%dT%H:%M:%SZ").date()
+    slack_user = slack_ids.get(release_manager)
+    if slack_user is None:
+        # Hack to pass correct user-id. Otherwise, Slack will not send the message.
+        slack_user = slack_ids.get("neonaot")
+
+    # Expected template on the Slack workflow side:
+    # Release branch for %release_version% is created
+    # %link%
+    # Release is planned for %date%
+    # Release manager is %slack_user%
+    message = {
+        "release_version": release_version,
+        "link": link,
+        "date": f'{date.day:02d}.{date.month:02d}.{date.year}',
+        "slack_user": slack_user
+    }
+    urlopen(webhook, data=json.dumps(message).encode())
+
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("--slack_webhook", type=str, required=True,
+                        help='Webhook is unique URL for the Slack workflow. After sending a request to it,'
+                             'the workflow will start doing its work.\n'
+                             'Looks like https://hooks.slack.com/workflows/{unique_part}, '
+                             'can be found on the workflow builder page.')
+
+    parser.add_argument("--slack_ids", type=str, required=True,
+                        help='slack_ids is a json looks like {"github-username1": "slack-ID1",  ... }.\n'
+                             'NOTE: slack ID for user can be found on their profile > ⋮ > Copy member ID.'
+                             'It is a set of random digits and letters, not @name.surname or any custom usernames.\n'
+                             'On slack workflow side it will be automatically treated as @username.')
+    args = parser.parse_args()
+
     patch_version = get_patch_version()
 
     release_branch = f"release-{patch_version}"
@@ -13,3 +64,8 @@ if __name__ == '__main__':
     git_command("add", GRADLE_PROPERTIES)
     git_command("commit", "-m", ":arrow_up: patch version")
     git_command("push", "origin", "master")
+
+    try:
+        send_slack_message(json.loads(args.slack_ids), patch_version, args.slack_webhook)
+    except Exception as e:
+        traceback.print_exc()

--- a/scripts/release_managers_common.py
+++ b/scripts/release_managers_common.py
@@ -1,0 +1,12 @@
+import re
+
+RELEASE_MANAGER_RE = re.compile("Release manager: @(\\w+)")
+
+# After editing maintainers list, don't forget to update `SLACK_USERNAMES` GitHub secret.
+# For more information see `make_release_branch.py` file.
+release_managers = [
+    "mchernyavsky",
+    "vlad20012",
+    "dima74",
+    "ozkriff"
+]


### PR DESCRIPTION
TODO:
Add secrets in this repo ✅ 
Set up workflow on the Slack side  (it sends in my private channel now) ✅ 

Possible TODO:
Check that the release branch exists. (In the current workflow, the message won't be sent if previous steps failed, but who knows...) 
Set up a notification if branch creation fails. 
other ideas?


Example: 
<img width="653" alt="image" src="https://user-images.githubusercontent.com/49211026/215114218-98421fe8-572d-4443-952f-b551627116bf.png">
