### PR TITLE
ANN: analyze reserved keywords in macro definition/calls better

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -521,6 +521,17 @@ private fun checkWherePred(holder: AnnotationHolder, boundPred: RsWherePred) {
 
 private fun checkReservedKeyword(holder: AnnotationHolder, item: PsiElement) {
     if (item.elementTypeOrNull == RsElementTypes.IDENTIFIER && item.text in RESERVED_KEYWORDS) {
+        val macroRelatedParent = item.parentOfTypes(
+            RsMacroArgument::class,
+            RsMacroExpansionContents::class,
+            RsMacroPatternContents::class,
+            // Should be more precise, see `RsReservedKeywordAnnotatorTest.test annotate reserved keyword in attributes`
+            RsMetaItemArgs::class,
+            RsCompactTT::class
+        )
+        // it's not an error to use reserved keyword tokens as a part of macro call or macro definition
+        if (macroRelatedParent != null) return
+
         val parent = item.parent
         val fixes = mutableListOf<LocalQuickFix>()
 


### PR DESCRIPTION
Don't annotate reserved keywords in declarative macro definitions and function-like macro calls - in such cases they should be treated as common identifier. Also, don't annotate reserved keywords if they are inside attribute argument

changelog: Merge with #10322
