### PR TITLE
bug fix of render external linter and parameter info

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
@@ -281,7 +281,7 @@ private data class RsExternalLinterFilteredMessage(
     }
 }
 
-private fun String.escapeUrls(): String = replace(URL_REGEX) { url -> "<a href='${url.value}'>${url.value}</a>" }
+private fun String.escapeUrls(): String = this.replace("&gt;", ">").replace(URL_REGEX) { url -> "<a href='${url.value}'>${url.value}</a>" }
 
 fun RustcSpan.isValid(): Boolean =
     line_end > line_start || (line_end == line_start && column_end >= column_start)

--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsParameterInfoHandler.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsParameterInfoHandler.kt
@@ -9,6 +9,7 @@ import com.intellij.lang.parameterInfo.ParameterInfoUIContext
 import com.intellij.lang.parameterInfo.ParameterInfoUtils
 import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.ide.utils.CallInfo
 import org.rust.lang.core.psi.RsCallExpr
@@ -23,11 +24,10 @@ import org.rust.stdext.buildList
  * Provides functions/methods arguments hint.
  */
 class RsParameterInfoHandler : RsAsyncParameterInfoHandler<RsValueArgumentList, RsArgumentsDescription>() {
-    override fun findTargetElement(file: PsiFile, offset: Int): RsValueArgumentList? =
-        file.findElementAt(offset)?.ancestorStrict()
+    override fun findTargetElement(file: PsiFile, offset: Int): RsValueArgumentList? = file.findElementAt(offset)?.ancestorStrict()
 
     override fun calculateParameterInfo(element: RsValueArgumentList): Array<RsArgumentsDescription>? {
-        return RsArgumentsDescription.findDescription(element)?.let { arrayOf(it) }
+        return RsArgumentsDescription.findDescriptionList(element)?.toTypedArray()
     }
 
     override fun updateParameterInfo(parameterOwner: RsValueArgumentList, context: UpdateParameterInfoContext) {
@@ -52,7 +52,8 @@ class RsParameterInfoHandler : RsAsyncParameterInfoHandler<RsValueArgumentList, 
             !context.isUIComponentEnabled,
             false,
             false,
-            context.defaultParameterColor)
+            context.defaultParameterColor
+        )
     }
 }
 
@@ -71,17 +72,8 @@ class RsArgumentsDescription(
     val presentText = if (arguments.isEmpty()) "<no arguments>" else arguments.joinToString(", ")
 
     companion object {
-        /**
-         * Finds declaration of the func/method and creates description of its arguments
-         */
-        fun findDescription(args: RsValueArgumentList): RsArgumentsDescription? {
-            val call = args.parent
-            val callInfo = when (call) {
-                is RsCallExpr -> CallInfo.resolve(call)
-                is RsMethodCall -> CallInfo.resolve(call)
-                else -> null
-            } ?: return null
-            val params = buildList<String> {
+        private fun getParams(call: PsiElement, callInfo: CallInfo): RsArgumentsDescription {
+            val params = buildList {
                 if (callInfo.selfParameter != null && call is RsCallExpr) {
                     add(callInfo.selfParameter)
                 }
@@ -95,6 +87,19 @@ class RsArgumentsDescription(
                 })
             }
             return RsArgumentsDescription(params.toTypedArray())
+        }
+
+        /**
+         * Finds declarations of the func/method and creates description of its arguments
+         */
+        fun findDescriptionList(args: RsValueArgumentList): List<RsArgumentsDescription>? {
+            val call = args.parent
+            val callInfos = when (call) {
+                is RsCallExpr -> CallInfo.muiltResolve(call)
+                is RsMethodCall -> CallInfo.muiltResolve(call)
+                else -> null
+            } ?: return null
+            return callInfos.map { getParams(call, it) }
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/utils/CallInfo.kt
+++ b/src/main/kotlin/org/rust/ide/utils/CallInfo.kt
@@ -9,6 +9,7 @@ import org.rust.ide.presentation.render
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.emptySubstitution
+import org.rust.lang.core.types.infer.type
 import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyFunction
@@ -41,10 +42,38 @@ class CallInfo private constructor(
             }
         }
 
+        fun muiltResolve(call: RsCallExpr): List<CallInfo>? {
+            val fns = (call.expr as? RsPathExpr)?.path?.reference?.multiResolve() ?: return null
+            return fns.map {
+                when (it) {
+                    is RsFunction -> buildFunctionParameters(it, it.type)
+                    else -> {
+                        return null
+                    }
+                }
+            }
+        }
+
         fun resolve(methodCall: RsMethodCall): CallInfo? {
             val function = (methodCall.reference.resolve() as? RsFunction) ?: return null
             val type = methodCall.inference?.getResolvedMethodType(methodCall) ?: return null
             return buildFunctionParameters(function, type)
+        }
+
+        fun muiltResolve(methodCall: RsMethodCall): List<CallInfo>? {
+            val functions = (methodCall.reference.multiResolve() as? List<*>) ?: return null // List<RsFunction>
+            return functions.map {
+                when (it) {
+                    is RsFunction -> {
+                        val type = methodCall.inference?.getResolvedMethodType(methodCall) ?: return null
+                        buildFunctionParameters(it, type)
+                    }
+
+                    else -> {
+                        return null
+                    }
+                }
+            }
         }
 
         private fun buildFunctionLike(fn: RsElement, ty: TyFunction): CallInfo? {
@@ -57,11 +86,13 @@ class CallInfo private constructor(
                 element is RsEnumVariant -> element.positionalFields.map { null to it.typeReference }
                 element is RsStructItem && element.isTupleStruct ->
                     element.tupleFields?.tupleFieldDeclList?.map { null to it.typeReference }
+
                 element is RsPatBinding -> {
                     val decl = element.ancestorStrict<RsLetDecl>() ?: return null
                     val lambda = decl.expr as? RsLambdaExpr ?: return null
                     lambda.valueParameters.map { (it.patText ?: "_") to it.typeReference }
                 }
+
                 else -> null
             }
         }


### PR DESCRIPTION
changelog:
Current regex will inclued "&gt" in the end of url.
I replace "&amp;gt;" with ">" before regex, so that regex to exclude it.

I add multiResolve method in CallInfo class, now ide can provide hint for same name function in defferent trait.
But it seems only work for associated function, can't resolve different implementation of same generic trait for same struct/enum.