### PR TITLE
Add internal SSR inspection that finds anonymous LocalQuickFix classes

### DIFF
--- a/.idea/inspectionProfiles/intellij_rust.xml
+++ b/.idea/inspectionProfiles/intellij_rust.xml
@@ -24,5 +24,11 @@
         </option>
       </scope>
     </inspection_tool>
+    <inspection_tool class="SSBasedInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <searchConfiguration name="Anonymous LocalQuickFix" suppressId="intellij_rust_anonymous_LocalQuickFix" problemDescriptor="Anonymous LocalQuickFix creates the risk of accidentally capturing a variable. Please, extract the quick-fix to a named class" text="object : $LocalQuickFix$ {}" recursive="true" caseInsensitive="false" type="Kotlin" pattern_context="default" search_injected="false">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="LocalQuickFix" regexp="com\.intellij\.codeInspection\.LocalQuickFix" withinHierarchy="true" target="true" within="" contains="" />
+      </searchConfiguration>
+    </inspection_tool>
   </profile>
 </component>


### PR DESCRIPTION
Add an internal Kotlin inspection for IntelliJ Rust developers (based on [Structural Search and Replace](https://www.jetbrains.com/help/idea/creating-custom-inspections.html)). The inspection warns about anonymous LocalQuickFix class implementations (`object : LocalQuickFix {}`):

![image](https://user-images.githubusercontent.com/3221931/225605573-652a376f-accd-4baa-be90-82cd796fb06d.png)

Anonymous LocalQuickFix creates the risk of accidentally capturing a variable, so it's better to use a named non-inner class instead.

The SSR template:
![image](https://user-images.githubusercontent.com/3221931/225606267-735ef04d-9456-44ce-984a-19183eec8bdc.png)
