### PR TITLE
MACRO: parse reserved keywords as identifiers in macro matching

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
@@ -323,7 +323,7 @@ class DeclMacroExpander(val project: Project): MacroExpander<RsDeclMacroData, De
     }
 
     companion object {
-        const val EXPANDER_VERSION = 18
+        const val EXPANDER_VERSION = 19
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR, BLOCK_EXPR
         )

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -209,7 +209,7 @@ class ProcMacroExpander private constructor(
         psi !is RsDotExpr && psi.childrenWithLeaves.any { it is PsiErrorElement || it !is RsExpr && hasErrorToHandle(it) }
 
     companion object {
-        const val EXPANDER_VERSION: Int = 8
+        const val EXPANDER_VERSION: Int = 9
 
         fun forCrate(crate: Crate): ProcMacroExpander {
             val project = crate.project

--- a/src/main/kotlin/org/rust/lang/core/psi/RsTokenType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsTokenType.kt
@@ -137,6 +137,6 @@ val RS_MOD_OR_FILE = tokenSetOf(MOD_ITEM, RsFileStub.Type)
  * but rustc's macro parser treats them as identifiers
  */
 val RS_IDENTIFIER_TOKENS = TokenSet.orSet(
-    tokenSetOf(IDENTIFIER, BOOL_LITERAL),
+    tokenSetOf(IDENTIFIER, BOOL_LITERAL, RESERVED_KEYWORD),
     RS_KEYWORDS
 )

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
@@ -1276,6 +1276,40 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn bar() {}
     """)
 
+    fun `test reserved keywords`() = doTest("""
+        macro_rules! foo {
+            ($ i:ident) => { fn foo () { let _ = stringify!($ i); } };
+        }
+
+        foo!(abstract);
+        foo!(become);
+        foo!(do);
+        foo!(final);
+        foo!(override);
+        foo!(priv);
+        foo!(typeof);
+        foo!(unsized);
+        foo!(virtual);
+    """, """
+        fn foo () { let _ = stringify!(abstract); }
+    """, """
+        fn foo () { let _ = stringify!(become); }
+    """, """
+        fn foo () { let _ = stringify!(do); }
+    """, """
+        fn foo () { let _ = stringify!(final); }
+    """, """
+        fn foo () { let _ = stringify!(override); }
+    """, """
+        fn foo () { let _ = stringify!(priv); }
+    """, """
+        fn foo () { let _ = stringify!(typeof); }
+    """, """
+        fn foo () { let _ = stringify!(unsized); }
+    """, """
+        fn foo () { let _ = stringify!(virtual); }
+    """)
+
     companion object {
         // BACKCOMPAT: Rust 1.62
         private val RUST_1_63 = "1.63.0".parseSemVer()

--- a/src/test/kotlin/org/rust/lang/core/macros/tt/TokenTreeParserTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/tt/TokenTreeParserTest.kt
@@ -231,6 +231,19 @@ class TokenTreeParserTest : RsTestBase() {
           IDENT   bar 2
     """)
 
+    fun `test reserved keywords`() = doTest("abstract become do final override priv typeof unsized virtual", """
+        SUBTREE $
+          IDENT   abstract 0
+          IDENT   become 1
+          IDENT   do 2
+          IDENT   final 3
+          IDENT   override 4
+          IDENT   priv 5
+          IDENT   typeof 6
+          IDENT   unsized 7
+          IDENT   virtual 8
+    """)
+
     fun doTest(code: String, expected: String) {
         val subtree = project.createRustPsiBuilder(code).parseSubtree().subtree
         assertEquals(subtree, FlatTree.fromSubtree(subtree).toTokenTree())


### PR DESCRIPTION
Fixes #10296

Rust currently has 9 reserved keywords - `abstract`, `become`, `do`, `final`, `override`, `priv`, `typeof`, `unsized` and `virtual`. Each reserved keyword token must be parsed as an identifier when passed to a declarative or procedural macro.

Declarative macro example:

```rust
macro_rules! foo {
    ($i:ident) => { fn foo () { let _ = stringify!($i); }};
}

foo!(final);
```

Previously, the plugin couldn't expand the macro:
![image](https://user-images.githubusercontent.com/3221931/228517797-a3b36426-fa08-43c4-bba0-9d87961f8f44.png)

You can find example with a proc macro in #10296.

changelog: Fix expansion of macros that contain reserved keywords (e.g. `do`) in their body