### PR TITLE
Add `sqlx_macros::test` to list of hardcoded macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
@@ -55,6 +55,7 @@ private val RS_HARDCODED_PROC_MACRO_ATTRIBUTES: Map<String, Map<String, KnownPro
     ),
     "uefi_macros" to mapOf("entry" to KnownProcMacroKind.CUSTOM_MAIN),
     "async_trait" to mapOf("async_trait" to KnownProcMacroKind.ASYNC_TRAIT),
+    "sqlx_macros" to mapOf("test" to KnownProcMacroKind.ASYNC_TEST),
 )
 
 fun getHardcodeProcMacroProperties(packageName: String, macroName: String): KnownProcMacroKind {


### PR DESCRIPTION
Fixes #10241
Related: #10139

changelog: Fix code analysis inside functions with `sqlx::test` macro