### PR TITLE
ANN: Fix showing error when assigning value to union field

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
@@ -80,6 +80,8 @@ class RsUnsafeExpressionAnnotator : AnnotatorBase() {
             }
         }
 
+        val exprParent = o.parent
+        if (exprParent is RsBinaryExpr && exprParent.operatorType == AssignmentOp.EQ && exprParent.left == o) return
         if (o.fieldLookup != null) {
             val type = o.expr.type
             if (type !is TyAdt) return

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionErrorAnnotatorTest.kt
@@ -162,6 +162,20 @@ class RsUnsafeExpressionErrorAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpress
     """
     )
 
+    fun `test no error only when use union field in assignment as left operand`() = checkErrors("""
+        union TTT {
+            v1: [u8; 2],
+            v2: u16,
+        }
+
+        fn test() {
+            let ttt = TTT { v2: 10 };
+            ttt.v1 = [1, 1];
+            let foo;
+            foo = /*error descr="Access to union field is unsafe and requires unsafe function or block [E0133]"*/ttt.v1/*error**/;
+        }
+    """)
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test need unsafe asm macro call`() = checkErrors("""
        use std::arch::asm; // required since 1.59


### PR DESCRIPTION
changelog: Fix showing error when assigning value to union field outside unsafe block.