### PR TITLE
ANN: Show E0206 for unknown type and for not a type

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1084,7 +1084,6 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         type.normType.let {
             // for ADT it is ok to impl Copy
             if (it is TyAdt
-                || it == TyUnknown
                 // should show different error than E0206
                 || it is TyPrimitive
                 || it is TyArray

--- a/src/test/kotlin/org/rust/ide/annotator/RsImplCopyRestrictionsTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsImplCopyRestrictionsTest.kt
@@ -42,11 +42,11 @@ class RsImplCopyRestrictionsTest : RsAnnotatorTestBase(RsErrorAnnotator::class) 
         impl Copy for Bar {}
     """)
 
-    fun `test E0206 no error when impl Copy for unknown type`() = checkErrors("""
+    fun `test E0206 error when impl Copy for unknown type`() = checkErrors("""
         #[lang = "copy"]
         trait Copy {}
 
-        impl Copy for Bar {}
+        impl Copy for /*error descr="The trait `Copy` may not be implemented for this type [E0206]"*/Bar/*error**/ {}
     """)
 
     fun `test E0206 no error when impl Copy for primitive type`() = checkErrors("""
@@ -82,5 +82,16 @@ class RsImplCopyRestrictionsTest : RsAnnotatorTestBase(RsErrorAnnotator::class) 
         }
 
         impl Copy for Bar {}
+    """)
+
+    fun `test E0206 error when impl Copy for not a type`() = checkErrors("""
+        #[lang = "copy"]
+        trait Copy {}
+
+        fn baz(){}
+        const THING: u32 = 0xABAD1DEA;
+
+        impl Copy for /*error descr="The trait `Copy` may not be implemented for this type [E0206]"*/THING/*error**/ {}
+        impl Copy for /*error descr="The trait `Copy` may not be implemented for this type [E0206]"*/baz()/*error**/ {}
     """)
 }


### PR DESCRIPTION
[E0206](https://doc.rust-lang.org/error_codes/E0206.html) is shown also when [E0573](https://doc.rust-lang.org/error_codes/E0573.html) or [E0412](https://doc.rust-lang.org/error_codes/E0412.html) is present.