### PR TITLE
Don't leak Rust project settings panel

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -24,7 +24,9 @@ class RsProjectConfigurable(
     project: Project
 ) : RsConfigurableBase(project, RsBundle.message("settings.rust.toolchain.name")), Configurable.NoScroll {
     private val projectDir = project.cargoProjects.allProjects.firstOrNull()?.rootDir?.pathAsPath ?: Paths.get(".")
-    private val rustProjectSettings = RustProjectSettingsPanel(projectDir)
+    // TODO: move creation of the panel inside `createPanel`
+    //  and use `onIsModified`, `onApply` and `onReset` methods
+    private val rustProjectSettings by lazy { RustProjectSettingsPanel(projectDir) }
 
     override fun createPanel(): DialogPanel = panel {
         rustProjectSettings.attachTo(this)


### PR DESCRIPTION
Previously, we created its panel in constructor with registration of all components which require a disposable object. And in a common case, all UI resources are disposed in `org.rust.cargo.project.configurable.RsProjectConfigurable.disposeUIResources` and everything is fine

But for some reason, `RsProjectConfigurable` object is created during closing of the settings window. And for this object, the platform doesn't call `disposeUIResources`. As a result, the UI panel created in constructor is not disposed, and we hold all objects in memory

Now, the panel is created only if it's really needed

Fixes #8727

changelog: Don't leak Rust project settings panel
