### PR TITLE
T: Get rid of `@ExpandMacros` annotation in `RsTestBase`-based tests

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx
 import com.intellij.openapi.util.*
@@ -106,8 +107,12 @@ interface MacroExpansionManager {
         cacheDirectory: String = "",
         clearCacheBeforeDispose: Boolean = false
     ): Disposable
+
     @TestOnly
     fun updateInUnitTestMode()
+
+    @TestOnly
+    fun setMacroExpansionEnabled(enabled: Boolean)
 
     companion object {
         @JvmStatic
@@ -288,6 +293,7 @@ class MacroExpansionManagerImpl(
         this.dirs = dir
         this.inner = impl
         impl.macroExpansionMode = mode
+        impl.enabledInUnitTests = true
 
         runWriteAction {
             ProjectRootManagerEx.getInstanceEx(project)
@@ -306,6 +312,10 @@ class MacroExpansionManagerImpl(
 
     override fun updateInUnitTestMode() {
         inner?.updateInUnitTestMode()
+    }
+
+    override fun setMacroExpansionEnabled(enabled: Boolean) {
+        inner?.setMacroExpansionEnabled(enabled)
     }
 
     override fun dispose() {
@@ -434,6 +444,8 @@ private class MacroExpansionServiceImplInner(
 
     @TestOnly
     var macroExpansionMode: MacroExpansionScope = MacroExpansionScope.NONE
+    @TestOnly
+    var enabledInUnitTests: Boolean = true
 
     fun isExpansionFileOfCurrentProject(file: VirtualFile): Boolean {
         return VfsUtil.isAncestor(expansionsDirVi, file, true)
@@ -450,7 +462,7 @@ private class MacroExpansionServiceImplInner(
         if (lastSavedStorageModCount == modificationTracker.modificationCount) return
 
         @Suppress("BlockingMethodInNonBlockingContext")
-        withContext(Dispatchers.IO) { // ensure dispatcher knows we are doing blocking IO
+        withIoContextIfNotUnitTestMode { // ensure dispatcher knows we are doing blocking IO
             // Using a buffer to avoid IO in the read action
             // BACKCOMPAT: 2020.1 use async read action and extract `runReadAction` from `withContext`
             val (buffer, modCount) = runReadAction {
@@ -469,6 +481,14 @@ private class MacroExpansionServiceImplInner(
             dataFile.newDeflaterDataOutputStream().use { it.write(buffer.internalBuffer) }
             MacroExpansionFileSystemRootsLoader.saveProjectDirs()
             lastSavedStorageModCount = modCount
+        }
+    }
+
+    private suspend fun <T> withIoContextIfNotUnitTestMode(block: suspend () -> T): T {
+        return if (isUnitTestMode) {
+            block()
+        } else {
+            withContext(Dispatchers.IO) { block() }
         }
     }
 
@@ -696,7 +716,9 @@ private class MacroExpansionServiceImplInner(
     }
 
     private fun processMacros(taskType: RsTask.TaskType) {
-        if (!isExpansionModeNew) return
+        if (!isExpansionModeNew || !enabledInUnitTests) return
+        if (isUnitTestMode && DumbService.isDumb(project)) return
+
         val task = MacroExpansionTask(
             project,
             modificationTracker,
@@ -962,16 +984,23 @@ private class MacroExpansionServiceImplInner(
         processChangedMacros()
     }
 
+    @TestOnly
+    fun setMacroExpansionEnabled(enabled: Boolean) {
+        enabledInUnitTests = enabled
+    }
+
     private fun disposeUnitTest(saveCacheOnDispose: Boolean, clearCacheBeforeDispose: Boolean) {
         check(isUnitTestMode)
 
-        project.taskQueue.cancelTasks(RsTask.TaskType.MACROS_CLEAR)
+        if (!project.isDisposed) {
+            project.taskQueue.cancelTasks(RsTask.TaskType.MACROS_CLEAR)
 
-        val taskQueue = project.taskQueue
-        if (!taskQueue.isEmpty) {
-            while (!taskQueue.isEmpty && !project.isDisposed) {
-                PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
-                Thread.sleep(10)
+            val taskQueue = project.taskQueue
+            if (!taskQueue.isEmpty) {
+                while (!taskQueue.isEmpty && !project.isDisposed) {
+                    PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+                    Thread.sleep(10)
+                }
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -31,6 +31,7 @@ import org.rust.lang.core.resolve2.util.createDollarCrateHelper
 import org.rust.openapiext.*
 import org.rust.stdext.HashCode
 import org.rust.stdext.getWithRethrow
+import java.nio.file.InvalidPathException
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import kotlin.math.ceil
@@ -447,8 +448,14 @@ class DefCollector(
                 propagateLegacyMacros = true
             )
         } else if (!context.isHangingMode) {
-            val filePath = parentDirectory.pathAsPath.resolve(includePath)
-            defMap.missedFiles.add(filePath)
+            val filePath = try {
+                parentDirectory.pathAsPath.resolve(includePath)
+            } catch (ignored: InvalidPathException) {
+                null
+            }
+            if (filePath != null) {
+                defMap.missedFiles.add(filePath)
+            }
         }
         if (includingFile != null) {
             recordChildFileInUnusualLocation(call.containingMod, includingFile.fileId)

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -34,6 +34,7 @@ import org.rust.openapiext.fileId
 import org.rust.openapiext.findFileByMaybeRelativePath
 import org.rust.openapiext.pathAsPath
 import org.rust.openapiext.toPsiFile
+import java.nio.file.InvalidPathException
 
 class ModCollectorContext(
     val defMap: CrateDefMap,
@@ -479,7 +480,11 @@ private class ModCollector(
         // but result is null, when e.g. file is too big (thus will be [PsiFile] and not [RsFile])
         if (virtualFiles.isEmpty() && !context.isHangingMode) {
             for (fileName in fileNames) {
-                val path = parentDirectory.pathAsPath.resolve(fileName)
+                val path = try {
+                    parentDirectory.pathAsPath.resolve(fileName)
+                } catch (ignored: InvalidPathException) {
+                    continue
+                }
                 defMap.missedFiles.add(path)
             }
         }

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -72,9 +72,12 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
         setupExperimentalFeatures()
         setupInspections()
         setupExcludedPaths()
-        findAnnotationInstance<ExpandMacros>()?.let {
-            val disposable = project.macroExpansionManager.setUnitTestExpansionModeAndDirectory(it.mode, it.cache)
-            Disposer.register(testRootDisposable, disposable)
+        if (findAnnotationInstance<WithDisabledMacroExpansion>() != null) {
+            val mgr = project.macroExpansionManager
+            mgr.setMacroExpansionEnabled(false)
+            Disposer.register(testRootDisposable) {
+                mgr.setMacroExpansionEnabled(true)
+            }
         }
         RecursionManager.disableMissedCacheAssertions(testRootDisposable)
         tempDirRoot = myFixture.findFileInTempDir(".")
@@ -85,7 +88,6 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
         val oldTempDirRootUrl = tempDirRootUrl
         val newTempDirRootUrl = tempDirRoot?.url
         super.tearDown()
-        checkMacroExpansionFileSystemAfterTest()
         // Check that temp root directory was not renamed during the test
         if (oldTempDirRootUrl != null && oldTempDirRootUrl != newTempDirRootUrl) {
             if (newTempDirRootUrl != null) {

--- a/src/test/kotlin/org/rust/WithDisabledMacroExpansion.kt
+++ b/src/test/kotlin/org/rust/WithDisabledMacroExpansion.kt
@@ -1,0 +1,8 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+annotation class WithDisabledMacroExpansion()

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -109,7 +109,6 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
         Disposer.dispose(earlyTestRootDisposable)
         rustupFixture.tearDown()
         super.tearDown()
-        checkMacroExpansionFileSystemAfterTest()
     }
 
     protected open fun createRustupFixture(): RustupTestFixture = RustupTestFixture(project)

--- a/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
@@ -12,7 +12,6 @@ import org.intellij.lang.annotations.Language
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.macros.errors.GetMacroExpansionError
 
@@ -114,7 +113,6 @@ class RsShowMacroExpansionActionsTest : RsTestBase() {
     """)
 
     @MinRustcVersion("1.46.0")
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test attribute proc macro`() = testSingleStepExpansion("""
@@ -129,7 +127,6 @@ class RsShowMacroExpansionActionsTest : RsTestBase() {
     """)
 
     @MinRustcVersion("1.46.0")
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test recursive attribute proc macro`() = testRecursiveExpansion("""

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
@@ -15,6 +15,7 @@ import org.intellij.lang.annotations.Language
 import org.rust.TestProject
 import org.rust.createAndOpenFileWithCaretMarker
 import org.rust.fileTreeFromText
+import org.rust.lang.core.macros.MacroExpansionManager
 import kotlin.reflect.KClass
 
 open class RsAnnotationTestFixture<C>(
@@ -121,8 +122,10 @@ open class RsAnnotationTestFixture<C>(
     private fun configureByFileTree(text: String, stubOnly: Boolean) {
         val testProject = configureByFileTree(text)
         if (stubOnly) {
-            (codeInsightFixture as CodeInsightTestFixtureImpl)
-                .setVirtualFileFilter { !it.path.endsWith(testProject.fileWithCaret) }
+            (codeInsightFixture as CodeInsightTestFixtureImpl).setVirtualFileFilter {
+                !it.path.endsWith(testProject.fileWithCaret)
+                    && !MacroExpansionManager.isExpansionFile(it)
+            }
         }
     }
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -8,7 +8,6 @@ package org.rust.ide.annotator
 import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsDebuggerExpressionCodeFragment
 import org.rust.lang.core.psi.RsExpressionCodeFragment
 
@@ -3081,7 +3080,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     """)
 
     @MockRustcVersion("1.56.0-nightly")
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test non-structural match type as const generic parameter E0741`() = checkErrors("""

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -17,16 +17,7 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
         super.annotationFixture.registerSeverities(RsColor.values().map(RsColor::testSeverity))
     }
 
-    private val implDisplayI32 = """
-        use std::fmt;
-        impl fmt::Display for i32 {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { unimplemented!() }
-        }
-    """
-
     fun `test missing argument`() = checkErrors("""
-        $implDisplayI32
-
         fn main() {
             println!("<error descr="Invalid reference to positional argument 0 (no arguments were given)">{}</error>");
             println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1</error>}</FORMAT_PARAMETER>", 1);
@@ -40,8 +31,6 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
     fun `test missing explicit arguments 1`() = checkErrors("""
         #![feature(format_args_capture)]
 
-        $implDisplayI32
-
         println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>foo</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>");
         println!("Hello <FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>foo${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1);
     """)
@@ -49,8 +38,6 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
     // TODO: the plugin should highlight unknown argument even if `format_args_capture` is available
     @MinRustcVersion("1.58.0-nightly")
     fun `test missing explicit arguments 2`() = checkErrors("""
-        $implDisplayI32
-
         println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>foo</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>");
         println!("Hello <FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>foo${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1);
     """)
@@ -74,8 +61,6 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
     """)
 
     fun `test missing parameter`() = checkErrors("""
-        $implDisplayI32
-
         fn main() {
             println!("", <error descr="Argument never used">1.2</error>);
             println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1, <error descr="Argument never used">1.2</error>);
@@ -90,8 +75,6 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
     """)
 
     fun `test argument matches parameter`() = checkErrors("""
-        $implDisplayI32
-
         struct Debug;
         impl std::fmt::Debug for Debug {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { unimplemented!() }
@@ -146,8 +129,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }     """)
 
     fun `test invalid syntax 2`() = checkErrors("""
-        $implDisplayI32
-
         fn main() {
             format!("<FORMAT_PARAMETER>{
            <error descr="Invalid format string: } expected.
@@ -369,8 +350,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
     """)
 
     fun `test format trait is implemented behind reference`() = checkErrors("""
-        $implDisplayI32
-
         fn main() {
             let s = S;
             println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", &1);
@@ -378,8 +357,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
     """)
 
     fun `test match format parameters`() = checkErrors("""
-        $implDisplayI32
-
         fn main() {
             let a = 5;
             println!("Hello <FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, a);
@@ -392,8 +369,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
     """)
 
     fun `test check format parameters type`() = checkErrors("""
-        $implDisplayI32
-
         fn main() {
             println!("Hello <FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, <error descr="Width specifier must be of type `usize`">"asd"</error>);
             println!("Hello <FORMAT_PARAMETER>{:.<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, <error descr="Precision specifier must be of type `usize`">2.0</error>);
@@ -402,8 +377,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
     """)
 
     fun `test check precision asterisk`() = checkErrors("""
-        $implDisplayI32
-
         fn main() {
             println!("<FORMAT_PARAMETER>{:.<FORMAT_SPECIFIER>*</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1, 2);
             println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:.<FORMAT_SPECIFIER>*</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1);
@@ -414,8 +387,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
     """)
 
     fun `test check precision after dot omitted`() = checkErrors("""
-        $implDisplayI32
-
         fn main() {
             println!("<FORMAT_PARAMETER>{:.}</FORMAT_PARAMETER>", 1);
             println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:.}</FORMAT_PARAMETER>", 1);
@@ -471,8 +442,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
     """)
 
     fun `test raw format string`() = checkErrors("""
-        $implDisplayI32
-
         fn main() {
             println!(r"\<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>!", 1);
             println!(r"\u<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>!", 1);
@@ -581,7 +550,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
     """)
 
-    @ExpandMacros
     fun `test custom macro`() = checkErrors("""
         macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
         fn main() {
@@ -594,8 +562,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
 
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test no highlighting in cfg-disabled code`() = checkErrors("""
-        $implDisplayI32
-
         #[cfg(not(intellij_rust))]
         fn foo() {
             println!("{}");

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -12,7 +12,6 @@ import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.colors.RsColor
 
-@ExpandMacros
 class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator::class, RsAttrHighlightingAnnotator::class) {
 
     override fun setUp() {

--- a/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
@@ -13,7 +13,6 @@ import org.rust.lang.core.macros.MacroExpansionManager
 
 // More tests are located in `RsHighlightingAnnotatorTest` (most of those tests are executed
 // in both plain and macro context)
-@ExpandMacros
 class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
 
     fun `test attributes inside macro call`() = checkHighlightingInsideMacro("""

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -7,7 +7,6 @@ package org.rust.ide.docs
 
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
@@ -1279,7 +1278,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         originalElement to originalElement.textOffset
     }
 
-    @ExpandMacros
     fun `test documentation provided via macro definition 1`() = doTest("""
         macro_rules! foobar {
             ($ name:ident) => {
@@ -1302,7 +1300,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='content'><p>Say hello!</p></div>
     """)
 
-    @ExpandMacros
     fun `test documentation provided via macro definition 2`() = doTest("""
         pub struct Bar {
             pub bar: i32
@@ -1332,7 +1329,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='content'><p>Say hello</p></div>
     """)
 
-    @ExpandMacros
     fun `test documentation provided via macro call`() = doTest("""
         macro_rules! foo {
             ($ i:item) => { $ i }

--- a/src/test/kotlin/org/rust/ide/hints/type/RsExpressionTypeProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsExpressionTypeProviderTest.kt
@@ -8,7 +8,6 @@ package org.rust.ide.hints.type
 import org.intellij.lang.annotations.Language
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.openapiext.escaped
 
 
@@ -83,7 +82,6 @@ class RsExpressionTypeProviderTest : RsTestBase() {
         }
     """, "i32, S")
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test attr proc macro`() = doTest("""
@@ -95,7 +93,6 @@ class RsExpressionTypeProviderTest : RsTestBase() {
         }
     """, "i32")
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test attr proc macro 2`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProviderTest.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.vfs.VirtualFileFilter
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
 import org.rust.ide.hints.parameter.RsInlayParameterHintsProvider
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsMethodCall
 
 class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsProvider::class) {
@@ -508,7 +507,6 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iterator into_iter`() = checkByText("""
         fn main() {
             let xs<hint text="[:  i32]"/> = vec![1, 2, 3]
@@ -519,7 +517,6 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iterator iter`() = checkByText("""
         fn main() {
             let xs<hint text="[:  [& i32]]"/> = vec![1, 2, 3]
@@ -529,7 +526,6 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test inside attribute macro call body`() = checkByText("""
@@ -645,7 +641,6 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test attribute macro inside function-like macro`() = checkByText("""
@@ -658,7 +653,6 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test function-like macro inside attribute macro`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
@@ -6,14 +6,11 @@
 package org.rust.ide.inspections
 
 import org.rust.CheckTestmarkHit
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.lang.core.macros.MacroExpansionScope
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspection::class) {
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test simple assert_eq fix`() = checkFixByText("Convert to assert_eq!", """
         fn main() {
             let x = 10;
@@ -28,7 +25,6 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test expr assert_eq fix`() = checkFixByText("Convert to assert_eq!", """
         fn answer() -> i32 {
             return 42
@@ -47,7 +43,6 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test simple assert_eq fix with format_args`() = checkFixByText("Convert to assert_eq!", """
         fn main() {
             let x = 10;
@@ -62,7 +57,6 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test simple assert_ne fix`() = checkFixByText("Convert to assert_ne!", """
         fn main() {
             let x = 10;
@@ -77,7 +71,6 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test expr assert_ne fix`() = checkFixByText("Convert to assert_ne!", """
         fn answer() -> i32 {
             return 42;
@@ -96,7 +89,6 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """, checkWeakWarn = true)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test simple assert_ne fix with format_args`() = checkFixByText("Convert to assert_ne!", """
         fn main() {
             let x = 10;

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.inspections
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmutableInspection::class) {
 
@@ -62,7 +60,6 @@ class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmuta
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test E0594 assign to field of immutable binding while iterating`() = checkByText("""
         struct Foo { a: i32 }
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
@@ -32,7 +32,6 @@ class RsDetachedFileInspectionTest : RsInspectionsTestBase(RsDetachedFileInspect
         /*caret*/
     """)
 
-    @ExpandMacros
     fun `test included file via macro`() = checkByFileTree("""
         //- lib.rs
             macro_rules! generate_include {

--- a/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import org.rust.ExpandMacros
 import org.rust.MockAdditionalCfgOptions
 
 class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImplementationInspection::class) {
@@ -159,7 +158,6 @@ class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImpleme
         }
     """)
 
-    @ExpandMacros
     fun `test ignore expanded methods`() = checkErrors("""
         macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
         trait T {

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -5,11 +5,13 @@
 
 package org.rust.ide.inspections.borrowck
 
-import org.rust.*
+import org.rust.CheckTestmarkHit
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.lang.core.macros.MacroExpansionManager
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection::class) {
     fun `test move by call`() = checkByText("""
@@ -272,7 +274,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move error E0382 on field getter`() = checkByText("""
         struct S {
             data: (u16, u16, u16)
@@ -335,7 +336,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move error E0507 when deref Rc with Copy type`() = checkByText("""
         use std::rc::Rc;
         fn main() {
@@ -420,7 +420,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move error E0507 on copyable array`() = checkByText("""
         fn copy(arr: &[i32; 4]) -> [i32; 4] {
             *arr
@@ -664,7 +663,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
 
     /** Issue [#4307](https://github.com/intellij-rust/intellij-rust/issues/4307) */
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move error copy slice`() = checkByText("""
         fn main() {
             let v: Vec<i32> = vec![1, 2, 3];
@@ -731,7 +729,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
         }
     """, checkWarn = false)
 
-    @ExpandMacros
     @CheckTestmarkHit(MacroExpansionManager.Testmarks.TooDeepExpansion::class)
     fun `test infinitely recursive macro call`() = checkByText("""
         macro_rules! infinite_macro {
@@ -747,7 +744,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move struct expr with base`() = checkByText("""
         struct S { x: i32, y: i32 }
 
@@ -759,7 +755,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move struct expr with base paren`() = checkByText("""
         struct S { x: i32, y: i32 }
 
@@ -771,7 +766,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move generic struct expr with base`() = checkByText("""
         struct S<T> { x: T, y: T }
 
@@ -794,7 +788,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move self struct expr with base`() = checkByText("""
         struct S { x: i32, y: i32 }
 
@@ -806,7 +799,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move self struct expr with complex base`() = checkByText("""
         struct A<T> { x: T }
         struct B<T> { a: A<T>, aa: i32 }
@@ -886,7 +878,6 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
     """, checkWarn = false)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test no move when Copy is implemented for struct named as a primitive type`() = checkByText("""
         struct f64;
         impl Copy for f64 {}

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -720,10 +720,10 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn foo(t: Rc/*caret*/<usize>) {}
     """)
 
-    fun `test import item from proc_macro`() = checkAutoImportFixByFileTree("""
+    fun `test import item from proc_macro`() = checkAutoImportFixByFileTreeWithMultipleChoice("""
     //- dep-proc-macro/lib.rs
         fn foo(_: <error descr="Unresolved reference: `TokenStream`">TokenStream/*caret*/</error>) {}
-    """, """
+    """, listOf("proc_macro::TokenStream", "proc_macro::bridge::server::TokenStream"), "proc_macro::TokenStream", """
     //- dep-proc-macro/lib.rs
         use proc_macro::TokenStream;
 

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -2638,7 +2638,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         pub fn foo() {}
     """)
 
-    @ExpandMacros
     fun `test import struct from macro`() = checkAutoImportFixByText("""
         mod foo {
             macro_rules! foo {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -9,7 +9,6 @@ import org.junit.ComparisonFailure
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspection::class) {
     fun `test unused import`() = checkByText("""
@@ -467,7 +466,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
     """)
 
     @MinRustcVersion("1.46.0")
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test usage inside derive proc macro expansion`() = checkByText("""
@@ -481,7 +479,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
     """)
 
     @MinRustcVersion("1.46.0")
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test usage inside attribute proc macro expansion`() = checkByText("""
@@ -494,7 +491,6 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test usage inside attribute proc macro expansion 2`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -5,13 +5,11 @@
 
 package org.rust.ide.inspections.typecheck
 
-import org.rust.ExpandMacros
 import org.rust.MockRustcVersion
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     fun `test type mismatch E0308 primitive`() = checkByText("""
@@ -245,7 +243,6 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
 
     /** Issue [2713](https://github.com/intellij-rust/intellij-rust/issues/2713) */
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test issue 2713`() = checkByText("""
         fn main() { u64::from(0u8); }
     """)

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntentionTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.intentions
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class ConvertClosureToFunctionIntentionTest : RsIntentionTestBase(ConvertClosureToFunctionIntention::class) {
 
@@ -49,7 +47,6 @@ class ConvertClosureToFunctionIntentionTest : RsIntentionTestBase(ConvertClosure
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test intention adds return type to function when closure doesnt have one`() = doAvailableTest("""
         fn main() {
             let foo = |x: i32/*caret*/| x + 1;

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
@@ -5,9 +5,11 @@
 
 package org.rust.ide.lineMarkers
 
-import org.rust.*
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.WithExperimentalFeatures
+import org.rust.WithProcMacroRustProjectDescriptor
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 
 /**
  * Tests for Bench Function Line Marker.
@@ -90,7 +92,6 @@ class CargoBenchRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         fn no_icon() { assert(true) }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test bench function under a proc macro attribute`() = doTestByText("""

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoExecutableRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoExecutableRunLineMarkerContributorTest.kt
@@ -9,12 +9,10 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.util.PathUtil
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithExperimentalFeatures
 import org.rust.WithProcMacroRustProjectDescriptor
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class CargoExecutableRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
 
@@ -50,7 +48,6 @@ class CargoExecutableRunLineMarkerContributorTest : RsLineMarkerProviderTestBase
         fn main() {}
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test main expanded from a attribute macro call`() = doTest("main.rs", """

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -11,7 +11,6 @@ import org.rust.*
 import org.rust.cargo.icons.CargoIcons
 import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.RsFileType
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsMod
@@ -147,7 +146,6 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         fn no_icon() { assert(true) }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test test function under a proc macro attribute`() = doTestByText("""

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
@@ -8,12 +8,10 @@ package org.rust.ide.lineMarkers
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithExperimentalFeatures
 import org.rust.WithProcMacroRustProjectDescriptor
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
 
@@ -77,7 +75,6 @@ class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         "Foo for FooBar"
     )
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test struct an trait under a proc macro attribute`() = doTestByText("""

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProviderTest.kt
@@ -5,12 +5,10 @@
 
 package org.rust.ide.lineMarkers
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithExperimentalFeatures
 import org.rust.WithProcMacroRustProjectDescriptor
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 
 /**
  * Tests for Rust Recursive Call Line Marker Provider
@@ -67,7 +65,6 @@ class RsRecursiveCallLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
     """)
 
     // TODO support attribute macros in `RsRecursiveCallLineMarkerProvider`
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test function under a proc macro attribute`() = expect<Throwable> {

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt
@@ -5,12 +5,10 @@
 
 package org.rust.ide.lineMarkers
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithExperimentalFeatures
 import org.rust.WithProcMacroRustProjectDescriptor
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 
 /**
  * Tests for Trait member (const, fn, type) Implementation Line Marker
@@ -40,7 +38,6 @@ class RsTraitItemImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test trait and impl under a proc macro attribute`() = doTestByText("""

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoImplementationsTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoImplementationsTest.kt
@@ -14,7 +14,6 @@ import com.intellij.testFramework.fixtures.CodeInsightTestUtil
 import org.intellij.lang.annotations.Language
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 import java.util.*
 import java.util.concurrent.Callable
 
@@ -113,7 +112,6 @@ class RsGotoImplementationsTest : RsTestBase() {
         "Trait for Baz<T> where T: Clone test_package"
     )
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test trait under a proc macro attribute`() = doSingleTargetTest("""
@@ -138,7 +136,6 @@ class RsGotoImplementationsTest : RsTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test impl under a proc macro attribute`() = doSingleTargetTest("""
@@ -163,7 +160,6 @@ class RsGotoImplementationsTest : RsTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test member when trait is under a proc macro attribute`() = doSingleTargetTest("""
@@ -186,7 +182,6 @@ class RsGotoImplementationsTest : RsTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test struct under a proc macro attribute`() = doSingleTargetTest("""

--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -9,7 +9,6 @@ import com.intellij.refactoring.BaseRefactoringProcessor
 import org.intellij.lang.annotations.Language
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope.WORKSPACE
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.openapiext.toPsiDirectory
@@ -698,7 +697,6 @@ class RenameTest : RsTestBase() {
         macro_rules! foo { ($ b:item) => { $ b }; }
     """)
 
-    @ExpandMacros(WORKSPACE)
     fun `test rename function expanded from declarative macro`() = doTest("bar", """
         macro_rules! foo { ($ i:item) => { $ i }; }
         foo! {
@@ -717,7 +715,6 @@ class RenameTest : RsTestBase() {
         }
     """)
 
-    @ExpandMacros(WORKSPACE)
     fun `test rename lifetime in function expanded from declarative macro`() = doTest("'b", """
         macro_rules! foo { ($ i:item) => { $ i }; }
         foo! {
@@ -755,7 +752,6 @@ class RenameTest : RsTestBase() {
     """)
 
     @MinRustcVersion("1.46.0")
-    @ExpandMacros(WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test rename function expanded from attr proc macro`() = doTest("bar", """
@@ -779,7 +775,6 @@ class RenameTest : RsTestBase() {
     """)
 
     @MinRustcVersion("1.46.0")
-    @ExpandMacros(WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test rename struct expanded from attr proc macro (the name in the attr)`() = doTest("Bar", """

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -10,7 +10,6 @@ import org.rust.*
 import org.rust.ide.refactoring.extractFunction.ExtractFunctionUi
 import org.rust.ide.refactoring.extractFunction.RsExtractFunctionConfig
 import org.rust.ide.refactoring.extractFunction.withMockExtractFunctionUi
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsExtractFunctionTest : RsTestBase() {
     fun `test extract a function without parameters and a return value`() = doTest("""
@@ -824,7 +823,6 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test extract a function with passing primitive`() = doTest("""
         fn foo() {
             let i = 1;
@@ -1776,7 +1774,6 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test extract println! argument expression`() = doTest("""
         fn main() {
             println!("{}", <selection>1 + 2</selection>);
@@ -1792,7 +1789,6 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test extract vec! argument expression`() = doTest("""
         fn main() {
             vec![<selection>1 + 2</selection>];

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceConstantTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceConstantTest.kt
@@ -6,19 +6,16 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.refactoring.introduceConstant.ExtractConstantUi
 import org.rust.ide.refactoring.introduceConstant.InsertionCandidate
 import org.rust.ide.refactoring.introduceConstant.withMockExtractConstantChooser
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsExpr
 
 class RsIntroduceConstantTest : RsTestBase() {
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test insertion binary expression`() = doTest("""
         fn foo() {
             let x = /*caret*/5 + 5;
@@ -151,7 +148,6 @@ class RsIntroduceConstantTest : RsTestBase() {
     """, replaceAll = true)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test expression containing a constant`() = doTest("""
         const C: i32 = 1;
 

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
@@ -8,7 +8,6 @@ package org.rust.ide.refactoring
 import org.intellij.lang.annotations.Language
 import org.rust.*
 import org.rust.ide.refactoring.introduceVariable.IntroduceVariableTestmarks
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsExpr
 
 
@@ -84,7 +83,6 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test replace occurrences forward`() = doTest("""
         fn hello() {
             foo(5 + /*caret*/10);
@@ -99,7 +97,6 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
     """, replaceAll = true)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test replace occurrences backward`() = doTest("""
         fn main() {
             let a = 1;
@@ -116,7 +113,6 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
     """, replaceAll = true)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test replace occurrences backward for expr stmt`() = doTest("""
         fn main() {
             let a = 1;
@@ -133,7 +129,6 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
     """, replaceAll = true)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test replace occurrences backward for returned expr`() = doTest("""
         fn main() {
             let _ = {

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.refactoring.generate
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class GenerateGetterActionTest : RsGenerateBaseTest() {
     override val generateId: String = "Rust.GenerateGetter"
@@ -221,7 +219,6 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test tuple copy`() = doTest("""
         struct S {
             a: (u32, u32)
@@ -414,7 +411,6 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test type alias 2`() = doTest("""
         type Alias = (u32, u32);
         struct S {

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.refactoring.move
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithEnabledInspections
 import org.rust.WithStdlibRustProjectDescriptor
@@ -349,7 +348,6 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod2/*target*/ {}
     """)
 
-    @ExpandMacros
     fun `test no exception when source file has reference to expanded item`() = doTestNoConflicts("""
     //- lib.rs
         mod mod1 {

--- a/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
+++ b/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.ui.TestDialog
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 import org.rust.RsTestBase
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.startOffset
@@ -293,7 +292,6 @@ class RsFindUsagesTest : RsTestBase() {
         fn func(_: super::Foo) {} // - type reference
     """)
 
-    @ExpandMacros
     fun `test usage in included file`() = doTestByFileTree("""
     //- main.rs
         mod foo;

--- a/src/test/kotlin/org/rust/ide/structure/RsStructureViewTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/structure/RsStructureViewTestBase.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.ui.Queryable
 import com.intellij.testFramework.PlatformTestUtil
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
+import org.rust.lang.core.macros.macroExpansionManagerIfCreated
 import javax.swing.JTree
 import javax.swing.tree.TreePath
 
@@ -31,6 +32,7 @@ abstract class RsStructureViewTestBase : RsTestBase() {
         actions: StructureViewComponent.() -> Unit,
     ) {
         myFixture.configureByText(fileName, code)
+        myFixture.project.macroExpansionManagerIfCreated?.updateInUnitTestMode()
         myFixture.testStructureView {
             it.actions()
         }

--- a/src/test/kotlin/org/rust/ide/template/postfix/IterPostFixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/IterPostFixTemplateTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.template.postfix
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.lang.core.macros.MacroExpansionScope
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 abstract class IterPostFixTemplateTestBase(private val key: String) :
@@ -20,7 +18,6 @@ abstract class IterPostFixTemplateTestBase(private val key: String) :
         """
     )
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iterable expr`() = doTest("""
         fn main(){
             let v = vec![1, 2, 3];

--- a/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.template.postfix
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class LetPostfixTemplateTest : RsPostfixTemplateTest(LetPostfixTemplate::class) {
     fun `test not expr 1`() = doTestNotApplicable("""
@@ -46,7 +44,6 @@ class LetPostfixTemplateTest : RsPostfixTemplateTest(LetPostfixTemplate::class) 
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test par expr`() = doTest("""
         fn foo() {
             (1 + 2).let/*caret*/;

--- a/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
@@ -5,13 +5,10 @@
 
 package org.rust.ide.template.postfix
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.lang.core.macros.MacroExpansionScope
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-@ExpandMacros(MacroExpansionScope.ALL, "std")
 class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate::class) {
     fun `test string`() = doTest("""
        fn main() {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
@@ -6,13 +6,11 @@
 package org.rust.lang.core.completion
 
 import com.intellij.openapi.util.SystemInfo
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithActualStdlibRustProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.wsl.RsWslToolchain
-import org.rust.lang.core.macros.MacroExpansionScope
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsStdlibCompletionTest : RsCompletionTestBase() {
@@ -92,7 +90,6 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
         use std::/*caret*/;
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test complete items from 'os' module unix`() {
         if (!SystemInfo.isUnix && project.toolchain !is RsWslToolchain) return
@@ -103,7 +100,6 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
         """)
     }
 
-    @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test complete items from 'os' module windows`() {
         if (!SystemInfo.isWindows || project.toolchain is RsWslToolchain) return

--- a/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
@@ -1348,7 +1348,6 @@ class RsControlFlowGraphTest : RsTestBase() {
         }
     """)
 
-    @ExpandMacros
     @CheckTestmarkHit(MacroExpansionManager.Testmarks.TooDeepExpansion::class)
     fun `test infinitely recursive macro call`() = testCFG("""
         macro_rules! infinite_macro {

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
@@ -6,11 +6,9 @@
 package org.rust.lang.core.macros
 
 import org.rust.CheckTestmarkHit
-import org.rust.ExpandMacros
 import org.rust.lang.core.resolve.RsResolveTestBase
 import org.rust.lang.core.resolve.ref.RsMacroBodyReferenceDelegateImpl.Testmarks
 
-@ExpandMacros
 class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
     @CheckTestmarkHit(Testmarks.Touched::class)
     fun `test item context`() = checkByCode("""

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallUnderCfgTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallUnderCfgTest.kt
@@ -19,7 +19,6 @@ import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.psi.ext.expansion
 
-@ExpandMacros
 class RsMacroCallUnderCfgTest : RsTestBase() {
     @MockCargoFeatures("feature_foo")
     fun `test simple`() = checkResolvedOnlyWhenFeatureIsEnabled("feature_foo", """

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingTest.kt
@@ -15,7 +15,6 @@ import com.intellij.psi.util.descendantsOfType
 import com.intellij.util.io.storage.HeavyProcessLatch
 import org.intellij.lang.annotations.Language
 import org.rust.CheckTestmarkHit
-import org.rust.ExpandMacros
 import org.rust.TestProject
 import org.rust.fileTreeFromText
 import org.rust.lang.core.psi.RsFile
@@ -25,7 +24,6 @@ import org.rust.lang.core.psi.RsMembers
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.Testmark
 
-@ExpandMacros
 class RsMacroExpansionCachingTest : RsMacroExpansionTestBase() {
     private fun type(text: String = "a"): () -> Unit = {
         myFixture.type(text)

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionRangeMappingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionRangeMappingTest.kt
@@ -13,7 +13,6 @@ import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.psi.RsBinaryExpr
 import org.rust.lang.core.psi.ext.*
 
-@ExpandMacros
 class RsMacroExpansionRangeMappingTest : RsTestBase() {
     fun `test struct name`() = checkOffset("""
         macro_rules! foo {

--- a/src/test/kotlin/org/rust/lang/core/macros/RsUndoAfterTypingInMacroTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsUndoAfterTypingInMacroTest.kt
@@ -7,10 +7,8 @@ package org.rust.lang.core.macros
 
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.psi.PsiDocumentManager
-import org.rust.ExpandMacros
 import org.rust.RsTestBase
 
-@ExpandMacros(MacroExpansionScope.WORKSPACE)
 class RsUndoAfterTypingInMacroTest : RsTestBase() {
     fun `test typing in a macro can be undone with single undo action invocation`() {
         val code = """

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroErrorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroErrorTest.kt
@@ -5,12 +5,10 @@
 
 package org.rust.lang.core.macros.decl
 
-import org.rust.ExpandMacros
 import org.rust.MockAdditionalCfgOptions
 import org.rust.lang.core.macros.RsMacroExpansionErrorTestBase
 import org.rust.lang.core.macros.errors.GetMacroExpansionError
 
-@ExpandMacros
 class RsMacroErrorTest : RsMacroExpansionErrorTestBase() {
     // https://github.com/intellij-rust/intellij-rust/pull/2583
     fun `test empty group definition`() = checkError<GetMacroExpansionError.ExpansionError>("""

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
@@ -11,7 +11,6 @@ import org.rust.ide.experiments.RsExperiments.DERIVE_PROC_MACROS
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.FN_LIKE_PROC_MACROS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.macros.RsMacroExpansionErrorTestBase
 import org.rust.lang.core.macros.errors.GetMacroExpansionError
 
@@ -21,7 +20,6 @@ import org.rust.lang.core.macros.errors.GetMacroExpansionError
  * @see RsProcMacroExpanderTest
  */
 @MinRustcVersion("1.46.0")
-@ExpandMacros(MacroExpansionScope.WORKSPACE)
 @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
 @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
 class RsProcMacroErrorTest : RsMacroExpansionErrorTestBase() {

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroSyntaxFixupTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroSyntaxFixupTest.kt
@@ -9,14 +9,12 @@ import com.intellij.openapi.util.text.StringUtil
 import org.intellij.lang.annotations.Language
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.ext.RsPossibleMacroCall
 import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.lang.core.psi.ext.expansion
 import org.rust.lang.core.psi.ext.isMacroCall
 
 @MinRustcVersion("1.46.0")
-@ExpandMacros(MacroExpansionScope.WORKSPACE)
 @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
 @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
 class RsProcMacroSyntaxFixupTest : RsTestBase() {

--- a/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDocumentManager
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
 import org.rust.lang.core.psi.RsRustStructureModificationTrackerTest.TestAction.INC
@@ -167,16 +166,10 @@ class RsRustStructureModificationTrackerTest : RsTestBase() {
         macro foo { () => { /*caret*/ } }
     """)
 
-    fun `test macro call (old engine)`() = checkModCount(INC, """
+    fun `test macro call`() = checkModCount(NOT_INC, """
         foo! { /*caret*/ }
     """, "a")
 
-    @ExpandMacros
-    fun `test macro call (new engine)`() = checkModCount(NOT_INC, """
-        foo! { /*caret*/ }
-    """, "a")
-
-    @ExpandMacros
     fun `test macro expanded call`() = checkModCount(INC, """
         macro_rules! foo {
             ($ i:ident) => { fn $ i() {} };
@@ -188,7 +181,6 @@ class RsRustStructureModificationTrackerTest : RsTestBase() {
         fn wrapped() { foo! { /*caret*/ } }
     """, "a")
 
-    @ExpandMacros
     fun `test macro call a function (new engine)`() = checkModCount(NOT_INC, """
         fn wrapped() { foo! { /*caret*/ } }
     """, "a")

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -5,7 +5,10 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.*
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.psi.RsTupleFieldDecl
 
 class RsCfgAttrResolveTest : RsResolveTestBase() {
@@ -237,7 +240,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }
      """)
 
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test macro expansion with cfg`() = checkByCode("""
         struct S { x: i32 }
@@ -372,7 +374,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }   //^
      """)
 
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test impl expanded from macro with cfg`() = checkByCode("""
         macro_rules! same {
@@ -393,7 +394,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }   //^
      """)
 
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg inside macros`() = checkByCode("""
         macro_rules! as_is { ($($ i:item)*) => { $($ i)* } }
@@ -415,7 +415,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }  //^
      """)
 
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg on macros inside macros`() = checkByCode("""
         macro_rules! as_is { ($($ i:item)*) => { $($ i)* } }
@@ -434,7 +433,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }  //^
      """)
 
-    @ExpandMacros
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test super mod with mod declaration with cfg`() = stubOnlyResolve("""
@@ -451,7 +449,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         fn bar() {}
      """)
 
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test macro definition with cfg`() = checkByCode("""
         #[cfg(intellij_rust)]
@@ -464,7 +461,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         //^
      """)
 
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test macro in inline mod with cfg`() = checkByCode("""
         #[macro_use]
@@ -481,7 +477,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         //^
      """)
 
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test macro in extracted mod with cfg`() = stubOnlyResolve("""
     //- foo.rs
@@ -499,7 +494,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         //^ foo.rs
      """)
 
-    @ExpandMacros
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test exported macro with cfg`() = stubOnlyResolve("""
@@ -521,7 +515,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         //^ foo.rs
      """)
 
-    @ExpandMacros
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test exported macro in mod with cfg`() = stubOnlyResolve("""
@@ -543,7 +536,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         //^ foo.rs
      """)
 
-    @ExpandMacros
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test macro from another crate with cfg`() = stubOnlyResolve("""
@@ -559,7 +551,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         //^ unresolved
      """)
 
-    @ExpandMacros
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test exported macro with cfg on 'extern crate' 1`() = stubOnlyResolve("""
@@ -580,7 +571,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         //^ lib.rs
      """)
 
-    @ExpandMacros
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test exported macro with cfg on 'extern crate' 2`() = stubOnlyResolve("""
@@ -600,7 +590,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         //^ lib.rs
      """)
 
-    @ExpandMacros
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test exported macro with cfg on use item`() = stubOnlyResolve("""
@@ -647,7 +636,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }  //^ foo.rs
      """)
 
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg-disabled macro call expanded to inline mod`() = stubOnlyResolve("""
     //- main.rs
@@ -670,7 +658,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     // From https://github.com/tokio-rs/tokio/blob/97c2c4203cd7c42960cac895987c43a17dff052e/tokio/src/process/mod.rs#L132-L134
     // Goal of these two tests is to check that there are no exceptions during building CrateDefMap.
     // Actual resolve result is not important, because proper multiresolve is not yet supported in new resolve.
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test import inside expanded shadowed mod 1`() = stubOnlyResolve("""
     //- lib.rs
@@ -695,7 +682,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     // From https://github.com/tokio-rs/tokio/blob/97c2c4203cd7c42960cac895987c43a17dff052e/tokio/src/process/mod.rs#L132-L134
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test import inside expanded shadowed mod 2`() = stubOnlyResolve("""
     //- lib.rs
@@ -720,7 +706,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     // From https://github.com/rust-lang/rust/blob/e0ef0fc392963438af5f0343bf7caa46fb9c3ec3/library/alloc/src/lib.rs#L164-L169
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test import to shadowed mod`() = checkByCode("""
         #[cfg(intellij_rust)]
@@ -736,7 +721,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     // We check that there are no exceptions during building CrateDefMap (actual resolve result is not important)
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test import to mod shadowed by expanded mod`() = checkByCode("""
         #[cfg(not(intellij_rust))]
@@ -959,7 +943,6 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         pub fn func() {}
     """)
 
-    @ExpandMacros
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg-disabled mod does not affect cfg-enabled mod`() = stubOnlyResolve("""
     //- main.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
@@ -7,7 +7,6 @@ package org.rust.lang.core.resolve
 
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments
-import org.rust.lang.core.macros.MacroExpansionScope
 
 class RsDoctestInjectionResolveTest : RsResolveTestBase() {
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -174,7 +173,6 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
     """)
 
     @MinRustcVersion("1.46.0")
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @WithExperimentalFeatures(RsExperiments.EVALUATE_BUILD_SCRIPTS, RsExperiments.PROC_MACROS)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test attribute proc macros`() = stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
@@ -6,9 +6,7 @@
 package org.rust.lang.core.resolve
 
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 
-@ExpandMacros
 class RsIncludeMacroResolveTest : RsResolveTestBase() {
 
     fun `test resolve struct to included file`() = checkResolve("""
@@ -333,6 +331,13 @@ class RsIncludeMacroResolveTest : RsResolveTestBase() {
     //- bar/foo.rs
         #[derive(Debug)]
         struct Foo;
+    """)
+
+    fun `test illegal included file path`() = checkResolve("""
+    //- lib.rs
+        include!("inner/fo<>\0.rs");
+        type T = Foo;
+               //^ unresolved
     """)
 
     private fun checkResolve(@Language("Rust") code: String) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -5,12 +5,10 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.stdext.BothEditions
 
-@ExpandMacros
 class RsMacroExpansionResolveTest : RsResolveTestBase() {
     override val followMacroExpansions: Boolean get() = true
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.resolve
 
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 import org.rust.lang.core.psi.ext.RsReferenceElement
 
 class RsMultiResolveTest : RsResolveTestBase() {
@@ -139,7 +138,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
     """)
 
     // From https://github.com/Alexhuszagh/rust-lexical/blob/1ec9d7660e70ab731eecb3390bdf95e767548dcc/lexical-core/src/util/slice_index.rs#L82
-    @ExpandMacros
     fun `test import item vs local item (inside expanded mod)`() = doTest("""
         mod m {
             pub fn foo() {}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroExpansionResolveTest.kt
@@ -11,10 +11,8 @@ import org.rust.ide.experiments.RsExperiments.DERIVE_PROC_MACROS
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.FN_LIKE_PROC_MACROS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
-import org.rust.lang.core.macros.MacroExpansionScope
 
 @MinRustcVersion("1.46.0")
-@ExpandMacros(MacroExpansionScope.WORKSPACE)
 @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
 @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
 class RsProcMacroExpansionResolveTest : RsResolveTestBase() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.util.SystemInfo
 import org.rust.*
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.wsl.RsWslToolchain
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 import org.rust.stdext.BothEditions
 
@@ -644,7 +643,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                          //^ ...alloc/src/rc.rs
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test AtomicUsize`() = stubOnlyResolve("""
     //- main.rs
         use std::sync::atomic::AtomicUsize;
@@ -720,7 +718,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                         //^ ...core/src/macros/mod.rs
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test resolve in os module unix`() {
         if (!SystemInfo.isUnix && project.toolchain !is RsWslToolchain) return
@@ -731,7 +728,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         """)
     }
 
-    @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test resolve in os module windows`() {
         if (!SystemInfo.isWindows || project.toolchain is RsWslToolchain) return

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -942,4 +942,11 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
             fn bar(&self) {}
         }
     """)
+
+    fun `test illegal mod decl path`() = stubOnlyResolve("""
+    //- main.rs
+        #[path = "fo<>\0.rs"]
+        mod foo;
+            //^ unresolved
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapMacroIndexConsistencyTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapMacroIndexConsistencyTest.kt
@@ -9,7 +9,6 @@ import org.intellij.lang.annotations.Language
 import org.rust.*
 import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.toPsiFile
@@ -38,7 +37,6 @@ class RsDefMapMacroIndexConsistencyTest : RsTestBase() {
         [0, 7] macro macro3
     """)
 
-    @ExpandMacros(MacroExpansionScope.WORKSPACE)
     @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
     fun `test proc macros`() = doTest("""
         use test_proc_macros::*;

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
@@ -9,11 +9,9 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDocumentManager
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 import org.rust.MockAdditionalCfgOptions
 
 /** Tests whether [CrateDefMap] should be updated after file modification */
-@ExpandMacros  // needed to enable precise modification tracker
 class RsDefMapUpdateChangeSingleFileTest : RsDefMapUpdateTestBase() {
 
     fun `test edit function body`() = doTestNotChanged(type(), """

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateCreateNewFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateCreateNewFileTest.kt
@@ -8,12 +8,10 @@ package org.rust.lang.core.resolve2
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.psi.PsiDirectory
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
 import org.rust.fileTreeFromText
 import org.rust.openapiext.toPsiDirectory
 
 /** Tests whether [CrateDefMap] should be updated after creation of new file */
-@ExpandMacros
 class RsDefMapUpdateCreateNewFileTest : RsDefMapUpdateTestBase() {
 
     private fun createFile(parent: PsiDirectory, fileToCreate: String): () -> Unit = {

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
@@ -16,6 +16,7 @@ import org.rust.lang.core.resolve2.CrateInfo.*
 
 /** Tests which exactly [CrateDefMap]s are updated when we modify some crate and then run resolve in some other crate */
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+@WithDisabledMacroExpansion
 class RsMultipleDefMapsUpdateTest : RsTestBase() {
 
     override fun setUp() {

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -5,7 +5,10 @@
 
 package org.rust.lang.core.type
 
-import org.rust.*
+import org.rust.CheckTestmarkHit
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.lang.core.macros.MacroExpansionManager
 
@@ -1754,7 +1757,6 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ i32
     """)
 
-    @ExpandMacros
     @CheckTestmarkHit(MacroExpansionManager.Testmarks.TooDeepExpansion::class)
     fun `test infinite macro type`() = testExpr("""
         fn main() {

--- a/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.type
 
 import org.rust.CheckTestmarkHit
-import org.rust.ExpandMacros
 import org.rust.lang.core.macros.MacroExpansionManager
 
 class RsMacroTypeInferenceTest : RsTypificationTestBase() {
@@ -129,7 +128,6 @@ class RsMacroTypeInferenceTest : RsTypificationTestBase() {
         } //^ <unknown>
     """)
 
-    @ExpandMacros
     @CheckTestmarkHit(MacroExpansionManager.Testmarks.TooDeepExpansion::class)
     fun `test infinite recursion`() = testExpr("""
         macro_rules! foo { () => { foo!(); }; }

--- a/src/test/kotlin/org/rust/lang/core/type/RsPrimitiveTypeImplsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsPrimitiveTypeImplsTest.kt
@@ -5,11 +5,9 @@
 
 package org.rust.lang.core.type
 
-import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTypeParamBounds
 import org.rust.lang.core.psi.ext.withSubst
@@ -17,7 +15,6 @@ import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.types.TraitRef
 import org.rust.lang.core.types.ty.*
 
-@ExpandMacros(MacroExpansionScope.ALL, "std")
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsPrimitiveTypeImplsTest : RsTestBase() {
     fun `test Sized types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyChar.INSTANCE + TyUnit.INSTANCE, "Sized")

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.lang.core.type
 
-import org.rust.*
-import org.rust.lang.core.macros.MacroExpansionScope
+import org.rust.MinRustcVersion
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibAndStdlibLikeDependencyRustProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyFloat
 import org.rust.lang.core.types.ty.TyInteger
@@ -541,7 +543,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test slice iter`() = stubOnlyTypeInfer("""
     //- main.rs
         struct S<T>(T);
@@ -554,7 +555,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test slice iter_mut`() = stubOnlyTypeInfer("""
     //- main.rs
         struct S<T>(T);
@@ -567,7 +567,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iter take`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
@@ -604,7 +603,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iterator cloned`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
@@ -650,7 +648,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test arithmetic op with unconstrained integer`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
@@ -660,7 +657,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test all arithmetic ops with all numeric types`() {
         TyInteger.NAMES.permutations(ArithmeticOp.values())
             .forEach { (numeric, op) -> doTestBinOp(numeric, op, "0", numeric) }
@@ -670,7 +666,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             .forEach { (numeric, op) -> doTestBinOp(numeric, op, "0.0", numeric) }
     }
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test all arithmetic assignment ops with all numeric types`() {
         TyInteger.NAMES.permutations(ArithmeticAssignmentOp.values())
             .forEach { (numeric, op) -> doTestBinOp(numeric, op, "0", "()") }
@@ -681,7 +676,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             .forEach { (numeric, op) -> doTestBinOp(numeric, op, "0.0", "()") }
     }
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test all cmp ops with all numeric types`() {
         val ops: List<OverloadableBinaryOperator> = EqualityOp.values() + ComparisonOp.values()
         TyInteger.NAMES.permutations(ops)
@@ -723,7 +717,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         """)
     }
 
-    @ExpandMacros
     fun `test write macro`() = stubOnlyTypeInfer("""
     //- main.rs
         use std::fmt::Write;
@@ -735,7 +728,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros
     fun `test write macro &mut`() = stubOnlyTypeInfer("""
     //- main.rs
         use std::fmt::Write;
@@ -748,7 +740,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
     """)
 
     /** Issue [#2514](https://github.com/intellij-rust/intellij-rust/issues/2514) */
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test issue 2514`() = stubOnlyTypeInfer("""
     //- main.rs
         struct Foo {
@@ -789,7 +780,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ Box<S> | Box<S, Global>
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iterate 'for' complex pattern in complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
@@ -799,7 +789,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test iterate 'while let' complex pattern = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
@@ -809,7 +798,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test 'if let' complex pattern = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
@@ -819,7 +807,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
     fun `test 'try expr' on a complex type = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {

--- a/src/test/kotlin/org/rustSlowTests/RsGcSoftlyReachableObjectsCacheTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsGcSoftlyReachableObjectsCacheTest.kt
@@ -6,7 +6,6 @@
 package org.rustSlowTests
 
 import com.intellij.util.ref.GCUtil
-import org.rust.ExpandMacros
 import org.rust.RsTestBase
 import org.rust.lang.core.crate.crateGraph
 import org.rust.lang.core.crate.impl.CrateGraphServiceImpl
@@ -58,7 +57,6 @@ class RsGcSoftlyReachableObjectsCacheTest : RsTestBase() {
     }
 
     // Issue https://github.com/intellij-rust/intellij-rust/issues/9468
-    @ExpandMacros
     fun `test only one in-memory macro expansion per macro call may exist in the memory at a time`() {
         InlineFile("""
             macro_rules! as_is { ($($ t:tt)*) => { $($ t)* } }


### PR DESCRIPTION
Now all macros are expanded by default in all `RsTestBase`-based tests. Note that `@ExpandMacros` is still used in `RsWithToolchainTestBase`-based tests

changelog: Now all macros are expanded by default in all `RsTestBase`-based tests, `@ExpandMacros` annotation is not needed there