### PR TITLE
ANN: add `RsDiagnostic`-based API for quick-fixes with arbitrary ranges

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddModuleFileFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddModuleFileFix.kt
@@ -77,7 +77,7 @@ class AddModuleFileFix(
     }
 
     companion object {
-        fun createFixes(modDecl: RsModDeclItem, expandModuleFirst: Boolean) = listOf(
+        fun createFixes(modDecl: RsModDeclItem, expandModuleFirst: Boolean): List<AddModuleFileFix> = listOf(
             AddModuleFileFix(modDecl, expandModuleFirst, Location.File),
             AddModuleFileFix(modDecl, expandModuleFirst, Location.Directory)
         )

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
@@ -149,4 +149,12 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         myFixture.configureFromExistingVirtualFile(codeFragment.virtualFile)
         myFixture.testHighlighting(checkWarn, checkInfo, checkWeakWarn)
     }
+
+    protected fun checkFixAvailableInSelectionOnly(
+        fixName: String,
+        @Language("Rust") before: String,
+        checkWarn: Boolean = true,
+        checkInfo: Boolean = false,
+        checkWeakWarn: Boolean = false,
+    ) = annotationFixture.checkFixAvailableInSelectionOnly(fixName, before, checkWarn, checkInfo, checkWeakWarn)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -233,11 +233,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             let closure_2 = |x, y| (x, y);
 
             closure_0();
-            closure_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0057]">(<error>42</error>)</error>;
-            closure_1<error descr="This function takes 1 parameter but 0 parameters were supplied [E0057]">(<error>)</error></error>;
+            closure_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0057]">42</error>);
+            closure_1(<error descr="This function takes 1 parameter but 0 parameters were supplied [E0057]">)</error>;
             closure_1(42);
-            closure_2<error descr="This function takes 2 parameters but 0 parameters were supplied [E0057]">(<error>)</error></error>;
-            closure_2<error descr="This function takes 2 parameters but 1 parameter was supplied [E0057]">(42<error>)</error></error>;
+            closure_2(<error descr="This function takes 2 parameters but 0 parameters were supplied [E0057]">)</error>;
+            closure_2(42<error descr="This function takes 2 parameters but 1 parameter was supplied [E0057]">)</error>;
             closure_2(42, 43);
         }
     """)
@@ -249,11 +249,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
 
         unsafe fn test() {
-            variadic_1<error descr="This function takes at least 1 parameter but 0 parameters were supplied [E0060]">(<error>)</error></error>;
+            variadic_1(<error descr="This function takes at least 1 parameter but 0 parameters were supplied [E0060]">)</error>;
             variadic_1(42);
             variadic_1(42, 43);
-            variadic_2<error descr="This function takes at least 2 parameters but 0 parameters were supplied [E0060]">(<error>)</error></error>;
-            variadic_2<error descr="This function takes at least 2 parameters but 1 parameter was supplied [E0060]">(42<error>)</error></error>;
+            variadic_2(<error descr="This function takes at least 2 parameters but 0 parameters were supplied [E0060]">)</error>;
+            variadic_2(42<error descr="This function takes at least 2 parameters but 1 parameter was supplied [E0060]">)</error>;
             variadic_2(42, 43);
         }
     """)
@@ -273,12 +273,12 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             par_0_cfg();
             par_1_cfg(1);
 
-            par_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
-            par_1<error descr="This function takes 1 parameter but 0 parameters were supplied [E0061]">(<error>)</error></error>;
-            par_1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(true, <error>false</error>)</error>;
-            par_3<error descr="This function takes 3 parameters but 2 parameters were supplied [E0061]">(5, 1.0<error>)</error></error>;
-            par_0_cfg<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
-            par_1_cfg<error descr="This function takes 1 parameter but 0 parameters were supplied [E0061]">(<error>)</error></error>;
+            par_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            par_1(<error descr="This function takes 1 parameter but 0 parameters were supplied [E0061]">)</error>;
+            par_1(true, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false</error>);
+            par_3(5, 1.0<error descr="This function takes 3 parameters but 2 parameters were supplied [E0061]">)</error>;
+            par_0_cfg(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            par_1_cfg(<error descr="This function takes 1 parameter but 0 parameters were supplied [E0061]">)</error>;
         }
     """)
 
@@ -293,8 +293,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             Foo::par_0();
             Foo::par_2(12, 7.1);
 
-            Foo::par_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
-            Foo::par_2<error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">(5, 1.0, <error>"three"</error>)</error>;
+            Foo::par_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            Foo::par_2(5, 1.0, <error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">"three"</error>);
         }
     """)
 
@@ -310,9 +310,9 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             foo.par_0();
             foo.par_2(12, 7.1);
 
-            foo.par_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
-            foo.par_2<error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">(5, 1.0, <error>"three"</error>)</error>;
-            foo.par_2<error descr="This function takes 2 parameters but 0 parameters were supplied [E0061]">(<error>)</error></error>;
+            foo.par_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            foo.par_2(5, 1.0, <error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">"three"</error>);
+            foo.par_2(<error descr="This function takes 2 parameters but 0 parameters were supplied [E0061]">)</error>;
         }
     """)
 
@@ -323,8 +323,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             let _ = Foo0();
             let _ = Foo1(1);
 
-            let _ = Foo0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
-            let _ = Foo1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(10, <error>false</error>)</error>;
+            let _ = Foo0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            let _ = Foo1(10, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false</error>);
         }
     """)
 
@@ -337,8 +337,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             let _ = Foo::VAR0();
             let _ = Foo::VAR1(1);
 
-            let _ = Foo::VAR0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
-            let _ = Foo::VAR1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(10, <error>false</error>)</error>;
+            let _ = Foo::VAR0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            let _ = Foo::VAR1(10, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false</error>);
         }
     """)
 
@@ -352,7 +352,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
         fn main() {
             let foo = Foo;
-            foo.bar<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>10</error>)</error>;
+            foo.bar(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">10</error>);
             foo.bar();
         }
     """)
@@ -710,7 +710,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
             fn main() {
                 unsafe { foo(1, 2, 3); }
-                bar<error>(<error>92</error>)</error>;
+                bar(<error>92</error>);
                 let _ = S {};
             }  //^
 
@@ -1237,7 +1237,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         struct S;
 
-        <error>impl <error descr="the trait bound `S: A` is not satisfied [E0277]">B</error> for S</error> {}
+        impl <error descr="the trait bound `S: A` is not satisfied [E0277]">B</error> for S {}
     """)
 
     fun `test supertrait is not implemented E0277 multiple traits`() = checkErrors("""
@@ -1248,7 +1248,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         struct S;
 
-        <error>impl <error descr="the trait bound `S: A` is not satisfied [E0277]"><error descr="the trait bound `S: B` is not satisfied [E0277]">C</error></error> for S</error> {}
+        impl <error descr="the trait bound `S: A` is not satisfied [E0277]"><error descr="the trait bound `S: B` is not satisfied [E0277]">C</error></error> for S {}
     """)
 
     fun `test supertrait is not implemented E0277 generic supertrait`() = checkErrors("""
@@ -1257,11 +1257,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         trait C<T>: A<T> {}
 
         struct S1;
-        <error>impl <error descr="the trait bound `S1: A<u32>` is not satisfied [E0277]">B</error> for S1</error> {}
+        impl <error descr="the trait bound `S1: A<u32>` is not satisfied [E0277]">B</error> for S1 {}
 
         struct S2;
         impl A<bool> for S2 {}
-        <error>impl <error descr="the trait bound `S2: A<u32>` is not satisfied [E0277]">B</error> for S2</error> {}
+        impl <error descr="the trait bound `S2: A<u32>` is not satisfied [E0277]">B</error> for S2 {}
 
         struct S3;
         impl A<bool> for S3 {}
@@ -1269,11 +1269,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl B for S3 {}
 
         struct S4;
-        <error>impl<T> <error descr="the trait bound `S4: A<T>` is not satisfied [E0277]">C<T></error> for S4</error> {}
+        impl<T> <error descr="the trait bound `S4: A<T>` is not satisfied [E0277]">C<T></error> for S4 {}
 
         struct S5;
         impl A<u32> for S5 {}
-        <error>impl<T> <error descr="the trait bound `S5: A<T>` is not satisfied [E0277]">C<T></error> for S5</error> {}
+        impl<T> <error descr="the trait bound `S5: A<T>` is not satisfied [E0277]">C<T></error> for S5 {}
 
         struct S6;
         impl<T> A<T> for S6 {}
@@ -1285,7 +1285,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         struct S8;
         impl A<bool> for S8 {}
-        <error>impl <error descr="the trait bound `S8: A<u32>` is not satisfied [E0277]">C<u32></error> for S8</error> {}
+        impl <error descr="the trait bound `S8: A<u32>` is not satisfied [E0277]">C<u32></error> for S8 {}
 
         struct S9;
         impl A<u32> for S9 {}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddMissingSupertraitImplFixTest.kt
@@ -10,13 +10,22 @@ import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
 class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test availability range`() = checkFixAvailableInSelectionOnly("Implement missing supertrait(s)", """
+        trait A {}
+        trait B: A {}
+
+        struct S;
+
+        <selection>impl <error>B</error> for S</selection> {}
+    """)
+
     fun `test empty supertrait`() = checkFixByText("Implement missing supertrait(s)", """
         trait A {}
         trait B: A {}
 
         struct S;
 
-        <error>impl <error>B/*caret*/</error> for S</error> {}
+        impl <error>B/*caret*/</error> for S {}
     """, """
         trait A {}
         trait B: A {}
@@ -38,7 +47,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S;
 
-        <error>impl <error>B/*caret*/</error> for S</error> {}
+        impl <error>B/*caret*/</error> for S {}
     """, """
         trait A {
             type FOO;
@@ -68,7 +77,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S;
 
-        <error>impl <error>C/*caret*/</error> for S</error> {}
+        impl <error>C/*caret*/</error> for S {}
     """, """
         trait A {}
         trait B {}
@@ -90,7 +99,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S;
 
-        <error>impl <error>C/*caret*/</error> for S</error> {}
+        impl <error>C/*caret*/</error> for S {}
     """, """
         trait A {}
         trait B: A {}
@@ -112,7 +121,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S;
 
-        <error>impl <error>C/*caret*/</error> for S</error> {}
+        impl <error>C/*caret*/</error> for S {}
     """, """
         trait A {}
         trait B: A {}
@@ -134,7 +143,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S;
 
-        <error>impl <error>C/*caret*/</error> for S</error> {}
+        impl <error>C/*caret*/</error> for S {}
     """, """
         trait A<T> {}
         trait B: A<u32> {}
@@ -160,7 +169,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         impl B for S {}
 
-        <error>impl <error>C/*caret*/</error> for S</error> {}
+        impl <error>C/*caret*/</error> for S {}
     """, """
         trait A {}
         trait B {}
@@ -183,7 +192,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S;
 
-        <error>impl <error>C<u32>/*caret*/</error> for S</error> {}
+        impl <error>C<u32>/*caret*/</error> for S {}
     """, """
         trait A<T> {
             fn foo(&self) -> T;
@@ -209,7 +218,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         impl A<u32> for S {}
 
-        <error>impl <R> <error>C<R>/*caret*/</error> for S</error> {}
+        impl <R> <error>C<R>/*caret*/</error> for S {}
     """, """
         trait A<T> {}
         trait C<T>: A<T> {}
@@ -229,7 +238,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S<T>(T);
 
-        <error>impl <R> <error>B<u32>/*caret*/</error> for S<R></error> {}
+        impl <R> <error>B<u32>/*caret*/</error> for S<R> {}
     """, """
         trait A<T> {}
         trait B<T>: A<T> {}
@@ -247,7 +256,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S<T>(T);
 
-        <error>impl <error>B<u32>/*caret*/</error> for S<bool></error> {}
+        impl <error>B<u32>/*caret*/</error> for S<bool> {}
     """, """
         trait A<T> {}
         trait B<T>: A<T> {}
@@ -271,7 +280,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S<T>(T);
 
-        <error>impl <R> <error>T7<R>/*caret*/</error> for S<R></error> {}
+        impl <R> <error>T7<R>/*caret*/</error> for S<R> {}
     """, """
         trait T1<A> {}
         trait T2<B>: T1<B> {}
@@ -304,7 +313,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S<T>(T);
 
-        <error>impl <R> <error>B<R>/*caret*/</error> for S<u32></error> {}
+        impl <R> <error>B<R>/*caret*/</error> for S<u32> {}
     """, """
         trait A {}
         trait B<T>: A {}
@@ -322,7 +331,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S<T>(T);
 
-        <error>impl <R> <error>B<R>/*caret*/</error> for S<u32></error> where R: A {}
+        impl <R> <error>B<R>/*caret*/</error> for S<u32> where R: A {}
     """, """
         trait A {}
         trait B<T>: A {}
@@ -342,7 +351,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S;
 
-        <error>impl <error>foo::B/*caret*/</error> for S</error> {}
+        impl <error>foo::B/*caret*/</error> for S {}
     """, """
         use crate::foo::A;
 
@@ -379,7 +388,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         struct S;
 
-        <error>impl <error>B/*caret*/</error> for <Struct as Trait>::Item</error> {}
+        impl <error>B/*caret*/</error> for <Struct as Trait>::Item {}
     """, """
         struct Struct;
         trait Trait { type Item; }
@@ -408,7 +417,7 @@ class AddMissingSupertraitImplFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cl
 
         impl A for S {}
 
-        <error>impl <error>C/*caret*/</error> for <Struct as Trait>::Item</error> {}
+        impl <error>C/*caret*/</error> for <Struct as Trait>::Item {}
     """, """
         struct Struct;
         trait Trait { type Item; }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
@@ -13,7 +13,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo() {}
 
         fn main() {
-            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>1/*caret*/</error>)</error>;
+            foo(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">1/*caret*/</error>);
         }
     """, """
         fn foo(i: i32) {}
@@ -27,7 +27,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo() {}
 
         fn main() {
-            foo<error descr="This function takes 0 parameters but 2 parameters were supplied [E0061]">(<error>1/*caret*/</error>, <error>false</error>)</error>;
+            foo(<error descr="This function takes 0 parameters but 2 parameters were supplied [E0061]">1/*caret*/, false</error>);
         }
     """, """
         fn foo(i: i32, x: bool) {}
@@ -41,7 +41,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(a: i32) {}
 
         fn main() {
-            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(0, <error>1/*caret*/</error>)</error>;
+            foo(0, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">1/*caret*/</error>);
             foo(5);
         }
     """, """
@@ -57,7 +57,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(a: i32) {}
 
         fn main() {
-            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(0, <error>1/*caret*/</error>)</error>;
+            foo(0, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">1/*caret*/</error>);
             foo(5,);
         }
     """, """
@@ -73,7 +73,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(a: i32) {}
 
         fn main() {
-            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(0, <error>false/*caret*/</error>)</error>;
+            foo(0, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false/*caret*/</error>);
             foo(5);
         }
     """, """
@@ -89,7 +89,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(a: i32, b: i32) {}
 
         fn main() {
-            foo<error descr="This function takes 2 parameters but 4 parameters were supplied [E0061]">(0, false, <error>3/*caret*/</error>, <error>4</error>)</error>;
+            foo(0, false, <error descr="This function takes 2 parameters but 4 parameters were supplied [E0061]">3/*caret*/, 4</error>);
             foo(0, 1);
         }
     """, """
@@ -105,7 +105,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(a: i32, b: i32) {}
 
         fn main() {
-            foo<error descr="This function takes 2 parameters but 4 parameters were supplied [E0061]">(0, false, <error>3/*caret*/</error>, <error>4</error>)</error>;
+            foo(0, false, <error descr="This function takes 2 parameters but 4 parameters were supplied [E0061]">3/*caret*/, 4</error>);
             foo(0, 1);
         }
     """, """
@@ -121,7 +121,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(a: i32, b: i32) {}
 
         fn main() {
-            foo<error>(true, true, <error>true/*caret*/</error>)</error>;
+            foo(true, true, <error>true/*caret*/</error>);
         }
     """, """
         fn foo(a: bool, b: bool, x: bool) {}
@@ -135,7 +135,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(a: i32, b: i32) {}
 
         fn main() {
-            foo<error>(true, false, <error>true/*caret*/</error>)</error>;
+            foo(true, false, <error>true/*caret*/</error>);
         }
     """)
 
@@ -143,7 +143,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(a: i32, b: i32) {}
 
         fn main() {
-            foo<error>(true, false, <error>true/*caret*/</error>)</error>;
+            foo(true, false, <error>true/*caret*/</error>);
         }
     """)
 
@@ -154,7 +154,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         }
 
         fn bar(s: S) {
-            s.foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>0/*caret*/</error>)</error>;
+            s.foo(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">0/*caret*/</error>);
         }
     """, """
         struct S;
@@ -171,7 +171,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo() {}
 
         fn main() {
-            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>Unknown/*caret*/</error>)</error>;
+            foo(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">Unknown/*caret*/</error>);
         }
     """, """
         fn foo(x: _) {}
@@ -187,7 +187,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         type Foo = u32;
 
         fn bar(f: Foo) {
-            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>f/*caret*/</error>)</error>;
+            foo(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">f/*caret*/</error>);
         }
     """, """
         fn foo(f: Foo) {}
@@ -205,7 +205,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         struct Foo<T = u32>(T);
 
         fn bar(f: Foo) {
-            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>f/*caret*/</error>)</error>;
+            foo(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">f/*caret*/</error>);
         }
     """, """
         fn foo(f: Foo) {}
@@ -226,7 +226,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
 
         fn main() {
             let s = S;
-            foo::bar<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>s/*caret*/</error>)</error>;
+            foo::bar(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">s/*caret*/</error>);
         }
     """, """
         mod foo {
@@ -273,7 +273,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         struct S(u32);
 
         fn main() {
-            let s = S<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(0, <error>1/*caret*/</error>)</error>;
+            let s = S(0, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">1/*caret*/</error>);
         }
     """)
 
@@ -282,7 +282,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
 
         fn main() {
             let x = 5;
-            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>x/*caret*/</error>)</error>;
+            foo(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">x/*caret*/</error>);
         }
     """, """
         fn foo(x: i32) {}
@@ -297,7 +297,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(i: i32) {}
 
         fn main() {
-            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(1/*caret*/, <error>2</error>)</error>;
+            foo(1/*caret*/, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">2</error>);
         }
     """, """
         fn foo(i: i32, i0: i32) {}
@@ -329,7 +329,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(i: i32, #[cfg(foo)] b: u32) {}
 
         fn main() {
-            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(1/*caret*/, <error>2</error>)</error>;
+            foo(1/*caret*/, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">2</error>);
         }
     """)
 
@@ -384,7 +384,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
     fun `test remove parameter simple binding`() = checkFixByText("Remove parameter `b` from function `foo`", """
         fn foo(a: u32, b: u32) {}
         fn bar() {
-            foo<error>(0/*caret*/<error>)</error></error>;
+            foo(0/*caret*/<error>)</error>;
         }
     """, """
         fn foo(a: u32) {}
@@ -396,7 +396,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
     fun `test remove parameter complex binding`() = checkFixByText("Remove `2nd` parameter from function `foo`", """
         fn foo(x: u32, (a, b): (u32, u32)) {}
         fn bar() {
-            foo<error>(0/*caret*/<error>)</error></error>;
+            foo(0/*caret*/<error>)</error>;
         }
     """, """
         fn foo(x: u32) {}
@@ -408,7 +408,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
     fun `test remove multiple parameters`() = checkFixByText("<html>Change signature to foo()</html>", """
         fn foo(a: u32, b: u32) {}
         fn bar() {
-            foo<error>(/*caret*/<error>)</error></error>;
+            foo(/*caret*/<error>)</error>;
         }
     """, """
         fn foo() {}
@@ -420,7 +420,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
     fun `test change type and remove parameters`() = checkFixByText("<html>Change signature to foo(<b>bool</b>)</html>", """
         fn foo(a: u32, b: u32, c: u32) {}
         fn bar() {
-            foo<error>(true/*caret*/<error>)</error></error>;
+            foo(true/*caret*/<error>)</error>;
         }
     """, """
         fn foo(a: bool) {}
@@ -432,7 +432,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
     fun `test remove parameters change usage`() = checkFixByText("<html>Change signature to foo()</html>", """
         fn foo(a: u32, b: u32) {}
         fn bar() {
-            foo<error>(/*caret*/<error>)</error></error>;
+            foo(/*caret*/<error>)</error>;
             foo(1, 2);
         }
     """, """
@@ -490,7 +490,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         }
 
         fn bar(s: S) {
-            S::foo<error>(&s/*caret*/<error>)</error></error>;
+            S::foo(&s/*caret*/<error>)</error>;
         }
     """, """
         struct S {}
@@ -510,7 +510,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         }
 
         fn bar(s: S) {
-            S::foo<error>(&s/*caret*/, true, <error>1</error>)</error>;
+            S::foo(&s/*caret*/, true, <error>1</error>);
         }
     """, """
         struct S {}
@@ -531,7 +531,7 @@ class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::cla
         fn foo(a: <Struct as Trait>::Item, b: <Struct as Trait>::Item) {}
 
         fn main() {
-            foo<error descr="This function takes 2 parameters but 4 parameters were supplied [E0061]">(0, false, <error>3/*caret*/</error>, <error>4</error>)</error>;
+            foo(0, false, <error descr="This function takes 2 parameters but 4 parameters were supplied [E0061]">3/*caret*/, 4</error>);
             foo(0, 1);
         }
     """, """

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/DoctestFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/DoctestFixTest.kt
@@ -42,7 +42,7 @@ class DoctestFixTest : RsAnnotationTestBase() {
     fun `test in doctest add missing tuple fields`() = doTest("Fill missing arguments", """
         struct S(i32, i32);
         fn main() {
-            let _ = S <error descr="This function takes 2 parameters but 1 parameter was supplied [E0061]">(2, <error descr="null">/*caret*/)</error></error>;
+            let _ = S (2, <error descr="This function takes 2 parameters but 1 parameter was supplied [E0061]">/*caret*/)</error>;
         }
     """, """
         struct S(i32, i32);
@@ -55,7 +55,7 @@ class DoctestFixTest : RsAnnotationTestBase() {
     fun `test in doctest fill function arguments`() = doTest("Fill missing arguments", """
         fn foo(a: u32) {}
         fn main() {
-            foo<error>(<error>/*caret*/)</error></error>;
+            foo(<error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32) {}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
@@ -9,11 +9,27 @@ import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
 class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test availability range one parameter no arguments`() = checkFixAvailableInSelectionOnly("Fill missing arguments", """
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo<selection>(<error>)</error></selection>;
+        }
+    """)
+
+    fun `test availability range multiple parameters single argument`() = checkFixAvailableInSelectionOnly("Fill missing arguments", """
+        fn foo(a: u32, b: u32, c: &str) {}
+
+        fn main() {
+            foo<selection>(1<error>)</error></selection>;
+        }
+    """)
+
     fun `test simple call`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32) {}
 
         fn main() {
-            foo<error>(<error>/*caret*/)</error></error>;
+            foo(<error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32) {}
@@ -27,7 +43,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
         fn foo(a: u32, b: u32, c: &str) {}
 
         fn main() {
-            foo<error>(1<error>/*caret*/)</error></error>;
+            foo(1<error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32, b: u32, c: &str) {}
@@ -43,7 +59,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
             fn foo(self, a: u32) {}
         }
         fn foo() {
-            S::foo<error>(<error>/*caret*/)</error></error>;
+            S::foo(<error>/*caret*/)</error>;
         }
     """, """
         struct S;
@@ -61,7 +77,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
             fn foo(&self, a: u32) {}
         }
         fn foo() {
-            S::foo<error>(<error>/*caret*/)</error></error>;
+            S::foo(<error>/*caret*/)</error>;
         }
     """, """
         struct S;
@@ -79,7 +95,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
             fn foo(&mut self, a: u32) {}
         }
         fn foo() {
-            S::foo<error>(<error>/*caret*/)</error></error>;
+            S::foo(<error>/*caret*/)</error>;
         }
     """, """
         struct S;
@@ -96,7 +112,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
             fn foo(&mut self, a: u32) {}
         }
         fn foo<T: Trait>() {
-            T::foo<error>(<error>/*caret*/)</error></error>;
+            T::foo(<error>/*caret*/)</error>;
         }
     """, """
         trait Trait {
@@ -113,7 +129,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
             fn foo(&self, a: u32, b: u32) {}
         }
         fn foo(s: S) {
-            s.foo<error>(1<error>/*caret*/)</error></error>;
+            s.foo(1<error>/*caret*/)</error>;
         }
     """, """
         struct S;
@@ -128,7 +144,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test tuple struct`() = checkFixByText("Fill missing arguments", """
         struct S(u32, u32);
         fn foo() {
-            S<error>(<error>/*caret*/)</error></error>;
+            S(<error>/*caret*/)</error>;
         }
     """, """
         struct S(u32, u32);
@@ -140,7 +156,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test closure known parameter`() = checkFixByText("Fill missing arguments", """
         fn main() {
             let closure = |x: i32| (x);
-            closure<error>(<error>/*caret*/)</error></error>;
+            closure(<error>/*caret*/)</error>;
         }
     """, """
         fn main() {
@@ -152,7 +168,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test closure unknown parameter`() = checkFixByText("Fill missing arguments", """
         fn main() {
             let closure = |x| (x);
-            closure<error>(<error>/*caret*/)</error></error>;
+            closure(<error>/*caret*/)</error>;
         }
     """, """
         fn main() {
@@ -164,7 +180,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test generic parameter turbofish`() = checkFixByText("Fill missing arguments", """
         fn foo<T>(a: T) {}
         fn main() {
-            foo::<bool><error>(<error>/*caret*/)</error></error>;
+            foo::<bool>(<error>/*caret*/)</error>;
         }
     """, """
         fn foo<T>(a: T) {}
@@ -180,7 +196,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
             fn foo(&self, a: R) {}
         }
         fn foo(s: S<u32>) {
-            s.foo<error>(<error>/*caret*/)</error></error>;
+            s.foo(<error>/*caret*/)</error>;
         }
     """, """
         struct S<T>(T);
@@ -196,7 +212,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test trailing comma`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: u32) {}
         fn main() {
-            foo<error>(0,<error>/*caret*/)</error></error>;
+            foo(0,<error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32, b: u32) {}
@@ -208,7 +224,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test empty argument in the middle`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: u32) {}
         fn main() {
-            foo<error>(0,<error>,</error> 2<error>/*caret*/)</error></error>;
+            foo(0,<error>,</error> 2<error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32, b: &str, c: u32) {}
@@ -220,7 +236,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test empty arguments in the middle`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
         fn main() {
-            foo<error>(0,<error>,</error>,2<error>/*caret*/)</error></error>;
+            foo(0,<error>,</error>,2<error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
@@ -232,7 +248,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test empty arguments at the beginning`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
         fn main() {
-            foo<error>(<error>,</error>,true<error>/*caret*/)</error></error>;
+            foo(<error>,</error>,true<error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
@@ -244,7 +260,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test empty arguments at the end 1`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
         fn main() {
-            foo<error>(1,<error>,</error>,<error>/*caret*/)</error></error>;
+            foo(1,<error>,</error>,<error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
@@ -256,7 +272,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test empty arguments at the end 2`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
         fn main() {
-            foo<error>(1,<error>,</error><error>/*caret*/)</error></error>;
+            foo(1,<error>,</error><error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
@@ -268,7 +284,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test interleaved empty arguments`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
         fn main() {
-            foo<error>(<error>,</error>"",<error>,</error> 2<error>/*caret*/)</error></error>;
+            foo(<error>,</error>"",<error>,</error> 2<error>/*caret*/)</error>;
         }
     """, """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
@@ -280,7 +296,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
     fun `test too many empty arguments`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: u32) {}
         fn main() {
-            foo<error>(1,<error>,</error>,,,/*caret*/<error>)</error></error>;
+            foo(1,<error>,</error>,,,/*caret*/<error>)</error>;
         }
     """, """
         fn foo(a: u32, b: u32) {}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
@@ -9,11 +9,19 @@ import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
 class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test availability range`() = checkFixAvailableInSelectionOnly("Remove redundant arguments", """
+        fn foo() {}
+
+        fn main() {
+            foo<selection>(<error>1, 2</error>)</selection>;
+        }
+    """)
+
     fun `test no parameters`() = checkFixByText("Remove redundant arguments", """
         fn foo() {}
 
         fn main() {
-            foo<error>(<error>1/*caret*/</error>)</error>;
+            foo(<error>1/*caret*/</error>);
         }
     """, """
         fn foo() {}
@@ -27,7 +35,7 @@ class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnot
         fn foo(a: u32) {}
 
         fn main() {
-            foo<error>(1, <error>2/*caret*/</error>)</error>;
+            foo(1, <error>2/*caret*/</error>);
         }
     """, """
         fn foo(a: u32) {}
@@ -41,7 +49,7 @@ class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnot
         fn foo() {}
 
         fn main() {
-            foo<error>(<error>1/*caret*/</error>, <error>2</error>)</error>;
+            foo(<error>1/*caret*/, 2</error>);
         }
     """, """
         fn foo() {}
@@ -55,7 +63,7 @@ class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnot
         fn foo(a: u32) {}
 
         fn main() {
-            foo<error>(0, <error>1/*caret*/</error>, <error>2</error>)</error>;
+            foo(0, <error>1/*caret*/, 2</error>);
         }
     """, """
         fn foo(a: u32) {}
@@ -72,7 +80,7 @@ class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnot
         }
 
         fn foo(s: S) {
-            s.foo<error>(<error>1/*caret*/</error>)</error>;
+            s.foo(<error>1/*caret*/</error>);
         }
     """, """
         struct S;
@@ -88,7 +96,7 @@ class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnot
     fun `test lambda`() = checkFixByText("Remove redundant arguments", """
         fn main() {
             let foo = |x| x + 1;
-            foo<error>(0, <error>1/*caret*/</error>)</error>;
+            foo(0, <error>1/*caret*/</error>);
         }
     """, """
         fn main() {
@@ -103,7 +111,7 @@ class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnot
 
         fn main() {
             let a = 1;
-            foo<error>(&<error>'/*caret*/</error>static<error> </error><error>a</error>)</error>;
+            foo(&<error>'/*caret*/</error>static<error> </error><error>a</error>);
         }
     """, """
         fn foo(a: &u32) {}


### PR DESCRIPTION
Use it for `AddMissingSupertraitImplFix`, `ChangeFunctionSignatureFix`, `FillFunctionArgumentsFix`, `RemoveRedundantFunctionArgumentsFix` quick-fixes (E0277, E0060, E0061, E0057 errors).

Previously these we registered multiple annotations for the same error in order to adjust a quick fix availability range: one annotation with error message and text attributes and one silent annotation without an error message (but with a quick fix). This resulted to fun bugs, for example blank lines after a batch inspection run:

![image](https://user-images.githubusercontent.com/3221931/224503340-996100b4-fd8e-4493-a0c8-a3f7f48441cf.png)

(actually it's not some special blank line, it is an error annotation without a message)

The platform is actually allows to adjust availability range of a quick fix, so there's no reason to add an extra annotation.

changelog: (i'm not sure it worth to add it to a changelog) provide `RsDiagnostic`-based API for quick-fixes with arbitrary ranges and use it for some diagnostics
