### PR TITLE
(INT): Fix `Add unsafe to function` quickfix false positives

### DIFF
--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -26,6 +26,7 @@ import org.rust.lang.core.parser.createRustPsiBuilder
 import org.rust.lang.core.parser.probe
 import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.doc.docElements
 import org.rust.lang.doc.psi.RsDocCodeFence
@@ -370,3 +371,9 @@ val RsElement.isDoctestInjection: Boolean
 
 val RsElement.isInsideInjection: Boolean
     get() = (contextualFile as? RsFile)?.virtualFile is VirtualFileWindow
+
+/**
+ * Checks if this is the synthetic main function generated for doctests.
+ */
+val RsFunction.isDoctestInjectedMain: Boolean
+    get() = name ==  RsDoctestLanguageInjector.INJECTED_MAIN_NAME && isDoctestInjection && parent is RsFile

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFixTest.kt
@@ -395,4 +395,37 @@ class AddUnsafeFixTest : RsAnnotationTestBase() {
 
         unsafe impl Trait/*caret*/ for () {}
     """)
+
+    fun `test no add unsafe to function fix if test`() = checkFixIsUnavailable("Add unsafe to function", """
+        unsafe fn foo() {}
+
+        #[test]
+        fn some_test() {
+            <error>foo()<caret></error>;
+        }
+    """)
+
+    fun `test no add unsafe to function fix if doctest`() = checkFixIsUnavailable("Add unsafe to function", """
+        /// ```
+        /// unsafe fn foo() {}
+        /// foo()<caret>;
+        /// ```
+        fn bar() {}
+    """)
+
+    fun `test no add unsafe to function fix if implementing safe function`() = checkFixIsUnavailable("Add unsafe to function", """
+        unsafe fn unsafe_foo() {}
+
+        trait Foo {
+            fn foo();
+        }
+
+        struct Bar;
+
+        impl Foo for Bar {
+            fn foo() {
+                <error>unsafe_foo()<caret></error>;
+            }
+        }
+    """)
 }


### PR DESCRIPTION
changelog:
 - The `add unsafe to function` quickfix is no longer raised when an unsafe call is made inside a test function, doctest main function, or in a implemented function where the parent trait function is not marked as unsafe. Suggests `Surround with unsafe block` instead.
 - Fixes #10312
 - Fixes #10183