### PR TITLE
T: Don't use `RsExtractTraitDialog` in tests

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitHandler.kt
@@ -52,12 +52,21 @@ class RsExtractTraitHandler : RefactoringActionHandler {
         if (members.isEmpty()) return
         val memberInfos = members.map { RsMemberInfo(it, false) }
 
-        val dialog = RsExtractTraitDialog(project, traitOrImpl, memberInfos)
         if (isUnitTestMode) {
-            dialog.doAction()
+            invokeInUnitTestMode(traitOrImpl)
         } else {
+            val dialog = RsExtractTraitDialog(project, traitOrImpl, memberInfos)
             dialog.show()
         }
+    }
+
+    private fun invokeInUnitTestMode(traitOrImpl: RsTraitOrImpl) {
+        val members = traitOrImpl.members
+            ?.childrenOfType<RsItemElement>()
+            .orEmpty()
+            .filter { it.getUserData(RS_EXTRACT_TRAIT_MEMBER_IS_SELECTED) != null }
+        val processor = RsExtractTraitProcessor(traitOrImpl, "Trait", members)
+        processor.run()
     }
 
     override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
@@ -76,6 +85,7 @@ class RsExtractTraitDialog(
     }
 
     init {
+        check(!isUnitTestMode)
         super.init()
         title = RsBundle.message("action.Rust.RsExtractTrait.dialog.title")
         validateButtons()
@@ -107,7 +117,7 @@ class RsExtractTraitDialog(
     override fun areButtonsValid(): Boolean =
         isValidRustVariableIdentifier(traitNameField.text) && memberInfos.any { it.isChecked }
 
-    public override fun doAction() {
+    override fun doAction() {
         try {
             CommandProcessor.getInstance().executeCommand(
                 project,
@@ -116,29 +126,16 @@ class RsExtractTraitDialog(
                 null
             )
         } catch (e: Exception) {
-            if (isUnitTestMode) throw e
             logger<RsExtractTraitHandler>().error(e)
             project.showRefactoringError(e.message)
         }
     }
 
     private fun doActionUndoCommand() {
-        val (traitName, members) = getTraitNameAndSelectedMembers()
+        val members = memberInfos.filter { it.isChecked }.map { it.member }
+        val traitName = traitNameField.text
         val processor = RsExtractTraitProcessor(traitOrImpl, traitName, members)
         invokeRefactoring(processor)
-    }
-
-    private fun getTraitNameAndSelectedMembers(): Pair<String, List<RsItemElement>> {
-        return if (isUnitTestMode) {
-            val members = traitOrImpl.members
-                ?.childrenOfType<RsItemElement>()
-                .orEmpty()
-                .filter { it.getUserData(RS_EXTRACT_TRAIT_MEMBER_IS_SELECTED) != null }
-            "Trait" to members
-        } else {
-            val members = memberInfos.filter { it.isChecked }.map { it.member }
-            traitNameField.text to members
-        }
     }
 }
 


### PR DESCRIPTION
Fixes possible flaky `RsExtractTraitBaseTest` test ([example](https://github.com/intellij-rust/intellij-rust/actions/runs/4617099684/jobs/8163087816?pr=10311))