### PR TITLE
ANN: Improve E0784 (union expr does not have exactly one field)

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
@@ -55,24 +55,21 @@ class RsExpressionAnnotator : AnnotatorBase() {
 
         if (body.dotdot != null) return  // functional update, no need to declare all the fields.
 
-        if (decl is RsStructItem && decl.kind == RsStructKind.UNION) {
-            if (body.structLiteralFieldList.size > 1) {
-                holder.createErrorAnnotation(body, "Union expressions should have exactly one field")
-            }
-        } else {
-            if (calculateMissingFields(body, decl).isNotEmpty()) {
-                if (!literal.existsAfterExpansion) return
+        if (decl is RsStructItem && decl.kind == RsStructKind.UNION) return
 
-                val structNameRange = literal.descendantOfTypeStrict<RsPath>()?.textRange
-                if (structNameRange != null) {
-                    holder.holder.newAnnotation(HighlightSeverity.ERROR, "Some fields are missing")
-                        .range(structNameRange)
-                        .newFix(AddStructFieldsFix(literal)).range(body.parent.textRange).registerFix()
-                        .newFix(AddStructFieldsFix(literal, recursive = true)).range(body.parent.textRange).registerFix()
-                        .create()
-                }
+        if (calculateMissingFields(body, decl).isNotEmpty()) {
+            if (!literal.existsAfterExpansion) return
+
+            val structNameRange = literal.descendantOfTypeStrict<RsPath>()?.textRange
+            if (structNameRange != null) {
+                holder.holder.newAnnotation(HighlightSeverity.ERROR, "Some fields are missing")
+                    .range(structNameRange)
+                    .newFix(AddStructFieldsFix(literal)).range(body.parent.textRange).registerFix()
+                    .newFix(AddStructFieldsFix(literal, recursive = true)).range(body.parent.textRange).registerFix()
+                    .create()
             }
         }
+
 
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveStructLiteralFieldFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveStructLiteralFieldFix.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsStructLiteralField
+import org.rust.lang.core.psi.ext.deleteWithSurroundingCommaAndWhitespace
+
+class RemoveStructLiteralFieldFix(
+    field: RsStructLiteralField,
+    private val removingFieldName: String = "`${field.text}`"
+) : LocalQuickFixAndIntentionActionOnPsiElement(field) {
+    override fun getFamilyName() = "Remove struct literal field"
+
+    override fun getText() = "Remove $removingFieldName"
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        val field = (startElement as? RsStructLiteralField) ?: return
+        field.deleteWithSurroundingCommaAndWhitespace()
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -567,6 +567,12 @@ class RsTypeInferenceWalker(
 
         inferStructTypeArguments(expr, typeParameters)
 
+        if (element is RsStructItem && element.kind == RsStructKind.UNION
+            && expr.structLiteralBody.structLiteralFieldList.size != 1
+        ) {
+            ctx.addDiagnostic(RsDiagnostic.UnionExprWithWrongFieldCount(expr))
+        }
+
         // Handle struct update syntax { ..expression }
         expr.structLiteralBody.expr?.inferTypeCoercableTo(type)
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -5,9 +5,11 @@
 
 package org.rust.lang.core.types.infer
 
+import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.psi.PsiElement
 import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.fixes.RemoveStructLiteralFieldFix
 import org.rust.lang.core.macros.MacroExpansion
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -570,7 +572,11 @@ class RsTypeInferenceWalker(
         if (element is RsStructItem && element.kind == RsStructKind.UNION
             && expr.structLiteralBody.structLiteralFieldList.size != 1
         ) {
-            ctx.addDiagnostic(RsDiagnostic.UnionExprWithWrongFieldCount(expr))
+            val fixes = mutableListOf<LocalQuickFix>()
+            for (e in expr.structLiteralBody.structLiteralFieldList) {
+                fixes.add(RemoveStructLiteralFieldFix(e))
+            }
+            ctx.addDiagnostic(RsDiagnostic.UnionExprWithWrongFieldCount(expr, fixes))
         }
 
         // Handle struct update syntax { ..expression }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1729,11 +1729,15 @@ sealed class RsDiagnostic(
         )
     }
 
-    class UnionExprWithWrongFieldCount(element: PsiElement) : RsDiagnostic(element) {
+    class UnionExprWithWrongFieldCount(
+        element: PsiElement,
+        private val fixes: List<LocalQuickFix>
+    ) : RsDiagnostic(element) {
         override fun prepare() = PreparedAnnotation(
             ERROR,
             E0784,
-            "Union expressions should have exactly one field"
+            "Union expressions should have exactly one field",
+            fixes = fixes.toQuickFixInfo(),
         )
     }
 }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1728,6 +1728,14 @@ sealed class RsDiagnostic(
             "Cannot define inherent `impl` for a dyn auto trait"
         )
     }
+
+    class UnionExprWithWrongFieldCount(element: PsiElement) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0784,
+            "Union expressions should have exactly one field"
+        )
+    }
 }
 
 enum class RsErrorCode {
@@ -1738,7 +1746,7 @@ enum class RsErrorCode {
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0437, E0438, E0449, E0451, E0463,
     E0517, E0518, E0537, E0552, E0554, E0562, E0569, E0571, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0642, E0658, E0666, E0667, E0695,
-    E0703, E0704, E0728, E0732, E0733, E0741, E0742, E0747, E0774, E0785;
+    E0703, E0704, E0728, E0732, E0733, E0741, E0742, E0747, E0774, E0784, E0785;
 
     val code: String
         get() = toString()

--- a/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
@@ -145,13 +145,4 @@ class RsExpressionAnnotatorTest : RsAnnotatorTestBase(RsExpressionAnnotator::cla
             let w = Win { foo: 92 };
         }
     """)
-
-    fun `test union`() = checkWarnings("""
-        union U { a: i32, b: f32 }
-
-        fn main() {
-            let _ = U { a: 92 };
-            let _ = U <error descr="Union expressions should have exactly one field">{ a: 92, b: 92.0}</error>;
-        }
-    """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnionExprWithWrongFieldCountTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnionExprWithWrongFieldCountTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+class RsUnionExprWithWrongFieldCountTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test E0784 union literal ok`() = checkErrors("""
+        union U { a: u8, b: u16 }
+        fn main() {
+            _ = U { a: 0 };
+            _ = U { b: 0 };
+        }
+    """)
+
+    fun `test E0784 union literal with wrong fields count`() = checkErrors("""
+        union U { a: u8, b: u16 }
+        fn main() {
+            _ = /*error descr="Union expressions should have exactly one field [E0784]"*/U {}/*error**/;
+            _ = /*error descr="Union expressions should have exactly one field [E0784]"*/U { a: 0, b: 1 }/*error**/;
+            _ = /*error descr="Union expressions should have exactly one field [E0784]"*/U { a: 0, b: 1, c: 2 }/*error**/;
+        }
+    """)
+
+    fun `test E0784 union literal with struct update instead of fields`() = checkErrors("""
+        union U { a: u8, b: u16 }
+        fn main() {
+             _ = /*error descr="Union expressions should have exactly one field [E0784]"*/U { ..u }/*error**/;
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnionExprWithWrongFieldCountTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnionExprWithWrongFieldCountTest.kt
@@ -29,4 +29,28 @@ class RsUnionExprWithWrongFieldCountTest : RsAnnotatorTestBase(RsErrorAnnotator:
              _ = /*error descr="Union expressions should have exactly one field [E0784]"*/U { ..u }/*error**/;
         }
     """)
+
+    fun `test E0784 fix by removing first field`() = checkFixByText("Remove `a: 0`", """
+        union U { a: u8, b: u16 }
+        fn main() {
+            _ = /*error descr="Union expressions should have exactly one field [E0784]"*/U { a: 0, b: 1 }/*caret*//*error**/;
+        }
+    """, """
+        union U { a: u8, b: u16 }
+        fn main() {
+            _ = U { b: 1 }/*caret*/;
+        }
+    """)
+
+    fun `test E0784 fix by removing last field`() = checkFixByText("Remove `b: 1`", """
+        union U { a: u8, b: u16 }
+        fn main() {
+            _ = /*error descr="Union expressions should have exactly one field [E0784]"*/U { a: 0, b: 1 }/*caret*//*error**/;
+        }
+    """, """
+        union U { a: u8, b: u16 }
+        fn main() {
+            _ = U { a: 0 }/*caret*/;
+        }
+    """)
 }


### PR DESCRIPTION
changelog: Improve support for [E0784](https://doc.rust-lang.org/error_codes/E0784.html) ("A union expression does not have exactly one field.")