### PR TITLE
INSP: Annotate mismatched members in trait impl (E0323, E0324, E0325)

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
@@ -11,6 +11,7 @@ import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
+import org.rust.stdext.mapToSet
 
 class RsTraitImplementationInspection : RsLocalInspectionTool() {
 
@@ -31,20 +32,27 @@ class RsTraitImplementationInspection : RsLocalInspectionTool() {
                     .addToHolder(holder)
             }
 
-            for (member in implInfo.nonExistentInTrait) {
+            val traitMembersNames = implInfo.declared.mapToSet { it.name!! }
+            for ((key, implMember) in implInfo.implementedByNameAndType) {
                 // ignore members expanded from macros
-                if (member.containingFile != impl.containingFile) continue
+                if (implMember.containingFile != impl.containingFile) continue
 
-                RsDiagnostic.UnknownMemberInTraitError(member.nameIdentifier!!, member, traitName)
-                    .addToHolder(holder)
-            }
+                val memberName = key.first
+                if (memberName in traitMembersNames) {
+                    val traitMember = implInfo.declaredByNameAndType[key]
 
-            for ((imp, dec) in implInfo.implementationToDeclaration) {
-                // ignore members expanded from macros
-                if (imp.containingFile != impl.containingFile) continue
+                    if (implMember is RsFunction && traitMember is RsFunction) {
+                        checkTraitFnImplParams(holder, implMember, traitMember, traitName)
+                    }
 
-                if (imp is RsFunction && dec is RsFunction) {
-                    checkTraitFnImplParams(holder, imp, dec, traitName)
+                    if (traitMember == null) {
+                        val nameIdentifier = implMember.nameIdentifier ?: continue
+                        RsDiagnostic.MismatchMemberInTraitImplError(nameIdentifier, implMember, traitName)
+                            .addToHolder(holder)
+                    }
+                } else {
+                    RsDiagnostic.UnknownMemberInTraitError(implMember.nameIdentifier!!, implMember, traitName)
+                        .addToHolder(holder)
                 }
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -155,22 +155,14 @@ class TraitImplementationInfo private constructor(
 ) {
     val declared = traitMembers.abstractable().filter { it.existsAfterExpansionSelf }
     private val implemented = implMembers.abstractable()
-    private val declaredByName = declared.associateBy { it.name!! }
-    private val implementedByNameAndType = implemented.associateBy { it.name!! to it.elementType }
+    val declaredByNameAndType = declared.associateBy { it.name!! to it.elementType }
+    val implementedByNameAndType = implemented.associateBy { it.name!! to it.elementType }
 
     val missingImplementations: List<RsAbstractable> =
         declared.filter { it.isAbstract }.filter { it.name to it.elementType !in implementedByNameAndType }
 
     val alreadyImplemented: List<RsAbstractable> =
         declared.filter { it.isAbstract }.filter { it.name to it.elementType in implementedByNameAndType }
-
-    val nonExistentInTrait: List<RsAbstractable> = implemented.filter { it.name !in declaredByName }
-
-    val implementationToDeclaration: List<Pair<RsAbstractable, RsAbstractable>> =
-        implemented.mapNotNull { imp ->
-            val dec = declaredByName[imp.name]
-            if (dec != null) imp to dec else null
-        }
 
     private fun RsMembers.abstractable(): List<RsAbstractable> =
         expandedMembers.filter { it.name != null }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -483,6 +483,34 @@ sealed class RsDiagnostic(
         }
     }
 
+    class MismatchMemberInTraitImplError(
+        element: PsiElement,
+        private val member: RsAbstractable,
+        private val traitName: String,
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            errorCode(),
+            errorText(),
+        )
+
+        private fun errorCode(): RsErrorCode =
+            when (member) {
+                is RsTypeAlias -> E0325
+                is RsConstant -> E0323
+                else -> E0324
+            }
+
+        private fun errorText(): String {
+            val itemType = when (member) {
+                is RsTypeAlias -> "type"
+                is RsConstant -> "const"
+                else -> "method"
+            }
+            return "item `${member.name}` is an associated $itemType, which doesn't match its trait `$traitName`"
+        }
+    }
+
     class ImplBothCopyAndDropError(
         element: PsiElement
     ) : RsDiagnostic(element) {
@@ -1686,7 +1714,7 @@ enum class RsErrorCode {
     E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0130, E0131, E0132, E0133, E0184, E0185, E0186, E0191, E0197, E0198, E0199,
     E0200, E0201, E0203, E0220, E0224, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
-    E0308, E0322, E0328, E0364, E0365, E0379, E0384,
+    E0308, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0437, E0438, E0449, E0451, E0463,
     E0517, E0518, E0537, E0552, E0554, E0562, E0569, E0571, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0642, E0658, E0666, E0667, E0695,

--- a/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
@@ -130,6 +130,35 @@ class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImpleme
         }
     """)
 
+    fun `test mismatch member in trait impl E0323, E0324, E0325`() = checkErrors("""
+        trait T {
+            fn method1();
+            fn method2();
+            fn method3();
+
+            type Type1;
+            type Type2;
+            type Type3;
+
+            const CONST1: i32;
+            const CONST2: i32;
+            const CONST3: i32;
+        }
+        /*error descr="Not all trait items implemented, missing: `method2`, `method3`, `Type1`, `Type3`, `CONST1`, `CONST2` [E0046]"*/impl T for ()/*error**/ {
+            fn method1() {}
+            fn /*error descr="item `Type1` is an associated method, which doesn't match its trait `T` [E0324]"*/Type1/*error**/() {}
+            fn /*error descr="item `CONST1` is an associated method, which doesn't match its trait `T` [E0324]"*/CONST1/*error**/() {}
+
+            type Type2 = i32;
+            type /*error descr="item `method2` is an associated type, which doesn't match its trait `T` [E0325]"*/method2/*error**/ = i32;
+            type /*error descr="item `CONST2` is an associated type, which doesn't match its trait `T` [E0325]"*/CONST2/*error**/ = i32;
+
+            const CONST3: i32 = 0;
+            const /*error descr="item `method3` is an associated const, which doesn't match its trait `T` [E0323]"*/method3/*error**/: i32 = 0;
+            const /*error descr="item `Type3` is an associated const, which doesn't match its trait `T` [E0323]"*/Type3/*error**/: i32 = 0;
+        }
+    """)
+
     @ExpandMacros
     fun `test ignore expanded methods`() = checkErrors("""
         macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
@@ -153,6 +182,17 @@ class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImpleme
         }
         <error descr="Not all trait items implemented, missing: `C` [E0046]">impl A for ()</error> {
             type C = ();
+        }
+    """)
+
+    fun `test const and type with same name`() = checkErrors("""
+        trait T {
+            const FOO: i32;
+            type FOO;
+        }
+        impl T for () {
+            const FOO: i32 = 0;
+            type FOO = i32;
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
@@ -62,7 +62,6 @@ class RsPsiStructureTest : RsTestBase() {
         impl T for S {
             fn another_required_fn() { }
             type same_name = ();
-            fn spam() {}
         }
     """) { impl ->
         val trait = impl.traitRef!!.resolveToTrait()!!
@@ -73,15 +72,6 @@ class RsPsiStructureTest : RsTestBase() {
 
         check(implInfo.missingImplementations.map { it.name } == listOf(
             "required_fn", "RequiredType", "same_name"
-        ))
-
-        check(implInfo.nonExistentInTrait.map { it.name } == listOf(
-            "spam"
-        ))
-
-        check(implInfo.implementationToDeclaration.map { (it.first.name to it.second.name) } == listOf(
-            "another_required_fn" to "another_required_fn",
-            "same_name" to "same_name"
         ))
     }
 


### PR DESCRIPTION
changelog: Annotate mismatched members in trait impl ([E0323](https://doc.rust-lang.org/error_codes/E0323.html), [E0324](https://doc.rust-lang.org/error_codes/E0324.html), [E0325](https://doc.rust-lang.org/error_codes/E0325.html))