### PR TITLE
INT: Make intention actions work inside an attribute macro expansion

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActions.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActions.kt
@@ -15,7 +15,7 @@ import com.intellij.openapi.project.Project
 import org.rust.lang.core.macros.errors.GetMacroExpansionError
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.RsPossibleMacroCall
-import org.rust.lang.core.psi.ext.ancestorMacroCall
+import org.rust.lang.core.psi.ext.contextMacroCall
 import org.rust.openapiext.editor
 import org.rust.openapiext.elementUnderCaretInEditor
 import org.rust.openapiext.project
@@ -78,5 +78,5 @@ class RsShowSingleStepMacroExpansionAction : RsShowMacroExpansionActionBase(expa
 fun getMacroUnderCaret(event: DataContext): RsPossibleMacroCall? {
     val elementUnderCaret = event.elementUnderCaretInEditor ?: return null
 
-    return elementUnderCaret.ancestorMacroCall
+    return elementUnderCaret.contextMacroCall
 }

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -34,6 +34,8 @@ object RsExperiments {
     const val WSL_TOOLCHAIN = "org.rust.wsl"
 
     const val EMULATE_TERMINAL = "org.rust.cargo.emulate.terminal"
+
+    const val INTENTIONS_IN_FN_LIKE_MACROS = "org.rust.ide.intentions.macros.function-like"
 }
 
 /**

--- a/src/main/kotlin/org/rust/ide/intentions/AddCurlyBracesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddCurlyBracesIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsUseItem
@@ -33,6 +34,8 @@ import org.rust.openapiext.moveCaretToOffset
 class AddCurlyBracesIntention : RsElementBaseIntentionAction<AddCurlyBracesIntention.Context>() {
     override fun getText() = "Add curly braces"
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     class Context(
         val useSpeck: RsUseSpeck,

--- a/src/main/kotlin/org/rust/ide/intentions/AddDeriveIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddDeriveIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.RsOuterAttr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
@@ -19,6 +20,8 @@ import org.rust.openapiext.moveCaretToOffset
 class AddDeriveIntention : RsElementBaseIntentionAction<AddDeriveIntention.Context>() {
     override fun getFamilyName() = "Add derive clause"
     override fun getText() = "Add derive clause"
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     class Context(
         val item: RsStructOrEnumItemElement,

--- a/src/main/kotlin/org/rust/ide/intentions/AddElseIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddElseIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiInsertionPlace
 import org.rust.lang.core.psi.RsIfExpr
 import org.rust.lang.core.psi.RsPsiFactory
@@ -19,6 +20,8 @@ import org.rust.openapiext.moveCaretToOffset
 class AddElseIntention : RsElementBaseIntentionAction<PsiInsertionPlace>() {
     override fun getText() = "Add else branch to this if statement"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): PsiInsertionPlace? {
         val ifExpr = element.ancestorStrict<RsIfExpr>() ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/AddImportForPatternIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImportForPatternIntention.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.ide.inspections.import.AutoImportFix
 import org.rust.ide.intentions.AddImportForPatternIntention.Context
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.RsMatchArm
 import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.RsPatIdent
@@ -22,8 +23,11 @@ class AddImportForPatternIntention : RsElementBaseIntentionAction<Context>() {
     override fun getText(): String = "Import"
     override fun getFamilyName(): String = "Add import for path in pattern"
 
-    override fun startInWriteAction(): Boolean = false
+    // TODO ideally, it should work inside macro expansions, but now it can't work with import chooser
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
+    override val functionLikeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
+    override fun startInWriteAction(): Boolean = false
     override fun getElementToMakeWritable(currentFile: PsiFile): PsiFile = currentFile
 
     class Context(val pat: RsPatIdent, val context: AutoImportFix.Context)

--- a/src/main/kotlin/org/rust/ide/intentions/ChangeReferenceMutabilityIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ChangeReferenceMutabilityIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsRefLikeType
@@ -55,6 +56,8 @@ class SetImmutableIntention : ChangeReferenceMutabilityIntention() {
 
 abstract class ChangeReferenceMutabilityIntention : RsElementBaseIntentionAction<ChangeReferenceMutabilityIntention.Context>() {
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     protected abstract val newMutability: Mutability
 

--- a/src/main/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntention.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.ide.utils.template.buildAndRunTemplate
@@ -23,6 +24,8 @@ import org.rust.openapiext.moveCaretToOffset
 class ConvertClosureToFunctionIntention : RsElementBaseIntentionAction<ConvertClosureToFunctionIntention.Context>() {
     override fun getText(): String = "Convert closure to function"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(
         val letDecl: RsLetDecl,
@@ -102,5 +105,4 @@ class ConvertClosureToFunctionIntention : RsElementBaseIntentionAction<ConvertCl
         val wildcardPaths = parameters.descendantsOfType<RsPath>().filter { it.path?.text == "_" }
         return wildcardPats + wildcardPaths
     }
-
 }

--- a/src/main/kotlin/org/rust/ide/intentions/ConvertFunctionToClosureIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ConvertFunctionToClosureIntention.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsLetDecl
@@ -20,6 +21,8 @@ import org.rust.openapiext.moveCaretToOffset
 class ConvertFunctionToClosureIntention : RsElementBaseIntentionAction<ConvertFunctionToClosureIntention.Context>() {
     override fun getText(): String = "Convert function to closure"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(val targetFunction: RsFunction)
 
@@ -58,5 +61,4 @@ class ConvertFunctionToClosureIntention : RsElementBaseIntentionAction<ConvertFu
             editor?.moveCaretToOffset(replaced, it)
         }
     }
-
 }

--- a/src/main/kotlin/org/rust/ide/intentions/DemorgansLawIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/DemorgansLawIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.ext.LogicOp.AND
@@ -25,6 +26,8 @@ class DemorgansLawIntention : RsElementBaseIntentionAction<DemorgansLawIntention
             else -> ""
         }
     }
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(
         val binaryExpr: RsBinaryExpr,

--- a/src/main/kotlin/org/rust/ide/intentions/DestructureIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/DestructureIntention.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.SearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.parentOfType
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.presentation.render
 import org.rust.ide.refactoring.findBinding
 import org.rust.ide.utils.import.RsImportHelper.importTypeReferencesFromTy
@@ -27,6 +28,10 @@ import org.rust.openapiext.createSmartPointer
 class DestructureIntention : RsElementBaseIntentionAction<DestructureIntention.Context>() {
     override fun getText(): String = "Use destructuring declaration"
     override fun getFamilyName(): String = text
+
+    // TODO should be InvokeInside.MACRO_EXPANSION, but reference search (needed for `renameNewBindings`)
+    //  is not handled well inside macro expansions for now
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     sealed class Context(val patIdent: RsPatIdent) {
         class Struct(patIdent: RsPatIdent, val struct: RsStructItem, val type: TyAdt) : Context(patIdent)

--- a/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.RsModItem
@@ -22,6 +23,8 @@ import org.rust.openapiext.Testmark
 class ExtractInlineModuleIntention : RsElementBaseIntentionAction<RsModItem>() {
     override fun getFamilyName() = "Extract inline module structure"
     override fun getText() = "Extract inline module"
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsModItem? {
         val mod = element.ancestorOrSelf<RsModItem>() ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.moveCaretToOffset
@@ -32,6 +33,8 @@ import org.rust.openapiext.moveCaretToOffset
 class FlattenUseStatementsIntention : RsElementBaseIntentionAction<FlattenUseStatementsIntention.Context>() {
     override fun getText() = "Flatten use statements"
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     interface Context {
         val useSpecks: List<RsUseSpeck>

--- a/src/main/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.RsBinaryExpr
 import org.rust.lang.core.psi.RsElementTypes.*
@@ -19,6 +20,8 @@ import org.rust.lang.core.psi.ext.operator
 class FlipBinaryExpressionIntention : RsElementBaseIntentionAction<RsBinaryExpr>() {
     override fun getText(): String = "Flip binary expression"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsBinaryExpr? {
         val binaryExpr = element.ancestorStrict<RsBinaryExpr>() ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/GenerateDocStubIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/GenerateDocStubIntention.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.util.text.CharArrayUtil
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.RsValueParameter
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.impl.RsFunctionImpl
@@ -20,6 +21,8 @@ import kotlin.math.max
 class GenerateDocStubIntention : RsElementBaseIntentionAction<GenerateDocStubIntention.Context>() {
     override fun getText() = "Generate documentation stub"
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(
         val func: RsElement,

--- a/src/main/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntention.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.elementType
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.template.newTemplateBuilder
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -20,6 +21,8 @@ import org.rust.openapiext.showErrorHint
 class ImplTraitToTypeParamIntention : RsElementBaseIntentionAction<ImplTraitToTypeParamIntention.Context>() {
     override fun getText(): String = "Convert `impl Trait` to type parameter"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(
         val argType: RsTraitType,

--- a/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntention.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.refactoring.introduceVariable.extractExpression
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.*
@@ -20,6 +21,8 @@ import org.rust.lang.core.types.type
 class IntroduceLocalVariableIntention : RsElementBaseIntentionAction<RsExpr>() {
     override fun getText(): String = "Introduce local variable"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsExpr? {
         val expr = element.ancestors

--- a/src/main/kotlin/org/rust/ide/intentions/InvertIfIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/InvertIfIntention.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import org.rust.ide.intentions.InvertIfIntention.Context.ContextWithElse
 import org.rust.ide.intentions.InvertIfIntention.Context.ContextWithoutElse
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyNever
@@ -54,6 +55,11 @@ import org.rust.lang.utils.negate
  * ```
  */
 class InvertIfIntention : RsElementBaseIntentionAction<InvertIfIntention.Context>() {
+    override fun getFamilyName(): String = text
+    override fun getText() = "Invert if condition"
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
+
     sealed interface Context {
         val ifCondition: RsExpr
 
@@ -177,10 +183,6 @@ class InvertIfIntention : RsElementBaseIntentionAction<InvertIfIntention.Context
 
     private fun getSuitableCondition(ifExpr: RsIfExpr): RsCondition? =
         ifExpr.condition?.takeIf { it.expr?.descendantOfTypeOrSelf<RsLetExpr>() == null }
-
-    override fun getFamilyName(): String = text
-
-    override fun getText() = "Invert if condition"
 }
 
 /**

--- a/src/main/kotlin/org/rust/ide/intentions/JoinWildcardsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/JoinWildcardsIntention.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
@@ -17,6 +18,8 @@ import org.rust.lang.core.psi.ext.startOffset
 
 class JoinWildcardsIntention : RsElementBaseIntentionAction<List<RsPatWild>>() {
     override fun getFamilyName(): String = "Replace successive `_` with `..`"
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): List<RsPatWild>? {
         var patUnderCaret = element.ancestorStrict<RsPat>() ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/ListIntentionBase.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ListIntentionBase.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.parser.RustParserDefinition.Companion.EOL_COMMENT
 import org.rust.lang.core.psi.RsElementTypes.COMMA
 import org.rust.lang.core.psi.ext.*
@@ -25,6 +26,8 @@ abstract class ListIntentionBase<TList : RsElement, TElement : RsElement>(
     }
 
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     protected val PsiElement.listContext: TList?
         get() = PsiTreeUtil.getParentOfType(this, listClass, true)

--- a/src/main/kotlin/org/rust/ide/intentions/MatchToIfLetIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/MatchToIfLetIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
@@ -16,6 +17,8 @@ import org.rust.lang.core.psi.ext.getNextNonCommentSibling
 class MatchToIfLetIntention : RsElementBaseIntentionAction<MatchToIfLetIntention.Context>() {
     override fun getText() = "Convert match statement to if let"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(
         val match: RsMatchExpr,

--- a/src/main/kotlin/org/rust/ide/intentions/MergeIfsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/MergeIfsIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -15,6 +16,8 @@ import org.rust.lang.core.psi.ext.*
 class MergeIfsIntention : RsElementBaseIntentionAction<MergeIfsIntention.Context>() {
     override fun getText(): String = "Merge with the nested 'if' expression"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     class Context(
         val ifExprBlock: RsBlock,

--- a/src/main/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
@@ -18,6 +19,8 @@ import org.rust.openapiext.moveCaretToOffset
 class MoveGuardToMatchArmIntention : RsElementBaseIntentionAction<MoveGuardToMatchArmIntention.Context>() {
     override fun getText(): String = "Move guard inside the match arm"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(
         val guard: RsMatchArmGuard,

--- a/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntention.kt
@@ -8,14 +8,16 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.moveCaretToOffset
 
 class MoveTypeConstraintToParameterListIntention : RsElementBaseIntentionAction<RsWhereClause>() {
-
     override fun getText() = "Move type constraint to parameter list"
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsWhereClause? {
         val whereClause = element.ancestorStrict<RsWhereClause>() ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.moveCaretToOffset
@@ -15,6 +16,8 @@ import org.rust.openapiext.moveCaretToOffset
 class MoveTypeConstraintToWhereClauseIntention : RsElementBaseIntentionAction<RsTypeParameterList>() {
     override fun getText() = "Move type constraint to where clause"
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsTypeParameterList? {
         val genericParams = element.contextStrict<RsTypeParameterList>() ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.moveCaretToOffset
@@ -33,6 +34,8 @@ import org.rust.openapiext.moveCaretToOffset
 class NestUseStatementsIntention : RsElementBaseIntentionAction<NestUseStatementsIntention.Context>() {
     override fun getText() = "Nest use statements"
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     interface Context {
         val useSpecks: List<RsUseSpeck>

--- a/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsPsiFactory
@@ -31,6 +32,8 @@ import org.rust.lang.core.psi.ext.*
 class RemoveCurlyBracesIntention : RsElementBaseIntentionAction<RemoveCurlyBracesIntention.Context>() {
     override fun getText() = "Remove curly braces"
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(
         val path: RsPath,

--- a/src/main/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntention.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.parser.RustParserDefinition.Companion.BLOCK_COMMENT
 import org.rust.lang.core.psi.RsPsiFactory
@@ -19,6 +20,9 @@ import org.rust.lang.core.psi.ext.elementType
 class ReplaceBlockCommentWithLineCommentIntention : RsElementBaseIntentionAction<PsiComment>() {
     override fun getText(): String = familyName
     override fun getFamilyName(): String = "Replace with end of line comment"
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
+    override val functionLikeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): PsiComment? =
         element.ancestorOrSelf<PsiComment>()

--- a/src/main/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntention.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.parser.RustParserDefinition.Companion.EOL_COMMENT
 import org.rust.lang.core.psi.RsPsiFactory
@@ -21,6 +22,9 @@ import org.rust.lang.core.psi.ext.getPrevNonWhitespaceSibling
 class ReplaceLineCommentWithBlockCommentIntention : RsElementBaseIntentionAction<PsiComment>() {
     override fun getText(): String = familyName
     override fun getFamilyName(): String = "Replace with block comment"
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
+    override val functionLikeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): PsiComment? {
         val comment = element.ancestorOrSelf<PsiComment>()

--- a/src/main/kotlin/org/rust/ide/intentions/RsElementBaseIntentionAction.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RsElementBaseIntentionAction.kt
@@ -9,9 +9,18 @@ import com.intellij.codeInsight.intention.BaseElementAtCaretIntentionAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.experiments.RsExperiments
+import org.rust.ide.intentions.util.macros.IntentionInMacroUtil
+import org.rust.ide.intentions.util.macros.InvokeInside
+import org.rust.lang.core.macros.findExpansionElements
+import org.rust.lang.core.psi.RsMacroArgument
+import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.isIntentionPreviewElement
+import org.rust.lang.core.psi.ext.startOffset
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.checkWriteAccessAllowed
+import org.rust.openapiext.isFeatureEnabled
 
 /**
  * A base class for implementing intentions: actions available via "light bulb" / `Alt+Enter`.
@@ -41,17 +50,108 @@ abstract class RsElementBaseIntentionAction<Ctx> : BaseElementAtCaretIntentionAc
     abstract fun invoke(project: Project, editor: Editor, ctx: Ctx)
 
     final override fun invoke(project: Project, editor: Editor, element: PsiElement) {
-        val ctx = findApplicableContext(project, editor, element) ?: return
-
         if (startInWriteAction() && !element.isIntentionPreviewElement) {
             checkWriteAccessAllowed()
         }
 
+        val possiblyExpandedElement = findTargetElement(element) ?: return
+        if (possiblyExpandedElement != element) {
+            invokeInsideMacroExpansion(project, editor, element.containingFile, possiblyExpandedElement)
+        } else {
+            invokeInner(project, editor, element)
+        }
+    }
+
+    private fun findTargetElement(element: PsiElement): PsiElement? {
+        val expandedElements = element.findExpansionElements()
+        return if (expandedElements == null) {
+            // The element is NOT inside a macro call - use the original element
+            element
+        } else {
+            // The element is inside a macro call
+            val isFunctionLike = element.ancestorOrSelf<RsMacroArgument>() != null
+            val strategy = if (isFunctionLike) functionLikeMacroHandlingStrategy else attributeMacroHandlingStrategy
+            if (strategy == InvokeInside.MACRO_CALL) return element
+            if (isFunctionLike && !isFeatureEnabled(RsExperiments.INTENTIONS_IN_FN_LIKE_MACROS)) return element
+            // Use the expanded element if it is single; The intention is unavailable if
+            // there are multiple or none expanded elements (e.g. if the macro expansion is failed)
+            expandedElements.singleOrNull()
+        }
+    }
+
+    private fun invokeInner(project: Project, editor: Editor, element: PsiElement) {
+        val ctx = findApplicableContext(project, editor, element) ?: return
         invoke(project, editor, ctx)
+    }
+
+    private fun invokeInsideMacroExpansion(
+        project: Project,
+        originalEditor: Editor,
+        originalFile: PsiFile,
+        expandedElement: PsiElement
+    ) {
+        IntentionInMacroUtil.runActionInsideMacroExpansionCopy(
+            project,
+            originalEditor,
+            originalFile,
+            expandedElement
+        ) { editorCopy, expandedElementCopy ->
+            invokeInner(project, editorCopy, expandedElementCopy)
+            return@runActionInsideMacroExpansionCopy true
+        }
     }
 
     final override fun isAvailable(project: Project, editor: Editor, element: PsiElement): Boolean {
         checkReadAccessAllowed()
-        return findApplicableContext(project, editor, element) != null
+        val possiblyExpandedElement = findTargetElement(element) ?: return false
+        return if (possiblyExpandedElement != element) {
+            IntentionInMacroUtil.doActionAvailabilityCheckInsideMacroExpansion(
+                editor,
+                element.containingFile,
+                possiblyExpandedElement,
+                possiblyExpandedElement.startOffset + (editor.caretModel.offset - element.startOffset)
+            ) { fakeEditor ->
+                findApplicableContext(project, fakeEditor, possiblyExpandedElement) != null
+            }
+        } else {
+            findApplicableContext(project, editor, possiblyExpandedElement) != null
+        }
     }
+
+    /**
+     * Controls how the intention action behaves inside an attribute macro call:
+     * ```
+     * #[a_macro_foo]
+     * fn foo() {
+     *     /*caret*/
+     * }
+     * ```
+     *
+     * If it returns [InvokeInside.MACRO_CALL] then the original PSI element under the caret
+     * is passed to [findApplicableContext]. If it returns [InvokeInside.MACRO_EXPANSION] then
+     * mapped element inside the expansion of macro `a_macro_foo` is passed to [findApplicableContext]
+     * (see [PsiElement.findExpansionElements]).
+     *
+     * Choose [InvokeInside.MACRO_CALL] if the intention is syntax-based and does not involve
+     * name resolution or type inference, or if the intention handles macros by itself
+     */
+    open val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_EXPANSION
+
+    /**
+     * Controls how the intention action behaves inside a function-like macro call:
+     * ```
+     * foo! {
+     *     foo /*caret*/bar baz
+     * }
+     * ```
+     *
+     * If it returns [InvokeInside.MACRO_CALL] then the original PSI element under the caret
+     * is passed to [findApplicableContext]. If it returns [InvokeInside.MACRO_EXPANSION] then
+     * mapped element inside the expansion of macro `foo` is passed to [findApplicableContext]
+     * (see [PsiElement.findExpansionElements]).
+     *
+     * Choose [InvokeInside.MACRO_CALL] if the intention is text-based and does not need a rich PSI
+     * structure, or if the intention handles macros by itself
+     */
+    open val functionLikeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_EXPANSION
 }

--- a/src/main/kotlin/org/rust/ide/intentions/RunCargoExpandIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RunCargoExpandIntention.kt
@@ -13,6 +13,7 @@ import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.tools.Cargo.Companion.checkNeedInstallCargoExpand
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.isUnderDarkTheme
 import org.rust.stdext.buildList
@@ -20,6 +21,9 @@ import org.rust.stdext.buildList
 class RunCargoExpandIntention : RsElementBaseIntentionAction<RunCargoExpandIntention.Context>(), LowPriorityAction {
     override fun getText(): String = "Show the result of macro expansion (cargo expand)"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
+    override val functionLikeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(
         val cargoProject: CargoProject,

--- a/src/main/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntention.kt
@@ -12,11 +12,15 @@ import com.intellij.psi.PsiElement
 import org.rust.RsBundle
 import org.rust.ide.actions.ShareInPlaygroundAction
 import org.rust.ide.actions.ShareInPlaygroundAction.Context
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.RsFile
 
 class ShareInPlaygroundIntention : RsElementBaseIntentionAction<Context>(), LowPriorityAction {
     override fun getText(): String = familyName
     override fun getFamilyName(): String = RsBundle.message("action.Rust.ShareInPlayground.text")
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
+    override val functionLikeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val file = element.containingFile as? RsFile ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/SplitIfIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SplitIfIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.ide.utils.skipParenExprDown
 import org.rust.ide.utils.skipParenExprUp
@@ -17,6 +18,8 @@ import org.rust.lang.core.psi.ext.*
 class SplitIfIntention : RsElementBaseIntentionAction<SplitIfIntention.Context>() {
     override fun getText(): String = "Split into 2 if's"
     override fun getFamilyName(): String = "Split if"
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(
         val binaryOp: RsBinaryOp,

--- a/src/main/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.findOuterAttr
@@ -16,6 +17,8 @@ import org.rust.lang.core.psi.ext.isTest
 class ToggleIgnoreTestIntention: RsElementBaseIntentionAction<ToggleIgnoreTestIntention.Context>() {
     override fun getText() = "Toggle ignore for tests"
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(val element: RsFunction)
 

--- a/src/main/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -19,6 +20,8 @@ import kotlin.math.min
 
 class UnwrapSingleExprIntention : RsElementBaseIntentionAction<UnwrapSingleExprIntention.Context>() {
     override fun getFamilyName() = "Remove braces from single expression"
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     data class Context(val blockExpr: RsBlockExpr, val expr: RsExpr)
 
@@ -54,5 +57,4 @@ class UnwrapSingleExprIntention : RsElementBaseIntentionAction<UnwrapSingleExprI
         val insertedElement = ctx.blockExpr.replace(element) as RsExpr
         editor.moveCaretToOffset(insertedElement, insertedElement.textOffset + relativeCaretPosition)
     }
-
 }

--- a/src/main/kotlin/org/rust/ide/intentions/WrapLambdaExprIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/WrapLambdaExprIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.ide.utils.PsiModificationUtil
 import org.rust.lang.core.psi.RsBlockExpr
 import org.rust.lang.core.psi.RsExpr
@@ -20,6 +21,8 @@ import org.rust.openapiext.moveCaretToOffset
 class WrapLambdaExprIntention : RsElementBaseIntentionAction<RsExpr>() {
     override fun getText() = "Add braces to lambda expression"
     override fun getFamilyName() = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsExpr? {
         val lambdaExpr = element.ancestorStrict<RsLambdaExpr>() ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
@@ -12,6 +12,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.ide.intentions.RsElementBaseIntentionAction
+import org.rust.ide.intentions.util.macros.IntentionInMacroUtil
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.macros.expansionContext
 import org.rust.lang.core.macros.isExprOrStmtContext
 import org.rust.lang.core.psi.RsElementTypes.STRING_LITERAL
@@ -27,6 +29,9 @@ import org.rust.openapiext.runWriteCommandAction
 class AddFmtStringArgumentIntention : RsElementBaseIntentionAction<AddFmtStringArgumentIntention.Context>() {
     override fun getText(): String = "Add format string argument"
     override fun getFamilyName(): String = text
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_EXPANSION
+    override val functionLikeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_EXPANSION
 
     override fun startInWriteAction(): Boolean = false
     override fun getElementToMakeWritable(currentFile: PsiFile): PsiFile = currentFile
@@ -115,6 +120,7 @@ class AddFmtStringArgumentIntention : RsElementBaseIntentionAction<AddFmtStringA
         )
 
         project.runWriteCommandAction(text) {
+            IntentionInMacroUtil.finishActionInMacroExpansionCopy(editor)
             val inserted = macroCall.replace(newMacroCall) as RsMacroCall
             editor.moveCaretToOffset(inserted, editor.caretModel.offset + newPlaceholder.length)
         }

--- a/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/RsAddFmtStringArgumentPopup.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/RsAddFmtStringArgumentPopup.kt
@@ -23,6 +23,7 @@ import com.intellij.ui.EditorTextField
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
+import org.rust.ide.intentions.util.macros.IntentionInMacroUtil
 import org.rust.lang.RsFileType
 import org.rust.lang.core.psi.RsCodeFragment
 import org.rust.openapiext.document
@@ -88,11 +89,13 @@ object RsAddFmtStringArgumentPopup {
             }
         })
 
-        val position = QuickEditAction.getBalloonPosition(editor)
-        var point = JBPopupFactory.getInstance().guessBestPopupLocation(editor)
+        val realEditor = IntentionInMacroUtil.unwrapEditor(editor)
+
+        val position = QuickEditAction.getBalloonPosition(realEditor)
+        var point = JBPopupFactory.getInstance().guessBestPopupLocation(realEditor)
         if (position == Balloon.Position.above) {
             val p = point.point
-            point = RelativePoint(point.component, Point(p.x, p.y - editor.lineHeight))
+            point = RelativePoint(point.component, Point(p.x, p.y - realEditor.lineHeight))
         }
         balloon.show(point, position)
         editorTextField.requestFocus()

--- a/src/main/kotlin/org/rust/ide/intentions/util/macros/IntentionInMacroUtil.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/util/macros/IntentionInMacroUtil.kt
@@ -1,0 +1,373 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions.util.macros
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.*
+import com.intellij.psi.impl.PsiDocumentManagerBase
+import com.intellij.psi.impl.source.codeStyle.CodeEditUtil
+import com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import com.intellij.psi.util.PsiTreeUtil
+import org.rust.lang.core.macros.*
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.isUnitTestMode
+import org.rust.openapiext.showErrorHint
+
+object IntentionInMacroUtil {
+    private val MUTABLE_EXPANSION_FILE_COPY = ThreadLocal<PsiFile>()
+
+    fun unwrapEditor(editor: Editor): Editor {
+        return if (editor is RsIntentionInsideMacroExpansionEditor) editor.originalEditor else editor
+    }
+
+    fun isMutableExpansionFile(file: PsiFile): Boolean {
+        return MUTABLE_EXPANSION_FILE_COPY.get() == file
+    }
+
+    private inline fun <T> withMutableExpansionFile(file: PsiFile, action: () -> T): T {
+        MUTABLE_EXPANSION_FILE_COPY.set(file)
+        try {
+            return action()
+        } finally {
+            MUTABLE_EXPANSION_FILE_COPY.remove()
+        }
+    }
+
+    fun doActionAvailabilityCheckInsideMacroExpansion(
+        originalEditor: Editor,
+        originalFile: PsiFile,
+        expandedElement: PsiElement,
+        caretOffset: Int,
+        action: (editorCopy: Editor) -> Boolean
+    ): Boolean {
+        val expansionFile = expandedElement.containingFile
+        val fakeEditor = RsIntentionInsideMacroExpansionEditor(
+            expansionFile,
+            originalFile,
+            originalEditor,
+            caretOffset,
+            null
+        )
+        return withMutableExpansionFile(expansionFile) { action(fakeEditor) }
+    }
+
+    fun <E: Editor?> runActionInsideMacroExpansionCopy(
+        project: Project,
+        originalEditor: E,
+        originalFile: PsiFile,
+        expandedElement: PsiElement,
+        action: (editorCopy: E, expandedElementCopy: PsiElement) -> Boolean
+    ) {
+        val originalDoc = originalFile.viewProvider.document
+        val macroCalls = expandedElement.macroCallExpandedFromSequence.toList()
+        val originalDeepestMacroCall = macroCalls.first()
+        val rootMacroCall = macroCalls.last()
+        val deepestMacroCall = if (originalDeepestMacroCall == rootMacroCall
+            && rootMacroCall.containingFile != originalFile
+            && rootMacroCall.containingFile == originalFile.originalFile) {
+            // Intention preview
+            PsiTreeUtil.findSameElementInCopy(rootMacroCall, originalFile)
+        } else {
+            originalDeepestMacroCall
+        }
+        val expansion = originalDeepestMacroCall.expansion!!
+        val rootMacroBodyRange = originalDoc.createRangeMarker(rootMacroCall.bodyTextRange ?: return)
+        val deepestMacroCallContext = deepestMacroCall.contextToSetForExpansion as? RsElement ?: return
+        val ranges = macroCalls
+            .asReversed()
+            .map { it.expansion!!.ranges }
+            .reduce { acc, range -> acc.mapAll(range) }
+            .let { MutableRangeMap(it.ranges.toMutableList()) }
+
+        val psiFileCopy = expansion.file.copy() as RsFile
+        psiFileCopy.setForcedReducedRangeMap(ranges)
+        for (child in psiFileCopy.children) {
+            if (child is RsExpandedElement) {
+                child.setContext(deepestMacroCallContext)
+                child.setExpandedFrom(deepestMacroCall)
+            }
+        }
+
+        val documentCopy = psiFileCopy.viewProvider.document!!
+        val context = RsIntentionInsideMacroExpansionContext(originalFile, documentCopy, ranges, rootMacroBodyRange)
+        val editorCopy = if (originalEditor != null) {
+            val initialMappedOffset = ranges.mapOffsetFromCallBodyToExpansion(originalEditor.caretModel.offset - rootMacroBodyRange.startOffset).singleOrNull()
+            RsIntentionInsideMacroExpansionEditor(psiFileCopy, originalFile, originalEditor, initialMappedOffset, context)
+        } else {
+            null
+        }
+
+        if (originalDoc.isWritable) {
+            val psiDocMgr = PsiDocumentManager.getInstance(project) as PsiDocumentManagerBase
+            documentCopy.addDocumentListener(object : DocumentListener {
+                override fun documentChanged(event: DocumentEvent) {
+                    val causedByPsiChange = psiDocMgr.synchronizer.isInSynchronization(documentCopy)
+                    val change = TextChange(TextRange(event.offset, event.offset + event.oldLength), event.newFragment)
+                    val mappedChange = ranges.mapAndApplyChange(change)
+                        ?.shiftRight(rootMacroBodyRange.startOffset)
+
+                    if (!context.applyChangesToOriginalDoc || context.broken) return
+                    if (mappedChange == null) {
+                        context.broken = true
+                        if (isUnitTestMode) {
+                            error("The action tried to modify unmappable range inside a macro expansion; " +
+                                "the action should not have been available in such context")
+                        }
+                        return
+                    }
+                    applyMappedChange(originalDoc, mappedChange)
+                    if (causedByPsiChange) {
+                        PsiDocumentManager.getInstance(project).commitDocument(originalDoc)
+                        val changedRange = originalDoc.createRangeMarker(
+                            mappedChange.range.startOffset,
+                            mappedChange.range.startOffset + mappedChange.newText.length
+                        )
+                        context.changedRanges += changedRange
+                    }
+                }
+            })
+        }
+
+        val expandedElementCopy = PsiTreeUtil.findSameElementInCopy(expandedElement, psiFileCopy)
+
+        val actionResult = withMutableExpansionFile(psiFileCopy) {
+            @Suppress("UNCHECKED_CAST")
+            action(editorCopy as E, expandedElementCopy)
+        }
+
+        if (!actionResult) return
+
+        if (context.broken) {
+            if (originalFile.isIntentionPreviewElement) return
+            // This message should not be shown to users really often since we do the best to filter out
+            // unsuitable intentions during availability check
+            originalEditor?.showErrorHint(
+                "Some of the elements that the action is going to change exist only in the macro expansion " +
+                    "and so cannot be changed by the action"
+            )
+            return
+        }
+
+        if (ApplicationManager.getApplication().isWriteAccessAllowed || originalFile.isIntentionPreviewElement) {
+            finishActionInMacroExpansionCopy(context, editorCopy)
+        }
+    }
+
+    private fun MutableRangeMap.mapAndApplyChange(change: TextChange): TextChange? {
+        val mappedRange = mapRangeOrOffset(this, change)
+            ?.takeIf { it.length == change.range.length }
+
+        textInExpansionReplaced(change.range, change.newText.length)
+        return if (mappedRange == null) {
+            null
+        } else {
+            TextChange(mappedRange, change.newText)
+        }
+    }
+
+    private fun applyMappedChange(originalDoc: Document, change: TextChange) {
+        originalDoc.replaceString(change.range.startOffset, change.range.endOffset, change.newText)
+    }
+
+    private fun mapRangeOrOffset(ranges: RangeMap, change: TextChange): TextRange? {
+        return if (change.range.length == 0) {
+            ranges.mapOffsetFromExpansionToCallBody(change.range.startOffset)
+                ?.let { TextRange(it, it) }
+        } else {
+            ranges.mapTextRangeFromExpansionToCallBody(change.range)
+                .singleOrNull()
+                ?.srcRange
+        }
+    }
+
+    fun finishActionInMacroExpansionCopy(editorCopy: Editor) {
+        if (editorCopy is RsIntentionInsideMacroExpansionEditor) {
+            finishActionInMacroExpansionCopy(editorCopy)
+        }
+    }
+
+    fun finishActionInMacroExpansionCopy(editorCopy: RsIntentionInsideMacroExpansionEditor) {
+        val mutableContext: RsIntentionInsideMacroExpansionContext = editorCopy.context ?: return
+        finishActionInMacroExpansionCopy(mutableContext, editorCopy)
+    }
+
+    private fun finishActionInMacroExpansionCopy(
+        mutableContext: RsIntentionInsideMacroExpansionContext,
+        editorCopy: RsIntentionInsideMacroExpansionEditor?
+    ) {
+        if (mutableContext.finished || mutableContext.broken) {
+            return
+        }
+        mutableContext.finished = true
+        val originalFile = mutableContext.originalFile
+        val project = originalFile.project
+        val originalDoc = originalFile.viewProvider.document
+
+        mutableContext.applyChangesToOriginalDoc = false
+        val psiDocMgr = PsiDocumentManager.getInstance(project)
+        psiDocMgr.doPostponedOperationsAndUnblockDocument(originalDoc)
+        psiDocMgr.commitDocument(originalDoc)
+        psiDocMgr.doPostponedOperationsAndUnblockDocument(mutableContext.documentCopy)
+        psiDocMgr.commitDocument(mutableContext.documentCopy)
+        mutableContext.applyChangesToOriginalDoc = true
+
+        if (editorCopy != null) {
+            val macroBodyStartOffset = mutableContext.rootMacroBodyRange.startOffset
+
+            val initialMappedOffset = editorCopy.initialMappedOffset
+            val editorCopyCaret = editorCopy.caretModel.currentCaret
+            if (initialMappedOffset != null && initialMappedOffset != editorCopyCaret.offset) {
+                val backMappedOffset = mutableContext.rangeMap.mapOffsetFromExpansionToCallBody(editorCopyCaret.offset)
+                if (backMappedOffset != null) {
+                    editorCopy.originalEditor.caretModel.moveToOffset(macroBodyStartOffset + backMappedOffset)
+                }
+            }
+
+            if (editorCopyCaret.hasSelection()) {
+                val selectionRange = TextRange(editorCopyCaret.selectionStart, editorCopyCaret.selectionEnd)
+                val backMappedRange = mutableContext.rangeMap.mapTextRangeFromExpansionToCallBody(selectionRange)
+                    .singleOrNull()
+                    ?.srcRange
+                    ?.shiftRight(macroBodyStartOffset)
+                if (backMappedRange != null) {
+                    editorCopy.originalEditor.caretModel.currentCaret.setSelection(
+                        backMappedRange.startOffset,
+                        backMappedRange.endOffset
+                    )
+                }
+            }
+        }
+
+        if (mutableContext.changedRanges.isEmpty()) {
+            return
+        }
+
+        markRangesToReformat(mutableContext.changedRanges, originalFile)
+        mutableContext.changedRanges.clear()
+    }
+
+    private fun markRangesToReformat(mappedChanges: List<RangeMarker>, originalFile: PsiFile) {
+        var someLeaf: PsiElement? = null
+        for (rangeMarker in mappedChanges) {
+            val range = rangeMarker.textRange
+            rangeMarker.dispose()
+            var leaf = originalFile.findElementAt(range.startOffset)
+            if (leaf != null && leaf.startOffset == range.startOffset) {
+                if (someLeaf !is PsiWhiteSpace){
+                    someLeaf = leaf
+                }
+                val prevLeaf = PsiTreeUtil.prevLeaf(leaf)
+                leaf = if (prevLeaf is PsiWhiteSpace) {
+                    prevLeaf
+                } else {
+                    CodeEditUtil.markToReformatBefore(leaf.node, true)
+                    PsiTreeUtil.nextLeaf(leaf)
+                }
+            }
+            while (leaf != null && leaf.startOffset <= range.endOffset) {
+                if (someLeaf !is PsiWhiteSpace){
+                    someLeaf = leaf
+                }
+                CodeEditUtil.markToReformatBefore(leaf.node, false)
+                CodeEditUtil.markToReformat(leaf.node, true)
+                leaf = PsiTreeUtil.nextLeaf(leaf)
+            }
+        }
+
+        // Make some PSI change to force the platform to actually reformat marked ranges in the file
+        if (someLeaf != null) {
+            if (someLeaf !is PsiWhiteSpace) {
+                val nextLeaf = PsiTreeUtil.nextLeaf(someLeaf)
+                if (nextLeaf is PsiWhiteSpace) {
+                    someLeaf = nextLeaf
+                }
+            }
+            if (someLeaf is PsiWhiteSpaceImpl) {
+                val ws = PsiParserFacade.getInstance(originalFile.project).createWhiteSpaceFromText(someLeaf.text)
+                CodeEditUtil.setNodeGenerated(ws.node, false)
+                val prevLeaf = PsiTreeUtil.prevLeaf(someLeaf)
+                val isMarkedToReformat = CodeEditUtil.isMarkedToReformat(someLeaf)
+                val isMarkedToReformatBefore = CodeEditUtil.isMarkedToReformatBefore(someLeaf)
+                someLeaf.replace(ws)
+                if (prevLeaf != null) {
+                    val recoveredWs = PsiTreeUtil.nextLeaf(prevLeaf)
+                    if (recoveredWs != null) {
+                        CodeEditUtil.setNodeGenerated(recoveredWs.node, false)
+                        if (isMarkedToReformat) {
+                            CodeEditUtil.markToReformat(recoveredWs.node, true)
+                        }
+                        if (isMarkedToReformatBefore) {
+                            CodeEditUtil.markToReformatBefore(recoveredWs.node, true)
+                        }
+                    }
+                }
+            } else {
+                val parent = someLeaf.parent
+                val ws = PsiParserFacade.getInstance(originalFile.project).createWhiteSpaceFromText(" ")
+                CodeEditUtil.setNodeGenerated(ws.node, false)
+                parent.addAfter(ws, someLeaf)
+                someLeaf.nextSibling.delete()
+            }
+        }
+    }
+
+    private data class TextChange(val range: TextRange, val newText: CharSequence) {
+        fun shiftRight(delta: Int): TextChange = TextChange(range.shiftRight(delta), newText)
+    }
+
+    private class MutableRangeMap(ranges: MutableList<MappedTextRange>) : RangeMap(ranges) {
+        private val rangesMut: MutableList<MappedTextRange> get() = super.ranges as MutableList<MappedTextRange>
+
+        fun textInExpansionReplaced(changedRange: TextRange, newLength: Int) {
+            val lengthDelta = newLength - changedRange.length
+            val iter = rangesMut.listIterator()
+            while (iter.hasNext()) {
+                val existingMappedRange = iter.next()
+                val existingRange = existingMappedRange.dstRange
+                if (changedRange.startOffset < existingRange.endOffset) {
+                    val replacement = if (changedRange.endOffset <= existingRange.startOffset) {
+                        // `changedRange` lays before `existingRange` -> shift `existingRange` to `lengthDelta`
+                        // `...[changedRange]...<existingRange>...`
+                        existingMappedRange.shiftRight(lengthDelta)
+                    } else if (existingRange.contains(changedRange)) {
+                        // `...<existing[changedRange]Range>...`
+                        val newLengthForRange = existingMappedRange.length + lengthDelta
+                        if (newLengthForRange > 0) {
+                            existingMappedRange.withLength(newLengthForRange)
+                        } else {
+                            null
+                        }
+                    }
+                    else if (changedRange.contains(existingRange)) {
+                        // `...[changed<existingRange>Range]...`
+                        null
+                    } else {
+                        // TODO cut the range instead of removing it in these cases:
+                        // `...<existing[Range>changedRange]...`
+                        // `...[changedRange<existing]Range>...`
+                        null
+                    }
+                    if (replacement != null) {
+                        iter.set(replacement)
+                    } else {
+                        iter.remove()
+                    }
+                } else {
+                    // Do nothing if the changed range is after the existing one
+                    // `...<existingRange>[changedRange]...`
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/intentions/util/macros/InvokeInside.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/util/macros/InvokeInside.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions.util.macros
+
+/**
+ * See [org.rust.ide.intentions.RsElementBaseIntentionAction.attributeMacroHandlingStrategy] and
+ * [org.rust.ide.intentions.RsElementBaseIntentionAction.functionLikeMacroHandlingStrategy]
+ */
+enum class InvokeInside {
+    MACRO_CALL,
+    MACRO_EXPANSION
+}

--- a/src/main/kotlin/org/rust/ide/intentions/util/macros/RsIntentionInsideMacroExpansionContext.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/util/macros/RsIntentionInsideMacroExpansionContext.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions.util.macros
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.macros.RangeMap
+
+class RsIntentionInsideMacroExpansionContext(
+    val originalFile: PsiFile,
+    val documentCopy: Document,
+    val rangeMap: RangeMap,
+    val rootMacroBodyRange: RangeMarker,
+    val changedRanges: MutableList<RangeMarker> = mutableListOf(),
+    var finished: Boolean = false,
+    var broken: Boolean = false,
+    var applyChangesToOriginalDoc: Boolean = true,
+) {
+    val rootMacroCallBodyOffset: Int get() = rootMacroBodyRange.startOffset
+}

--- a/src/main/kotlin/org/rust/ide/intentions/util/macros/RsIntentionInsideMacroExpansionEditor.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/util/macros/RsIntentionInsideMacroExpansionEditor.kt
@@ -1,0 +1,66 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions.util.macros
+
+import com.intellij.openapi.editor.*
+import com.intellij.openapi.editor.impl.EmptySoftWrapModel
+import com.intellij.openapi.editor.impl.ImaginaryEditor
+import com.intellij.psi.PsiFile
+import kotlin.math.min
+
+class RsIntentionInsideMacroExpansionEditor(
+    val psiFileCopy: PsiFile,
+    val originalFile: PsiFile,
+    val originalEditor: Editor,
+    val initialMappedOffset: Int?,
+    val context: RsIntentionInsideMacroExpansionContext?,
+) : ImaginaryEditor(psiFileCopy.project, psiFileCopy.viewProvider.document!!) {
+
+    init {
+        if (initialMappedOffset != null) {
+            caretModel.moveToOffset(initialMappedOffset)
+        }
+    }
+
+    override fun notImplemented(): RuntimeException = IntentionInsideMacroExpansionEditorUnsupportedOperationException()
+
+    override fun isViewer(): Boolean = true
+
+    override fun isOneLineMode(): Boolean = false
+
+    override fun getSettings(): EditorSettings {
+        return originalEditor.settings
+    }
+
+    override fun logicalPositionToOffset(pos: LogicalPosition): Int {
+        val document = document
+        val lineStart = document.getLineStartOffset(pos.line)
+        val lineEnd = document.getLineEndOffset(pos.line)
+        return min(lineEnd, lineStart + pos.column)
+    }
+
+    override fun logicalToVisualPosition(logicalPos: LogicalPosition): VisualPosition {
+        // No folding support: logicalPos is always the same as visual pos
+        return VisualPosition(logicalPos.line, logicalPos.column)
+    }
+
+    override fun visualToLogicalPosition(visiblePos: VisualPosition): LogicalPosition {
+        return LogicalPosition(visiblePos.line, visiblePos.column)
+    }
+
+    override fun offsetToLogicalPosition(offset: Int): LogicalPosition {
+        val clamped = offset.coerceIn(0, document.textLength)
+        val document = document
+        val line = document.getLineNumber(clamped)
+        val col = clamped - document.getLineStartOffset(line)
+        return LogicalPosition(line, col)
+    }
+
+    override fun getSoftWrapModel(): SoftWrapModel = EmptySoftWrapModel()
+}
+
+class IntentionInsideMacroExpansionEditorUnsupportedOperationException
+    : UnsupportedOperationException("It's unexpected to invoke this method on macro expansion fake editor")

--- a/src/main/kotlin/org/rust/ide/intentions/visibility/ChangeVisibilityIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/visibility/ChangeVisibilityIntention.kt
@@ -10,11 +10,14 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.intentions.RsElementBaseIntentionAction
+import org.rust.ide.intentions.util.macros.InvokeInside
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 
 abstract class ChangeVisibilityIntention : RsElementBaseIntentionAction<ChangeVisibilityIntention.Context>() {
     override fun getFamilyName(): String = "Change item visibility"
+
+    override val attributeMacroHandlingStrategy: InvokeInside get() = InvokeInside.MACRO_CALL
 
     abstract val visibility: String
     abstract fun isApplicable(element: RsVisibilityOwner): Boolean

--- a/src/main/kotlin/org/rust/ide/utils/PsiModificationUtil.kt
+++ b/src/main/kotlin/org/rust/ide/utils/PsiModificationUtil.kt
@@ -11,7 +11,9 @@ import com.intellij.psi.PsiElement
 import com.intellij.testFramework.LightVirtualFile
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.isGeneratedFile
+import org.rust.lang.core.macros.findMacroCallExpandedFrom
 import org.rust.lang.core.macros.isExpandedFromMacro
+import org.rust.lang.core.macros.mapRangeFromExpansionToCallBodyStrict
 import org.rust.openapiext.testAssert
 
 object PsiModificationUtil {
@@ -24,10 +26,12 @@ object PsiModificationUtil {
     }
 
     fun canReplace(element: PsiElement): Boolean {
-        return if (!element.isExpandedFromMacro) {
+        val macroCall = element.findMacroCallExpandedFrom()
+        return if (macroCall == null) {
             isWriteableRegardlessMacros(element)
         } else {
-            false
+            val sourceRange = mapRangeFromExpansionToCallBodyStrict(element, element.textRange)
+            sourceRange != null && isWriteableRegardlessMacros(macroCall)
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/RangeMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RangeMap.kt
@@ -18,7 +18,7 @@ import kotlin.math.min
 /**
  * Must provide [equals] method because it is used to track changes in the macro expansion mechanism
  */
-data class RangeMap(val ranges: List<MappedTextRange>) {
+open class RangeMap(val ranges: List<MappedTextRange>) {
 
     constructor(range: MappedTextRange) : this(listOf(range))
 
@@ -27,8 +27,12 @@ data class RangeMap(val ranges: List<MappedTextRange>) {
     fun isEmpty(): Boolean = ranges.isEmpty()
 
     fun mapOffsetFromExpansionToCallBody(offset: Int): Int? {
+        return mapOffsetFromExpansionToCallBody(offset, false) ?: mapOffsetFromExpansionToCallBody(offset, true)
+    }
+
+    fun mapOffsetFromExpansionToCallBody(offset: Int, stickToLeft: Boolean): Int? {
         return ranges.singleOrNull { range ->
-            offset >= range.dstOffset && offset < range.dstEndOffset
+            offset >= range.dstOffset && (offset < range.dstEndOffset || stickToLeft && offset == range.dstEndOffset)
         }?.let { range ->
             range.srcOffset + (offset - range.dstOffset)
         }
@@ -42,7 +46,7 @@ data class RangeMap(val ranges: List<MappedTextRange>) {
         }
     }
 
-    private fun mapTextRangeFromExpansionToCallBody(toMap: TextRange): List<MappedTextRange> {
+    fun mapTextRangeFromExpansionToCallBody(toMap: TextRange): List<MappedTextRange> {
         return ranges.mapNotNull { it.dstIntersection(toMap) }
     }
 
@@ -65,6 +69,21 @@ data class RangeMap(val ranges: List<MappedTextRange>) {
         ranges.forEach {
             data.writeMappedTextRange(it)
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RangeMap
+
+        if (ranges != other.ranges) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return ranges.hashCode()
     }
 
     companion object {
@@ -111,6 +130,10 @@ val MappedTextRange.dstRange: TextRange get() = TextRange(dstOffset, dstOffset +
 
 fun MappedTextRange.srcShiftLeft(delta: Int) = copy(srcOffset = srcOffset - delta)
 fun MappedTextRange.dstShiftRight(delta: Int) = copy(dstOffset = dstOffset + delta)
+
+fun MappedTextRange.shiftRight(delta: Int) = copy(srcOffset = srcOffset + delta, dstOffset = dstOffset + delta)
+
+fun MappedTextRange.withLength(length: Int) = copy(length = length)
 
 private fun MappedTextRange.dstIntersection(range: TextRange): MappedTextRange? {
     val newDstStart = max(dstOffset, range.startOffset)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -21,6 +21,7 @@ import com.intellij.psi.util.descendantsOfType
 import com.intellij.psi.util.prevLeaf
 import com.intellij.util.SmartList
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.lang.core.macros.findMacroCallExpandedFrom
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.openapiext.document
@@ -334,7 +335,11 @@ fun PsiElement.isKeywordLike(): Boolean {
     }
 }
 
-val PsiElement.isIntentionPreviewElement: Boolean get() = IntentionPreviewUtils.isPreviewElement(this)
+val PsiElement.isIntentionPreviewElement: Boolean
+    get() {
+        val source = findMacroCallExpandedFrom() ?: this
+        return IntentionPreviewUtils.isPreviewElement(source)
+    }
 
 /**
  * Consider we do some `resolve` in a quick-fix which is called in preview mode.

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPossibleMacroCall.kt
@@ -61,8 +61,8 @@ val RsPossibleMacroCall.kind: RsPossibleMacroCallKind
         else -> error("unreachable")
     }
 
-val PsiElement.ancestorMacroCall: RsPossibleMacroCall?
-    get() = ancestors
+val PsiElement.contextMacroCall: RsPossibleMacroCall?
+    get() = contexts
         .filterIsInstance<RsPossibleMacroCall>()
         .find { it.isMacroCall }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/util/DollarCrateUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/util/DollarCrateUtil.kt
@@ -72,7 +72,7 @@ class DollarCrateHelper(
                 }
             }
             defHasLocalInnerMacros -> {
-                val pathOffsetInCall = ranges.mapOffsetFromExpansionToCallBody(offsetInExpansion)
+                val pathOffsetInCall = ranges.mapOffsetFromExpansionToCallBody(offsetInExpansion, false)
                 val isExpandedFromDef = pathOffsetInCall == null
                 if (!isExpandedFromDef) return path
                 arrayOf(MACRO_DOLLAR_CRATE_IDENTIFIER, defCrate.toString()) + path
@@ -109,7 +109,7 @@ private fun findCrateIdForEachDollarCrate(
     val ranges = expansion.ranges  // between `call.body` and `expandedText`
     return expansion.dollarCrateOccurrences.asSequence()
         .mapNotNull { indexInExpandedText ->
-            val indexInCallBody = ranges.mapOffsetFromExpansionToCallBody(indexInExpandedText)
+            val indexInCallBody = ranges.mapOffsetFromExpansionToCallBody(indexInExpandedText, false)
             val crateId: CratePersistentId = if (indexInCallBody != null) {
                 if (call.body is MacroCallBody.FunctionLike) {
                     testAssert {

--- a/src/main/kotlin/org/rust/openapiext/Editor.kt
+++ b/src/main/kotlin/org/rust/openapiext/Editor.kt
@@ -9,23 +9,35 @@ import com.intellij.codeInsight.hint.HintManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.NlsContexts
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.util.macros.IntentionInMacroUtil
+import org.rust.ide.intentions.util.macros.RsIntentionInsideMacroExpansionEditor
 
-@Suppress("UNUSED_PARAMETER")
 fun Editor.moveCaretToOffset(context: PsiElement, absoluteOffsetInFile: Int) {
-    caretModel.moveToOffset(absoluteOffsetInFile)
+    val targetEditor = if (this is RsIntentionInsideMacroExpansionEditor && originalFile == context.containingFile) {
+        originalEditor
+    } else {
+        this
+    }
+    targetEditor.caretModel.moveToOffset(absoluteOffsetInFile)
 }
 
-@Suppress("UNUSED_PARAMETER")
 fun Editor.setSelection(context: PsiElement, startOffset: Int, endOffset: Int) {
-    selectionModel.setSelection(startOffset, endOffset)
+    val targetEditor = if (this is RsIntentionInsideMacroExpansionEditor && originalFile == context.containingFile) {
+        originalEditor
+    } else {
+        this
+    }
+    targetEditor.selectionModel.setSelection(startOffset, endOffset)
 }
 
 @Suppress("UnstableApiUsage")
 fun Editor.showErrorHint(@NlsContexts.HintText text: String, @HintManager.PositionFlags position: Short) {
-    HintManager.getInstance().showErrorHint(this, text, position)
+    val editor = IntentionInMacroUtil.unwrapEditor(this)
+    HintManager.getInstance().showErrorHint(editor, text, position)
 }
 
 @Suppress("UnstableApiUsage")
 fun Editor.showErrorHint(@NlsContexts.HintText text: String) {
-    HintManager.getInstance().showErrorHint(this, text)
+    val editor = IntentionInMacroUtil.unwrapEditor(this)
+    HintManager.getInstance().showErrorHint(editor, text)
 }

--- a/src/main/kotlin/org/rust/openapiext/ui.kt
+++ b/src/main/kotlin/org/rust/openapiext/ui.kt
@@ -24,6 +24,7 @@ import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.Row
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.util.Alarm
+import org.rust.ide.intentions.util.macros.RsIntentionInsideMacroExpansionEditor
 import org.rust.lang.RsFileType
 import org.rust.lang.core.psi.ext.RsElement
 import javax.swing.JComponent
@@ -109,9 +110,15 @@ fun JTextField.addTextChangeListener(listener: (DocumentEvent) -> Unit) {
 
 fun selectElement(element: RsElement, editor: Editor) {
     val start = element.textRange.startOffset
-    editor.caretModel.moveToOffset(start)
-    editor.scrollingModel.scrollToCaret(ScrollType.RELATIVE)
-    editor.selectionModel.setSelection(start, element.textRange.endOffset)
+    val unwrappedEditor = if (editor is RsIntentionInsideMacroExpansionEditor && element.containingFile != editor.psiFileCopy) {
+        if (element.containingFile != editor.originalFile) return
+        editor.originalEditor
+    } else {
+        editor
+    }
+    unwrappedEditor.caretModel.moveToOffset(start)
+    unwrappedEditor.scrollingModel.scrollToCaret(ScrollType.RELATIVE)
+    unwrappedEditor.selectionModel.setSelection(start, element.textRange.endOffset)
 }
 
 fun <T : JComponent> Row.fullWidthCell(component: T): Cell<T> {

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -30,5 +30,8 @@
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="100">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.ide.intentions.macros.function-like" percentOfUsers="0">
+            <description>Invoke intention actions inside function-like macro expansions</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -30,5 +30,8 @@
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="100">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.ide.intentions.macros.function-like" percentOfUsers="0">
+            <description>Invoke intention actions inside function-like macro expansions</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
It's not so easy to find a real proc-macro where the effect of this PR would be visible. The main reason for this PR is that after merging of #9834 our intention actions may stop working in attribute macros without this PR. So let's check it in action using artificial macro `attr_add_to_fn_beginning`!

<details>
  <summary>attr_add_to_fn_beginning</summary>
  
  ```rust
  #[proc_macro_attribute]
pub fn attr_add_to_fn_beginning(attr: TokenStream, item: TokenStream) -> TokenStream {
    item.into_iter().map(|tt| {
        match tt {
            TokenTree::Group(g) => {
                if g.delimiter() == Delimiter::Brace {
                    let mut dg = Group::new(
                        g.delimiter(),
                        attr.clone().into_iter().chain(g.stream().into_iter()).collect()
                    );
                    dg.set_span(g.span());
                    TokenTree::Group(dg)
                } else {
                    TokenTree::Group(g)
                }
            }
            TokenTree::Ident(..) => tt,
            TokenTree::Punct(..) | TokenTree::Literal(..) => tt,
        }
    }).collect()
}
  ```
</details>

This macro translates this code
```rust
#[attr_add_to_fn_beginning(let a = 0;)]
fn main() {
    let b = a;
}
```

to this:

```rust
fn main() {
    let a = 0;
    let b = a;
}
```

Previously, the intention `Specify type explicitly` was unavailable for variable `b`. Now it's available and inserts a correct type.

#### Function-like macros

Also this PR introduces an experimental feature `org.rust.ide.intentions.macros.function-like` that enables intention actions in function-like macros! Previously almost none of intentions was available in function-like macros.
There are to reasons why intentions is function-like macros are not enabled by default:
1. They are not fully tested to the moment
2. Formatter is not applied after an intention action invocation, and intention action may produce quite messy unformatted code.

#### Non-supported intention actions

Some intentions still does not (properly) work in macros: `IntroduceLocalVariableIntention`, `ConvertToStructIntention`, `ConvertToTupleIntention`, `ExtractEnumVariantIntention`, `ExtractStructFieldsIntention`, `AddImportForPatternIntention`, `DestructureIntention`. They will be supported in further PRs.

#### Under the hood

Under the hood an intention action is applied to a copy of an expansion of the macro call where it was invoked (`RsElementBaseIntentionAction.findApplicableContext()` and `RsElementBaseIntentionAction.invoke()` are applied to elements from a macro expansion). This behavior can be altered using `RsElementBaseIntentionAction.attributeMacroHandlingStrategy` and `RsElementBaseIntentionAction.functionLikeMacroHandlingStrategy` properties, so you can make an intention action that would be invoked for a macro call instead of a macro expansion.

When an intention action modifies a copy of a macro expansion, these changes are automatically translated to the source macro call using `RangeMap`. If the changed range can't be mapped to the source macro call, the user may see the message `The action tried to modify unmappable range inside a macro expansion; the action should not have been available in such context`, but in most cases an intention action should not be available if it's going to edit some unmappable range in a macro expansion (thanks to `PsiInsertionPlace` API introduced in #10134).

It's currently possible to see the error message if you enable `org.rust.ide.intentions.macros.function-like` and try to apply `UnElideLifetimesIntention` to this code:

```rust
macro_rules! foo {
    ($($t:tt)*) => {
        fn make_s($($t)*) { unimplemented!() }
    };
}

struct S<'a> { x: &'a u32 }
foo!(x:/*caret*/ S);
```

(It's a rare case when an intention action does not use `PsiInsertionPlace` API and hence available in a macro call where it can't really edit what it's going to)

changelog: Make intention actions work inside an attribute macro expansion
