### PR TITLE
RES: Improve support for identity attribute proc macros

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1895,10 +1895,8 @@ private fun checkRecursiveAsyncFunction(holder: RsAnnotationHolder, fn: RsFuncti
 }
 
 private fun RsFunction.hasAsyncRecursionProcMacro(): Boolean {
-    val attr = ProcMacroAttribute
-        .getProcMacroAttributeWithoutResolve(this, ignoreProcMacrosDisabled = true)
-        as? ProcMacroAttribute.Attr ?: return false
-    return attr.attr.path?.referenceName == "async_recursion"
+    return ProcMacroAttribute.getProcMacroAttributeWithoutResolve(this, ignoreProcMacrosDisabled = true)
+        .any { it is ProcMacroAttribute.Attr && it.attr.path?.referenceName == "async_recursion" }
 }
 
 private fun RsAttr.isBuiltinWithName(target: String): Boolean {

--- a/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
@@ -91,7 +91,7 @@ class RsMacroExpansionHighlightingPass(
                 }
                 is RsAttrProcMacroOwner -> {
                     if (it.textRange?.intersects(restrictedRange) != true) return@processElements true
-                    macros += it.procMacroAttribute.attr?.prepareForExpansionHighlighting() ?: return@processElements true
+                    macros += it.procMacroAttribute?.attr?.prepareForExpansionHighlighting() ?: return@processElements true
                 }
             }
             true // Continue
@@ -120,7 +120,7 @@ class RsMacroExpansionHighlightingPass(
                 if (element is RsMacroCall) {
                     macros += element.prepareForExpansionHighlighting(macro) ?: continue
                 } else if (element is RsAttrProcMacroOwner) {
-                    macros += element.procMacroAttribute.attr?.prepareForExpansionHighlighting(macro) ?: continue
+                    macros += element.procMacroAttribute?.attr?.prepareForExpansionHighlighting(macro) ?: continue
                 }
             }
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsWithMacrosInspectionVisitor.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWithMacrosInspectionVisitor.kt
@@ -155,7 +155,7 @@ abstract class RsWithMacrosInspectionVisitor : RsVisitor() {
     private fun visitMacroExpansion(item: RsAttrProcMacroOwner) {
         if (processingMacros) return
 
-        val preparedMacro = item.procMacroAttribute.attr?.prepareForExpansionHighlighting() ?: return
+        val preparedMacro = item.procMacroAttribute?.attr?.prepareForExpansionHighlighting() ?: return
         val macros = mutableListOf(preparedMacro)
 
         processingMacros = true
@@ -165,7 +165,7 @@ abstract class RsWithMacrosInspectionVisitor : RsVisitor() {
             for (element in macro.elementsForHighlighting) {
                 element.accept(this)
                 if (element is RsAttrProcMacroOwner) {
-                    macros += element.procMacroAttribute.attr?.prepareForExpansionHighlighting(macro) ?: continue
+                    macros += element.procMacroAttribute?.attr?.prepareForExpansionHighlighting(macro) ?: continue
                 }
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -834,7 +834,7 @@ private class MacroExpansionServiceImplInner(
             owner as? RsMacroCall
         } else {
             if (owner !is RsAttrProcMacroOwner) return null
-            owner.findAttrOrDeriveMacroCall(macroIndex.last, crate)
+            owner.findAttrOrDeriveMacroCall(macroIndex.last, kind == DERIVE, crate)
         }
     }
 
@@ -868,18 +868,25 @@ private class MacroExpansionServiceImplInner(
 
     private fun RsAttrProcMacroOwner.findAttrOrDeriveMacroCall(
         macroIndexInParent: Int,
+        isDerive: Boolean,
         crate: Crate,
     ): RsPossibleMacroCall? {
-        val attr = ProcMacroAttribute.getProcMacroAttributeWithoutResolve(
+        val attrs = ProcMacroAttribute.getProcMacroAttributeWithoutResolve(
             this,
             explicitCrate = crate,
             withDerives = true
         )
-        return when (attr) {
-            is ProcMacroAttribute.Attr -> attr.attr
-            is ProcMacroAttribute.Derive -> attr.derives.elementAtOrNull(macroIndexInParent)
-            null -> null
+        for (attr in attrs) {
+            when (attr) {
+                is ProcMacroAttribute.Attr -> if (!isDerive) {
+                    return attr.attr
+                }
+                is ProcMacroAttribute.Derive -> if (isDerive) {
+                    return attr.derives.elementAtOrNull(macroIndexInParent)
+                }
+            }
         }
+        return null
     }
 
     private fun getExpansionFile(defMap: CrateDefMap, callIndex: MacroIndex): RsFile? {

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -909,7 +909,7 @@ private class MacroExpansionServiceImplInner(
             return GetMacroExpansionError.CfgDisabled
         }
 
-        val resolveResult = call.resolveToMacroWithoutPsiWithErr()
+        val resolveResult = call.resolveToMacroWithoutPsiWithErr(errorIfIdentity = true)
 
         val isProcMacro = resolveResult is Ok && resolveResult.ok.data is RsProcMacroData
             || resolveResult is Err && resolveResult.err is ResolveMacroWithoutPsiError.NoProcMacroArtifact

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -878,7 +878,7 @@ private class MacroExpansionServiceImplInner(
         return when (attr) {
             is ProcMacroAttribute.Attr -> attr.attr
             is ProcMacroAttribute.Derive -> attr.derives.elementAtOrNull(macroIndexInParent)
-            ProcMacroAttribute.None -> null
+            null -> null
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroDataWithHash.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroDataWithHash.kt
@@ -52,7 +52,7 @@ class RsMacroDataWithHash<out T : RsMacroData>(
             }
         }
 
-        fun fromDefInfo(def: MacroDefInfo, skipIdentity: Boolean = true): RsResult<RsMacroDataWithHash<*>, ResolveMacroWithoutPsiError> {
+        fun fromDefInfo(def: MacroDefInfo, errorIfIdentity: Boolean = false): RsResult<RsMacroDataWithHash<*>, ResolveMacroWithoutPsiError> {
             return when (def) {
                 is DeclMacroDefInfo -> Ok(
                     if (def.hasRustcBuiltinMacro) {
@@ -72,7 +72,7 @@ class RsMacroDataWithHash<out T : RsMacroData>(
                     val name = def.path.name
                     val procMacroArtifact = def.procMacroArtifact
                         ?: return Err(ResolveMacroWithoutPsiError.NoProcMacroArtifact)
-                    if (skipIdentity && def.kind.treatAsBuiltinAttr) {
+                    if (errorIfIdentity && def.kind.treatAsBuiltinAttr) {
                         return Err(ResolveMacroWithoutPsiError.HardcodedProcMacroAttribute)
                     }
                     val hash = HashCode.mix(procMacroArtifact.hash, HashCode.compute(name))

--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroDataWithHash.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroDataWithHash.kt
@@ -52,7 +52,7 @@ class RsMacroDataWithHash<out T : RsMacroData>(
             }
         }
 
-        fun fromDefInfo(def: MacroDefInfo): RsResult<RsMacroDataWithHash<*>, ResolveMacroWithoutPsiError> {
+        fun fromDefInfo(def: MacroDefInfo, skipIdentity: Boolean = true): RsResult<RsMacroDataWithHash<*>, ResolveMacroWithoutPsiError> {
             return when (def) {
                 is DeclMacroDefInfo -> Ok(
                     if (def.hasRustcBuiltinMacro) {
@@ -72,7 +72,7 @@ class RsMacroDataWithHash<out T : RsMacroData>(
                     val name = def.path.name
                     val procMacroArtifact = def.procMacroArtifact
                         ?: return Err(ResolveMacroWithoutPsiError.NoProcMacroArtifact)
-                    if (def.kind.treatAsBuiltinAttr) {
+                    if (skipIdentity && def.kind.treatAsBuiltinAttr) {
                         return Err(ResolveMacroWithoutPsiError.HardcodedProcMacroAttribute)
                     }
                     val hash = HashCode.mix(procMacroArtifact.hash, HashCode.compute(name))

--- a/src/main/kotlin/org/rust/lang/core/psi/AttrCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/AttrCache.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi
 
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.psi.ext.RsAttrProcMacroOwner
+import java.util.*
 
 /**
  * A simple single-thread cache used for caching of attribute macros
@@ -17,18 +18,18 @@ sealed class AttrCache {
 
     object NoCache : AttrCache() {
         override fun cachedGetProcMacroAttribute(owner: RsAttrProcMacroOwner): RsMetaItem? =
-            owner.procMacroAttribute.attr
+            owner.procMacroAttribute?.attr
     }
 
     class HashMapCache(
         private val crate: Crate?
     ): AttrCache() {
-        private val cache: MutableMap<RsAttrProcMacroOwner, ProcMacroAttribute<RsMetaItem>> = hashMapOf()
+        private val cache: MutableMap<RsAttrProcMacroOwner, Optional<RsMetaItem>> = hashMapOf()
 
         override fun cachedGetProcMacroAttribute(owner: RsAttrProcMacroOwner): RsMetaItem? {
             return cache.getOrPut(owner) {
-                ProcMacroAttribute.getProcMacroAttribute(owner, explicitCrate = crate)
-            }.attr
+                Optional.ofNullable(ProcMacroAttribute.getProcMacroAttribute(owner, explicitCrate = crate)?.attr)
+            }.orElse(null)
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
@@ -63,7 +63,7 @@ fun getHardcodeProcMacroProperties(packageName: String, macroName: String): Know
         return kind
     }
 
-    if (isUnitTestMode && packageName == "test_proc_macros" && macroName == "attr_hardcoded_not_a_macro") {
+    if (isUnitTestMode && packageName == "test_proc_macros" && macroName in listOf("attr_hardcoded_not_a_macro", "attr_hardcoded_as_is")) {
         return KnownProcMacroKind.IDENTITY
     }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAttrProcMacroOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAttrProcMacroOwner.kt
@@ -16,10 +16,10 @@ import org.rust.lang.core.stubs.common.RsAttrProcMacroOwnerPsiOrStub
  */
 interface RsAttrProcMacroOwner : RsOuterAttributeOwner, RsAttrProcMacroOwnerPsiOrStub<RsMetaItem> {
     /** @see ProcMacroAttribute */
-    val procMacroAttribute: ProcMacroAttribute<RsMetaItem>
+    val procMacroAttribute: ProcMacroAttribute<RsMetaItem>?
         get() = ProcMacroAttribute.getProcMacroAttribute(this)
 
     /** @see ProcMacroAttribute */
-    val procMacroAttributeWithDerives: ProcMacroAttribute<RsMetaItem>
+    val procMacroAttributeWithDerives: ProcMacroAttribute<RsMetaItem>?
         get() = ProcMacroAttribute.getProcMacroAttribute(this, withDerives = true)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -158,7 +158,7 @@ private fun RsElement.processItem(
                 }
             }
             is ProcMacroAttribute.Derive -> attr.derives
-            ProcMacroAttribute.None -> null
+            null -> null
         }
     } else {
         null

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMembers.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMembers.kt
@@ -28,7 +28,7 @@ val RsMembers.expandedMembers: List<RsAbstractable>
             val macroCall = when (val attr = memberOrMacroCall.procMacroAttribute) {
                 is ProcMacroAttribute.Attr -> attr.attr
                 is ProcMacroAttribute.Derive -> null
-                ProcMacroAttribute.None -> when (memberOrMacroCall) {
+                null -> when (memberOrMacroCall) {
                     is RsMacroCall -> memberOrMacroCall
                     is RsAbstractable -> {
                         members += memberOrMacroCall

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
@@ -79,7 +79,7 @@ val RsPossibleMacroCall.isMacroCall: Boolean
                 when (val attr = ProcMacroAttribute.getProcMacroAttributeWithoutResolve(owner, ignoreProcMacrosDisabled = true)) {
                     is ProcMacroAttribute.Attr -> attr.attr == this
                     is ProcMacroAttribute.Derive -> RsProcMacroPsiUtil.canBeCustomDerive(kind.meta)
-                    ProcMacroAttribute.None -> false
+                    null -> false
                 }
             }
         }
@@ -153,7 +153,7 @@ private fun doPrepareProcMacroCallBody(
             val body = doPrepareCustomDeriveMacroCallBody(project, text, endOfAttrsOffset, crate) ?: return null
             PreparedProcMacroCallBody.Derive(body)
         }
-        ProcMacroAttribute.None -> null
+        null -> null
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -1559,7 +1559,7 @@ private fun collectNestedMacroCallsAndImpls(
         when (val attr = possibleMacroCall.procMacroAttributeWithDerives) {
             is ProcMacroAttribute.Attr -> macroCalls += attr.attr
             is ProcMacroAttribute.Derive -> macroCalls += attr.derives
-            ProcMacroAttribute.None -> when (possibleMacroCall) {
+            null -> when (possibleMacroCall) {
                 is RsMacroCall -> macroCalls += possibleMacroCall
                 is RsImplItem -> impls?.add(possibleMacroCall)
             }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -27,9 +27,6 @@ import org.rust.lang.core.resolve2.util.PerNsHashMap
 import org.rust.lang.core.resolve2.util.SmartListMap
 import org.rust.openapiext.fileId
 import org.rust.stdext.HashCode
-import org.rust.stdext.writeVarInt
-import java.io.DataOutput
-import java.io.IOException
 import java.nio.file.Path
 import java.util.*
 import kotlin.math.min
@@ -227,17 +224,8 @@ value class MacroIndex(private val indices: IntArray) : Comparable<MacroIndex> {
     val last: Int get() = indices.last()
 
     fun append(index: Int): MacroIndex = MacroIndex(indices + index)
-    fun append(index: MacroIndex): MacroIndex = MacroIndex(indices + index.indices)
 
     override fun compareTo(other: MacroIndex): Int = Arrays.compare(indices, other.indices)
-
-    @Throws(IOException::class)
-    fun writeTo(data: DataOutput) {
-        data.writeVarInt(indices.size)
-        for (index in indices) {
-            data.writeVarInt(index)
-        }
-    }
 
     companion object {
         /** Equivalent to `call < mod && !isPrefix(call, mod)` */

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -218,7 +218,7 @@ class FileInfo(
  *   to determine modules to which propagate
  */
 @JvmInline
-value class MacroIndex(private val indices: IntArray) : Comparable<MacroIndex> {
+value class MacroIndex(val indices: IntArray) : Comparable<MacroIndex> {
 
     val parent: MacroIndex get() = MacroIndex(indices.copyOfRange(0, indices.size - 1))
     val last: Int get() = indices.last()

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
@@ -58,7 +58,7 @@ class CollectorContext(
     val imports: MutableList<Import> = mutableListOf()
 
     /** All macro calls */
-    val macroCalls: MutableList<MacroCallInfo> = mutableListOf()
+    val macroCalls: MutableList<MacroCallInfoBase> = mutableListOf()
 }
 
 private fun buildDefMapContainingExplicitItems(

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -277,7 +277,7 @@ fun RsModInfo.getMacroIndex(element: PsiElement, elementCrate: Crate): MacroInde
         return when (attr) {
             is ProcMacroAttribute.Derive -> ownerIndex.append(attr.derives.indexOf(element))
             is ProcMacroAttribute.Attr -> ownerIndex
-            is ProcMacroAttribute.None -> return null
+            null -> return null
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -346,9 +346,11 @@ private class ModCollector(
     override fun collectProcMacroCall(call: ProcMacroCallLight) {
         require(modData.isDeeplyEnabledByCfg) { "for performance reasons cfg-disabled macros should not be collected" }
         val macroIndex = parentMacroIndex.append(call.macroIndexInParent)
+        var deriveIndexCounter = -1
         val attrs = call.attrs.map2Array {
             val path = dollarCrateHelper?.convertPath(it.path, it.pathStartOffsetInExpansion) ?: it.path
-            ProcMacroCallInfo.AttrInfo(path, it.index)
+            val deriveIndex = if (it.index == -1) ++deriveIndexCounter else -1
+            ProcMacroCallInfo.AttrInfo(path, it.index, deriveIndex)
         }
         val dollarCrateMap = dollarCrateHelper?.getDollarCrateMap(
             call.bodyStartOffsetInExpansion,

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -5,9 +5,9 @@
 
 package org.rust.lang.core.resolve2
 
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.StubElement
+import com.intellij.util.containers.map2Array
 import com.intellij.util.io.IOUtil
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.macros.MacroCallBody
@@ -57,31 +57,28 @@ class ModCollectorBase private constructor(
         }
     }
 
+    private class AttrInfo(val attr: RsMetaItemStub, val index: Int)
+
     private fun collectElement(element: StubElement<out PsiElement>, macroIndexInParent: Int) {
-        var customDerives = emptyList<RsMetaItemStub>()
         if (element is RsAttrProcMacroOwnerStub) {
             // TODO store CustomAttributes in defMap, pass it to getProcMacroAttributeRaw
-            when (val attr = ProcMacroAttribute.getProcMacroAttributeWithoutResolve(element, element, crate, withDerives = true)) {
-                is ProcMacroAttribute.Attr -> {
-                    collectAttrProcMacroCall(element, attr, macroIndexInParent)
-                    return
+            val attrsAndDerives = ProcMacroAttribute.getAllPossibleProcMacroAttributes(element, element, crate)
+                .flatMap {
+                    when (it) {
+                        is ProcMacroAttribute.Attr -> listOf(AttrInfo(it.attr, it.index))
+                        is ProcMacroAttribute.Derive -> it.derives.mapTo(mutableListOf()) { derive ->
+                            AttrInfo(derive, -1)
+                        }
+                    }
                 }
-                is ProcMacroAttribute.Derive -> if (element.mayHaveCustomDerive) {
-                    customDerives = attr.derives.toList()
-                }
-                ProcMacroAttribute.None -> Unit
+
+            if (attrsAndDerives.isNotEmpty()) {
+                collectProcMacroCall(element, attrsAndDerives, macroIndexInParent)
+                if (attrsAndDerives.any { it.index != -1 }) return
             }
         }
 
         collectElementWithoutAttrMacros(element, macroIndexInParent)
-
-        customDerives.forEachIndexed { i, customDerive ->
-            collectCustomDeriveProcMacroCall(
-                element as RsAttrProcMacroOwnerStub,
-                customDerive,
-                MacroIndex(intArrayOf(macroIndexInParent, i))
-            )
-        }
     }
 
     private fun collectElementWithoutAttrMacros(element: StubElement<out PsiElement>, macroIndexInParent: Int) {
@@ -217,61 +214,36 @@ class ModCollectorBase private constructor(
         visitor.collectMacroCall(callLight, call)
     }
 
-    private fun collectAttrProcMacroCall(
+    private fun collectProcMacroCall(
         item: RsAttrProcMacroOwnerStub,
-        attr: ProcMacroAttribute.Attr<RsMetaItemStub>,
+        attrsAndDerives: List<AttrInfo>,
         macroIndexInParent: Int
     ) {
         val isCallDeeplyEnabledByCfg = isDeeplyEnabledByCfg && item.isEnabledByCfgSelf(crate)
         if (!isCallDeeplyEnabledByCfg) return
         val rawBody = item.stubbedText ?: return
-        val attrPath = attr.attr.path ?: return
-        val attrPathSegments = attrPath.getPathWithAdjustedDollarCrate() ?: return
+        val attrInfos = attrsAndDerives.map2Array {
+            val attrPath = it.attr.path ?: return
+            val attrPathSegments = attrPath.getPathWithAdjustedDollarCrate() ?: return
+            ProcMacroCallLight.AttrInfo(attrPathSegments, it.index, attrPath.startOffset)
+        }
+        val hasAttrMacro = attrInfos.any { it.index != -1 }
 
-        val originalItem = if (item is RsNamedStub && RsProcMacroPsiUtil.canFallBackAttrMacroToOriginalItem(item)) {
+        val originalItem = if (hasAttrMacro && item is RsNamedStub && RsProcMacroPsiUtil.canFallBackAttrMacroToOriginalItem(item)) {
             lowerSimpleItem(item)
         } else {
             null
         }
         val callLight = ProcMacroCallLight(
-            attrPathSegments,
+            attrInfos,
             rawBody,
             item.stubbedTextHash,
             item.endOfAttrsOffset,
-            attr.index,
-            MacroIndex(intArrayOf(macroIndexInParent)),
-            attrPathStartOffsetInExpansion = attrPath.startOffset,
+            macroIndexInParent,
             bodyStartOffsetInExpansion = item.startOffset,
             bodyEndOffsetInExpansion = item.startOffset + rawBody.length,
             originalItem,
-            fixupRustSyntaxErrors = item is RsFunctionStub
-        )
-        visitor.collectProcMacroCall(callLight)
-    }
-
-    private fun collectCustomDeriveProcMacroCall(
-        item: RsAttrProcMacroOwnerStub,
-        customDeriveAttr: RsMetaItemStub,
-        macroIndexInParent: MacroIndex
-    ) {
-        val isCallDeeplyEnabledByCfg = isDeeplyEnabledByCfg && item.isEnabledByCfgSelf(crate)
-        if (!isCallDeeplyEnabledByCfg) return
-        val rawBody = item.stubbedText ?: return
-        val attrPath = customDeriveAttr.path ?: return
-        val attrPathSegments = attrPath.getPathWithAdjustedDollarCrate() ?: return
-
-        val callLight = ProcMacroCallLight(
-            attrPathSegments,
-            rawBody,
-            item.stubbedTextHash,
-            item.endOfAttrsOffset,
-            -1,
-            macroIndexInParent,
-            attrPathStartOffsetInExpansion = attrPath.startOffset,
-            bodyStartOffsetInExpansion = item.startOffset,
-            bodyEndOffsetInExpansion = item.startOffset + rawBody.length,
-            null,
-            fixupRustSyntaxErrors = false
+            fixupRustSyntaxErrors = hasAttrMacro && item is RsFunctionStub
         )
         visitor.collectProcMacroCall(callLight)
     }
@@ -570,20 +542,19 @@ class MacroCallLight(
 }
 
 class ProcMacroCallLight(
-    val attrPath: Array<String>,
+    val attrs: Array<AttrInfo>,
     val body: String,
+    // Null `bodyHash` means that body contains `#[cfg_attr]`, hence the hash should be computed from the lowered body
     val bodyHash: HashCode?,
-    private val endOfAttrsOffset: Int,
-    private val attrIndex: Int,
+    val endOfAttrsOffset: Int,
     /** See [MacroIndex] */
-    val macroIndexInParent: MacroIndex,
+    val macroIndexInParent: Int,
     /**
      * $crate::foo! { ... $crate ... }
      *                               ^ [bodyEndOffsetInExpansion]
      *              ^ [bodyStartOffsetInExpansion]
-     * ^ [attrPathStartOffsetInExpansion]
+     * ^ [ProcMacroCallLight.AttrInfo.pathStartOffsetInExpansion]
      */
-    val attrPathStartOffsetInExpansion: Int,
     val bodyStartOffsetInExpansion: Int,
     val bodyEndOffsetInExpansion: Int,
 
@@ -592,40 +563,20 @@ class ProcMacroCallLight(
 ) : Writeable {
 
     override fun writeTo(data: DataOutput) {
-        data.writePath(attrPath)
         if (bodyHash != null) {
             data.writeHashCodeNullable(bodyHash)
         } else {
-            // Null `bodyHash` means that body contains `#[cfg_attr]`, hence the hash should be computed
-            // from the lowered body (`lowerBody`)
             IOUtil.writeUTF(data, body)
         }
-        data.writeVarInt(endOfAttrsOffset)
-        data.writeVarInt(attrIndex)
-        macroIndexInParent.writeTo(data)
+        data.writeVarInt(macroIndexInParent)
     }
 
-    fun lowerBody(project: Project, crate: Crate): MacroCallBodyWithHash? {
-        val body = if (attrIndex != -1) {
-            doPrepareAttributeProcMacroCallBody(
-                project,
-                body,
-                endOfAttrsOffset,
-                crate,
-                attrIndex,
-                fixupRustSyntaxErrors,
-            )
-        } else {
-            doPrepareCustomDeriveMacroCallBody(
-                project,
-                body,
-                endOfAttrsOffset,
-                crate
-            )
-        } ?: return null
-        val hash = bodyHash ?: body.bodyHash
-        return MacroCallBodyWithHash(body, hash)
-    }
+    class AttrInfo(
+        val path: Array<String>,
+        // -1 for derive macros
+        val index: Int,
+        val pathStartOffsetInExpansion: Int,
+    )
 }
 
 data class MacroCallBodyWithHash(

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -61,16 +61,16 @@ class ModCollectorBase private constructor(
 
     private fun collectElement(element: StubElement<out PsiElement>, macroIndexInParent: Int) {
         if (element is RsAttrProcMacroOwnerStub) {
-            // TODO store CustomAttributes in defMap, pass it to getProcMacroAttributeRaw
-            val attrsAndDerives = ProcMacroAttribute.getAllPossibleProcMacroAttributes(element, element, crate)
+            // TODO store CustomAttributes in defMap, pass it to getProcMacroAttributeWithoutResolve
+            val attrsAndDerives = ProcMacroAttribute.getProcMacroAttributeWithoutResolve(element, element, crate, withDerives = true)
                 .flatMap {
                     when (it) {
-                        is ProcMacroAttribute.Attr -> listOf(AttrInfo(it.attr, it.index))
-                        is ProcMacroAttribute.Derive -> it.derives.mapTo(mutableListOf()) { derive ->
+                        is ProcMacroAttribute.Attr -> sequenceOf(AttrInfo(it.attr, it.index))
+                        is ProcMacroAttribute.Derive -> it.derives.map { derive ->
                             AttrInfo(derive, -1)
                         }
                     }
-                }
+                }.toList()
 
             if (attrsAndDerives.isNotEmpty()) {
                 collectProcMacroCall(element, attrsAndDerives, macroIndexInParent)

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionRangeMappingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionRangeMappingTest.kt
@@ -239,7 +239,7 @@ class RsMacroExpansionRangeMappingTest : RsTestBase() {
         InlineFile(preparedCode)
         val macroCall = myFixture.file
             .descendantsOfType<RsAttrProcMacroOwner>()
-            .mapNotNull { it.procMacroAttribute.attr }
+            .mapNotNull { it.procMacroAttribute?.attr }
             .single()
         val expansion = macroCall.expansionResult.unwrap()
         val ranges = expansion.ranges.ranges

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpansionTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.proc
+
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithExperimentalFeatures
+import org.rust.WithProcMacroRustProjectDescriptor
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.macros.MacroExpansionScope
+import org.rust.lang.core.macros.RsMacroExpansionTestBase
+
+/**
+ * See more tests in [RsProcMacroExpanderTest] and in [org.rust.lang.core.resolve.RsProcMacroExpansionResolveTest]
+ */
+@ExpandMacros(MacroExpansionScope.WORKSPACE)
+@WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
+@ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
+class RsProcMacroExpansionTest : RsMacroExpansionTestBase() {
+    fun `test item with hardcoded identity attr macro after normal as_is macro`() = doTest("""
+        #[test_proc_macros::attr_as_is]
+        #[test_proc_macros::attr_hardcoded_as_is]
+        fn foo() {}
+    """, """
+        #[test_proc_macros::attr_hardcoded_as_is]
+        fn foo() {}
+    """)
+}

--- a/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
@@ -371,6 +371,30 @@ class ProcMacroAttributeTest : RsTestBase() {
         mod m {}
     """, Attr("attr_hardcoded_not_a_macro", 0))
 
+    fun `test 2 hardcoded identity macros`() = doTest("""
+        use test_proc_macros::attr_hardcoded_not_a_macro;
+
+        #[attr_hardcoded_not_a_macro]
+        #[attr_hardcoded_not_a_macro]
+        struct S;
+    """, None)
+
+    fun `test hardcoded identity macro and then a non-hardcoded attr macro`() = doTest("""
+        use test_proc_macros::*;
+
+        #[attr_hardcoded_not_a_macro]
+        #[attr_as_is]
+        struct S;
+    """, Attr("attr_hardcoded_not_a_macro", 0))
+
+    fun `test hardcoded identity macro and then a non-hardcoded derive macro`() = doTest("""
+        use test_proc_macros::*;
+
+        #[attr_hardcoded_not_a_macro]
+        #[derive(DeriveImplForFoo)]
+        struct S;
+    """, Attr("attr_hardcoded_not_a_macro", 0))
+
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
     fun `test not a macro if proc macro expansion is disabled`() {
         setExperimentalFeatureEnabled(PROC_MACROS, false, testRootDisposable)

--- a/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
@@ -442,7 +442,7 @@ class ProcMacroAttributeTest : RsTestBase() {
         when (this) {
             is ProcMacroAttribute.Attr -> Attr(attr.path!!.text, index)
             is ProcMacroAttribute.Derive -> Derive
-            ProcMacroAttribute.None -> None
+            null -> None
         }
 
     private sealed class TestProcMacroAttribute {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -430,6 +430,68 @@ class RsProcMacroExpansionResolveTest : RsResolveTestBase() {
         }    //^
     """)
 
+    fun `test hardcoded attr and macro attr 1`() = checkByCode("""
+        #[test_proc_macros::attr_hardcoded_as_is]
+        #[test_proc_macros::attr_as_is]
+        fn foo() {}
+         //X
+        fn main() {
+            foo();
+        } //^
+    """)
+
+    fun `test hardcoded attr and macro attr 2`() = checkByCode("""
+        #[test_proc_macros::attr_hardcoded_as_is]
+        #[test_proc_macros::attr_replace_with_attr(fn bar() {})]
+        fn foo() {}                                 //X
+        fn main() {
+            bar();
+        } //^
+    """)
+
+    fun `test hardcoded attr and macro attr 3`() = checkByCode("""
+        #[test_proc_macros::attr_hardcoded_as_is]
+        #[test_proc_macros::attr_replace_with_attr(fn bar() {})]
+        fn foo() {}
+        fn main() {
+            foo();
+        } //^ unresolved
+    """)
+
+    fun `test two hardcoded attrs`() = checkByCode("""
+        #[test_proc_macros::attr_hardcoded_as_is]
+        #[test_proc_macros::attr_hardcoded_as_is]
+        fn foo() {}
+         //X
+        fn main() {
+            foo();
+        } //^
+    """)
+
+    fun `test hardcoded attr and macro derive`() = checkByCode("""
+        #[test_proc_macros::attr_hardcoded_as_is]
+        #[derive(test_proc_macros::DeriveStructFooDeclaration)]
+        struct Bar {}
+        impl Foo {
+            fn method(&self) {}
+        }    //X
+        fn main() {
+            Foo.method();
+        }     //^
+    """)
+
+    fun `test macro derive and hardcoded attr`() = checkByCode("""
+        #[derive(test_proc_macros::DeriveStructFooDeclaration)]
+        #[test_proc_macros::attr_hardcoded_as_is]
+        struct Bar {}
+        impl Foo {
+            fn method(&self) {}
+        }    //X
+        fn main() {
+            Foo.method();
+        }     //^
+    """)
+
     fun `test attr legacy macro 2`() = checkByCode("""
         use test_proc_macros::attr_hardcoded_not_a_macro;
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -84,6 +84,21 @@ class RsProcMacroExpansionResolveTest : RsResolveTestBase() {
         }           //^
     """)
 
+    fun `test custom derive with unresolved custom derive`() = checkByCode("""
+        use test_proc_macros::DeriveImplForFoo;
+
+        #[derive(Unresolved, DeriveImplForFoo)] // impl Foo { fn foo(&self) -> Bar {} }
+        struct Foo;
+        struct Bar;
+        impl Bar {
+            fn bar(&self) {}
+        }     //X
+
+        fn main() {
+            Foo.foo().bar()
+        }           //^
+    """)
+
     fun `test custom derive dollar crate`() = checkByCode("""
         use test_proc_macros::DeriveImplForFoo;
 
@@ -490,6 +505,15 @@ class RsProcMacroExpansionResolveTest : RsResolveTestBase() {
         fn main() {
             Foo.method();
         }     //^
+    """)
+
+    fun `test hardcoded attr and macro attr inside a function body`() = checkByCode("""
+        fn main() {
+            #[test_proc_macros::attr_hardcoded_as_is]
+            #[test_proc_macros::attr_replace_with_attr(fn bar() {})]
+            fn foo() {}                                 //X
+            bar();
+        } //^
     """)
 
     fun `test attr legacy macro 2`() = checkByCode("""

--- a/testData/test-proc-macros/src/lib.rs
+++ b/testData/test-proc-macros/src/lib.rs
@@ -141,6 +141,8 @@ pub fn attr_declare_struct_with_name(attr: TokenStream, _item: TokenStream) -> T
 pub fn attr_hardcoded_not_a_macro(_attr: TokenStream, item: TokenStream) -> TokenStream {
    panic!("Must not be called")
 }
+
+/// The macro is hardcoded to be an "identity" macro in `HardcodedProcMacroProperties.kt`
 #[proc_macro_attribute]
 pub fn attr_hardcoded_as_is(_attr: TokenStream, item: TokenStream) -> TokenStream {
    item

--- a/testData/test-proc-macros/src/lib.rs
+++ b/testData/test-proc-macros/src/lib.rs
@@ -141,6 +141,10 @@ pub fn attr_declare_struct_with_name(attr: TokenStream, _item: TokenStream) -> T
 pub fn attr_hardcoded_not_a_macro(_attr: TokenStream, item: TokenStream) -> TokenStream {
    panic!("Must not be called")
 }
+#[proc_macro_attribute]
+pub fn attr_hardcoded_as_is(_attr: TokenStream, item: TokenStream) -> TokenStream {
+   item
+}
 
 /// Such a macro call
 /// ```ignore


### PR DESCRIPTION
We have [a hardcoded list of attribute macros](https://github.com/intellij-rust/intellij-rust/blob/97f47d412d72801dbdaa7f2f769e5ca699804313/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt#L16) that the plugin does not expand. This list usually contains macros that does not make sense to expand because they do almost nothing from the IDE perspective and so can be treated as built-in attributes.

Rust allows to apply several attribute macros to an item. In this case, they are applied sequentially.
It is possible that one of the macros macros is present in our hardcoded list, but another is not. In this case, currently there is a bug - the plugin will not expand both of the macros. This PR changes this behavior. Now if any of the macros should be expanded, the plugin expands **all** of them.

In this example, previously `auto_impl::auto_impl` was not expanded and hence the type of `b` was unknown.

```rust
#[async_trait::async_trait]  // `async_trait` is a hardcoded identity macro
#[auto_impl::auto_impl(Box)] // `auto_impl` is a usual attribute macro
trait Foo {
    type Item;
    fn bar(&self) -> Self::Item { todo!() }
}

struct S;
impl Foo for S { type Item = i32; }

fn baz<T: Foo>(t: T) -> T::Item { todo!() }

fn main() {
    let a = Box::new(S);
    let b = baz(a);
    b;
} //^ i32
```

changelog: Improve support for multiple attribute macro calls on a single item