### PR TITLE
REF: Support control flow in `Extract function` refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/surroundWith/utils.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/utils.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.surroundWith
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
 import org.rust.lang.core.psi.RsBlock
 import org.rust.lang.core.psi.RsPsiFactory
 
@@ -17,4 +18,11 @@ fun RsBlock.addStatements(statements: Array<out PsiElement>) {
     addBefore(factory.createWhitespace("\n    "), rbrace)
     addRangeBefore(statements.first(), statements.last(), rbrace)
     addBefore(factory.createNewline(), rbrace)
+}
+
+fun RsBlock.addStatement(statement: PsiElement) {
+    val newline = RsPsiFactory(project).createNewline()
+    if ((rbrace?.prevSibling as? PsiWhiteSpace)?.textContains('\n') != true) addBefore(newline, rbrace)
+    addBefore(statement, rbrace)
+    addBefore(newline, rbrace)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLambdaExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLambdaExpr.kt
@@ -8,6 +8,9 @@ package org.rust.lang.core.psi.ext
 import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsLambdaExpr
 import org.rust.lang.core.psi.RsValueParameter
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyFunction
+import org.rust.lang.core.types.type
 
 val RsLambdaExpr.isAsync: Boolean
     get() = node.findChildByType(RsElementTypes.ASYNC) != null
@@ -17,3 +20,6 @@ val RsLambdaExpr.isConst: Boolean
 
 val RsLambdaExpr.valueParameters: List<RsValueParameter>
     get() = valueParameterList.valueParameterList
+
+val RsLambdaExpr.returnType: Ty?
+    get() = (type as? TyFunction)?.retType

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStmt.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStmt.kt
@@ -10,10 +10,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubBase
 import org.rust.lang.core.macros.RsExpandedElement
-import org.rust.lang.core.psi.RsBlock
-import org.rust.lang.core.psi.RsExprStmt
-import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.RsStmt
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsExprStmtStub
 
 abstract class RsStmtMixin : RsStubbedElementImpl<StubBase<*>>, RsStmt {
@@ -35,3 +32,12 @@ fun RsExprStmt.addSemicolon() {
     if (hasSemicolon) return
     add(RsPsiFactory(project).createSemicolon())
 }
+
+fun RsExprStmt.addSemicolonIfNeeded() {
+    if (expr.needsSemicolon()) {
+        addSemicolon()
+    }
+}
+
+private fun RsExpr.needsSemicolon(): Boolean =
+    this !is RsWhileExpr && this !is RsIfExpr && this !is RsForExpr && this !is RsLoopExpr && this !is RsMatchExpr

--- a/src/test/kotlin/org/rust/FileTree.kt
+++ b/src/test/kotlin/org/rust/FileTree.kt
@@ -367,4 +367,7 @@ sealed class Entry {
 
 fun replaceCaretMarker(text: String): String = text.replace("/*caret*/", "<caret>")
 fun hasCaretMarker(text: String): Boolean = text.contains("/*caret*/") || text.contains("<caret>")
+fun replaceSelectionMarker(text: String): String = text
+    .replace("/*selection*/", "<selection>")
+    .replace("/*selection**/", "</selection>")
 fun hasSelectionMarker(text: String): Boolean = text.contains("<selection>") && text.contains("</selection>")


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/6505554/229310712-e3143b92-febf-48eb-b348-bfbd0c60afa1.gif" width="700">

Here is an overview of supported control flow and how refactoring works with them:

| Extracted control-flow       | Extracted type | Resulted return type         | Resulted invocation                                     |
|------------------------------|----------------|------------------------------|---------------------------------------------------------|
| None                         | stmt           | `()`                         | `f();`                                                  |
| None                         | expr           | `T`                          | `let x = f();`                                          |
| return/break/continue   | stmt           | `bool`                       | `if f() return;`                                        |
| return/break/continue   | expr           | `Option<T>`                  | `let x = match f() { Some(v) => v, None => return };`   |
| return/break with value | stmt           | `Option<E>`                  | `if let Some(v) = f() { return v; }`                    |
| return/break with value | expr           | `Result<T, E>`               | `let x = match f() { Ok(v) => v, Err(v) => return v };` |
| ? operator              | stmt           | `Result<(), E>` / `Option<()>` | `f()?;`                                                 |
| ? operator              | expr           | `Result<T, E>` / `Option<T>`   | `let x = f()?;`                                         |

Current limitations:
* Mixed control flow is not supported (e.g. both `break` and `continue` inside extracted fragment)
* `?` operator is supported only for stdlib `Option` and `Result` types

changelog: Support extracting code containing control flow in `Extract function` (`Refactor | Extract Method` or <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd>)