### PR TITLE
support let-else statement for CFG

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
@@ -212,7 +212,13 @@ class CFGBuilder(
         val initExit = process(letDecl.expr, pred)
         val exit = process(letDecl.pat, initExit)
 
-        finishWithAstNode(letDecl, exit)
+        val elseBranch = letDecl.letElseBranch
+        if (elseBranch != null) {
+            val elseBranchExit = process(elseBranch.block, initExit)
+            finishWithAstNode(letDecl, exit, elseBranchExit)
+        } else {
+            finishWithAstNode(letDecl, exit)
+        }
     }
 
     override fun visitLetExpr(letExpr: RsLetExpr) {

--- a/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ExprUseWalker.kt
@@ -363,16 +363,18 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
 
     private fun walkLet(declaration: RsLetDecl) {
         val init = declaration.expr
-        val pat = declaration.pat ?: return
-        if (init != null) {
-            walkExpr(init)
-            val initCmt = mc.processExpr(init)
-            walkIrrefutablePat(initCmt, pat)
-        } else {
-            for (binding in pat.descendantsOfType<RsPatBinding>()) {
-                delegate.declarationWithoutInit(binding)
+        declaration.pat?.let {
+            if (init != null) {
+                walkExpr(init)
+                val initCmt = mc.processExpr(init)
+                walkIrrefutablePat(initCmt, it)
+            } else {
+                for (binding in it.descendantsOfType<RsPatBinding>()) {
+                    delegate.declarationWithoutInit(binding)
+                }
             }
         }
+        declaration.letElseBranch?.block?.let { walkBlock(it) }
     }
 
     private fun walkLetExpr(letExpr: RsLetExpr) {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspectionTest.kt
@@ -136,6 +136,18 @@ class RsUnreachableCodeInspectionTest : RsInspectionsTestBase(RsUnreachableCodeI
         }
     """)
 
+    fun `test else branch of let-else statement`() = checkByText("""
+        fn main() {
+            1;
+            let Some(_) = None::<i32> else {
+                2;
+                return;
+                <warning descr="Unreachable code">3;</warning>
+            };
+            4;
+        }
+    """)
+
     fun `test if else tail expr unconditional return`() = checkByText("""
         fn foo(flag: bool) {
             if flag {
@@ -299,6 +311,15 @@ class RsUnreachableCodeInspectionTest : RsInspectionsTestBase(RsUnreachableCodeI
             match a {
                 42 => todo!(),
                 _ => return 123,
+            }
+        }
+    """)
+
+    // Issue https://github.com/intellij-rust/intellij-rust/issues/9681
+    fun `test no false-positive when let-else statement inside loop block`() = checkByText("""
+        fn main() {
+            loop {
+                let Some(_) = None::<i32> else { break; };
             }
         }
     """)

--- a/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
@@ -311,6 +311,28 @@ class RsControlFlowGraphTest : RsTestBase() {
         }
     """)
 
+    fun `test let else`() = testCFG("""
+        fn foo() {
+            let Some(s) = x else { return; };
+        }
+    """, """
+        digraph {
+            "0: Entry" -> "3: x";
+            "3: x" -> "4: s";
+            "4: s" -> "5: s";
+            "5: s" -> "6: Some(s)";
+            "3: x" -> "7: return";
+            "7: return" -> "1: Exit";
+            "8: Unreachable" -> "9: return;";
+            "9: return;" -> "10: BLOCK";
+            "6: Some(s)" -> "11: let Some(s) = x else { return; };";
+            "10: BLOCK" -> "11: let Some(s) = x else { return; };";
+            "11: let Some(s) = x else { return; };" -> "12: BLOCK";
+            "12: BLOCK" -> "1: Exit";
+            "1: Exit" -> "2: Termination";
+        }
+    """)
+
     fun `test loop`() = testCFG("""
         fn main() {
             loop {


### PR DESCRIPTION
fix: #9681 (cc: @ortem)
Follow-up for #7798

This pull request addresses issue #9681 by correctly handling the else block of let-else statements in the construction of the ControlFlowGraph.

Due to issues with my environment, not all tests could be executed. I apologize if any failures occurred.

changelog: Fix false-positive detection of unreachable code with [`let else`](https://rust-lang.github.io/rfcs/3137-let-else.html) syntax
