### PR TITLE
MACRO: recover PUNCT and delimiter token mappings discarded by a proc macro

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -209,7 +209,7 @@ class ProcMacroExpander private constructor(
         psi !is RsDotExpr && psi.childrenWithLeaves.any { it is PsiErrorElement || it !is RsExpr && hasErrorToHandle(it) }
 
     companion object {
-        const val EXPANDER_VERSION: Int = 7
+        const val EXPANDER_VERSION: Int = 8
 
         fun forCrate(crate: Crate): ProcMacroExpander {
             val project = crate.project

--- a/src/main/kotlin/org/rust/lang/core/macros/tt/TokenTreeParser.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/tt/TokenTreeParser.kt
@@ -53,7 +53,7 @@ private class TokenTreeParser(
     }
 
     private fun parseSubtree(offset: Int, delimKind: MacroBraces, result: MutableList<TokenTree>) {
-        val delimLeaf = Delimiter(allocDelimId(offset, nextWhitespaceOrCommentText()), delimKind)
+        val delimLeaf = Delimiter(allocDelimId(offset, nextWhitespaceOrCommentText(), delimKind), delimKind)
         val subtreeResult = mutableListOf<TokenTree>()
 
         lexer.advanceLexer()
@@ -150,9 +150,10 @@ private class TokenTreeParser(
         tokenMap += TokenMetadata.Token(textOffset + startOffset, rightTrivia, leaf)
     }
 
-    private fun allocDelimId(openOffset: Int, rightTrivia: CharSequence): Int {
+    private fun allocDelimId(openOffset: Int, rightTrivia: CharSequence, delimKind: MacroBraces): Int {
         val id = nextId()
-        tokenMap += TokenMetadata.Delimiter(TokenMetadata.Delimiter.DelimiterPart(textOffset + openOffset, rightTrivia), null)
+        val open = TokenMetadata.Delimiter.DelimiterPart(textOffset + openOffset, rightTrivia)
+        tokenMap += TokenMetadata.Delimiter(open, null, delimKind)
         return id
     }
 

--- a/testData/test-proc-macros/src/lib.rs
+++ b/testData/test-proc-macros/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate proc_macro;
 
-use proc_macro::{Delimiter, Group, Ident, Span, TokenStream, TokenTree};
+use proc_macro::{Delimiter, Group, Ident, Punct, Span, TokenStream, TokenTree};
 
 #[proc_macro]
 pub fn function_like_as_is(input: TokenStream) -> TokenStream {
@@ -176,4 +176,26 @@ pub fn attr_add_to_fn_beginning(attr: TokenStream, item: TokenStream) -> TokenSt
             TokenTree::Punct(..) | TokenTree::Literal(..) => tt,
         }
     }).collect()
+}
+
+#[proc_macro_attribute]
+pub fn attr_as_is_discard_punct_spans(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    discard_punct_spans_stream(item)
+}
+
+fn discard_punct_spans_stream(ts: TokenStream) -> TokenStream {
+    ts.into_iter().map(discard_punct_spans_tree).collect()
+}
+
+fn  discard_punct_spans_tree(tt: TokenTree) -> TokenTree {
+    match tt {
+        TokenTree::Group(g) => {
+            let dg = Group::new(g.delimiter(), discard_punct_spans_stream(g.stream()));
+            TokenTree::Group(dg)
+        }
+        TokenTree::Punct(p) => {
+            TokenTree::Punct(Punct::new(p.as_char(), p.spacing()))
+        }
+        TokenTree::Ident(..) | TokenTree::Literal(..) => tt,
+    }
 }


### PR DESCRIPTION
`syn`-based procedural macros tend to discard spans (token ids) from `TokenTree.Leaf.Punct` tokens and subtree `Delimiter`s. In this PR I introduce a routine that tries to recover them using a simple heuristic: if a token without a mapping (with id == -1) follows a token *with* a mapping, then it most likely should be mapped with the next token in the source. The only thing should be checked is that its type and text is equal to the token in the source.

This is mostly needed to improve error highlighting in attribute procedural macros (#10037) and for intention actions and quick fixes in macros