### PR TITLE
ANN: Add E0316 "nested quantification over lifetimes"

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1764,13 +1764,25 @@ sealed class RsDiagnostic(
             fixes = fixes.toQuickFixInfo(),
         )
     }
+
+    class NestedQuantificationOfLifetimeBoundsError(
+        element: RsPolybound,
+        private val fixes: List<LocalQuickFix>
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0316,
+            "Nested quantification of lifetimes",
+            fixes = fixes.toQuickFixInfo(),
+        )
+    }
 }
 
 enum class RsErrorCode {
     E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0130, E0131, E0132, E0133, E0184, E0185, E0186, E0191, E0197, E0198, E0199,
     E0200, E0201, E0203, E0206, E0220, E0224, E0226, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
-    E0308, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0384,
+    E0308, E0316, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0437, E0438, E0449, E0451, E0463,
     E0517, E0518, E0537, E0552, E0554, E0562, E0569, E0571, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0642, E0658, E0666, E0667, E0695,

--- a/src/test/kotlin/org/rust/ide/annotator/RsNestedQuantificationOfLifetimeBoundsTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsNestedQuantificationOfLifetimeBoundsTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+class RsNestedQuantificationOfLifetimeBoundsTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
+    fun `test E0316 one lifetime quantification`() = checkByText("""
+        fn _foo<T>(t: T)
+        where
+            for<'a, 'b> &'a T: Tr<'a, 'b>,
+        {}
+    """)
+
+    fun `test E0316 simple nested lifetime quantification`() = checkByText("""
+        fn _foo<T>(t: T)
+        where
+            for<'a> &'a T: /*error descr="Nested quantification of lifetimes [E0316]"*/for<'b> Tr<'a, 'b>/*error**/,
+        {}
+    """)
+
+    fun `test E0316 two nested lifetime quantifications`() = checkByText("""
+        fn _foo<T>(t: T)
+        where
+            for<'a> &'a T:
+                /*error descr="Nested quantification of lifetimes [E0316]"*/for<'b> Tr<'a, 'b>/*error**/
+                + /*error descr="Nested quantification of lifetimes [E0316]"*/for<'b> Tr<'a, 'b>/*error**/,
+        {}
+    """)
+
+    fun `test E0316 fix by removing inner for quantification`() = checkFixByText("Remove `for<'b> Tr<'a, 'b>` bound", """
+        fn _foo<T>(t: T)
+        where
+            for<'a> &'a T: /*error descr="Nested quantification of lifetimes [E0316]"*/for<'b> Tr<'a, 'b>/*error**//*caret*/,
+        {}
+    """, """
+        fn _foo<T>(t: T)
+        where
+            for<'a> &'a T:/*caret*/,
+        {}
+    """)
+}


### PR DESCRIPTION
changelog: Add support for [E0316](https://doc.rust-lang.org/error_codes/E0316.html) ("A where clause contains a nested quantification over lifetimes")