### PR TITLE
CI: use `actions/checkout@v3` instead of `v2`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,7 +50,7 @@ jobs:
     check-license:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Check license
               run: python scripts/check_license.py


### PR DESCRIPTION
It uses Node.js 16 instead of deprecated Node.js 12