### PR TITLE
COMP: fix `.await` completion for async fn returned type

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1643,13 +1643,13 @@ private fun KnownItems.makeGenerator(yieldTy: Ty, returnTy: Ty): Ty {
     val boundGenerator = generatorTrait
         .substAssocType("Yield", yieldTy)
         .substAssocType("Return", returnTy)
-    return TyAnon(null, listOf(boundGenerator))
+    return TyAnon(null, listOfNotNull(boundGenerator, Sized?.withSubst()))
 }
 
 private fun KnownItems.makeFuture(outputTy: Ty): Ty {
     val futureTrait = Future ?: return TyUnknown
     val boundFuture = futureTrait.substAssocType("Output", outputTy)
-    return TyAnon(null, listOf(boundFuture))
+    return TyAnon(null, listOfNotNull(boundFuture, Sized?.withSubst()))
 }
 
 fun isBuiltinIndex(baseType: Ty, indexType: Ty) =

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
@@ -6,6 +6,8 @@
 package org.rust.lang.core.completion
 
 import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsAwaitCompletionTest : RsCompletionTestBase() {
@@ -87,6 +89,19 @@ class RsAwaitCompletionTest : RsCompletionTestBase() {
         struct S;
         impl IntoFuture for S { type Output = i32; }
         fn foo() -> S { unimplemented!() }
+        fn main() {
+            foo().await/*caret*/;
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test async fn with stdlib`() = doSingleCompletion("""
+        async fn foo() { unimplemented!() }
+        fn main() {
+            foo().aw/*caret*/;
+        }
+    """, """
+        async fn foo() { unimplemented!() }
         fn main() {
             foo().await/*caret*/;
         }


### PR DESCRIPTION
Fixes #10407

The bug was triggered by #9315

changelog: Can be omitted since the bug was triggered in the same release
