### PR TITLE
Provide options for Rust line markers

### DIFF
--- a/js/src/main/kotlin/org/rust/js/RsWasmBindgenLineMarkerProvider.kt
+++ b/js/src/main/kotlin/org/rust/js/RsWasmBindgenLineMarkerProvider.kt
@@ -21,13 +21,19 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import icons.JavaScriptPsiIcons
+import org.rust.RsBundle
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import java.nio.file.InvalidPathException
 import java.nio.file.Paths
+import javax.swing.Icon
 
 @Suppress("NAME_SHADOWING")
 class RsWasmBindgenLineMarkerProvider : RelatedItemLineMarkerProvider() {
+
+    override fun getName(): String = RsBundle.message("gutter.rust.generated.typescript.declarations.name")
+    override fun getIcon(): Icon = JavaScriptPsiIcons.FileTypes.TypeScriptFile
+
     override fun getLineMarkerInfo(element: PsiElement): RelatedItemLineMarkerInfo<*>? {
         val element = element as? RsOuterAttributeOwner ?: return null
         if (element !is RsFunction && element !is RsEnumItem && element !is RsStructItem && element !is RsImplItem) {
@@ -74,9 +80,9 @@ class RsWasmBindgenLineMarkerProvider : RelatedItemLineMarkerProvider() {
         return RelatedItemLineMarkerInfo(
             attr,
             attr.textRange,
-            JavaScriptPsiIcons.FileTypes.TypeScriptFile,
-            { "Go to generated declaration" },
-            DefaultGutterIconNavigationHandler(listOf(destination), "Generated Declarations"),
+            icon,
+            { RsBundle.message("gutter.rust.generated.typescript.declarations.tooltip") },
+            DefaultGutterIconNavigationHandler(listOf(destination), RsBundle.message("gutter.rust.generated.typescript.declarations.popup.title")),
             GutterIconRenderer.Alignment.RIGHT,
             { listOf(GotoRelatedItem(destination)) }
         )

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsCrateDocLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsCrateDocLineMarkerProvider.kt
@@ -6,19 +6,24 @@
 package org.rust.ide.lineMarkers
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
+import org.rust.RsBundle
 import org.rust.ide.docs.getExternalDocumentationBaseUrl
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsExternCrateItem
 import org.rust.lang.core.psi.ext.containingCargoPackage
+import javax.swing.Icon
 
 /**
  * Provides an external crate imports with gutter icons that open documentation on docs.rs.
  */
-class RsCrateDocLineMarkerProvider : LineMarkerProvider {
+class RsCrateDocLineMarkerProvider : LineMarkerProviderDescriptor() {
+
+    override fun getName(): String = RsBundle.message("gutter.rust.open.documentation.name")
+    override fun getIcon(): Icon = RsIcons.DOCS_MARK
 
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? {
         val parent = element.parent
@@ -32,9 +37,9 @@ class RsCrateDocLineMarkerProvider : LineMarkerProvider {
         return RsLineMarkerInfoUtils.create(
             element,
             element.textRange,
-            RsIcons.DOCS_MARK,
+            icon,
             { _, _ -> BrowserUtil.browse("$baseUrl${crate.pkg.name}/${crate.pkg.version}/${crate.normName}") },
             GutterIconRenderer.Alignment.LEFT
-        ) { "Open documentation for `${crate.pkg.normName}`" }
+        ) { RsBundle.message("gutter.rust.open.documentation.for", crate.pkg.normName) }
     }
 }

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
@@ -6,12 +6,13 @@
 package org.rust.ide.lineMarkers
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.NotNullLazyValue
 import com.intellij.psi.PsiElement
 import com.intellij.util.Query
 import org.jetbrains.annotations.TestOnly
+import org.rust.RsBundle
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.navigation.goto.RsGoToImplRenderer
 import org.rust.lang.core.psi.RsEnumItem
@@ -20,6 +21,7 @@ import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.filterQuery
 import org.rust.openapiext.mapQuery
+import javax.swing.Icon
 
 /**
  * Annotates trait declaration with an icon on the gutter that allows to jump to
@@ -27,7 +29,10 @@ import org.rust.openapiext.mapQuery
  *
  * See [org.rust.ide.navigation.goto.RsImplsSearch]
  */
-class RsImplsLineMarkerProvider : LineMarkerProvider {
+class RsImplsLineMarkerProvider : LineMarkerProviderDescriptor() {
+
+    override fun getName(): String = RsBundle.message("gutter.rust.implemented.item.name")
+    override fun getIcon(): Icon = RsIcons.IMPLEMENTED
 
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? = null
 
@@ -39,9 +44,9 @@ class RsImplsLineMarkerProvider : LineMarkerProvider {
             // if (query.isEmptyQuery) return null
             val query = implsQuery(el) ?: continue
             val targets: NotNullLazyValue<Collection<PsiElement>> = NotNullLazyValue.createValue { query.findAll() }
-            val info = ImplsGutterIconBuilder(el.text, RsIcons.IMPLEMENTED)
+            val info = ImplsGutterIconBuilder(el.text, icon)
                 .setTargets(targets)
-                .setTooltipText("Has implementations")
+                .setTooltipText(RsBundle.message("gutter.rust.implemented.item.tooltip"))
                 .setCellRenderer { RsGoToImplRenderer() }
                 .createLineMarkerInfo(el)
 

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProvider.kt
@@ -6,21 +6,25 @@
 package org.rust.ide.lineMarkers
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
+import org.rust.RsBundle
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.openapiext.document
-import java.util.*
+import javax.swing.Icon
 
 /**
  * Line marker provider that annotates recursive function and method calls with
  * an icon on the gutter.
  */
-class RsRecursiveCallLineMarkerProvider : LineMarkerProvider {
+class RsRecursiveCallLineMarkerProvider : LineMarkerProviderDescriptor() {
+
+    override fun getName(): String = RsBundle.message("gutter.rust.recursive.call.name")
+    override fun getIcon(): Icon = RsIcons.RECURSIVE_CALL
 
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
 
@@ -46,10 +50,10 @@ class RsRecursiveCallLineMarkerProvider : LineMarkerProvider {
                 result.add(RsLineMarkerInfoUtils.create(
                     el,
                     el.textRange,
-                    RsIcons.RECURSIVE_CALL,
+                    icon,
                     null,
                     GutterIconRenderer.Alignment.RIGHT
-                ) { "Recursive call" })
+                ) { RsBundle.message("gutter.rust.recursive.call.name") })
             }
         }
     }

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProvider.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.psi.PsiElement
+import org.rust.RsBundle
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsConstant
 import org.rust.lang.core.psi.RsFunction
@@ -24,6 +25,23 @@ import javax.swing.Icon
  * Annotates the implementation of a trait members (const, fn, type) with an icon on the gutter.
  */
 class RsTraitItemImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
+
+    private val implementingOption: Option = Option(
+        "rust.implementing.item",
+        RsBundle.message("gutter.rust.implementing.item"),
+        RsIcons.IMPLEMENTING_METHOD
+    )
+    private val overridingOption: Option = Option(
+        "rust.overriding.item",
+        RsBundle.message("gutter.rust.overriding.item"),
+        RsIcons.OVERRIDING_METHOD
+    )
+
+    // Exact value doesn't matter since `getOptions` returns not empty array.
+    // It just shouldn't be `null` since it means "No configuration needed"
+    override fun getName(): String = ""
+    override fun getOptions(): Array<Option> = arrayOf(implementingOption, overridingOption)
+
     override fun collectNavigationMarkers(el: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<*>>) {
         if (el !is RsAbstractable) return
 
@@ -33,9 +51,11 @@ class RsTraitItemImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
         val action: String
         val icon: Icon
         if (superItem.isAbstract) {
+            if (!implementingOption.isEnabled) return
             action = "Implements"
             icon = RsIcons.IMPLEMENTING_METHOD
         } else {
+            if (!overridingOption.isEnabled) return
             action = "Overrides"
             icon = RsIcons.OVERRIDING_METHOD
         }

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -71,6 +71,19 @@ cargo.commandline.description=Configures Cargo projects under the given folder
 group.Rust.MacroExpansionActions.text=Show Macro Expansion
 group.Rust.Tools.text=Rust
 
+gutter.rust.generated.typescript.declarations.name=Generated TypeScript declarations
+gutter.rust.generated.typescript.declarations.popup.title=Generated Declarations
+gutter.rust.generated.typescript.declarations.tooltip=Go to generated declaration
+gutter.rust.implemented.item.name=Implemented item
+gutter.rust.implemented.item.tooltip=Has implementations
+gutter.rust.implementing.item=Implementing item
+# for example: Open documentation for `rand`
+gutter.rust.open.documentation.for=Open documentation for `{0}`
+gutter.rust.open.documentation.name=Open documentation
+gutter.rust.open.documentation.toml.name=Open documentation (TOML)
+gutter.rust.overriding.item=Overriding item
+gutter.rust.recursive.call.name=Recursive call
+
 dialog.create.project.custom.add.template.action.add=Add
 dialog.create.project.custom.add.template.name=Name:
 dialog.create.project.custom.add.template.title=Add Custom Template

--- a/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
@@ -6,19 +6,25 @@
 package org.rust.toml
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
 import com.intellij.util.io.URLUtil
+import org.rust.RsBundle
 import org.rust.cargo.CargoConstants
 import org.rust.ide.docs.getExternalDocumentationBaseUrl
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.lineMarkers.RsLineMarkerInfoUtils
 import org.rust.lang.core.psi.ext.elementType
 import org.toml.lang.psi.*
+import javax.swing.Icon
 
-class CargoCrateDocLineMarkerProvider : LineMarkerProvider {
+class CargoCrateDocLineMarkerProvider : LineMarkerProviderDescriptor() {
+
+    override fun getName(): String = RsBundle.message("gutter.rust.open.documentation.toml.name")
+    override fun getIcon(): Icon = RsIcons.DOCS_MARK
+
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
 
     override fun collectSlowLineMarkers(elements: List<PsiElement>, result: MutableCollection<in LineMarkerInfo<*>>) {
@@ -67,7 +73,7 @@ class CargoCrateDocLineMarkerProvider : LineMarkerProvider {
             RsIcons.DOCS_MARK,
             { _, _ -> BrowserUtil.browse("$baseUrl$name/${URLUtil.encodeURIComponent(urlVersion)}") },
             GutterIconRenderer.Alignment.LEFT
-        ) { "Open documentation for `$name@$urlVersion`" }
+        ) { RsBundle.message("gutter.rust.open.documentation.for", "$name@$urlVersion") }
     }
 }
 


### PR DESCRIPTION
Now, it's possible to enable/disable line markers provided Rust plugin via `Preferences | Editor | General | Gutter Icons` settings

Fixes #10036

Note, because of [platform bug](https://youtrack.jetbrains.com/issue/IDEA-311515), IDE may show several groups with the same name. For Rust line markers as well. It's already fixed in the platform master and will be landed with 2023.1 EAP 3

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/2539310/215346686-5e128876-cae7-4b02-9de5-bb7f23e2bff7.png">

Note 2: I intentionally didn't add option for gutter icons in Cargo.toml to change Cargo feature state (`CargoFeatureLineMarkerProvider`) since it's an essential feature of the plugin, from my point of view. I consider it doesn't make sense to allow users to disable it. Otherwise, it would be impossible to change the state of Cargo features

changelog: Add a way to disable gutter icons provided by the plugin via `Preferences | Editor | General | Gutter Icons` settings
