### PR TITLE
HINT: Show parameter hints in attribute procedural macros

### DIFF
--- a/src/test/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProviderTest.kt
@@ -157,6 +157,7 @@ class RsChainMethodTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsChainMetho
     fun `test inside attribute macro call body`() = doTest("""
         $types
 
+        #[test_proc_macros::attr_as_is]
         fn main() {
             let foo = A;
             foo


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/6505554/224586683-bb08b28b-eb35-48b3-a089-a16436a8e771.png" width="350">

changelog: Show parameter hints inside attribute procedural macros