### PR TITLE
RUN: Allow to use Cargo targets in `Embedded GDB Server` configurations

### DIFF
--- a/clion/src/main/kotlin/org/rust/clion/cargo/CargoBuildConfigurationHelper.kt
+++ b/clion/src/main/kotlin/org/rust/clion/cargo/CargoBuildConfigurationHelper.kt
@@ -1,0 +1,31 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.cargo
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.cidr.execution.CidrBuildConfigurationHelper
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.PackageOrigin
+
+class CargoBuildConfigurationHelper(private val project: Project)
+    : CidrBuildConfigurationHelper<CLionCargoBuildConfiguration, CargoBuildTarget>() {
+
+    override fun getTargets(): List<CargoBuildTarget> {
+        val result = mutableListOf<CargoBuildTarget>()
+        for (cargoProject in project.cargoProjects.allProjects) {
+            val workspace = cargoProject.workspace ?: continue
+            for (pkg in workspace.packages) {
+                if (pkg.origin != PackageOrigin.WORKSPACE) continue
+                for (target in pkg.targets) {
+                    result.add(CargoBuildTarget(project, target))
+                }
+            }
+        }
+        return result
+    }
+
+    override fun allowEditBuildConfiguration(): Boolean = false
+}

--- a/clion/src/main/kotlin/org/rust/clion/cargo/CargoBuildConfigurationProvider.kt
+++ b/clion/src/main/kotlin/org/rust/clion/cargo/CargoBuildConfigurationProvider.kt
@@ -8,6 +8,10 @@ package org.rust.clion.cargo
 import com.intellij.execution.RunManager
 import com.intellij.execution.impl.RunManagerImpl
 import com.intellij.openapi.project.Project
+import com.jetbrains.cidr.CidrRunnerBundle
+import com.jetbrains.cidr.cpp.execution.compound.CidrCompoundRunConfiguration
+import com.jetbrains.cidr.execution.BuildConfigurationProblems
+import com.jetbrains.cidr.execution.BuildTargetAndConfigurationData
 import com.jetbrains.cidr.execution.build.CidrBuildConfigurationProvider
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.createBuildEnvironment
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
@@ -16,10 +20,42 @@ import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 class CargoBuildConfigurationProvider : CidrBuildConfigurationProvider {
     override fun getBuildableConfigurations(project: Project): List<CLionCargoBuildConfiguration> {
         val runManager = RunManager.getInstance(project) as? RunManagerImpl ?: return emptyList()
-        val configuration = runManager.selectedConfiguration?.configuration as? CargoCommandConfiguration
-            ?: return emptyList()
-        val buildConfiguration = getBuildConfiguration(configuration) ?: return emptyList()
-        val environment = createBuildEnvironment(buildConfiguration) ?: return emptyList()
-        return listOf(CLionCargoBuildConfiguration(buildConfiguration, environment))
+        val buildConfiguration = when (val configuration = runManager.selectedConfiguration?.configuration) {
+            is CargoCommandConfiguration -> {
+                val buildConfiguration = getBuildConfiguration(configuration) ?: return emptyList()
+                val environment = createBuildEnvironment(buildConfiguration) ?: return emptyList()
+                CLionCargoBuildConfiguration(buildConfiguration, environment)
+            }
+
+            is CidrCompoundRunConfiguration -> getCidrBuildConfiguration(project, configuration)
+            else -> null
+        } ?: return emptyList()
+        return listOf(buildConfiguration)
     }
+}
+
+fun getCidrBuildConfiguration(project: Project, runConfig: CidrCompoundRunConfiguration): CLionCargoBuildConfiguration? {
+    val problems = BuildConfigurationProblems()
+    val helper = runConfig.context?.getHelper(project) as? CargoBuildConfigurationHelper ?: return null
+    val buildTargetData = runConfig.targetAndConfigurationData ?: return null
+    if (!BuildTargetAndConfigurationData.checkData(helper, buildTargetData, problems, false, true)) return null
+
+    val buildTarget = helper.findTarget(buildTargetData.target)
+    if (buildTarget == null) {
+        problems.problems.add(
+            CidrRunnerBundle.message(
+                "build.configuration.parameterNotSelected",
+                CidrRunnerBundle.message("build.configuration.target")
+            )
+        )
+        return null
+    }
+
+    val configuration = if (buildTargetData.configurationName == null) {
+        helper.getDefaultConfiguration(buildTarget)
+    } else {
+        helper.findConfiguration(buildTarget, buildTargetData.configurationName)
+    }
+
+    return if (problems.hasProblems()) null else configuration
 }

--- a/clion/src/main/kotlin/org/rust/clion/cargo/CargoBuildTarget.kt
+++ b/clion/src/main/kotlin/org/rust/clion/cargo/CargoBuildTarget.kt
@@ -1,0 +1,70 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.cargo
+
+import com.intellij.execution.RunManager
+import com.intellij.openapi.project.Project
+import com.jetbrains.cidr.execution.CidrBuildTarget
+import org.rust.cargo.icons.CargoIcons
+import org.rust.cargo.project.toolwindow.launchCommand
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.createCargoCommandRunConfiguration
+import org.rust.cargo.toolchain.CargoCommandLine
+import javax.swing.Icon
+
+class CargoBuildTarget(
+    private val project: Project,
+    private val target: CargoWorkspace.Target
+) : CidrBuildTarget<CLionCargoBuildConfiguration> {
+
+    override fun getName(): String {
+        val name = target.name
+        val kind = when (target.kind) {
+            is CargoWorkspace.TargetKind.Lib -> "lib"
+            CargoWorkspace.TargetKind.Bin -> "bin"
+            CargoWorkspace.TargetKind.Test -> "test"
+            CargoWorkspace.TargetKind.Bench -> "bench"
+            CargoWorkspace.TargetKind.ExampleBin, is CargoWorkspace.TargetKind.ExampleLib -> "example"
+            CargoWorkspace.TargetKind.CustomBuild -> "build.rs"
+            else -> ""
+        }
+        return "$name ($kind)"
+    }
+
+    override fun getProjectName(): String = target.pkg.name
+
+    override fun getIcon(): Icon? = when (target.kind) {
+        is CargoWorkspace.TargetKind.Lib -> CargoIcons.LIB_TARGET
+        CargoWorkspace.TargetKind.Bin -> CargoIcons.BIN_TARGET
+        CargoWorkspace.TargetKind.Test -> CargoIcons.TEST_TARGET
+        CargoWorkspace.TargetKind.Bench -> CargoIcons.BENCH_TARGET
+        CargoWorkspace.TargetKind.ExampleBin, is CargoWorkspace.TargetKind.ExampleLib -> CargoIcons.EXAMPLE_TARGET
+        CargoWorkspace.TargetKind.CustomBuild -> CargoIcons.CUSTOM_BUILD_TARGET
+        CargoWorkspace.TargetKind.Unknown -> null
+    }
+
+    override fun isExecutable(): Boolean = when (target.kind) {
+        CargoWorkspace.TargetKind.Bin,
+        CargoWorkspace.TargetKind.Test,
+        CargoWorkspace.TargetKind.Bench,
+        CargoWorkspace.TargetKind.ExampleBin -> true
+        else -> false
+    }
+
+    override fun getBuildConfigurations(): List<CLionCargoBuildConfiguration> {
+        val command = target.launchCommand() ?: return emptyList()
+        val commandLine = CargoCommandLine.forTarget(target, command)
+        val runnerAndConfiguration = RunManager.getInstance(project).createCargoCommandRunConfiguration(commandLine)
+        val configuration = runnerAndConfiguration.configuration as? CargoCommandConfiguration ?: return emptyList()
+        val buildConfiguration = CargoBuildManager.getBuildConfiguration(configuration) ?: return emptyList()
+        val environment = CargoBuildManager.createBuildEnvironment(buildConfiguration) ?: return emptyList()
+        return listOf(CLionCargoBuildConfiguration(buildConfiguration, environment))
+    }
+
+    override fun toString(): String = "$name ($projectName)"
+}

--- a/clion/src/main/kotlin/org/rust/clion/cargo/CargoCompoundConfigurationContext.kt
+++ b/clion/src/main/kotlin/org/rust/clion/cargo/CargoCompoundConfigurationContext.kt
@@ -1,0 +1,76 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.cargo
+
+import com.intellij.execution.BeforeRunTask
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.project.Project
+import com.jetbrains.cidr.cpp.execution.CLionLauncher
+import com.jetbrains.cidr.cpp.execution.compound.CidrCompoundConfigurationContextBase
+import com.jetbrains.cidr.cpp.execution.compound.CidrCompoundRunConfiguration
+import com.jetbrains.cidr.cpp.execution.compound.ConfigurationHelperType
+import com.jetbrains.cidr.cpp.toolchains.CPPEnvironment
+import com.jetbrains.cidr.cpp.toolchains.CPPToolchains
+import com.jetbrains.cidr.execution.ExecutableData
+import com.jetbrains.cidr.toolchains.EnvironmentProblems
+import org.rust.cargo.runconfig.RsExecutableRunner.Companion.ARTIFACTS
+import org.rust.cargo.runconfig.RsExecutableRunner.Companion.artifacts
+import org.rust.cargo.runconfig.buildtool.CargoBuildTaskProvider
+import java.io.File
+import java.util.concurrent.CompletableFuture
+
+class CargoCompoundConfigurationContext : CidrCompoundConfigurationContextBase(CargoBuildTarget::class.java) {
+    override val id: String = ID
+
+    @Throws(ExecutionException::class)
+    override fun getRunFileAndEnvironment(launcher: CLionLauncher): Pair<File?, CPPEnvironment?> =
+        getRunFile(launcher) to getRunEnvironment(launcher)
+
+    override fun executeBuildTask(
+        context: DataContext,
+        configuration: RunConfiguration,
+        env: ExecutionEnvironment,
+        task: BeforeRunTask<*>
+    ): Boolean {
+        if (configuration !is CidrCompoundRunConfiguration) return false
+        val buildConfiguration = getCidrBuildConfiguration(env.project, configuration) ?: return false
+        env.putUserData(ARTIFACTS, CompletableFuture())
+        val result = CargoBuildTaskProvider().executeTask(context, buildConfiguration.configuration, env, CargoBuildTaskProvider.BuildTask())
+        val artifacts = env.artifacts.orEmpty()
+        val artifact = artifacts.firstOrNull()
+        val binary = artifact?.executables?.firstOrNull()
+        if (binary != null) {
+            configuration.executableData = ExecutableData(binary)
+        }
+        return result
+    }
+
+    override fun getHelper(project: Project): ConfigurationHelperType = CargoBuildConfigurationHelper(project)
+
+    companion object {
+        private const val ID: String = "CargoCompoundConfigurationContext"
+
+        private fun getRunFile(launcher: CLionLauncher): File? {
+            val configuration = launcher.configuration as? CidrCompoundRunConfiguration
+            val path = configuration?.executableData?.path
+            return path?.let { File(it) }
+        }
+
+        @Throws(ExecutionException::class)
+        private fun getRunEnvironment(launcher: CLionLauncher): CPPEnvironment {
+            val environmentProblems = EnvironmentProblems()
+            val projectBaseDir = launcher.project.basePath?.let { File(it) }
+            val environment = CPPToolchains.createCPPEnvironment(launcher.project, projectBaseDir, null, environmentProblems, false, null)
+            if (environment == null) {
+                environmentProblems.throwAsExecutionException()
+            }
+            return environment!!
+        }
+    }
+}

--- a/clion/src/main/resources/org.rust.clion.xml
+++ b/clion/src/main/resources/org.rust.clion.xml
@@ -1,4 +1,4 @@
-<idea-plugin package="org.rust.clion" xmlns:xi="http://www.w3.org/2001/XInclude">
+<idea-plugin package="org.rust.clion">
     <!--suppress PluginXmlValidity -->
     <dependencies>
         <plugin id="com.intellij.clion"/>
@@ -13,6 +13,10 @@
 
     <extensions defaultExtensionNs="com.jetbrains.cidr">
         <fus.projectModelTypeProvider implementation="org.rust.clion.statistics.CargoProjectModelTypeProvider"/>
+    </extensions>
+
+    <extensions defaultExtensionNs="clion">
+        <compoundConfigurationContext implementation="org.rust.clion.cargo.CargoCompoundConfigurationContext"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectsTree.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectsTree.kt
@@ -64,7 +64,7 @@ open class CargoProjectsTree : SimpleTree() {
     }
 }
 
-private fun CargoWorkspace.Target.launchCommand(): String? = when (kind) {
+fun CargoWorkspace.Target.launchCommand(): String? = when (kind) {
     CargoWorkspace.TargetKind.Bin -> "run"
     is CargoWorkspace.TargetKind.Lib -> "build"
     CargoWorkspace.TargetKind.Test -> "test"

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
@@ -134,7 +134,7 @@ abstract class RsExecutableRunner(
     }
 
     companion object {
-        private val ARTIFACTS: Key<CompletableFuture<List<CompilerArtifactMessage>>> =
+        val ARTIFACTS: Key<CompletableFuture<List<CompilerArtifactMessage>>> =
             Key.create("CARGO.CONFIGURATION.ARTIFACTS")
 
         var ExecutionEnvironment.artifacts: List<CompilerArtifactMessage>?


### PR DESCRIPTION
<img width="835" alt="Screenshot 2023-03-13 at 07 46 22" src="https://user-images.githubusercontent.com/6079006/224627217-2be2a9cc-e024-40a1-8861-f15ddcac4793.png">

changelog: Allow to use Cargo targets in `Embedded GDB Server` configurations
