### PR TITLE
Fix inspection & intention descriptions

### DIFF
--- a/src/main/resources/inspectionDescriptions/RsApproxConstant.html
+++ b/src/main/resources/inspectionDescriptions/RsApproxConstant.html
@@ -2,7 +2,7 @@
 <body>
 Reports hard coded numeric constants such as <code>std::f64::consts::PI</code>.
 
-Corresponds to <a href="https://github.com/Manishearth/rust-clippy/wiki#approx_constant">approx_constant</a> lint from
+Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#approx_constant">approx_constant</a> lint from
 Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsCStringPointer.html
+++ b/src/main/resources/inspectionDescriptions/RsCStringPointer.html
@@ -1,7 +1,8 @@
 <html>
 <body>
-Detects unsafe usage of `CString`.
+Detects unsafe usage of <code>CString</code>.
 
-The code like `CString::new("hello").unwrap().as_ptr()` may lead to memory unsafety because the string is deallocated at the end of the expression.
+The code like <code>CString::new("hello").unwrap().as_ptr()</code> may lead to memory unsafety
+because the string is deallocated at the end of the expression.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsDanglingElse.html
+++ b/src/main/resources/inspectionDescriptions/RsDanglingElse.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-Detects suspiciously looking <code>`else if`</code>-statements split by new lines.<br>
+Detects suspiciously looking <code>else if</code>-statements split by new lines.<br>
 Partially corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#suspicious_else_formatting">suspicious_else_formatting</a> lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsDanglingElse.html
+++ b/src/main/resources/inspectionDescriptions/RsDanglingElse.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 Detects suspiciously looking <code>`else if`</code>-statements split by new lines.<br>
-Partially corresponds to <a href="https://github.com/Manishearth/rust-clippy/wiki#suspicious_else_formatting">suspicious_else_formatting</a> lint from Rust Clippy.
+Partially corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#suspicious_else_formatting">suspicious_else_formatting</a> lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsDoubleNeg.html
+++ b/src/main/resources/inspectionDescriptions/RsDoubleNeg.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 Detects expressions of the form --x which might be mistook for pre-decrements.<br>
-Corresponds to <a href="https://github.com/Manishearth/rust-clippy/wiki#double_neg">double_neg</a> lint from Rust Clippy.
+Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#double_neg">double_neg</a> lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsDropRef.html
+++ b/src/main/resources/inspectionDescriptions/RsDropRef.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 Checks for calls to std::mem::drop with a reference instead of an owned value.<br>
-Corresponds to <a href="https://github.com/Manishearth/rust-clippy/wiki#drop_ref">drop_ref</a> lint from Rust Clippy.
+Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#drop_ref">drop_ref</a> lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsMissingElse.html
+++ b/src/main/resources/inspectionDescriptions/RsMissingElse.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 Detects suspiciously looking <code>if</code>-statements with potentially missing <code>else</code>s.<br>
-Partially corresponds to <a href="https://github.com/Manishearth/rust-clippy/wiki#suspicious_else_formatting">suspicious_else_formatting</a> lint from Rust Clippy.
+Partially corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#suspicious_else_formatting">suspicious_else_formatting</a> lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsNeedlessLifetimes.html
+++ b/src/main/resources/inspectionDescriptions/RsNeedlessLifetimes.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 Checks for lifetime annotations which can be removed by relying on lifetime elision.
-Corresponds to <a href="https://rust-lang-nursery.github.io/rust-clippy/stable/#needless_lifetimes">needless_lifetimes</a>
+Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#needless_lifetimes">needless_lifetimes</a>
 lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsNeedlessLifetimes.html
+++ b/src/main/resources/inspectionDescriptions/RsNeedlessLifetimes.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 Checks for lifetime annotations which can be removed by relying on lifetime elision.
-Corresponds to <a href="https://rust-lang-nursery.github.io/rust-clippy/master/index.html#needless_lifetimes">needless_lifetimes</a>
+Corresponds to <a href="https://rust-lang-nursery.github.io/rust-clippy/stable/#needless_lifetimes">needless_lifetimes</a>
 lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsRedundantElse.html
+++ b/src/main/resources/inspectionDescriptions/RsRedundantElse.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Detects <code>`else`</code>-statements preceded by irrefutable patterns.
+Detects <code>else</code>-statements preceded by irrefutable patterns.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsSelfConvention.html
+++ b/src/main/resources/inspectionDescriptions/RsSelfConvention.html
@@ -2,7 +2,7 @@
 <body>
 Checks some naming conventions for methods.
 
-Corresponds to <a href="https://github.com/Manishearth/rust-clippy/wiki#wrong_self_convention">wrong_self_convention</a>
+Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#wrong_self_convention">wrong_self_convention</a>
 lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsSuspiciousAssignment.html
+++ b/src/main/resources/inspectionDescriptions/RsSuspiciousAssignment.html
@@ -1,8 +1,8 @@
 <html>
 <body>
 Detects use of the non-existent <code>=*</code>, <code>=!</code> and <code>=-</code>
-    operators that are probably typos.<br>
-Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#suspicious_assignment_formatting">
-    suspicious_assignment_formatting</a> lint from Rust Clippy.
+operators that are probably typos.<br>
+Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#suspicious_assignment_formatting">suspicious_assignment_formatting</a>
+lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsSuspiciousAssignment.html
+++ b/src/main/resources/inspectionDescriptions/RsSuspiciousAssignment.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 Detects use of the non-existent <code>=*</code>, <code>=!</code> and <code>=-</code> operators that are probably typos.<br>
-Corresponds to <a href="https://github.com/Manishearth/rust-clippy/wiki#suspicious_assignment_formatting">suspicious_assignment_formatting</a> lint from Rust Clippy.
+Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#suspicious_assignment_formatting">suspicious_assignment_formatting</a> lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RsSuspiciousAssignment.html
+++ b/src/main/resources/inspectionDescriptions/RsSuspiciousAssignment.html
@@ -1,6 +1,8 @@
 <html>
 <body>
-Detects use of the non-existent <code>=*</code>, <code>=!</code> and <code>=-</code> operators that are probably typos.<br>
-Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#suspicious_assignment_formatting">suspicious_assignment_formatting</a> lint from Rust Clippy.
+Detects use of the non-existent <code>=*</code>, <code>=!</code> and <code>=-</code>
+    operators that are probably typos.<br>
+Corresponds to <a href="https://rust-lang.github.io/rust-clippy/stable/#suspicious_assignment_formatting">
+    suspicious_assignment_formatting</a> lint from Rust Clippy.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/AddStructFieldsLiteralIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddStructFieldsLiteralIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-This intention expands actual struct fields instead of `..` in struct literals.
+This intention expands actual struct fields instead of <code>..</code> in struct literals.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/AddStructFieldsLiteralRecursiveIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddStructFieldsLiteralRecursiveIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-This intention expands actual struct fields instead of `..` in struct literals recursively.
+This intention expands actual struct fields instead of <code>..</code> in struct literals recursively.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/AddStructFieldsPatIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddStructFieldsPatIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-This intention expands actual struct fields instead of `..`.
+This intention expands actual struct fields instead of <code>..</code> in struct patterns.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/AddWildcardArmIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddWildcardArmIntention/description.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-Adds <code>`_`</code> pattern in <code>match</code> expression if the expression is not exhaustive,
+Adds <code>_</code> pattern in <code>match</code> expression if the expression is not exhaustive,
 i.e. not all possible patterns are covered.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/AddWildcardArmIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddWildcardArmIntention/description.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-Adds `_` pattern in <code>match</code> expression if the expression is not exhaustive,
+Adds <code>`_`</code> pattern in <code>match</code> expression if the expression is not exhaustive,
 i.e. not all possible patterns are covered.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/MoveTypeConstraintToParameterListIntention/description.html
+++ b/src/main/resources/intentionDescriptions/MoveTypeConstraintToParameterListIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-This intention moves type parameter bounds from the where clause to parameter list.
+This intention moves type parameter bounds from the <code>where</code> clause to parameter list.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/MoveTypeConstraintToWhereClauseIntention/description.html
+++ b/src/main/resources/intentionDescriptions/MoveTypeConstraintToWhereClauseIntention/description.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 This intention moves the type constraints (lifetime and traits) of a
-function to a where clause.
+function to a <code>where</code> clause.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/NestUseStatementsIntention/description.html
+++ b/src/main/resources/intentionDescriptions/NestUseStatementsIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-This intention nests use statements.
+This intention nests <code>use</code> statements.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/RemoveCurlyBracesIntention/description.html
+++ b/src/main/resources/intentionDescriptions/RemoveCurlyBracesIntention/description.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-This intention removes unnecessary curly braces from a use statement that
+This intention removes unnecessary curly braces from a <code>use</code> statement that
 imports only one item.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/ShareInPlaygroundIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ShareInPlaygroundIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Shares code in Rust Playground (https://play.rust-lang.org/).
+Shares code in <a href="https://play.rust-lang.org/">Rust Playground</a>.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/SplitIfIntention/description.html
+++ b/src/main/resources/intentionDescriptions/SplitIfIntention/description.html
@@ -1,5 +1,6 @@
 <html>
 <body>
-This intention converts if statement containing conjunction operation into two nested if statements with simplified conditions.
+This intention converts <code>if</code> statement containing conjunction operation into
+two nested <code>if</code> statements with simplified conditions.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/ToggleFeatureIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ToggleFeatureIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Toggles Cargo feature state from a cfg attribute.
+Toggles Cargo feature state from a <code>#[cfg(..)]</code> attribute.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/UnwrapToMatchIntention/description.html
+++ b/src/main/resources/intentionDescriptions/UnwrapToMatchIntention/description.html
@@ -1,5 +1,6 @@
 <html>
 <body>
-Replaces an <tt>.unwrap()</tt> call with a <b>match</b> expression if the call receiver has either <tt>Option</tt> or <tt>Result</tt> type.
+Replaces an <code>.unwrap()</code> call with a <code>match</code> expression if the call
+receiver has either <code>Option</code> or <code>Result</code> type.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/UnwrapToMatchIntention/description.html
+++ b/src/main/resources/intentionDescriptions/UnwrapToMatchIntention/description.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-Replaces an <code>.unwrap()</code> call with a <code>match</code> expression if the call
+Replaces an <code>unwrap()</code> call with a <code>match</code> expression if the call
 receiver has either <code>Option</code> or <code>Result</code> type.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/UnwrapToTryIntention/description.html
+++ b/src/main/resources/intentionDescriptions/UnwrapToTryIntention/description.html
@@ -1,5 +1,6 @@
 <html>
 <body>
-This intention transforms an expression with unwrap to a try operator.
+This intention transforms an expression with <code>.unwrap()</code> to a
+<code>try</code> (<code>?</code>) operator.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/UnwrapToTryIntention/description.html
+++ b/src/main/resources/intentionDescriptions/UnwrapToTryIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-This intention transforms an expression with <code>.unwrap()</code> to the <code>?</code> operator.
+This intention transforms an expression with <code>unwrap()</code> to the <code>?</code> operator.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/UnwrapToTryIntention/description.html
+++ b/src/main/resources/intentionDescriptions/UnwrapToTryIntention/description.html
@@ -1,6 +1,5 @@
 <html>
 <body>
-This intention transforms an expression with <code>.unwrap()</code> to a
-<code>try</code> (<code>?</code>) operator.
+This intention transforms an expression with <code>.unwrap()</code> to the <code>?</code> operator.
 </body>
 </html>


### PR DESCRIPTION
* Fix links to Clippy list of lints.
* Fix formatting of some code elements in the intention descriptions.
* Fix hyperlink to Playground in intention description.

Closes #9370

changelog: Fix formatting and links in descriptions of some intentions and inspections
