### PR TITLE
REF: Don't add mod declaration for crate root in move refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsDialog.kt
@@ -263,6 +263,7 @@ private fun createNewRustFile(filePath: Path, project: Project, crateRoot: RsMod
 
 /** Finds parent mod of [file] and adds mod declaration to it */
 private fun attachFileToParentMod(file: RsFile, project: Project, crateRoot: RsMod?): Boolean {
+    if (file.isCrateRoot) return true
     val (parentModOwningDirectory, modName) = if (file.name == RsConstants.MOD_RS_FILE) {
         file.parent?.parent to file.parent?.name
     } else {

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -3021,4 +3021,19 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
     //- inner/foo/mod.rs
         fn func() {}
     """)
+
+    fun `test don't add mod decl when created file is crate root`() = doTestCreateFile("lib.rs", """
+    //- main.rs
+        fn main() {
+            func();
+        }
+        fn func/*caret*/() {}
+    """, """
+    //- main.rs
+        fn main() {
+            test_package::func();
+        }
+    //- lib.rs
+        pub fn func() {}
+    """)
 }


### PR DESCRIPTION
Fixes #10297

changelog: Don't add mod declaration for crate root if it was created by move refactoring (`Refactor | Move` or <kbd>F6</kbd>)