### PR TITLE
MIR: Annotate E0382

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/mir/borrowck/FacadeBorrowck.kt
+++ b/src/main/kotlin/org/rust/lang/core/mir/borrowck/FacadeBorrowck.kt
@@ -26,5 +26,6 @@ fun doMirBorrowCheck(body: MirBody): MirBorrowCheckResult {
 }
 
 data class MirBorrowCheckResult(
+    val usesOfMovedValue: List<RsElement>,
     val usesOfUninitializedVariable: List<RsElement>,
 )

--- a/src/main/kotlin/org/rust/lang/core/mir/borrowck/MirBorrowCheckVisitor.kt
+++ b/src/main/kotlin/org/rust/lang/core/mir/borrowck/MirBorrowCheckVisitor.kt
@@ -17,10 +17,11 @@ class MirBorrowCheckVisitor(
     private val moveData: MoveData,
 ) : ResultsVisitor<BorrowCheckResults.State> {
 
+    private val usesOfMovedValue: MutableSet<RsElement> = hashSetOf()
     private val usesOfUninitializedVariable: MutableSet<RsElement> = hashSetOf()
 
     val result: MirBorrowCheckResult
-        get() = MirBorrowCheckResult(usesOfUninitializedVariable.toList())
+        get() = MirBorrowCheckResult(usesOfMovedValue.toList(), usesOfUninitializedVariable.toList())
 
     override fun visitStatementBeforePrimaryEffect(
         state: BorrowCheckResults.State,
@@ -118,7 +119,7 @@ class MirBorrowCheckVisitor(
         if (moveOutIndices.isEmpty()) {
             usesOfUninitializedVariable += element
         } else {
-            // usesOfMovedValue += UseOfMovedValueError(element, TODO())
+            usesOfMovedValue += element
         }
     }
 
@@ -163,8 +164,8 @@ class MirBorrowCheckVisitor(
                 for (moveOut in moveData.locMap[location].orEmpty()) {
                     if (moveOut.path in movePaths) {
                         result += moveOut
+                        return true
                     }
-                    return true
                 }
             }
 

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1989,6 +1989,18 @@ sealed class RsDiagnostic(
         )
     }
 
+    class UseOfMovedValueError(
+        element: PsiElement,
+        private val fix: LocalQuickFix?,
+    ) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0382,
+            "Use of moved value",
+            fixes = listOfFixes(fix)
+        )
+    }
+
     class UseOfUninitializedVariableError(
         element: PsiElement,
         private val fix: LocalQuickFix?,
@@ -2006,7 +2018,7 @@ enum class RsErrorCode {
     E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0045, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0130, E0131, E0132, E0133, E0183, E0184, E0185, E0186, E0191, E0197, E0198,
     E0199, E0200, E0201, E0203, E0206, E0220, E0224, E0225, E0226, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
-    E0308, E0316, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0381, E0384,
+    E0308, E0316, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0381, E0382, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0437, E0438, E0449, E0451, E0463,
     E0517, E0518, E0536, E0537, E0538, E0541, E0551, E0552, E0554, E0561, E0562, E0569, E0571, E0583, E0586, E0590, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0642, E0658, E0666, E0667, E0695, E0696,


### PR DESCRIPTION
Implement error E0382 using MIR-dataflow. Works only if `org.rust.mir.borrow-check` experimental feature is enabled. See #10452