### PR TITLE
GRAM&MACRO: Parse and expand macros in attributes: `#[doc = foo!()]`

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -162,9 +162,11 @@ fake MetaItem ::= Path [ '=' LitExpr | MetaItemArgs ] | CompactTT {
 //   ~~~~~~~~~~~~~
 // #![crate_type = "lib"]
 //    ~~~~~~~~~~~~~~~~~~
+// #[doc = concat!("foo", "bar")]
+//   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // #[some::path]
 //   ~~~~~~~~~~
-MetaItemWithoutTT ::= PathWithoutTypeArgs [ '=' LitExprWithoutAttrs | MetaItemArgs ] { elementType = MetaItem }
+MetaItemWithoutTT ::= PathWithoutTypeArgs [ '=' (LitExprWithoutAttrs | MacroCallInMetaItem) | MetaItemArgs ] { elementType = MetaItem }
 
 // #[assert_instr(add_a.b)]
 //                ~~~~~~~
@@ -1537,6 +1539,12 @@ BlockElementMacroCall ::= <<parseMacroCall 'MacroCallParsingMode.BLOCK'>> {
 
 // Parses macro calls in expr/pat/type context, which do not require a semicolon
 ExprLikeMacroCall ::= <<parseMacroCall 'MacroCallParsingMode.EXPR'>> {
+  elementType = MacroCall
+  name = "macro call"
+}
+
+// Parses macro calls in meta item context, which do not require a semicolon
+MacroCallInMetaItem ::= <<parseMacroCall 'MacroCallParsingMode.META'>> {
   elementType = MacroCall
   name = "macro call"
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -18,7 +18,7 @@ import org.rust.stdext.RsResult.Ok
 import org.rust.stdext.unwrapOrElse
 
 enum class MacroExpansionContext {
-    EXPR, PAT, TYPE, STMT, ITEM
+    EXPR, PAT, TYPE, STMT, META_ITEM_VALUE, ITEM
 }
 
 val RsMacroCall.expansionContext: MacroExpansionContext
@@ -27,6 +27,7 @@ val RsMacroCall.expansionContext: MacroExpansionContext
         is RsBlock -> MacroExpansionContext.STMT
         is RsPatMacro -> MacroExpansionContext.PAT
         is RsMacroType -> MacroExpansionContext.TYPE
+        is RsMetaItem -> MacroExpansionContext.META_ITEM_VALUE
         else -> MacroExpansionContext.ITEM
     }
 
@@ -62,6 +63,11 @@ sealed class MacroExpansion(val file: RsFile) {
             get() = listOf(type)
     }
 
+    class MetaItemValue(file: RsFile, val value: RsExpandedElement) : MacroExpansion(file) {
+        override val elements: List<RsExpandedElement>
+            get() = listOf(value)
+    }
+
     /** Can contains items, macros and macro calls */
     class Items(file: RsFile, override val elements: List<RsExpandedElement>) : MacroExpansion(file)
 
@@ -87,6 +93,7 @@ fun MacroExpansionContext.prepareExpandedTextForParsing(
     MacroExpansionContext.PAT -> "fn f($expandedText:())"
     MacroExpansionContext.TYPE -> "type T=$expandedText;"
     MacroExpansionContext.STMT -> "fn f(){$expandedText}"
+    MacroExpansionContext.META_ITEM_VALUE -> "#[a=$expandedText]fn f(){}"
     MacroExpansionContext.ITEM -> expandedText
 }
 
@@ -96,6 +103,7 @@ val MacroExpansionContext.expansionFileStartOffset: Int
         MacroExpansionContext.PAT -> 5
         MacroExpansionContext.TYPE -> 7
         MacroExpansionContext.STMT -> 7
+        MacroExpansionContext.META_ITEM_VALUE -> 4
         MacroExpansionContext.ITEM -> 0
     }
 
@@ -118,6 +126,12 @@ fun getExpansionFromExpandedFile(context: MacroExpansionContext, expandedFile: R
             val block = expandedFile.stubDescendantOfTypeOrStrict<RsBlock>() ?: return null
             val itemsAndStatements = block.stubChildrenOfType<RsExpandedElement>()
             MacroExpansion.Stmts(expandedFile, itemsAndStatements)
+        }
+        MacroExpansionContext.META_ITEM_VALUE -> {
+            val attr = expandedFile.stubDescendantOfTypeOrStrict<RsAttr>() ?: return null
+            val metaItem = attr.metaItem
+            val value = metaItem.litExpr ?: metaItem.childOfType<RsMacroCall>() ?: return null
+            MacroExpansion.MetaItemValue(expandedFile, value)
         }
         MacroExpansionContext.ITEM -> {
             val items = expandedFile.stubChildrenOfType<RsExpandedElement>()

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -111,6 +111,6 @@ class RustParserDefinition : ParserDefinition {
         /**
          * Should be increased after any change of parser rules
          */
-        const val PARSER_VERSION: Int = LEXER_VERSION + 47
+        const val PARSER_VERSION: Int = LEXER_VERSION + 48
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -20,8 +20,11 @@ import com.intellij.util.containers.Stack
 import org.rust.lang.core.parser.RustParserDefinition.Companion.EOL_COMMENT
 import org.rust.lang.core.parser.RustParserDefinition.Companion.OUTER_BLOCK_DOC_COMMENT
 import org.rust.lang.core.parser.RustParserDefinition.Companion.OUTER_EOL_DOC_COMMENT
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.MacroBraces
+import org.rust.lang.core.psi.RS_BLOCK_LIKE_EXPRESSIONS
+import org.rust.lang.core.psi.RS_KEYWORDS
 import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.lang.core.psi.tokenSetOf
 import org.rust.stdext.makeBitMask
 import kotlin.math.max
 
@@ -77,12 +80,15 @@ object RustParserUtil : GeneratedParserUtilBase() {
         val attrsAndVis: Boolean,
         val semicolon: Boolean,
         val pin: Boolean,
-        val forbidExprSpecialMacros: Boolean
+        val specialMacros: SpecialMacroParsingMode
     ) {
-        ITEM(attrsAndVis = false, semicolon = true, pin = true, forbidExprSpecialMacros = false),
-        BLOCK(attrsAndVis = true, semicolon = true, pin = false, forbidExprSpecialMacros = true),
-        EXPR(attrsAndVis = true, semicolon = false, pin = true, forbidExprSpecialMacros = false)
+        ITEM(attrsAndVis = false, semicolon = true, pin = true, specialMacros = SpecialMacroParsingMode.PARSE_AS_SPECIAL),
+        BLOCK(attrsAndVis = true, semicolon = true, pin = false, specialMacros = SpecialMacroParsingMode.FORBID),
+        EXPR(attrsAndVis = true, semicolon = false, pin = true, specialMacros = SpecialMacroParsingMode.PARSE_AS_SPECIAL),
+        META(attrsAndVis = false, semicolon = false, pin = false, specialMacros = SpecialMacroParsingMode.PARSE_AS_USUAL),
     }
+
+    enum class SpecialMacroParsingMode { FORBID, PARSE_AS_SPECIAL, PARSE_AS_USUAL }
 
     private val FLAGS: Key<Int> = Key("RustParserUtil.FLAGS")
     private var PsiBuilder.flags: Int
@@ -571,7 +577,7 @@ object RustParserUtil : GeneratedParserUtilBase() {
         }
 
         val macroName = getMacroName(b, -2)
-        if (mode.forbidExprSpecialMacros && macroName in SPECIAL_EXPR_MACROS) return false
+        if (mode.specialMacros == SpecialMacroParsingMode.FORBID && macroName in SPECIAL_EXPR_MACROS) return false
 
         // foo! bar {}
         //      ^ this ident
@@ -579,7 +585,10 @@ object RustParserUtil : GeneratedParserUtilBase() {
 
         val braceKind = b.tokenType?.let { MacroBraces.fromToken(it) }
 
-        if (macroName != null && !hasIdent && braceKind != null) { // try special macro
+        val trySpecialMacro = mode.specialMacros == SpecialMacroParsingMode.PARSE_AS_SPECIAL
+            && macroName != null
+            && !hasIdent
+        if (trySpecialMacro && braceKind != null) {
             val specialParser = SPECIAL_MACRO_PARSERS[macroName]
             if (specialParser != null && specialParser(b, level + 1)) {
                 if (braceKind.needsSemicolon && mode.semicolon && !consumeToken(b, SEMICOLON)) {

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
@@ -195,6 +195,19 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
          fn bar() {}
     """)
 
+    fun `test meta with a macro call`() = doTest("""
+        macro_rules! foo {
+            ($ i:meta) => (
+                #[$ i]
+                fn bar() {}
+            )
+        }
+        foo! { doc = concat!("foo", "bar") }
+    """, """
+        #[doc = concat!("foo", "bar")]
+         fn bar() {}
+    """)
+
     fun `test tt block`() = doTest("""
         macro_rules! foo {
             ($ i:tt) => { fn foo() $ i }
@@ -1308,6 +1321,18 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo () { let _ = stringify!(unsized); }
     """, """
         fn foo () { let _ = stringify!(virtual); }
+    """)
+
+    fun `test macro call in an attribute`() = checkSingleMacro("""
+        macro_rules! foo {
+            () => {"bar"}
+        }
+
+        #[doc = foo!()]
+              //^
+        fn foo() {}
+    """, """
+        "bar"
     """)
 
     companion object {


### PR DESCRIPTION
Fixes expansion of `foo!()` in such caese:
```rust
macro_rules! foo {
    ($ i:meta) => (
        #[$ i]
        fn bar() {}
    )
}
foo! { doc = concat!("foo", "bar") }
```

Also now the plugin can expand `foo` in a meta item value context:
```rust
macro_rules! foo {
    () => {"bar"}
}

#[doc = foo!()]
      //^
fn foo() {}
```

Also fixes name resolution in `axum` crate

```toml
[dependencies]
axum = "0.6.17"
```

```rust
use axum::routing::{post};
                             //^ can be resolved now
```