### PR TITLE
Fix IndexNotReadyException in NavBar

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -311,8 +311,8 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
         val baseIcon = when (val owner = if (allowNameResolution) owner else ownerBySyntaxOnly) {
             is RsAbstractableOwner.Free, is RsAbstractableOwner.Foreign ->
                 when {
-                    isTest -> RsIcons.FUNCTION.addTestMark()
-                    isProcMacroDef -> RsIcons.PROC_MACRO
+                    allowNameResolution && isTest -> RsIcons.FUNCTION.addTestMark()
+                    allowNameResolution && isProcMacroDef -> RsIcons.PROC_MACRO
                     else -> RsIcons.FUNCTION
                 }
 


### PR DESCRIPTION
Fixes #10109
Related: #10014

no changelog since the exception should not be visible to users