### PR TITLE
T: run tests with JUnit4

### DIFF
--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -24,6 +24,7 @@ import com.intellij.util.ThrowableRunnable
 import com.intellij.util.text.SemVer
 import junit.framework.AssertionFailedError
 import org.intellij.lang.annotations.Language
+import org.junit.runner.RunWith
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.impl.DEFAULT_EDITION_FOR_TESTS
@@ -45,6 +46,7 @@ import org.rust.stdext.RsResult
 import kotlin.reflect.KMutableProperty0
 import kotlin.reflect.full.createInstance
 
+@RunWith(RsJUnit4TestRunner::class)
 abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
 
     // Needed for assertion that the directory doesn't accidentally renamed during the test

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -17,6 +17,7 @@ import com.intellij.testFramework.common.runAll
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
 import com.intellij.util.ThrowableRunnable
 import com.intellij.util.ui.UIUtil
+import org.junit.runner.RunWith
 import org.rust.*
 import org.rust.cargo.project.model.impl.testCargoProjects
 import org.rust.cargo.toolchain.tools.rustc
@@ -31,6 +32,7 @@ import org.rust.stdext.RsResult
  * Unlike [org.rust.RsTestBase] it does not use in-memory temporary VFS
  * and instead copies real files.
  */
+@RunWith(RsJUnit4TestRunner::class)
 abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtureBuilder<*>>() {
 
     protected lateinit var rustupFixture: RustupTestFixture

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterTestBase.kt
@@ -9,11 +9,14 @@ import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.psi.formatter.FormatterTestCase
 import com.intellij.util.ThrowableRunnable
 import org.intellij.lang.annotations.Language
+import org.junit.runner.RunWith
 import org.rust.IgnoreInPlatform
+import org.rust.RsJUnit4TestRunner
 import org.rust.TestCase
 import org.rust.findAnnotationInstance
 import kotlin.reflect.KMutableProperty0
 
+@RunWith(RsJUnit4TestRunner::class)
 abstract class RsFormatterTestBase : FormatterTestCase() {
     override fun getTestDataPath() = "src/test/resources"
 

--- a/src/test/kotlin/org/rust/lang/core/lexer/LexerTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/lexer/LexerTestCaseBase.kt
@@ -12,11 +12,14 @@ import com.intellij.openapi.vfs.CharsetToolkit
 import com.intellij.testFramework.LexerTestCase
 import com.intellij.testFramework.UsefulTestCase
 import org.jetbrains.annotations.NonNls
+import org.junit.runner.RunWith
+import org.rust.RsJUnit4TestRunner
 import org.rust.TestCase
 import org.rust.pathToGoldTestFile
 import org.rust.pathToSourceTestFile
 import java.io.IOException
 
+@RunWith(RsJUnit4TestRunner::class)
 abstract class LexerTestCaseBase : LexerTestCase(), TestCase {
     override fun getDirPath(): String = throw UnsupportedOperationException()
 

--- a/src/test/kotlin/org/rust/lang/core/parser/RsParsingTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/parser/RsParsingTestCaseBase.kt
@@ -14,11 +14,14 @@ import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
 import com.intellij.testFramework.ParsingTestCase
 import org.jetbrains.annotations.NonNls
+import org.junit.runner.RunWith
+import org.rust.RsJUnit4TestRunner
 import org.rust.RsTestCase
 import org.rust.TestCase
 import org.rust.ide.typing.RsBraceMatcher
 import org.rust.lang.RsLanguage
 
+@RunWith(RsJUnit4TestRunner::class)
 abstract class RsParsingTestCaseBase(@NonNls dataPath: String) : ParsingTestCase(
     "org/rust/lang/core/parser/fixtures/$dataPath",
     "rs",


### PR DESCRIPTION
Since #10277 we run *some* tests (descendants of `RsIntentionTestBase` class) using JUnit4, but we still run most of the tests using JUnit3. I'd want to put all tests in line in order to avoid possible differences in the framework behavior and also to benefit from JUnit4 features like the `@Ignore` annotation.

JUnit4 basically implies using `@Test` annotations to mark a test function, but I managed to avoid it by using a custom test runner (I don't want to bring `> 10000` changes in `> 600` files right now).

If everything goes well, this PR won't affect anything (since you can write and run tests as usual).

changelog: migrate tests to JUnit4