### PR TITLE
Revert "INSP: Add support for multiple spans in external linter check inspection"

### DIFF
--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
@@ -90,7 +90,7 @@ class ApplySuggestionFixTest : RsWithToolchainTestBase() {
     fun `test multi-primary fix suggestion`() = checkFixIsUnavailable("""
         #[deny(clippy::let_and_return)]
         fn _foo() -> i32 {
-            <error>let x = 42;</error>
+            let x = 42;
             <error>x</error>
         }
     """, externalLinter = ExternalLinter.CLIPPY)
@@ -102,44 +102,13 @@ class ApplySuggestionFixTest : RsWithToolchainTestBase() {
         type _SendVec<T: Send> = Vec<T>;
     """, "Suppress `type_alias_bounds` for type _SendVec")
 
-    fun `test multi-span fix`() = checkFixByText("""
-        pub mod bar {
-            pub mod foo {
-                pub fn fst() {}
-                pub fn snd() {}
-            }
-            pub mod foo2 {
-                pub fn fst2() {}
-                pub fn snd2() {}
-            }
-        }
-
-        use bar::{
-            foo::{<weak_warning>fst</weak_warning>, <weak_warning>snd</weak_warning>},
-            foo2::{<weak_warning>fst2</weak_warning>, <weak_warning>snd2</weak_warning>},
-        };
-    """, """
-        pub mod bar {
-            pub mod foo {
-                pub fn fst() {}
-                pub fn snd() {}
-            }
-            pub mod foo2 {
-                pub fn fst2() {}
-                pub fn snd2() {}
-            }
-        }
-
-
-    """, "External Linter: remove the whole `use` item")
-
     private fun checkFixByText(
         @Language("Rust") before: String,
         @Language("Rust") after: String,
         fixName: String? = null,
         externalLinter: ExternalLinter = ExternalLinter.DEFAULT
     ) {
-        val action = getQuickFixes(before, fixName, externalLinter).distinct().singleOrNull() ?: return // BACKCOMPAT: Rust ???
+        val action = getQuickFixes(before, fixName, externalLinter).singleOrNull() ?: return // BACKCOMPAT: Rust ???
         myFixture.launchAction(action)
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }

--- a/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
@@ -31,7 +31,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
     fun `test highlights type errors`() = doTest("""
         struct X; struct Y;
         fn main() {
-            let _: <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">X</error> = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">Y</error>;
+            let _: X = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">Y</error>;
         }
     """)
 
@@ -39,9 +39,9 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
     fun `test highlights errors from macro`() = doTest("""
         fn main() {
             let mut x = 42;
-            let r = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">&mut x</error>;
-            dbg!(x);
-            dbg!(<error descr="${RsExternalLinterUtils.TEST_MESSAGE}">r</error>);
+            let r = &mut x;
+            <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">dbg!(x)</error>;
+            dbg!(r);
         }
     """)
 
@@ -50,7 +50,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
 
         #[test]
         fn test() {
-            let x: <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">i32</error> = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">0.0</error>;
+            let x: i32 = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">0.0</error>;
         }
     """)
 
@@ -65,7 +65,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
 
         #[cfg(feature = "enabled_feature")]
         fn foo() {
-            let x: <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">i32</error> = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">0.0</error>;
+            let x: i32 = <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">0.0</error>;
         }
 
         #[cfg(feature = "disabled_feature")]
@@ -260,7 +260,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
         }.create()
         myFixture.openFileInEditor(cargoProjectDirectory.findFileByRelativePath("src/main.rs")!!)
         val highlight = myFixture.doHighlighting(HighlightSeverity.WEAK_WARNING)
-            .first { it.description == RsExternalLinterUtils.TEST_MESSAGE }
+            .single { it.description == RsExternalLinterUtils.TEST_MESSAGE }
         assertEquals(tooltip.trimIndent().replace("\n", "<br>"), highlight.toolTip)
     }
 }


### PR DESCRIPTION
Reverts #7509,
Fixes #10429
Fixes #10401
