### PR TITLE
ANN: Add support for E0045 | Fix checking use of variadic

### DIFF
--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -408,7 +408,7 @@ private val RsItemElement.declarationModifiers: List<String>
                 }
                 if (isActuallyExtern) {
                     modifiers += "extern"
-                    abiName?.let { modifiers += "\"$it\"" }
+                    literalAbiName?.let { modifiers += "\"$it\"" }
                 }
                 modifiers += "fn"
             }

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -92,7 +92,7 @@ open class RsPsiRenderer(
         }
         if (fn.isActuallyExtern) {
             sb.append("extern ")
-            val abiName = fn.abiName
+            val abiName = fn.literalAbiName
             if (abiName != null) {
                 sb.append("\"")
                 sb.append(abiName)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -70,11 +70,20 @@ val RsFunction.isVariadic: Boolean
         return stub?.isVariadic ?: (valueParameterList?.variadic != null)
     }
 
-val RsFunction.abiName: String?
+val RsFunction.literalAbiName: String?
     get() {
         val stub = greenStub
-        return stub?.abiName ?: abi?.litExpr?.stringValue
+        if (stub != null) {
+            return stub.abiName
+        }
+        return abi?.litExpr?.stringValue
     }
+
+val RsFunction.actualAbiName: String
+    get() = literalAbiName ?: abi?.let { "C" } ?: "Rust"
+
+val RsFunction.isCOrCdeclAbi
+    get() = actualAbiName == "C" || actualAbiName == "cdecl"
 
 /**
  * Those function parameters that are not disabled by cfg attributes.

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -950,7 +950,7 @@ class RsFunctionStub(
                 parentStub,
                 this,
                 name = psi.name,
-                abiName = psi.abiName,
+                abiName = psi.literalAbiName,
                 flags = flags,
                 procMacroInfo = procMacroInfo,
             )

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1865,10 +1865,20 @@ sealed class RsDiagnostic(
             fixes = listOfFixes(fix),
         )
     }
+
+    class VariadicParametersUsedOnNonCABIError(
+        element: PsiElement
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0045,
+            "C-variadic function must have a compatible calling convention, like `C` or `cdecl`"
+        )
+    }
 }
 
 enum class RsErrorCode {
-    E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
+    E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0045, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0130, E0131, E0132, E0133, E0183, E0184, E0185, E0186, E0191, E0197, E0198,
     E0199, E0200, E0201, E0203, E0206, E0220, E0224, E0225, E0226, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0316, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0384,

--- a/src/test/kotlin/org/rust/ide/annotator/RsFunctionSignatureSyntaxTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFunctionSignatureSyntaxTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+class RsFunctionSignatureSyntaxTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
+    fun `test E0045 error when use variadic parameter on non-C ABI`() = checkErrors("""
+        extern "Rust" {
+            /*error descr="C-variadic function must have a compatible calling convention, like `C` or `cdecl` [E0045]"*/fn foo(x: u8, ...);/*error**/
+        }
+    """)
+
+    fun `test E0045 no error when use variadic parameter on C ABI`() = checkErrors("""
+        extern "C" {
+            fn foo (x: u8, ...);
+        }
+    """)
+
+    fun `test E0045 no error when use variadic parameter on cdecl ABI`() = checkErrors("""
+        extern "cdecl" {
+            fn foo (x: u8, ...);
+        }
+    """)
+
+    fun `test E0045 no error when use variadic parameter on default ABI`() = checkErrors("""
+        extern {
+            fn foo (x: u8, ...);
+        }
+    """)
+
+    fun `test E0045 no error when use variadic parameter in extern function declaration`() = checkErrors("""
+        unsafe extern fn foo(x: u8, ...) -> bool {
+            x == 1
+        }
+    """)
+}


### PR DESCRIPTION
changelog:
- support for [E0045](https://doc.rust-lang.org/error_codes/E0045.html)
- fix: don't show error `function cannot be variadic` when use default ABI

