### PR TITLE
RUN: Support `Rebuild ...` and `Clean` actions

### DIFF
--- a/clion/src/main/kotlin/org/rust/clion/cargo/CargoCleanTaskRunner.kt
+++ b/clion/src/main/kotlin/org/rust/clion/cargo/CargoCleanTaskRunner.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.cargo
+
+import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.project.Project
+import com.intellij.task.ProjectTask
+import com.intellij.task.ProjectTaskContext
+import com.intellij.task.ProjectTaskRunner
+import com.jetbrains.cidr.execution.build.tasks.CidrCleanTask
+import org.jetbrains.concurrency.Promise
+import org.jetbrains.concurrency.rejectedPromise
+import org.rust.cargo.runconfig.cleanProject
+
+class CargoCleanTaskRunner : ProjectTaskRunner() {
+
+    override fun run(project: Project, context: ProjectTaskContext, vararg tasks: ProjectTask): Promise<Result> {
+        if (project.isDisposed) return rejectedPromise("Project is already disposed")
+        invokeLater { project.cleanProject() }
+        return rejectedPromise()
+    }
+
+    override fun canRun(projectTask: ProjectTask): Boolean = projectTask is CidrCleanTask
+}

--- a/clion/src/main/resources/org.rust.clion.xml
+++ b/clion/src/main/resources/org.rust.clion.xml
@@ -1,4 +1,4 @@
-<idea-plugin package="org.rust.clion" xmlns:xi="http://www.w3.org/2001/XInclude">
+<idea-plugin package="org.rust.clion">
     <!--suppress PluginXmlValidity -->
     <dependencies>
         <plugin id="com.intellij.clion"/>
@@ -25,6 +25,8 @@
 
         <programRunner implementation="org.rust.clion.valgrind.RsValgrindRunner"/>
         <programRunner implementation="org.rust.clion.valgrind.legacy.RsValgrindRunnerLegacy"/>
+
+        <projectTaskRunner implementation="org.rust.clion.cargo.CargoCleanTaskRunner"/>
     </extensions>
 
     <extensions defaultExtensionNs="org.rust">

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -51,7 +51,7 @@ fun RunManager.createCargoCommandRunConfiguration(cargoCommandLine: CargoCommand
         CargoCommandConfigurationType.getInstance().factory
     )
     val configuration = runnerAndConfigurationSettings.configuration as CargoCommandConfiguration
-    configuration.setFromCmd(cargoCommandLine.copy(emulateTerminal = configuration.emulateTerminal))
+    configuration.setFromCmd(cargoCommandLine)
     return runnerAndConfigurationSettings
 }
 
@@ -76,6 +76,18 @@ fun Project.buildProject() {
 
     for (cargoProject in cargoProjects.allProjects) {
         CargoCommandLine.forProject(cargoProject, "build", arguments).run(cargoProject, saveConfiguration = false)
+    }
+}
+
+fun Project.cleanProject() {
+    checkIsDispatchThread()
+
+    // Initialize run content manager
+    RunContentManager.getInstance(this)
+
+    for (cargoProject in cargoProjects.allProjects) {
+        CargoCommandLine.forProject(cargoProject, "clean", emulateTerminal = false)
+            .run(cargoProject, saveConfiguration = false)
     }
 }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -32,6 +32,7 @@ import com.intellij.ui.SystemNotifications
 import com.intellij.util.execution.ParametersListUtil
 import com.intellij.util.ui.UIUtil
 import org.jetbrains.annotations.TestOnly
+import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.runconfig.*
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.ParsedCommand
@@ -109,10 +110,14 @@ object CargoBuildManager {
         }
     }
 
+    fun clean(project: CargoProject): Future<Boolean> =
+        CargoCommandLine.forProject(project, "clean", emulateTerminal = false)
+            .runAsync(project, saveConfiguration = false)
+
     private fun execute(
         context: CargoBuildContext,
         doExecute: CargoBuildContext.() -> Unit
-    ): CompletableFuture<CargoBuildResult> {
+    ): Future<CargoBuildResult> {
         context.environment.notifyProcessStartScheduled()
         val processCreationLock = Any()
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
@@ -109,6 +109,7 @@ class Rustfmt(toolchain: RsToolchainBase) : RustupComponent(NAME, toolchain) {
             cargoProject,
             "fmt",
             listOf("--all", "--") + arguments,
+            false,
             toolchain,
             settingsState.channel,
             EnvironmentVariablesData.create(settingsState.envs, true)


### PR DESCRIPTION
Now `Rebuild` actions run `cargo clean` for the corresponding cargo project before build and `Clean` action just runs `cargo clean` for all cargo projects.

<img width="222" alt="Screenshot 2023-03-21 at 18 48 50" src="https://user-images.githubusercontent.com/6079006/226697652-c57d512d-811e-48a4-92ec-8ce49c645939.png">

changelog:  Support `Rebuild ...` and `Clean` actions
