### PR TITLE
Refactoring - remove `when{}.exhaustive` call where possible

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -62,7 +62,6 @@ import org.rust.openapiext.modules
 import org.rust.openapiext.pathAsPath
 import org.rust.stdext.AsyncValue
 import org.rust.stdext.applyWithSymlink
-import org.rust.stdext.exhaustive
 import org.rust.stdext.mapNotNullToSet
 import org.rust.taskQueue
 import java.nio.file.Path
@@ -322,7 +321,7 @@ open class CargoProjectsServiceImpl(
                         }
                     }
                 }
-            }.exhaustive
+            }
         }
     }
 

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/UserDisabledFeatures.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/UserDisabledFeatures.kt
@@ -6,7 +6,6 @@
 package org.rust.cargo.project.model.impl
 
 import org.rust.cargo.project.workspace.*
-import org.rust.stdext.exhaustive
 
 abstract class UserDisabledFeatures {
     abstract val pkgRootToDisabledFeatures: Map<PackageRoot, Set<FeatureName>>
@@ -62,10 +61,11 @@ class MutableUserDisabledFeatures(
             FeatureState.Enabled -> {
                 pkgRootToDisabledFeatures[packageRoot]?.remove(feature.name)
             }
+
             FeatureState.Disabled -> {
                 pkgRootToDisabledFeatures.getOrPut(packageRoot) { hashSetOf() }
                     .add(feature.name)
             }
-        }.exhaustive
+        }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
@@ -20,7 +20,6 @@ import org.rust.cargo.project.workspace.PackageOrigin.*
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.ide.icons.RsIcons
 import org.rust.stdext.buildList
-import org.rust.stdext.exhaustive
 import javax.swing.Icon
 
 /**
@@ -88,7 +87,7 @@ private val CargoProject.ideaLibraries: Collection<SyntheticLibrary>
                 STDLIB, STDLIB_DEPENDENCY -> stdlibPackages += pkg
                 DEPENDENCY -> dependencyPackages += pkg
                 WORKSPACE -> Unit
-            }.exhaustive
+            }
         }
 
         return buildList {

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -26,7 +26,6 @@ import org.rust.lang.core.types.ty.TyPrimitive
 import org.rust.lang.core.types.ty.TyTypeParameter
 import org.rust.lang.utils.escapeRust
 import org.rust.lang.utils.evaluation.evaluate
-import org.rust.stdext.exhaustive
 import org.rust.stdext.joinToWithBuffer
 
 /** Return text of the element without switching to AST (loses non-stubbed parts of PSI) */
@@ -530,8 +529,8 @@ open class RsPsiRenderer(
                 sb.append(kind.value.orEmpty().escapeRust())
                 sb.append('"')
             }
-            null -> "{}"
-        }.exhaustive
+            null -> Unit
+        }
     }
 
     protected open fun appendBlockExpr(sb: StringBuilder, expr: RsBlockExpr) {

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/CrateGraphServiceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/CrateGraphServiceImpl.kt
@@ -33,7 +33,6 @@ import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.isUnitTestMode
 import org.rust.stdext.applyWithSymlink
 import org.rust.stdext.enumSetOf
-import org.rust.stdext.exhaustive
 import java.nio.file.Path
 
 class CrateGraphServiceImpl(val project: Project) : CrateGraphService {
@@ -251,7 +250,7 @@ private class CrateGraphBuilder {
                     CargoWorkspace.DepKind.Normal -> normal += dependency
                     CargoWorkspace.DepKind.Development -> dev += dependency
                     CargoWorkspace.DepKind.Build -> build += dependency
-                }.exhaustive
+                }
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
@@ -123,7 +123,7 @@ fun DataOutput.writeMacroExpansionError(err: MacroExpansionError) {
         is ProcMacroExpansionError.ProcessAborted -> writeInt(err.exitCode)
         is ProcMacroExpansionError.Timeout -> writeLong(err.timeout)
         else -> Unit
-    }.exhaustive
+    }
 }
 
 @Throws(IOException::class)
@@ -175,7 +175,7 @@ private fun DataOutput.saveMatchingError(value: MacroMatchingError) {
             IOUtil.writeUTF(this, value.variableName)
         }
         else -> Unit
-    }.exhaustive
+    }
 }
 
 @Throws(IOException::class)

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/Request.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/Request.kt
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.SerializerProvider
 import org.rust.lang.core.macros.tt.FlatTree
 import org.rust.lang.core.macros.tt.FlatTreeJsonSerializer
-import org.rust.stdext.exhaustive
 import org.rust.util.RsJacksonSerializer
 
 // This is a sealed class because there is `ListMacro` request kind which we don't use for now
@@ -42,7 +41,7 @@ class RequestJsonSerializer : RsJacksonSerializer<Request>(Request::class.java) 
                     writeStringField("current_dir", request.currentDir)
                 }
             }
-        }.exhaustive
+        }
     }
 
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -695,7 +695,7 @@ class ImplLookup(
             }
             BuiltinImplConditions.None -> Unit
             BuiltinImplConditions.Ambiguous -> candidates.ambiguous = true
-        }.exhaustive
+        }
     }
 
     // https://github.com/rust-lang/rust/blob/3a90bedb332d/compiler/rustc_trait_selection/src/traits/select/mod.rs#L1820

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -386,7 +386,7 @@ sealed class VisibilityLight : Writeable {
                 data.writeByte(3)
                 data.writePath(inPath)
             }
-        }.exhaustive
+        }
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/openapiext/psi.kt
+++ b/src/main/kotlin/org/rust/openapiext/psi.kt
@@ -16,7 +16,6 @@ import org.rust.lang.core.psi.ProcMacroAttribute
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.ext.*
-import org.rust.stdext.exhaustive
 
 
 /**
@@ -74,7 +73,7 @@ fun processElementsWithMacros(element: PsiElement, processor: PsiTreeProcessor):
             TreeStatus.VISIT_CHILDREN -> Unit
             TreeStatus.SKIP_CHILDREN -> return true
             TreeStatus.ABORT -> return false
-        }.exhaustive
+        }
         for (child in element.children) {
             if (child is RsMacroCall && child.macroArgument != null) {
                 child.expansion?.elements?.forEach {
@@ -123,7 +122,7 @@ private class RsWithMacrosRecursiveElementWalkingVisitor(
                 stopWalking()
                 result = false
             }
-        }.exhaustive
+        }
     }
 
     private fun shouldExpandMacro(element: RsMacroCall): Boolean {

--- a/src/main/kotlin/org/rust/util/RsBackgroundTaskQueue.kt
+++ b/src/main/kotlin/org/rust/util/RsBackgroundTaskQueue.kt
@@ -21,7 +21,6 @@ import org.rust.openapiext.DelayedBackgroundableProcessIndicator
 import org.rust.openapiext.checkIsDispatchThread
 import org.rust.openapiext.isHeadlessEnvironment
 import org.rust.openapiext.isUnitTestMode
-import org.rust.stdext.exhaustive
 import java.util.function.BiConsumer
 
 /** Inspired by [com.intellij.openapi.progress.BackgroundTaskQueue] */
@@ -170,7 +169,7 @@ class RsBackgroundTaskQueue {
                 }
                 State.Canceled -> Unit
                 State.CanceledContinued -> Unit
-            }.exhaustive
+            }
         }
 
         private sealed class State {


### PR DESCRIPTION
Since Kotlin 1.7 `when` must be exhaustive for enums and sealed classes, so no `.exhaustive` call is required to make them exhaustive

[skip ci]