### PR TITLE
GRD: move plugin ids from `build.gradle.kts` to `gradle-*.properties`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,9 +30,9 @@ val baseVersion = when (baseIDE) {
 }
 
 val tomlPlugin = "org.toml.lang"
-val nativeDebugPlugin = "com.intellij.nativeDebug:${prop("nativeDebugPluginVersion")}"
+val nativeDebugPlugin: String by project
 val graziePlugin = "tanvd.grazi"
-val psiViewerPlugin = "PsiViewer:${prop("psiViewerPluginVersion")}"
+val psiViewerPlugin: String by project
 val intelliLangPlugin = "org.intellij.intelliLang"
 val copyrightPlugin = "com.intellij.copyright"
 val javaPlugin = "com.intellij.java"

--- a/gradle-231.properties
+++ b/gradle-231.properties
@@ -5,9 +5,9 @@ ideaVersion=IU-2023.1
 clionVersion=CL-2023.1
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=231.8109.91
+nativeDebugPlugin=com.intellij.nativeDebug:231.8109.91
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
-psiViewerPluginVersion=231-SNAPSHOT
+psiViewerPlugin=PsiViewer:231-SNAPSHOT
 
 # please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
 sinceBuild=231.7515

--- a/gradle-232.properties
+++ b/gradle-232.properties
@@ -5,9 +5,9 @@ ideaVersion=IU-232.5150-EAP-CANDIDATE-SNAPSHOT
 clionVersion=CL-232.5150-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=232.5150.113
+nativeDebugPlugin=com.intellij.nativeDebug:232.5150.113
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
-psiViewerPluginVersion=232.2-SNAPSHOT
+psiViewerPlugin=PsiViewer:232.2-SNAPSHOT
 
 # please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
 sinceBuild=232.5150


### PR DESCRIPTION
It makes `gradle-*.properties` files contain all necessary information about dependency plugins, and allows us to automatically update them