### PR TITLE
Add `tokio_macros::test_rt` to list of hardcoded macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
@@ -16,7 +16,9 @@ import org.rust.openapiext.isUnitTestMode
 private val RS_HARDCODED_PROC_MACRO_ATTRIBUTES: Map<String, Map<String, KnownProcMacroKind>> = mapOf(
     "tokio_macros" to mapOf(
         "main" to KnownProcMacroKind.ASYNC_MAIN,
+        "main_rt" to KnownProcMacroKind.ASYNC_MAIN,
         "test" to KnownProcMacroKind.ASYNC_TEST,
+        "test_rt" to KnownProcMacroKind.ASYNC_TEST,
     ),
     "async_attributes" to mapOf(
         "main" to KnownProcMacroKind.ASYNC_MAIN,


### PR DESCRIPTION
Fixes #10015

`tokio::test` resolves to either `tokio_macros::test` or `tokio_macros::test_rt` depending on tokio features enabled (`rt-multi-thread` vs `rt`). Cause of the original issue was that we do expand `tokio_macros::test_rt` to invocation of `std::prelude::v1::test` macro which probably also should be treated as identity.

changelog: Fix handling of attribute macro `tokio::test` in some cases