### PR TITLE
bug fix of render external linter and parameter info

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterUtils.kt
@@ -281,7 +281,7 @@ private data class RsExternalLinterFilteredMessage(
     }
 }
 
-private fun String.escapeUrls(): String = replace(URL_REGEX) { url -> "<a href='${url.value}'>${url.value}</a>" }
+private fun String.escapeUrls(): String = this.replace("&gt;", ">").replace(URL_REGEX) { url -> "<a href='${url.value}'>${url.value}</a>" }
 
 fun RustcSpan.isValid(): Boolean =
     line_end > line_start || (line_end == line_start && column_end >= column_start)


### PR DESCRIPTION
changelog:
Current regex will inclued "&gt" in the end of url.
I replace "&amp;gt;" with ">" before regex, so that regex to exclude it.

I add multiResolve method in CallInfo class, now ide can provide hint for same name function in defferent trait.
But it seems only work for associated function, can't resolve different implementation of same generic trait for same struct/enum.