### PR TITLE
ANN: Add E0226: Too many lifetime bounds on traitobj

### DIFF
--- a/src/main/kotlin/org/rust/ide/fixes/RemovePolyBoundFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemovePolyBoundFix.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.fixes
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsPolybound
+import org.rust.lang.core.psi.ext.deleteWithSurroundingPlus
+
+class RemovePolyBoundFix(
+    bound: RsPolybound,
+    private val boundName: String = "`${bound.text}`"
+) : LocalQuickFixOnPsiElement(bound) {
+    override fun getText() = "Remove $boundName bound"
+    override fun getFamilyName() = "Remove bound"
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val bound = (startElement as? RsPolybound) ?: return
+        bound.deleteWithSurroundingPlus()
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -200,6 +200,25 @@ fun RsElement.deleteWithSurroundingCommaAndWhitespace() {
     deleteWithSurroundingComma()
 }
 
+/**
+ * Delete the element along with a neighbour plus signs.
+ * Same as deleteWithSurroundingComma but for "+" instead of ",".
+ *
+ * It's useful for removing parts of trait bounds.
+ */
+fun RsElement.deleteWithSurroundingPlus() {
+    val followingPlus = getNextNonCommentSibling()
+    if (followingPlus?.elementType == RsElementTypes.PLUS) {
+        followingPlus?.delete()
+    } else {
+        val precedingPlus = getPrevNonCommentSibling()
+        if (precedingPlus?.elementType == RsElementTypes.PLUS) {
+            precedingPlus?.delete()
+        }
+    }
+    delete()
+}
+
 private val PsiElement.isWhitespaceOrComment
     get(): Boolean = this is PsiWhiteSpace || this is PsiComment
 

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1740,12 +1740,24 @@ sealed class RsDiagnostic(
             fixes = fixes.toQuickFixInfo(),
         )
     }
+
+    class TooManyLifetimeBoundsOnTraitObjectError(
+        element: PsiElement,
+        private val fixes: List<LocalQuickFix>
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0226,
+            "Only a single explicit lifetime bound is permitted",
+            fixes = fixes.toQuickFixInfo(),
+        )
+    }
 }
 
 enum class RsErrorCode {
     E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0130, E0131, E0132, E0133, E0184, E0185, E0186, E0191, E0197, E0198, E0199,
-    E0200, E0201, E0203, E0206, E0220, E0224, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
+    E0200, E0201, E0203, E0206, E0220, E0224, E0226, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0437, E0438, E0449, E0451, E0463,
     E0517, E0518, E0537, E0552, E0554, E0562, E0569, E0571, E0583, E0586, E0594,

--- a/src/test/kotlin/org/rust/ide/annotator/RsTooManyLifetimeBoundsOnTraitObjectTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsTooManyLifetimeBoundsOnTraitObjectTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+class RsTooManyLifetimeBoundsOnTraitObjectTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
+    fun `test E0226 one lifetime bound`() = checkByText("""
+        trait Foo {}
+        type T1<'a> = dyn Foo + 'a;
+    """)
+
+    fun `test E0226 typedef with two lifetime bounds`() = checkByText("""
+        trait Foo {}
+        type T<'a, 'b> = /*error descr="Only a single explicit lifetime bound is permitted [E0226]"*/dyn Foo + 'a + 'b/*error**/;
+    """)
+
+    fun `test E0226 typedef with two lifetime bounds in mixed order`() = checkByText("""
+        trait Foo {}
+        type T<'a, 'b> = /*error descr="Only a single explicit lifetime bound is permitted [E0226]"*/dyn 'a + Foo + 'b/*error**/;
+    """)
+
+    fun `test E0226 trait object as function argument with two lifetime bounds`() = checkByText("""
+        trait Foo {}
+        fn _bar<'b, 'c>(_: Box</*error descr="Only a single explicit lifetime bound is permitted [E0226]"*/dyn Foo + 'b + 'c/*error**/>) {}
+    """)
+
+    fun `test E0226 fix by removing first lt`() = checkFixByText("Remove `'a` bound", """
+        trait Foo {}
+        type T<'a, 'b> = /*error descr="Only a single explicit lifetime bound is permitted [E0226]"*/dyn 'a + Foo + 'b/*error**//*caret*/;
+    """, """
+        trait Foo {}
+        type T<'a, 'b> = dyn Foo + 'b/*caret*/;
+    """)
+
+    fun `test E0226 fix by removing middle lt`() = checkFixByText("Remove `'a` bound", """
+        trait Foo {}
+        type T<'a, 'b> = /*error descr="Only a single explicit lifetime bound is permitted [E0226]"*/dyn Foo + 'a + 'b/*error**//*caret*/;
+    """, """
+        trait Foo {}
+        type T<'a, 'b> = dyn Foo + 'b/*caret*/;
+    """)
+
+    fun `test E0226 fix by removing last lt`() = checkFixByText("Remove `'b` bound", """
+        trait Foo {}
+        type T<'a, 'b> = /*error descr="Only a single explicit lifetime bound is permitted [E0226]"*/dyn 'a + Foo + 'b/*error**//*caret*/;
+    """, """
+        trait Foo {}
+        type T<'a, 'b> = dyn 'a + Foo/*caret*/;
+    """)
+}


### PR DESCRIPTION
changelog: Add support for [E0226](https://doc.rust-lang.org/error_codes/E0226.html) ("More than one explicit lifetime bound was used on a trait object.")