### PR TITLE
CLEAN: simplify `RsTemplateBuilder` API

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddTypeFix.kt
@@ -14,7 +14,6 @@ import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.types.ty.Ty
-import org.rust.openapiext.createSmartPointer
 
 /**
  * Adds type ascription after the given element.
@@ -41,6 +40,6 @@ class AddTypeFix(anchor: PsiElement, ty: Ty) : LocalQuickFixAndIntentionActionOn
         val type = factory.createType(typeText)
         val insertedType = parent.addAfter(type, anchor)
 
-        editor?.buildAndRunTemplate(parent, listOf(insertedType.createSmartPointer()))
+        editor?.buildAndRunTemplate(parent, listOf(insertedType))
     }
 }

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
@@ -26,7 +26,6 @@ import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyFunction
 import org.rust.lang.core.types.type
-import org.rust.openapiext.createSmartPointer
 
 class FillFunctionArgumentsFix(element: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
     override fun getText(): String = "Fill missing arguments"
@@ -88,7 +87,7 @@ class FillFunctionArgumentsFix(element: PsiElement) : LocalQuickFixAndIntentionA
         val insertedArguments = arguments.replace(newArgumentList) as RsValueArgumentList
         val toBeChanged = newArgumentIndices.map { insertedArguments.exprList[it] }
 
-        editor?.buildAndRunTemplate(insertedArguments, toBeChanged.map { it.createSmartPointer() })
+        editor?.buildAndRunTemplate(insertedArguments, toBeChanged)
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddAssocTypeBindingsFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddAssocTypeBindingsFix.kt
@@ -17,7 +17,6 @@ import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsTraitRef
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.startOffset
-import org.rust.openapiext.createSmartPointer
 
 class AddAssocTypeBindingsFix(
     element: PsiElement,
@@ -51,6 +50,6 @@ class AddAssocTypeBindingsFix(
         val missingTypes = missingTypes.map { factory.createAssocTypeBinding(it, defaultType) }
         val addedArguments = arguments.addElements(missingTypes, lastArgument, factory)
 
-        editor?.buildAndRunTemplate(element, addedArguments.mapNotNull { it.typeReference?.createSmartPointer() })
+        editor?.buildAndRunTemplate(element, addedArguments.mapNotNull { it.typeReference })
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddGenericArguments.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddGenericArguments.kt
@@ -20,7 +20,6 @@ import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsTypeArgumentList
 import org.rust.lang.core.psi.ext.*
-import org.rust.openapiext.createSmartPointer
 
 class AddGenericArguments(
     @SafeFieldForPreview
@@ -39,7 +38,7 @@ class AddGenericArguments(
     ) {
         val element = startElement as? RsMethodOrPath ?: return
         val inserted = insertGenericArgumentsIfNeeded(element) ?: return
-        editor?.buildAndRunTemplate(element, inserted.map { it.createSmartPointer() })
+        editor?.buildAndRunTemplate(element, inserted.map { it })
     }
 
     private val argumentsName: String

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/InitializeWithDefaultValueFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/InitializeWithDefaultValueFix.kt
@@ -18,7 +18,6 @@ import org.rust.lang.core.psi.ext.getLocalVariableVisibleBindings
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.declaration
 import org.rust.lang.core.types.type
-import org.rust.openapiext.createSmartPointer
 
 class InitializeWithDefaultValueFix(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
     override fun getText() = "Initialize with a default value"
@@ -37,7 +36,7 @@ class InitializeWithDefaultValueFix(element: RsElement) : LocalQuickFixAndIntent
             declaration.addBefore(psiFactory.createEq(), semicolon)
         }
         val addedInitExpr = declaration.addBefore(initExpr, semicolon)
-        editor?.buildAndRunTemplate(declaration, listOf(addedInitExpr.createSmartPointer()))
+        editor?.buildAndRunTemplate(declaration, listOf(addedInitExpr))
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspection.kt
@@ -5,11 +5,11 @@
 
 package org.rust.ide.inspections.lints
 
-import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.openapi.project.Project
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -18,11 +18,11 @@ import org.rust.ide.annotator.getFunctionCallContext
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.utils.template.newTemplateBuilder
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.expandedStmtsAndTailExpr
+import org.rust.lang.core.psi.ext.findFirstMetaItem
 import org.rust.lang.core.types.implLookupAndKnownItems
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.type
-import org.rust.openapiext.createSmartPointer
 
 private fun RsExpr.returnsStdResult(): Boolean {
     val (_, knownItems) = implLookupAndKnownItems
@@ -38,11 +38,10 @@ private class FixAddLetUnderscore(anchor: PsiElement) : LocalQuickFixAndIntentio
         val originalExpr = startElement as RsExpr
         val letExpr = RsPsiFactory(project).createLetDeclaration("_", originalExpr)
         val newLetExpr = originalExpr.parent.replace(letExpr) as RsLetDecl
-        val patPointer = newLetExpr.pat?.createSmartPointer() ?: return
-        val template = editor?.newTemplateBuilder(newLetExpr) ?: return
-        val pat = patPointer.element ?: return
-        template.replaceElement(pat)
-        template.runInline()
+        val pat = newLetExpr.pat ?: return
+        val tpl = editor?.newTemplateBuilder(newLetExpr) ?: return
+        tpl.replaceElement(pat)
+        tpl.runInline()
     }
 }
 
@@ -63,12 +62,11 @@ private class FixAddExpect(anchor: PsiElement) : LocalQuickFixAndIntentionAction
         val dotExpr = RsPsiFactory(project).createExpression("${startElement.text}.expect(\"\")")
         val newDotExpr = startElement.replace(dotExpr) as RsDotExpr
         val expectArgs = newDotExpr.methodCall?.valueArgumentList?.exprList
-        val stringLiteralPointer = (expectArgs?.singleOrNull() as RsLitExpr).createSmartPointer()
-        val template = editor?.newTemplateBuilder(newDotExpr) ?: return
-        val stringLiteral = stringLiteralPointer.element ?: return
+        val stringLiteral = expectArgs?.singleOrNull() as RsLitExpr
+        val tpl = editor?.newTemplateBuilder(newDotExpr) ?: return
         val rangeWithoutQuotes = TextRange(1, stringLiteral.textRange.length - 1)
-        template.replaceElement(stringLiteral, rangeWithoutQuotes, "TODO: panic message")
-        template.runInline()
+        tpl.replaceElement(stringLiteral, rangeWithoutQuotes, "TODO: panic message")
+        tpl.runInline()
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntention.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import com.intellij.psi.SmartPsiElementPointer
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.*
@@ -18,7 +17,6 @@ import org.rust.lang.core.types.ty.TyFunction
 import org.rust.lang.core.types.ty.TyUnit
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
-import org.rust.openapiext.createSmartPointer
 
 class ConvertClosureToFunctionIntention : RsElementBaseIntentionAction<ConvertClosureToFunctionIntention.Context>() {
 
@@ -80,11 +78,11 @@ class ConvertClosureToFunctionIntention : RsElementBaseIntentionAction<ConvertCl
 
         // in case we auto-generated a function name, we encourage the user to change it by running a template on the replacement
         if (useDefaultName || placeholders.isNotEmpty()) {
-            val placeholderElements = mutableListOf<SmartPsiElementPointer<PsiElement>>()
+            val placeholderElements = mutableListOf<PsiElement>()
             if (useDefaultName) {
-                placeholderElements.add(replaced.identifier.createSmartPointer())
+                placeholderElements.add(replaced.identifier)
             }
-            placeholderElements += placeholders.map { it.createSmartPointer() }
+            placeholderElements += placeholders
             editor.buildAndRunTemplate(replaced, placeholderElements)
         } else {
             editor.caretModel.moveToOffset(replaced.endOffset)

--- a/src/main/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntention.kt
@@ -8,7 +8,6 @@ package org.rust.ide.intentions
 import com.intellij.codeInsight.hint.HintManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.elementType
 import org.rust.ide.utils.template.newTemplateBuilder
@@ -74,9 +73,7 @@ class ImplTraitToTypeParamIntention : RsElementBaseIntentionAction<ImplTraitToTy
 
         val newArgType = argType.replace(psiFactory.createType(typeParameterName)).createSmartPointer()
 
-        PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
-
-        val tpl = editor.newTemplateBuilder(fnSignature) ?: return
+        val tpl = editor.newTemplateBuilder(fnSignature)
         tpl.introduceVariable(typeParameter.identifier, typeParameterName).apply {
             replaceElementWithVariable(newArgType.element ?: return)
         }

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateFunctionIntention.kt
@@ -23,7 +23,6 @@ import org.rust.lang.core.types.expectedType
 import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
-import org.rust.openapiext.createSmartPointer
 
 class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionIntention.Context>() {
     override fun getFamilyName() = "Create function"
@@ -153,7 +152,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
             }
 
             toBeReplaced += listOfNotNull(inserted.block?.syntaxTailStmt)
-            editor.buildAndRunTemplate(inserted, toBeReplaced.map { it.createSmartPointer() })
+            editor.buildAndRunTemplate(inserted, toBeReplaced)
         } else {
             // template builder cannot be used for a different file
             inserted.navigate(true)

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
@@ -56,24 +56,23 @@ class CreateStructIntention : RsElementBaseIntentionAction<CreateStructIntention
         val fields = inserted.blockFields?.namedFieldDeclList.orEmpty().map { it.createSmartPointer() }
         if (inserted.containingFile == function.containingFile && fields.isNotEmpty()) {
             val unknownTypes = inserted.descendantsOfType<RsInferType>()
-                .map { it.createSmartPointer() }
-            val builder = editor.newTemplateBuilder(inserted.containingFile) ?: return
+            val tpl = editor.newTemplateBuilder(inserted.containingFile)
 
             // Replace unknown types
             unknownTypes.forEach {
-                builder.replaceElement(it.element ?: return@forEach)
+                tpl.replaceElement(it)
             }
 
             // Replace field names
             for (field in fields) {
                 val element = field.element?.identifier ?: continue
-                val variable = builder.introduceVariable(element)
+                val variable = tpl.introduceVariable(element)
                 val fieldLiteralIdentifier = ctx.literalElement.structLiteralBody.structLiteralFieldList.find {
                     it.identifier?.text == element.text
                 }?.identifier ?: continue
                 variable.replaceElementWithVariable(fieldLiteralIdentifier)
             }
-            builder.runInline()
+            tpl.runInline()
         } else {
             inserted.navigate(true)
         }

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateTupleStructIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateTupleStructIntention.kt
@@ -22,7 +22,6 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.expectedType
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
-import org.rust.openapiext.createSmartPointer
 
 class CreateTupleStructIntention : RsElementBaseIntentionAction<CreateTupleStructIntention.Context>() {
     override fun getFamilyName() = "Create tuple struct"
@@ -65,7 +64,7 @@ class CreateTupleStructIntention : RsElementBaseIntentionAction<CreateTupleStruc
         if (inserted.containingFile == ctx.call.containingFile && fields.isNotEmpty()) {
             val unknownTypes = inserted.descendantsOfType<RsInferType>()
             if (unknownTypes.isNotEmpty()) {
-                editor.buildAndRunTemplate(inserted, unknownTypes.map { it.createSmartPointer() })
+                editor.buildAndRunTemplate(inserted, unknownTypes)
             } else {
                 editor.caretModel.moveToOffset(fields[0].textOffset)
             }

--- a/src/main/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplate.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.template.postfix
 
-import com.intellij.codeInsight.template.TemplateResultListener
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateWithExpressionSelector
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiDocumentManager
@@ -62,16 +61,10 @@ class MatchPostfixTemplate(provider: RsPostfixTemplateProvider) :
             moveCaretToMatchArmBlock(editor, blockExpr)
         } else {
             val blockExprPointer = blockExpr.createSmartPointer()
-            editor.buildAndRunTemplate(
-                matchBody,
-                toBeReplaced.map { it.createSmartPointer() },
-                TemplateResultListener {
-                    if (it == TemplateResultListener.TemplateResult.Finished) {
-                        val restoredBlockExpr = blockExprPointer.element ?: return@TemplateResultListener
-                        moveCaretToMatchArmBlock(editor, restoredBlockExpr)
-                    }
-                }
-            )
+            editor.buildAndRunTemplate(matchBody, toBeReplaced) {
+                val restoredBlockExpr = blockExprPointer.element ?: return@buildAndRunTemplate
+                moveCaretToMatchArmBlock(editor, restoredBlockExpr)
+            }
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/typing/paste/RsConvertJsonToStructCopyPasteProcessor.kt
@@ -370,7 +370,7 @@ private fun replacePlaceholders(
             RsBundle.message("copy.paste.convert.json.to.struct.dialog.title")
         ) {
             if (!file.isValid) return@runWriteCommandAction
-            val template = editor.newTemplateBuilder(file) ?: return@runWriteCommandAction
+            val tpl = editor.newTemplateBuilder(file)
 
             // Gather usages of structs in fields
             val structNames = nameMap.values.toSet()
@@ -384,7 +384,7 @@ private fun replacePlaceholders(
             for (item in items) {
                 val identifier = item.identifier
                 if (identifier != null) {
-                    val variable = template.introduceVariable(identifier)
+                    val variable = tpl.introduceVariable(identifier)
                     for (usage in nameUsages[identifier.text].orEmpty()) {
                         variable.replaceElementWithVariable(usage)
                     }
@@ -394,11 +394,11 @@ private fun replacePlaceholders(
                 item.accept(underscoreVisitor)
 
                 for (wildcard in underscoreVisitor.types) {
-                    template.replaceElement(wildcard)
+                    tpl.replaceElement(wildcard)
                 }
             }
 
-            template.runInline()
+            tpl.runInline()
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
+++ b/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
@@ -14,7 +14,6 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.resolve.ref.deepResolve
-import org.rust.openapiext.createSmartPointer
 
 fun addMissingFieldsToStructLiteral(
     factory: RsPsiFactory,
@@ -32,7 +31,7 @@ fun addMissingFieldsToStructLiteral(
         fieldsToAdd,
         structLiteral.getLocalVariableVisibleBindings()
     )
-    editor?.buildAndRunTemplate(body, addedFields.mapNotNull { it.expr?.createSmartPointer() })
+    editor?.buildAndRunTemplate(body, addedFields.mapNotNull { it.expr })
 }
 
 fun expandStructFields(factory: RsPsiFactory, patStruct: RsPatStruct) {
@@ -74,7 +73,7 @@ fun expandTupleStructFields(factory: RsPsiFactory, editor: Editor?, patTuple: Rs
     val missingFieldsAmount = declaration.fields.size - bodyFields.size
     addFieldsToPat(factory, patTuple, createTupleStructMissingFields(factory, missingFieldsAmount), hasTrailingComma)
     patTuple.patRest?.delete()
-    editor?.buildAndRunTemplate(patTuple, patTuple.childrenOfType<RsPatBinding>().map { it.createSmartPointer() })
+    editor?.buildAndRunTemplate(patTuple, patTuple.childrenOfType<RsPatBinding>())
 }
 
 private fun createTupleStructMissingFields(factory: RsPsiFactory, amount: Int): List<RsPatBinding> {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
@@ -189,7 +189,7 @@ private fun <T: RsElement>reformat(element: T): T? {
 }
 
 private fun runTemplate(element: RsElement, editor: Editor) {
-    editor.buildAndRunTemplate(element.parent, listOf(element.createSmartPointer()))
+    editor.buildAndRunTemplate(element.parent, listOf(element))
 }
 
 private fun removePrefix(text: String, keyword: PsiElement?): String {


### PR DESCRIPTION
This slightly simplifies `RsTemplateBuilder`. Now it's not needed to wrap all PSI elements being replaced with pointers (but elements used in a callback still have to be wrapped). But the real motivation for these changes is preparing for intentions & quick-fixes inside macros.

changelog: Slightly simplifiy `RsTemplateBuilder` API