### PR TITLE
RES: Skip lambda argument processing when walking upward from arg list

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1614,6 +1614,7 @@ private fun processLexicalDeclarations(
 
         is RsLambdaExpr -> {
             if (Namespace.Values !in ns) return false
+            if (scope.expr != cameFrom) return false
             for (parameter in scope.valueParameters) {
                 val pat = parameter.pat
                 if (pat != null && processPattern(pat, processor)) return true


### PR DESCRIPTION
This should not affect users. In theory this could improve performance, but very slightly