### PR TITLE
COMP: Don't complete built-in attributes for qualified path

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsAttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsAttributeCompletionProvider.kt
@@ -41,6 +41,7 @@ import org.rust.lang.core.psi.ext.name
 import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.psi.ext.queryAttributes
 import org.rust.lang.core.psiElement
+import org.rust.lang.core.with
 
 object RsAttributeCompletionProvider : RsCompletionProvider() {
 
@@ -82,10 +83,12 @@ object RsAttributeCompletionProvider : RsCompletionProvider() {
     }
 
     override val elementPattern: ElementPattern<PsiElement>
-        get() {
-            return psiElement(RsElementTypes.IDENTIFIER)
-                .withParent(psiElement<RsPath>().withParent(rootMetaItem))
-        }
+        get() = psiElement(RsElementTypes.IDENTIFIER)
+            .withParent(
+                psiElement<RsPath>()
+                    .with("Unqualified") { it: RsPath -> !it.hasColonColon }
+                    .withParent(rootMetaItem)
+            )
 
     private fun createLookupElement(name: String): LookupElement =
         if (name.endsWith("()")) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt
@@ -272,6 +272,16 @@ class RsAttributeCompletionTest : RsAttributeCompletionTestBase() {
         fn foo() {}
     """)
 
+    fun `test no builtin attr completion for qualified path 1`() = checkNoCompletion("""
+        #[tokio::tes/*caret*/]
+        fn main() {}
+    """)
+
+    fun `test no builtin attr completion for qualified path 2`() = checkNoCompletion("""
+        #[::tes/*caret*/]
+        fn main() {}
+    """)
+
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test attribute proc macro (unqualified)`() = doSingleCompletionByFileTree("""
     //- dep-proc-macro/lib.rs


### PR DESCRIPTION
Fixes #10058

changelog: Don't complete built-in attributes for qualified path