### PR TITLE
COMP: complete `let` after `if` and `while`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
@@ -86,6 +86,8 @@ class RsKeywordCompletionContributor : CompletionContributor(), DumbAware {
                 }
             }
         })
+
+        extend(CompletionType.BASIC, afterIfOrWhilePattern(), RsKeywordCompletionProvider("let"))
     }
 
     override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
@@ -230,6 +232,18 @@ class RsKeywordCompletionContributor : CompletionContributor(), DumbAware {
 
     private fun afterVisInherentImplDeclarationPattern(): PsiElementPattern.Capture<PsiElement> {
         return baseInherentImplDeclarationPattern().and(afterVis())
+    }
+
+    private fun afterIfOrWhilePattern(): PsiElementPattern.Capture<PsiElement> {
+        return afterIfPattern().or(afterWhilePattern())
+    }
+
+    private fun afterIfPattern(): PsiElementPattern.Capture<PsiElement> {
+        return psiElement().afterLeaf(psiElement(IF).withParent(psiElement(IF_EXPR)))
+    }
+
+    private fun afterWhilePattern(): PsiElementPattern.Capture<PsiElement> {
+        return psiElement().afterLeaf(psiElement(WHILE).withParent(psiElement(WHILE_EXPR)))
     }
 
     // TODO(parser recovery?): it would be really nice to just say something like element.prevSibling is RsVis

--- a/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
@@ -916,6 +916,72 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test if let completion`() = checkCompletion("let", """
+        fn main() {
+            if l/*caret*/
+        }
+    """, """
+        fn main() {
+            if let /*caret*/
+        }
+    """)
+
+
+    fun `test if let completion in else`() = checkCompletion("let", """
+        fn main() {
+            if 1 == 1 { } else if l/*caret*/
+        }
+    """, """
+        fn main() {
+            if 1 == 1 { } else if let /*caret*/
+        }
+    """)
+
+    fun `test if let completion in struct literal`() = checkCompletion("let", """
+        struct S { a: i32 }
+        fn main() {
+            let s = S { a: if l/*caret*/ }
+        }
+    """, """
+        struct S { a: i32 }
+        fn main() {
+            let s = S { a: if let /*caret*/ }
+        }
+    """)
+
+
+    fun `test if let completion within struct`() = checkNotContainsCompletion("let", """
+        struct S { if l/*caret*/ }
+    """)
+
+
+    fun `test while let completion`() = checkCompletion("let", """
+        fn main() {
+            while l/*caret*/
+        }
+    """, """
+        fn main() {
+            while let /*caret*/
+        }
+    """)
+
+    fun `test while let completion in struct literal`() = checkCompletion("let", """
+        struct S { a: i32 }
+        fn main() {
+            let s = S { a: while l/*caret*/ }
+        }
+    """, """
+        struct S { a: i32 }
+        fn main() {
+            let s = S { a: while let /*caret*/ }
+        }
+    """)
+
+
+    fun `test while let completion within struct`() = checkNotContainsCompletion("let", """
+        struct S { while l/*caret*/ }
+    """)
+
     // Smart mode is used for not completion tests to disable additional results
     // from language agnostic `com.intellij.codeInsight.completion.WordCompletionContributor`
     override fun checkNoCompletion(@Language("Rust") code: String) {


### PR DESCRIPTION
changelog: Add completion for keyword `let` after `if` and `while`
