### PR TITLE
Do not run inspections which uses resolve on files outside valid project

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
@@ -23,8 +23,6 @@ abstract class RsLintInspection : RsLocalInspectionTool() {
 
     protected abstract fun getLint(element: PsiElement): RsLint?
 
-    override val isSyntaxOnly: Boolean = true
-
     protected fun RsProblemsHolder.registerLintProblem(
         element: PsiElement,
         @InspectionMessage descriptionTemplate: String,

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspection.kt
@@ -33,6 +33,8 @@ class RsNonShorthandFieldPatternsInspection : RsLintInspection() {
         }
     }
 
+    override val isSyntaxOnly: Boolean get() = true
+
     private class UseShorthandFieldPatternFix(private val identifier: String) : LocalQuickFix {
         override fun getFamilyName(): String = "Use shorthand field pattern: `$identifier`"
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspection.kt
@@ -66,4 +66,6 @@ class RsRedundantSemicolonsInspection : RsLintInspection() {
             tryRegisterProblemAndClearSeq(seq)
         }
     }
+
+    override val isSyntaxOnly: Boolean get() = true
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspection.kt
@@ -56,6 +56,8 @@ class RsSelfConventionInspection : RsLintInspection() {
             }
         }
 
+    override val isSyntaxOnly: Boolean get() = true
+
     private companion object {
         val SELF_CONVENTIONS = listOf(
             SelfConvention("as_", listOf(SelfSignature.BY_REF, SelfSignature.BY_MUT_REF)),

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
@@ -34,6 +34,8 @@ class RsUnknownCrateTypesInspection : RsLintInspection() {
             }
         }
 
+    override val isSyntaxOnly: Boolean get() = true
+
     companion object {
         val KNOWN_CRATE_TYPES = listOf("bin", "lib", "dylib", "staticlib", "cdylib", "rlib", "proc-macro")
     }


### PR DESCRIPTION
#6013 introduces the concept of `syntax-only` inspections - lightweight inspections which don't require resolve and can be run on detached files (files outside valid rust project). But some inspections was marked `syntax-only` by a mistake. Currently, all `RsLintInspection` are considered `syntax-only`, but actually some of them use name resolution (e.g. `RsUnusedImportInspection`). This PR makes the following inspections **not** `syntax-only`, so they will not be run on detached files:

* `RsBareTraitObjectsInspection`
* `RsDeprecationInspection`
* `RsDoubleMustUseInspection`
* `RsLivenessInspection`
* `RsNeedlessLifetimesInspection`
* `RsUnnecessaryQualificationsInspection`
* `RsUnreachableCodeInspection`
* `RsUnreachablePatternsInspection`
* `RsUnusedImportInspection`
* `RsUnusedMustUseInspection`

changelog: Don’t run some inspections on Rust files outside a valid Cargo project to avoid expected false positive errors