### PR TITLE
ANN: Add attribute errors support

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsAttrErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsAttrErrorAnnotator.kt
@@ -1,0 +1,189 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.psi.PsiElement
+import org.rust.ide.fixes.RemoveElementFix
+import org.rust.ide.fixes.SubstituteTextFix
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.addToHolder
+
+class RsAttrErrorAnnotator : AnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        when (element) {
+            is RsMetaItem -> {
+                checkMetaBadDelim(element, holder)
+                checkAttrTemplateCompatible(element, holder)
+                checkLiteralSuffix(element, holder)
+            }
+
+            is RsDocAndAttributeOwner -> checkRsDocAndAttributeOwner(element, holder)
+        }
+    }
+}
+
+private fun checkRsDocAndAttributeOwner(element: RsDocAndAttributeOwner, holder: AnnotationHolder) {
+    val attrs = element.queryAttributes.metaItems
+    val duplicates = attrs.filter { it.name in RS_BUILTIN_ATTRIBUTES }.groupBy { it.name }
+
+    fun getFix(item: RsMetaItem): RemoveElementFix {
+        val parent = item.parent
+        return if (parent is RsAttr) RemoveElementFix(parent) else RemoveElementFix(item)
+    }
+
+    for ((name, entries) in duplicates) {
+        if (name == null) continue
+        if (entries.size == 1) continue
+        val attrInfo = (RS_BUILTIN_ATTRIBUTES[name] as? BuiltinAttributeInfo) ?: continue
+        when (attrInfo.duplicates) {
+            AttributeDuplicates.DuplicatesOk -> continue
+
+            AttributeDuplicates.WarnFollowing -> {
+                RsDiagnostic.UnusedAttribute(entries.first(), getFix(entries.last())).addToHolder(holder)
+            }
+
+            AttributeDuplicates.WarnFollowingWordOnly -> {
+                val wordStyleArgs = entries.filter { it.templateType == AttributeTemplateType.Word }
+                if (wordStyleArgs.size == 1) continue
+                RsDiagnostic.UnusedAttribute(wordStyleArgs.first(), getFix(wordStyleArgs.last())).addToHolder(holder)
+            }
+
+            AttributeDuplicates.ErrorFollowing -> {
+                RsDiagnostic.MultipleAttributes(entries.first(), name, getFix(entries.last())).addToHolder(holder)
+            }
+
+            AttributeDuplicates.ErrorPreceding -> {
+                RsDiagnostic.MultipleAttributes(entries.last(), name, getFix(entries.first())).addToHolder(holder)
+            }
+
+            AttributeDuplicates.FutureWarnFollowing -> {
+                RsDiagnostic.UnusedAttribute(entries.first(), getFix(entries.last()), isFutureWarning = true)
+                    .addToHolder(holder)
+            }
+
+            AttributeDuplicates.FutureWarnPreceding -> {
+                RsDiagnostic.UnusedAttribute(entries.last(), getFix(entries.first()), isFutureWarning = true)
+                    .addToHolder(holder)
+            }
+        }
+
+    }
+}
+
+private fun checkLiteralSuffix(metaItem: RsMetaItem, holder: AnnotationHolder) {
+    val name = metaItem.name ?: return
+    if (name !in RS_BUILTIN_ATTRIBUTES) return
+    val exprList = metaItem.metaItemArgs?.litExprList ?: return
+    for (expr in exprList) {
+        val kind = expr.kind
+        if (kind is RsLiteralWithSuffix) {
+            val suffix = kind.suffix ?: continue
+            val editedText = expr.text.removeSuffix(suffix)
+            val fix = SubstituteTextFix.replace(
+                "Remove suffix", metaItem.containingFile, expr.textRange, editedText
+            )
+            RsDiagnostic.AttributeSuffixedLiteral(expr, fix).addToHolder(holder)
+        }
+    }
+}
+
+private fun checkAttrTemplateCompatible(metaItem: RsMetaItem, holder: AnnotationHolder) {
+    val name = metaItem.name ?: return
+    val attrInfo = (RS_BUILTIN_ATTRIBUTES[name] as? BuiltinAttributeInfo) ?: return
+    val template = attrInfo.template
+    var isError = false
+    when (metaItem.templateType) {
+        AttributeTemplateType.List -> {
+            if (template.list == null) {
+                isError = true
+            }
+        }
+
+        AttributeTemplateType.NameValueStr -> {
+            if (template.nameValueStr == null) {
+                isError = true
+            }
+        }
+
+        AttributeTemplateType.Word -> {
+            if (!template.word) {
+                isError = true
+            }
+        }
+    }
+    if (isError) {
+        emitMalformedAttribute(metaItem, name, template, holder)
+    }
+}
+
+private fun emitMalformedAttribute(
+    metaItem: RsMetaItem,
+    name: String,
+    template: AttributeTemplate,
+    holder: AnnotationHolder
+) {
+    val inner = if (metaItem.context is RsInnerAttr) "!" else ""
+    var first = true
+    val stringBuilder = StringBuilder()
+    if (template.word) {
+        first = false
+        stringBuilder.append("#${inner}[${name}]")
+    }
+    if (template.list != null) {
+        if (!first) stringBuilder.append(" or ")
+        first = false
+        stringBuilder.append("#${inner}[${name}(${template.list})]")
+    }
+    if (template.nameValueStr != null) {
+        if (!first) stringBuilder.append(" or ")
+        stringBuilder.append("#${inner}[${name} = ${template.nameValueStr}]")
+    }
+    val msg = if (first) "Must be of the form" else "The following are the possible correct uses"
+    RsDiagnostic.MalformedAttributeInput(metaItem, name, "$msg $stringBuilder").addToHolder(holder)
+}
+
+private fun setParen(text: String): String {
+    val leftIdx = text.indexOfLast { it == '[' || it == '{' }
+    val rightIdx = text.indexOfFirst { it == ']' || it == '}' }
+    val chars = text.toCharArray()
+    chars[leftIdx] = '('
+    chars[rightIdx] = ')'
+    return chars.concatToString()
+}
+
+private fun checkMetaBadDelim(element: RsMetaItem, holder: AnnotationHolder) {
+    // When the wrong delimiter is used, RsMetaItem is not fully parsed, and we can't easily retrieve an attribute name
+    // With the same reason we can't check the expression in cfg_attr(condition, expression)
+
+    // element.path is used when cfg_attr is supplied
+    val name = element.path ?: element.compactTT?.children?.firstOrNull {
+        it.elementType == IDENTIFIER
+    } ?: return
+    if (name.text !in RS_BUILTIN_ATTRIBUTES) return
+    val openDelim = element.compactTT?.children?.firstOrNull {
+        it.elementType == RsElementTypes.EQ ||
+            it.elementType == RsElementTypes.LBRACE ||
+            it.elementType == RsElementTypes.LBRACK
+    }
+        ?: return
+    if (openDelim.elementType == RsElementTypes.EQ) return
+    val closingDelim =
+        element.compactTT?.children?.lastOrNull { it.elementType == RsElementTypes.RBRACE || it.elementType == RsElementTypes.RBRACK }
+            ?: return
+    when (Pair(openDelim.elementType, closingDelim.elementType)) {
+        Pair(RsElementTypes.LBRACE, RsElementTypes.RBRACE), Pair(RsElementTypes.LBRACK, RsElementTypes.RBRACK) -> {
+            val fixedText = setParen(element.text)
+            val fix = SubstituteTextFix.replace(
+                "Replace brackets", element.containingFile, element.textRange, fixedText
+            )
+            RsDiagnostic.WrongMetaDelimiters(openDelim, closingDelim, fix).addToHolder(holder)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
@@ -89,3 +89,23 @@ abstract class RsMetaItemImplMixin : RsStubbedElementImpl<RsMetaItemStub>,
 
     override val value: String? get() = litExpr?.stringValue
 }
+
+/** AttributeTemplate type from builtin meta attributes **/
+enum class AttributeTemplateType {
+    Word,
+    List,
+    NameValueStr,
+}
+
+val RsMetaItem.templateType: AttributeTemplateType
+    get() {
+        return if (metaItemArgs?.litExprList?.isNotEmpty() == true ||
+            metaItemArgs?.metaItemList?.isNotEmpty() == true
+        ) {
+            AttributeTemplateType.List
+        } else if (eq != null) {
+            AttributeTemplateType.NameValueStr
+        } else {
+            AttributeTemplateType.Word
+        }
+    }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1798,6 +1798,73 @@ sealed class RsDiagnostic(
             "Only auto traits can be used as additional traits in a trait object"
         )
     }
+
+    class WrongMetaDelimiters(
+        beginElement: PsiElement,
+        endElement: PsiElement,
+        private val fix: LocalQuickFix
+    ) : RsDiagnostic(beginElement, endElement) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            null,
+            "Wrong meta list delimiters",
+            description = "The delimiters should be `(` and `)`",
+            fixes = listOfFixes(fix),
+        )
+    }
+
+    class MalformedAttributeInput(
+        element: PsiElement,
+        private val name: String,
+        private val suggestions: String
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            null,
+            "Malformed `${name}` attribute input",
+            description = suggestions,
+        )
+    }
+
+    class AttributeSuffixedLiteral(
+        element: PsiElement,
+        private val fix: LocalQuickFix
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            null,
+            "Suffixed literals are not allowed in attributes",
+            description = "Instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `\n" + "1.0`, etc.)",
+            fixes = listOfFixes(fix),
+        )
+    }
+
+    class UnusedAttribute(
+        element: PsiElement,
+        private val fix: LocalQuickFix,
+        private val isFutureWarning: Boolean = false
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            WARN,
+            null,
+            "Unused attribute",
+            description = if (isFutureWarning) "This was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!" else "",
+            fixes = listOfFixes(fix)
+        )
+    }
+
+    class MultipleAttributes(
+        element: PsiElement,
+        private val name: String,
+        private val fix: LocalQuickFix
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            null,
+            "Multiple '$name' attributes",
+            fixes = listOfFixes(fix),
+        )
+    }
 }
 
 enum class RsErrorCode {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -199,6 +199,7 @@
         <!-- Annotator -->
 
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsDoctestAnnotator"/>
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsAttrErrorAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsDocHighlightingAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsSyntaxErrorsAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsEdition2018KeywordsAnnotator"/>

--- a/src/test/kotlin/org/rust/ide/annotator/RsAttrErrorAnnotator.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAttrErrorAnnotator.kt
@@ -1,0 +1,142 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+class RsAttrErrorAnnotatorTest : RsAnnotatorTestBase(RsAttrErrorAnnotator::class) {
+
+    fun `test attributes wrong delimiter`() = checkByText("""
+        #![crate_type = foo!()]
+
+        #[allow <error descr="Wrong meta list delimiters">{ foo_lint }</error> ]
+        fn delim_brace() {}
+
+        #[allow <error descr="Wrong meta list delimiters">[ foo_lint ]</error> ]
+        fn delim_bracket() {}
+
+        #[cfg_attr(unix, allow { foo_lint })]
+        fn cfg() {}
+
+        #[cfg_attr(unix, cfg_attr(unix, foo{bar}))]
+        fn nested_cfg() {}
+    """)
+
+    fun `test any delimiter is allowed for custom attributes`() = checkByText("""
+        #[attr_macro_foo{foo_meta}]
+        fn delim_brace() {}
+
+        #[attr_macro_foo[foo_meta]]
+        fn delim_bracket() {}
+
+        #[cfg_attr(unix, attr_macro_foo{foo_meta})]
+        fn cfg() {}
+
+        #[cfg_attr(unix, cfg_attr(unix, attr_macro_foo{foo_meta}))]
+        fn nested_cfg() {}
+    """)
+
+    fun `test attributes template compatibility`() = checkByText("""
+        #![<error descr="Malformed `recursion_limit` attribute input">recursion_limit</error>]
+
+        #[<error descr="Malformed `rustc_lint_query_instability` attribute input">rustc_lint_query_instability(a)</error>]
+        fn f1() {}
+
+        #[<error descr="Malformed `link_name` attribute input">link_name</error>]
+        extern "C" {
+            fn bar() -> u32;
+        }
+
+        #[<error descr="Malformed `marker` attribute input">marker(always)</error>]
+        trait Marker1 {}
+
+        #[<error descr="Malformed `marker` attribute input">marker("never")</error>]
+        trait Marker2 {}
+
+        #[<error descr="Malformed `marker` attribute input">marker(key = "value")</error>]
+        trait Marker3 {}
+
+        trait Foo {}
+
+        #[<error descr="Malformed `rustc_on_unimplemented` attribute input">rustc_on_unimplemented</error>]
+        impl Foo for u32 {}
+
+        #[<error descr="Malformed `track_caller` attribute input">track_caller(1)</error>]
+        fn f() {}
+
+        #[<error descr="Malformed `rustc_must_implement_one_of` attribute input">rustc_must_implement_one_of</error>]
+        trait Tr3 {}
+    """)
+
+    fun `test literal with suffixes in attrs are not allowed`() = checkByText("""
+        #[<error descr="Multiple 'rustc_legacy_const_generics' attributes">rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1usize</error>)</error>]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1u8</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1u16</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1u32</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1u64</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1isize</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1i8</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1i16</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1i32</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1i64</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1.0f32</error>)]
+        #[rustc_legacy_const_generics(<error descr="Suffixed literals are not allowed in attributes">1.0f64</error>)]
+        fn bar<const X: usize>() {}
+    """)
+
+    fun `test literal with suffixes in attrs are allowed in attr macros`() = checkByText("""
+        #[attr_macro_foo(1usize)]
+        #[attr_macro_foo(1u8)]
+        #[attr_macro_foo(1u16)]
+        #[attr_macro_foo(1u32)]
+        #[attr_macro_foo(1u64)]
+        #[attr_macro_foo(1isize)]
+        #[attr_macro_foo(1i8)]
+        #[attr_macro_foo(1i16)]
+        #[attr_macro_foo(1i32)]
+        #[attr_macro_foo(1i64)]
+        #[attr_macro_foo(1.0f32)]
+        #[attr_macro_foo(1.0f64)]
+        fn bar<const X: usize>() {}
+    """)
+
+    fun `test duplicates`() = checkByText("""
+        #[<warning descr="Unused attribute">ignore</warning>]
+        #[ignore]
+        fn foo() {}
+
+
+        #[<warning descr="Unused attribute">macro_use</warning>]
+        #[macro_use(lazy_static)]
+        #[macro_use]
+        extern crate a;
+
+        #[<error descr="Multiple 'proc_macro' attributes">proc_macro</error>]
+        #[proc_macro]
+        pub fn make_answer(_item: TokenStream) -> TokenStream {
+            "fn answer() -> u32 { 42 }".parse().unwrap()
+        }
+
+        #[instruction_set(arm::a32)]
+        #[<error descr="Multiple 'instruction_set' attributes">instruction_set(arm::a32)</error>]
+        fn foo_arm_code() {}
+
+        #[<warning descr="Unused attribute">should_panic(expected = "values don't match")</warning>]
+        #[should_panic(expected = "values don't match")]
+        fn mytest() {
+            assert_eq!(1, 2, "values don't match");
+        }
+
+        extern {
+            #[link_name = "actual_symbol_name"]
+            #[<warning descr="Unused attribute">link_name = "actual_symbol_name"</warning>]
+            fn name_in_rust();
+        }
+
+
+        #[cfg_attr(unix, cfg_attr(unix, <warning descr="Unused attribute">macro_use</warning>))]
+        #[cfg_attr(unix, cfg_attr(unix, macro_use))]
+        fn nested_cfg() {}
+    """)
+}


### PR DESCRIPTION
This PR is based on #10146.

changelog:

- Check that the proper delimiter is applied when specifying an attribute

e.g. the following code is incorrect (`{}` used instead of `()`):
```rust
#[allow { foo_lint }]
fn delim_brace() {}
```
Compiler reference: https://github.com/rust-lang/rust/blob/c9ae38c71e2838f1ac282803ddde47f21f4ca76e/compiler/rustc_parse/src/validate_attr.rs#L87


- Check that attribute format is conforming with the respective template. 

e.g. `recursion_limit` attribute has the following template: 
```{"word":false,"list":null,"nameValueStr":"N"}```
which means the only way to specify this attribute is by providing an integer as a parameter, thus making the following code produce an error:
```rust
#![recursion_limit]
```
More on attribute templates: https://github.com/rust-lang/rust/blob/c9ae38c71e2838f1ac282803ddde47f21f4ca76e/compiler/rustc_feature/src/builtin_attrs.rs#L89
Compiler implementation reference: https://github.com/rust-lang/rust/blob/c9ae38c71e2838f1ac282803ddde47f21f4ca76e/compiler/rustc_parse/src/validate_attr.rs#L103

- Check that no literal suffixes are used when specifying an attribute

e.g. the following code is incorrect:
```rust
#[rustc_legacy_const_generics(1.0f64)]
fn bar<const X: usize>() {}
```
Compiler reference: https://github.com/rust-lang/rust/blob/c9ae38c71e2838f1ac282803ddde47f21f4ca76e/compiler/rustc_parse/src/validate_attr.rs#L52


- Check if an attribute is used multiple times on the same item. 

Every attribute has its own error-warning policy when used multiple times. Add a check that considers this.
e.g. the following code is incorrect:
```rust
#[proc_macro]
#[proc_macro]
pub fn make_answer(_item: TokenStream) -> TokenStream {
    "fn answer() -> u32 { 42 }".parse().unwrap()
}
```
While the next one produces a warning:
```rust
#[cfg_attr(unix, cfg_attr(unix, macro_use))]
#[cfg_attr(unix, cfg_attr(unix, macro_use))]
fn nested_cfg() {}
```
More on the error-warning policy: https://github.com/rust-lang/rust/blob/c9ae38c71e2838f1ac282803ddde47f21f4ca76e/compiler/rustc_feature/src/builtin_attrs.rs#L101
