### PR TITLE
T: set up tests for an intention action inside an attribute macro

### DIFF
--- a/intelliLang/src/test/kotlin/org/rust/ide/intentions/InjectLanguageIntentionTest.kt
+++ b/intelliLang/src/test/kotlin/org/rust/ide/intentions/InjectLanguageIntentionTest.kt
@@ -15,8 +15,10 @@ import org.intellij.lang.annotations.Language
 import org.intellij.plugins.intelliLang.inject.InjectLanguageAction
 import org.intellij.plugins.intelliLang.inject.InjectedLanguage
 import org.intellij.plugins.intelliLang.inject.UnInjectLanguageAction
+import org.rust.SkipTestWrapping
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 
+@SkipTestWrapping
 class InjectLanguageIntentionTest : RsIntentionTestBase(InjectLanguageAction::class) {
     fun `test available inside string`() = checkAvailable("""
         const C: &str = "/*caret*/";

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -484,7 +484,9 @@ private class WorkspaceImpl(
                         val dependencyPackage = newIdToPackage[dep.pkg.id] ?: return@mapNotNull null
                         dep.withPackage(dependencyPackage)
                     })
-                    pkg.dependencies.add(pkgToAddDependency)
+                    if (pkg.origin != STDLIB && pkg.origin != STDLIB_DEPENDENCY) {
+                        pkg.dependencies.add(pkgToAddDependency)
+                    }
                 }
             }
         }

--- a/src/test/kotlin/org/rust/RsJUnit4ParameterizedTestRunner.kt
+++ b/src/test/kotlin/org/rust/RsJUnit4ParameterizedTestRunner.kt
@@ -1,0 +1,84 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import org.junit.runner.Description
+import org.junit.runner.Runner
+import org.junit.runner.manipulation.Filter
+import org.junit.runners.Parameterized
+import org.junit.runners.model.FrameworkMethod
+import org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParameters
+import org.junit.runners.parameterized.ParametersRunnerFactory
+import org.junit.runners.parameterized.TestWithParameters
+
+/**
+ * Almost standard JUnit 4 parametrized test runner (see [Parameterized]), but unlike the standard one
+ * it adds JUnit3-style test methods to the list of tests.
+ * In essence, you don't have to add `@Test` annotation to each test method when using this runner.
+ *
+ * Use it like this:
+ * ```
+ * @RunWith(RsJUnit4ParameterizedTestRunner::class)
+ * @UseParametersRunnerFactory(RsJUnit4ParameterizedTestRunner.RsRunnerForParameters.Factory::class)
+ * ```
+ */
+class RsJUnit4ParameterizedTestRunner(testClass: Class<*>): Parameterized(testClass) {
+    override fun filter(filter: Filter) {
+        val wrappedFilter = object : Filter() {
+            override fun shouldRun(description: Description): Boolean {
+                if (filter.shouldRun(description)) return true
+
+                val descriptionCopy = Description.createSuiteDescription(
+                    description.displayName,
+                    *description.annotations.toTypedArray()
+                )
+                for (child in description.children) {
+                    descriptionCopy.addChild(removeParamsFromDescription(child))
+                }
+                return filter.shouldRun(descriptionCopy)
+            }
+
+            override fun describe(): String = filter.describe()
+            override fun apply(child: Any) = filter.apply(child)
+        }
+        super.filter(wrappedFilter)
+    }
+
+    class RsRunnerForParameters(test: TestWithParameters) : BlockJUnit4ClassRunnerWithParameters(test) {
+        override fun filter(filter: Filter) {
+            val wrappedFilter = object : Filter() {
+                override fun shouldRun(description: Description): Boolean {
+                    if (filter.shouldRun(description)) return true
+                    return filter.shouldRun(removeParamsFromDescription(description))
+                }
+
+                override fun describe(): String = filter.describe()
+                override fun apply(child: Any) = filter.apply(child)
+            }
+            super.filter(wrappedFilter)
+        }
+
+        override fun computeTestMethods(): List<FrameworkMethod> =
+            RsJUnit4TestRunner.addJUnit3Methods(super.computeTestMethods(), testClass)
+
+        class Factory : ParametersRunnerFactory {
+            override fun createRunnerForTestWithParameters(test: TestWithParameters): Runner =
+                RsRunnerForParameters(test)
+        }
+    }
+}
+
+private fun removeParamsFromDescription(description: Description): Description? {
+    val name = description.displayName
+    val i = name.indexOf("[")
+    if (i == -1) return description
+
+    return Description.createTestDescription(
+        description.testClass,
+        name.substring(0, i),
+        *description.annotations.toTypedArray()
+    )
+}

--- a/src/test/kotlin/org/rust/RsJUnit4TestRunner.kt
+++ b/src/test/kotlin/org/rust/RsJUnit4TestRunner.kt
@@ -1,0 +1,66 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import junit.framework.Test
+import org.junit.internal.MethodSorter
+import org.junit.runners.BlockJUnit4ClassRunner
+import org.junit.runners.model.FrameworkMethod
+import org.junit.runners.model.TestClass
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.util.*
+
+/**
+ * Almost standard JUnit 4 test runner (see [BlockJUnit4ClassRunner]), but unlike the standard one
+ * it adds JUnit3-style test methods to the list of tests.
+ * In essence, you don't have to add `@Test` annotation to each test method when using this runner.
+ */
+class RsJUnit4TestRunner(testClass: Class<*>) : BlockJUnit4ClassRunner(testClass) {
+    override fun computeTestMethods(): List<FrameworkMethod> =
+        addJUnit3Methods(super.computeTestMethods(), testClass)
+
+    companion object {
+        fun addJUnit3Methods(junit4Methods: List<FrameworkMethod>, testClass: TestClass): List<FrameworkMethod> {
+            val junit3Methods = computeJUnit3TestMethods(testClass)
+
+            return if (junit3Methods.isEmpty()) {
+                junit4Methods
+            } else {
+                val all = junit4Methods.toMutableList()
+                junit3Methods.mapTo(all) { FrameworkMethod(it) }
+                Collections.unmodifiableList(all)
+            }
+        }
+
+        private fun computeJUnit3TestMethods(testClass: TestClass): List<Method> {
+            val theClass = testClass.javaClass
+            var superClass = theClass
+            val names = mutableSetOf<String>()
+            val testMethods = mutableListOf<Method>()
+            while (Test::class.java.isAssignableFrom(superClass)) {
+                for (method in MethodSorter.getDeclaredMethods(superClass)) {
+                    val name = method.name
+                    if (!names.contains(name) && isJUnit3TestMethod(method)) {
+                        names.add(name)
+                        testMethods += method
+                    }
+                }
+                superClass = superClass.superclass
+            }
+
+            return testMethods
+        }
+
+        private fun isJUnit3TestMethod(m: Method): Boolean {
+            return m.parameterTypes.isEmpty()
+                && m.name.startsWith("test")
+                && m.returnType == Void.TYPE
+                && Modifier.isPublic(m.modifiers)
+                && m.getAnnotation(org.junit.Test::class.java) == null
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/SkipTestWrapping.kt
+++ b/src/test/kotlin/org/rust/SkipTestWrapping.kt
@@ -1,0 +1,18 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import java.lang.annotation.Inherited
+
+/**
+ * You can mark a test with this annotation to skip the test when it is run with [TestWrapping].
+ * Leave the [wrapping] list empty to skip all wrappings (except [TestWrapping.NONE]) or
+ * enumerate [TestWrapping]s you want the test to skip.
+ */
+@Inherited
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SkipTestWrapping(vararg val wrapping: TestWrapping)

--- a/src/test/kotlin/org/rust/TestWrapping.kt
+++ b/src/test/kotlin/org/rust/TestWrapping.kt
@@ -1,0 +1,132 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import com.intellij.openapi.application.runUndoTransparentWriteAction
+import com.intellij.openapi.project.Project
+import com.intellij.psi.*
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.*
+
+enum class TestWrapping(
+    private val testDescription: String,
+    private val impl: TestWrappingImpl
+) {
+    NONE("no wrapping", NoneTestWrappingImpl()),
+
+    /**
+     * Adds `#[attr_as_is]` attribute macro invocation to a top level item
+     * under the caret marker. For example, this code snippet:
+     * ```
+     * fn foo() { /*caret*/ }
+     * ```
+     * will be transformed to
+     * ```
+     * #[attr_as_is]
+     * fn foo() { /*caret*/ }
+     * ```
+     *
+     * The macro `attr_as_is` is an "identity" macro. That is, it expands to its input, just like there isn't
+     * a macro invocation.
+     */
+    ATTR_MACRO_AS_IS(
+        "wrapped with `#[attr_as_is]` macro",
+        AttrMacroTestWrappingImpl("attr_as_is")
+    );
+
+    override fun toString(): String = testDescription
+
+    fun wrapProjectDescriptor(originalDescriptor: RustProjectDescriptorBase): RustProjectDescriptorBase? =
+        impl.wrapProjectDescriptor(originalDescriptor)
+
+    fun wrapCode(project: Project, code: String): Pair<String, TestUnwrapper?> =
+        impl.wrapCode(project, code)
+}
+
+private interface TestWrappingImpl {
+    fun wrapProjectDescriptor(originalDescriptor: RustProjectDescriptorBase): RustProjectDescriptorBase?
+    fun wrapCode(project: Project, code: String): Pair<String, TestUnwrapper?>
+}
+
+private class NoneTestWrappingImpl : TestWrappingImpl {
+    override fun wrapProjectDescriptor(originalDescriptor: RustProjectDescriptorBase): RustProjectDescriptorBase =
+        originalDescriptor
+
+    override fun wrapCode(project: Project, code: String): Pair<String, TestUnwrapper?> =
+        code to null
+}
+
+private class AttrMacroTestWrappingImpl(private val macroName: String) : TestWrappingImpl {
+    override fun wrapProjectDescriptor(originalDescriptor: RustProjectDescriptorBase): RustProjectDescriptorBase? {
+        return when {
+            originalDescriptor is WithProcMacros -> null
+            originalDescriptor === DefaultDescriptor -> WithProcMacroRustProjectDescriptor
+            else -> WithProcMacros(originalDescriptor)
+        }
+    }
+
+    override fun wrapCode(project: Project, code: String): Pair<String, TestUnwrapper?> {
+        var caretMarker = ""
+        var caretOffset = -1
+        for (m in CARET_MARKERS) {
+            caretMarker = m
+            caretOffset = code.indexOf(m)
+            if (caretOffset != -1) break
+        }
+        if (caretOffset == -1) {
+            error("No /*caret*/ marker provided")
+        }
+
+        val file = RsPsiFactory(project, markGenerated = false, eventSystemEnabled = true)
+            .createFile(code.replaceFirst(caretMarker, ""))
+        val owner = file.findElementAt(caretOffset)
+            ?.contexts
+            ?.toList()
+            ?.findLast { it is RsAttrProcMacroOwner }
+            ?: return code to null
+
+        val mutableText = StringBuilder(code)
+        mutableText.insert(owner.startOffset, "#[test_proc_macros::$macroName]")
+
+        return mutableText.toString() to TestUnwrapper(owner.startOffset)
+    }
+
+    companion object {
+        private val CARET_MARKERS = listOf("/*caret*/", "<caret>", "<selection>")
+    }
+}
+
+/**
+ * Removes the [TestUnwrapper] applied by [TestWrapping.wrapCode]
+ */
+class TestUnwrapper(
+    val offset: Int,
+    var file: PsiFile? = null,
+    var attr: SmartPsiElementPointer<RsAttr>? = null
+) {
+    fun init(file: PsiFile) {
+        this.file = file
+        val attr = file.findElementAt(offset)?.ancestorOrSelf<RsAttr>() ?: return
+        this.attr = SmartPointerManager.createPointer(attr)
+    }
+
+    fun unwrap() {
+        val file = file
+        if (file != null) {
+            PsiDocumentManager.getInstance(file.project).commitDocument(file.viewProvider.document)
+        }
+        val attr = attr?.element
+        if (attr != null) {
+            val toDelete = mutableListOf<PsiElement>(attr)
+            attr.rightSiblings.takeWhile { it is PsiWhiteSpace }.toCollection(toDelete)
+            runUndoTransparentWriteAction {
+                for (element in toDelete.asReversed()) {
+                    element.delete()
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/ide/intentions/AddImportForPatternIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImportForPatternIntentionTest.kt
@@ -151,6 +151,7 @@ class AddImportForPatternIntentionTest : RsIntentionTestBase(AddImportForPattern
     ) = checkAutoImportWithMultipleChoice(expectedElements, choice = null) {
         InlineFile(before.trimIndent()).withCaret()
         launchAction()
+        testWrappingUnwrapper?.unwrap()
         myFixture.checkResult(replaceCaretMarker(before.trimIndent()))
     }
 }

--- a/src/test/kotlin/org/rust/ide/intentions/AddImportIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImportIntentionTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.intentions
 
+import org.rust.SkipTestWrapping
+
 class AddImportIntentionTest : RsIntentionTestBase(AddImportIntention::class) {
 
     override val previewExpected: Boolean get() = false
@@ -444,6 +446,7 @@ class AddImportIntentionTest : RsIntentionTestBase(AddImportIntention::class) {
         }
     """)
 
+    @SkipTestWrapping // TODO fix reference search in macro
     fun `test replace usage inside module`() = doAvailableTest("""
         mod foo {
             pub mod bar {

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntentionTest.kt
@@ -264,7 +264,7 @@ class ConvertMethodCallToUFCSIntentionTest : RsIntentionTestBase(ConvertMethodCa
         }
     """)
 
-    fun `test target in a different mod `() = doAvailableTest("""
+    fun `test target in a different mod`() = doAvailableTest("""
         mod foo {
             pub struct Foo;
             impl Foo {

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.intentions
 
 import org.rust.ProjectDescriptor
+import org.rust.SkipTestWrapping
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.intentions.createFromUsage.CreateFunctionIntention
 
@@ -113,6 +114,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
+    @SkipTestWrapping
     fun `test create function in an existing file`() = doAvailableTestWithFileTreeComplete("""
         //- main.rs
             mod foo;
@@ -137,6 +139,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
             }
     """)
 
+    @SkipTestWrapping
     fun `test create function in an existing file in other crate`() = doAvailableTestWithFileTreeComplete("""
     //- main.rs
         fn main() {
@@ -723,6 +726,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
+    @SkipTestWrapping
     fun `test create method for struct in other crate`() = doAvailableTestWithFileTreeComplete("""
     //- main.rs
         fn main(s: test_package::S) {

--- a/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
@@ -7,8 +7,10 @@ package org.rust.ide.intentions
 
 import org.rust.CheckTestmarkHit
 import org.rust.FileTree
+import org.rust.SkipTestWrapping
 import org.rust.fileTree
 
+@SkipTestWrapping
 class ExtractInlineModuleIntentionTest : RsIntentionTestBase(ExtractInlineModuleIntention::class) {
     override val dataPath = "org/rust/ide/intentions/fixtures/"
     override val previewExpected: Boolean get() = false

--- a/src/test/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntentionTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.intentions
 
+import org.rust.SkipTestWrapping
+
+@SkipTestWrapping
 class FlattenUseStatementsIntentionTest : RsIntentionTestBase(FlattenUseStatementsIntention::class) {
     fun `test use statement with alias`() = doAvailableTest("""
         use std::collections::{

--- a/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.intentions
 
+import org.rust.SkipTestWrapping
+
+@SkipTestWrapping
 class NestUseStatementsIntentionTest : RsIntentionTestBase(NestUseStatementsIntention::class) {
     fun `test simple use statements`() = doAvailableTest("""
         use /*caret*/std::error;

--- a/src/test/kotlin/org/rust/ide/intentions/RemoveDbgIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RemoveDbgIntentionTest.kt
@@ -42,13 +42,13 @@ class RemoveDbgIntentionTest : RsIntentionTestBase(RemoveDbgIntention::class) {
         fn f1(a: usize, b: usize) {}
 
         fn test() {
-            f1(1 + dbg!((3 + 1/*caret*/) * 2)), dbg!(10));
+            f1(1 + dbg!((3 + 1/*caret*/) * 2), dbg!(10));
         }
     """, """
         fn f1(a: usize, b: usize) {}
 
         fn test() {
-            f1(1 + ((3 + 1/*caret*/) * 2)), dbg!(10));
+            f1(1 + ((3 + 1/*caret*/) * 2), dbg!(10));
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -13,20 +13,44 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.util.PathUtil
 import com.intellij.util.ui.UIUtil
 import org.intellij.lang.annotations.Language
-import org.rust.RsTestBase
-import org.rust.fileTreeFromText
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.rust.*
 import org.rust.ide.checkNoPreview
 import org.rust.ide.checkPreviewAndLaunchAction
+import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 
+/**
+ * A base test class for intention action tests.
+ *
+ * By default, each test declared in a subclass of this class will run several times - one per each
+ * [TestWrapping] value returned from [RsIntentionTestBase.data] method. This allows to test intention
+ * actions under different circumstances, e.g. inside a procedural macro call. Use [SkipTestWrapping]
+ * annotation to skip test run with a specific (or all) [TestWrapping] (s).
+ */
+@RunWith(RsJUnit4ParameterizedTestRunner::class)
+@Parameterized.UseParametersRunnerFactory(RsJUnit4ParameterizedTestRunner.RsRunnerForParameters.Factory::class)
 abstract class RsIntentionTestBase(private val intentionClass: KClass<out IntentionAction>) : RsTestBase() {
+
+    @field:Parameterized.Parameter(0)
+    override lateinit var testWrapping: TestWrapping
+
+    companion object {
+        @Parameterized.Parameters(name = "{index}: {0}")
+        @JvmStatic fun data(): Iterable<TestWrapping> = listOf(
+            TestWrapping.NONE,
+            TestWrapping.ATTR_MACRO_AS_IS,
+        )
+    }
 
     protected val intention: IntentionAction
         get() = findIntention() ?: error("Failed to find `${intentionClass.simpleName}` intention")
 
     protected open val previewExpected: Boolean get() = intention.startInWriteAction()
 
+    @SkipTestWrapping
     fun `test intention has documentation`() {
         if (!intentionClass.isSubclassOf(RsElementBaseIntentionAction::class)) return
 
@@ -49,6 +73,7 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
     ) {
         InlineFile(before.trimIndent(), fileName).withCaret()
         launchAction(preview)
+        this.testWrappingUnwrapper?.unwrap()
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }
 
@@ -72,6 +97,7 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
         assertNotNull(TemplateManagerImpl.getTemplateState(myFixture.editor))
         myFixture.type(toType)
         assertNull(TemplateManagerImpl.getTemplateState(myFixture.editor))
+        this.testWrappingUnwrapper?.unwrap()
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }
 
@@ -82,6 +108,7 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
     ) {
         fileTreeFromText(fileStructureBefore).createAndOpenFileWithCaretMarker()
         launchAction()
+        this.testWrappingUnwrapper?.unwrap()
         myFixture.checkResult(replaceCaretMarker(openedFileAfter.trimIndent()))
     }
 
@@ -91,6 +118,7 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
     ) {
         fileTreeFromText(fileStructureBefore).createAndOpenFileWithCaretMarker()
         launchAction()
+        testWrappingUnwrapper?.unwrap()
         fileTreeFromText(replaceCaretMarker(fileStructureAfter)).check(myFixture)
     }
 
@@ -99,7 +127,8 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
         // Check preview only for intentions from Rust plugin
         if (intentionClass.isSubclassOf(RsElementBaseIntentionAction::class)) {
             if (previewExpected) {
-                myFixture.checkPreviewAndLaunchAction(intention, preview)
+                val isWrappingActive = testWrappingUnwrapper != null
+                myFixture.checkPreviewAndLaunchAction(intention, preview, isWrappingActive)
             } else {
                 myFixture.checkNoPreview(intention)
                 myFixture.launchAction(intention)

--- a/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.codeInsight.intention.IntentionManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import org.rust.SkipTestWrapping
 import org.rust.ide.actions.macroExpansion.MacroExpansionViewDetails
 
 class RsShowMacroExpansionIntentionBaseTest : RsIntentionTestBase(RsShowMacroExpansionIntention::class) {
@@ -22,6 +23,7 @@ class RsShowMacroExpansionIntentionBaseTest : RsIntentionTestBase(RsShowMacroExp
         super.tearDown()
     }
 
+    @SkipTestWrapping
     fun `test availability range`() = checkAvailableInSelectionOnly("""
         <selection>foo!</selection> {
             bar baz

--- a/src/test/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntentionTest.kt
@@ -7,9 +7,11 @@ package org.rust.ide.intentions
 
 import org.intellij.lang.annotations.Language
 import org.rust.MockServerFixture
+import org.rust.SkipTestWrapping
 import org.rust.cargo.project.model.impl.DEFAULT_EDITION_FOR_TESTS
 import org.rust.ide.actions.ShareInPlaygroundActionTest
 
+@SkipTestWrapping
 class ShareInPlaygroundIntentionTest : RsIntentionTestBase(ShareInPlaygroundIntention::class) {
 
     private val mockServerFixture: MockServerFixture = MockServerFixture()

--- a/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.intentions
 
 import org.intellij.lang.annotations.Language
 import org.rust.MockCargoFeatures
+import org.rust.SkipTestWrapping
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.FeatureState
 import org.rust.cargo.project.workspace.PackageOrigin
@@ -17,6 +18,7 @@ class ToggleFeatureIntentionTest : RsIntentionTestBase(ToggleFeatureIntention::c
 
     override val previewExpected: Boolean get() = false
 
+    @SkipTestWrapping // TODO fix `PsiElement.findExpansionElementsNonRecursive` for `cfg_attr` condition
     @MockCargoFeatures("foo")
     fun `test availability range`() = checkAvailableInSelectionOnly("""
         #[cfg(<selection>feature = "foo"</selection>)]

--- a/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.intentions
 
 import org.rust.MockAdditionalCfgOptions
+import org.rust.SkipTestWrapping
 
 class UnElideLifetimesIntentionTest : RsIntentionTestBase(UnElideLifetimesIntention::class) {
     fun `test unavailable without references 1`() = doUnavailableTest("""
@@ -59,6 +60,7 @@ class UnElideLifetimesIntentionTest : RsIntentionTestBase(UnElideLifetimesIntent
         fn foo<'a>(p: &/*caret*/'a mut i32) -> &'a i32 { p }
     """)
 
+    @SkipTestWrapping // TODO fix formatter in the case of an attribute macro
     fun `test nested ref`() = doAvailableTest("""
         fn foo(p: &&/*caret*/ i32) -> & i32 { unimplemented!() }
     """, """

--- a/src/test/kotlin/org/rust/ide/previewUtils.kt
+++ b/src/test/kotlin/org/rust/ide/previewUtils.kt
@@ -14,13 +14,18 @@ import com.intellij.codeInspection.ex.QuickFixWrapper
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import org.junit.Assert.assertEquals
 
-fun CodeInsightTestFixture.checkPreviewAndLaunchAction(intention: IntentionAction, preview: String?) {
+fun CodeInsightTestFixture.checkPreviewAndLaunchAction(
+    intention: IntentionAction,
+    preview: String?,
+    isWrappingActive: Boolean = false,
+) {
     val actualPreview = getIntentionPreviewText(intention)
     check(actualPreview != null) {
         "No intention preview for `${intention.getClassName()}`. " +
             "Either support preview or pass `previewExpected = false`"
     }
     launchAction(intention)
+    if (isWrappingActive && preview != null) return //TODO support custom preview with test wrapping
     val expectedPreview = preview?.trimIndent() ?: file.text
     assertEquals(
         "Intention `${intention.getClassName()}` produced different result when invoked in preview mode",

--- a/toml/src/test/kotlin/org/rust/toml/intentions/CargoTomlIntentionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/intentions/CargoTomlIntentionTestBase.kt
@@ -7,9 +7,11 @@ package org.rust.toml.intentions
 
 import com.intellij.codeInsight.intention.IntentionAction
 import org.intellij.lang.annotations.Language
+import org.rust.SkipTestWrapping
 import org.rust.ide.intentions.RsIntentionTestBase
 import kotlin.reflect.KClass
 
+@SkipTestWrapping
 abstract class CargoTomlIntentionTestBase(intentionClass: KClass<out IntentionAction>) : RsIntentionTestBase(intentionClass) {
     protected fun doAvailableTest(
         @Language("TOML") before: String,


### PR DESCRIPTION
Set up tests for an intention action inside an attr proc macro using JUnit4 parameterized tests. 
The idea is that we have many tests for intention actions, and we can re-use them in the context of a macro call. I've called this approach "test wrapping".

Since now, every intention action test (in descendants of `RsIntentionTestBase` class) will run twice - first time without wrapping (as before), and second one with "wrapping":

![image](https://user-images.githubusercontent.com/3221931/226452002-907b1a06-1b0d-41e9-8437-58baf4251229.png)

"wrapped with `#[attr_as_is]` macro" (see the screenshot) means that we run basically the same test, but it's code sample is slightly modified to become a macro invocation, that is, "wrapped" inside a macro invocation of `#[attr_as_is]` macro.

For example, the test `AddRemainingArmsIntentionTest.test empty match`:
```rust
enum E { A, B, C }
fn main() {
    let a = E::A;
    match a {
        /*caret*/
    }
}
```

after applying the wrapping will look like this:

```rust
enum E { A, B, C }
#[attr_as_is]
fn main() {
    let a = E::A;
    match a {
        /*caret*/
    }
}
```

Then, after applying an intention action, the test code is "unwrapped" and checked against the `expected` code. 

It's possible to skip testing with wrapping for a specific test using `@SkipTestWrapping` annotation.

Using parameterized tests requires us to switch to JUnit4 that basically implies using `@Test` annotations to mark a test function, but I managed to avoid it by using a custom test runner.

changelog: Set up tests for an intention action inside an attribute macro