### PR TITLE
PERF: Don't expand cfg-disabled macro calls inside functions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -1031,6 +1031,9 @@ private fun expandMacroToMemoryFile(call: RsPossibleMacroCall, storeRangeMap: Bo
         .unwrapOrElse { return CachedValueProvider.Result(Err(it.toExpansionError()), modificationTrackers) }
     val crate = call.containingCrate
     if (crate is FakeCrate) return CachedValueProvider.Result(Err(GetMacroExpansionError.Unresolved), modificationTrackers)
+    if (!call.isEnabledByCfg(crate)) {
+        return CachedValueProvider.Result(Err(GetMacroExpansionError.CfgDisabled), modificationTrackers)
+    }
     val result = FunctionLikeMacroExpander.forCrate(crate).expandMacro(
         def,
         call,


### PR DESCRIPTION
Related: #5989

changelog: Skip expansion of cfg-disabled macro calls inside functions