### PR TITLE
MIR: Annotate E0381

### DIFF
--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -40,6 +40,8 @@ object RsExperiments {
     const val SSR = "org.rust.ssr"
 
     const val SOURCE_BASED_COVERAGE = "org.rust.coverage.source"
+
+    const val MIR_BORROW_CHECK = "org.rust.mir.borrow-check"
 }
 
 /**

--- a/src/main/kotlin/org/rust/lang/core/mir/borrowck/FacadeBorrowck.kt
+++ b/src/main/kotlin/org/rust/lang/core/mir/borrowck/FacadeBorrowck.kt
@@ -5,15 +5,15 @@
 
 package org.rust.lang.core.mir.borrowck
 
-import org.rust.lang.core.dfa.borrowck.BorrowCheckResult
 import org.rust.lang.core.mir.dataflow.framework.BorrowCheckResults
 import org.rust.lang.core.mir.dataflow.framework.getBasicBlocksInPostOrder
 import org.rust.lang.core.mir.dataflow.framework.visitResults
 import org.rust.lang.core.mir.dataflow.impls.MaybeUninitializedPlaces
 import org.rust.lang.core.mir.dataflow.move.MoveData
 import org.rust.lang.core.mir.schemas.MirBody
+import org.rust.lang.core.psi.ext.RsElement
 
-fun doMirBorrowCheck(body: MirBody): BorrowCheckResult {
+fun doMirBorrowCheck(body: MirBody): MirBorrowCheckResult {
     val moveData = MoveData.gatherMoves(body)
     val uninitializedPlaces = MaybeUninitializedPlaces(moveData)
         .intoEngine(body)
@@ -24,3 +24,7 @@ fun doMirBorrowCheck(body: MirBody): BorrowCheckResult {
     visitResults(results, body.getBasicBlocksInPostOrder(), visitor)
     return visitor.result
 }
+
+data class MirBorrowCheckResult(
+    val usesOfUninitializedVariable: List<RsElement>,
+)

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -16,6 +16,9 @@ import org.rust.lang.core.dfa.borrowck.BorrowCheckContext
 import org.rust.lang.core.dfa.borrowck.BorrowCheckResult
 import org.rust.lang.core.dfa.liveness.Liveness
 import org.rust.lang.core.dfa.liveness.LivenessContext
+import org.rust.lang.core.mir.borrowck.MirBorrowCheckResult
+import org.rust.lang.core.mir.borrowck.doMirBorrowCheck
+import org.rust.lang.core.mir.mirBody
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
@@ -182,6 +185,16 @@ val RsInferenceContextOwner.borrowCheckResult: BorrowCheckResult?
         val bccx = BorrowCheckContext.buildFor(this)
         val borrowCheckResult = bccx?.check()
         createCachedResult(borrowCheckResult)
+    }
+
+private val MIR_BORROW_CHECKER_KEY: Key<CachedValue<MirBorrowCheckResult>> = Key.create("MIR_BORROW_CHECKER_KEY")
+
+val RsInferenceContextOwner.mirBorrowCheckResult: MirBorrowCheckResult?
+    get() = CachedValuesManager.getCachedValue(this, MIR_BORROW_CHECKER_KEY) {
+        if (!existsAfterExpansion) return@getCachedValue createCachedResult(null)
+        val mirBody = mirBody ?: return@getCachedValue createCachedResult(null)
+        val result = doMirBorrowCheck(mirBody)
+        createCachedResult(result)
     }
 
 fun RsNamedElement?.asTy(): Ty =

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1975,13 +1975,25 @@ sealed class RsDiagnostic(
             "Incorrect meta item",
         )
     }
+
+    class UseOfUninitializedVariableError(
+        element: PsiElement,
+        private val fix: LocalQuickFix?,
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0381,
+            "Use of possibly uninitialized variable",
+            fixes = listOfFixes(fix)
+        )
+    }
 }
 
 enum class RsErrorCode {
     E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0045, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0130, E0131, E0132, E0133, E0183, E0184, E0185, E0186, E0191, E0197, E0198,
     E0199, E0200, E0201, E0203, E0206, E0220, E0224, E0225, E0226, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
-    E0308, E0316, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0384,
+    E0308, E0316, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0381, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0437, E0438, E0449, E0451, E0463,
     E0517, E0518, E0536, E0537, E0538, E0541, E0551, E0552, E0554, E0561, E0562, E0569, E0571, E0583, E0586, E0590, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0642, E0658, E0666, E0667, E0695,

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -36,5 +36,8 @@
         <experimentalFeature id="org.rust.coverage.source" percentOfUsers="0">
             <description>Use source-based coverage</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.mir.borrow-check" percentOfUsers="0">
+            <description>Code analysis based on MIR borrow checker</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -36,5 +36,8 @@
         <experimentalFeature id="org.rust.coverage.source" percentOfUsers="0">
             <description>Use source-based coverage</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.mir.borrow-check" percentOfUsers="0">
+            <description>Code analysis based on MIR borrow checker</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Implement error E0381 using MIR-dataflow. Works only if `org.rust.mir.borrow-check` experimental feature is enabled. See #10452