### PR TITLE
INT: Fix `StackOverflowError` in `Invert if condition` intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/InvertIfIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/InvertIfIntention.kt
@@ -246,28 +246,16 @@ private fun IfStmts.convertReturnToTailExpr(block: RsBlock, factory: RsPsiFactor
  * `loop { ...; }` => `loop { ...; continue; }`
  */
 private fun IfStmts.addImplicitReturnOrContinue(block: RsBlock, factory: RsPsiFactory): IfStmts {
-    val tailStmt = nextStmts.findLast { it is RsExprStmt && it.isTailStmt } as? RsExprStmt
-    val expr = tailStmt?.expr
-    check(expr == null || expr.type is TyUnit)
-    return when {
-        expr != null && expr.canBeStmtWithoutSemicolon() -> {
-            copy(nextStmts = nextStmts.replace(expr, expr.wrapInStmt(factory)))
-                .addImplicitReturnOrContinue(block, factory)
-        }
-        expr == null -> {
-            val lastStmt = nextStmts.filterIsInstance<RsExprStmt>().lastOrNull()?.expr
-            if (lastStmt is RsMacroCall) return this
-            if (lastStmt?.isDiverges() == true) return this
-            val addedStmt = when (block.parent) {
-                is RsFunctionOrLambda -> factory.createStatement("return;")
-                is RsLooplikeExpr -> factory.createStatement("continue;")
-                else -> return this
-            }
-            val newline = listOfNotNull(factory.createNewline().takeIf { lastStmt != null })
-            copy(nextStmts = nextStmts + addedStmt + newline)
-        }
+    val lastStmt = nextStmts.filterIsInstance<RsExprStmt>().lastOrNull()?.expr
+    if (lastStmt is RsMacroCall) return this
+    if (lastStmt?.isDiverges() == true) return this
+    val addedStmt = when (block.parent) {
+        is RsFunctionOrLambda -> factory.createStatement("return;")
+        is RsLooplikeExpr -> factory.createStatement("continue;")
         else -> return this
     }
+    val newline = listOfNotNull(factory.createNewline().takeIf { lastStmt != null })
+    return copy(nextStmts = nextStmts + addedStmt + newline)
 }
 
 private fun IfStmts.removeImplicitReturnOrContinue(block: RsBlock): IfStmts {
@@ -342,10 +330,6 @@ private fun PsiElement.isDiverges() =
 
 private fun List<PsiElement>.hasStmts(): Boolean =
     any { it !is PsiWhiteSpace && it !is PsiComment }
-
-private fun RsExpr.canBeStmtWithoutSemicolon(): Boolean =
-    this is RsWhileExpr || this is RsForExpr || this is RsLoopExpr
-        || this is RsIfExpr || this is RsMatchExpr || this is RsBlockExpr
 
 private fun RsExpr.wrapInStmt(factory: RsPsiFactory): RsExprStmt =
     factory.tryCreateExprStmtWithSemicolon(text)!!

--- a/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
@@ -168,6 +168,21 @@ class InvertIfIntentionTest : RsIntentionTestBase(InvertIfIntention::class) {
         }
     """)
 
+    fun `test if without else in function 6`() = doAvailableTest("""
+        fn foo(f: bool, g: bool) {
+            /*caret*/if f {
+                return;
+            }
+            if g {}
+        }
+    """, """
+        fn foo(f: bool, g: bool) {
+            if !f {
+                if g {}
+            }
+        }
+    """)
+
     fun `test if without else nested 1`() = doAvailableSymmetricTest("""
         fn foo(f: bool, g: bool) -> i32 {
             if f {


### PR DESCRIPTION
Fixes #10251

changelog: Fix `Invert if condition` intention when there is another `if` after current one