### PR TITLE
Test inspections and error annotators against attribute procedural macros

### DIFF
--- a/duplicates/src/test/kotlin/org/rust/ide/clones/RsDuplicateInspectionTest.kt
+++ b/duplicates/src/test/kotlin/org/rust/ide/clones/RsDuplicateInspectionTest.kt
@@ -14,9 +14,12 @@ import com.jetbrains.clones.configuration.DuplicateInspectionConfiguration
 import com.jetbrains.clones.configuration.DuplicateLanguageState
 import com.jetbrains.clones.index.HashFragmentIndex
 import org.intellij.lang.annotations.Language
+import org.junit.runner.RunWith
+import org.rust.RsJUnit4TestRunner
 import org.rust.ide.inspections.RsInspectionsTestBase
 
 // Based on [com.jetbrains.clones.DuplicateBaseTest]
+@RunWith(RsJUnit4TestRunner::class)
 class RsDuplicateInspectionTest : RsInspectionsTestBase(DuplicateInspection::class) {
 
     private val scope = RsDuplicateScope()

--- a/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
+++ b/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
@@ -18,10 +18,13 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.util.ThrowableRunnable
 import org.intellij.lang.annotations.Language
+import org.junit.runner.RunWith
+import org.rust.RsJUnit4TestRunner
 import org.rust.ide.annotator.RsAnnotationTestFixture
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.lang.RsLanguage
 
+@RunWith(RsJUnit4TestRunner::class)
 class RsGrammarCheckingTest : RsInspectionsTestBase(GrazieInspection::class) {
 
     override fun createAnnotationFixture(): RsAnnotationTestFixture<Unit> =

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
@@ -17,6 +17,7 @@ import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.cargo.project.workspace.FeatureDep
 import org.rust.cargo.project.workspace.PackageFeature
+import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.lang.core.psi.rustPsiManager
 import org.rust.openapiext.pathAsPath
 import java.nio.file.Path
@@ -38,12 +39,14 @@ class TestCargoProjectsServiceImpl(project: Project) : CargoProjectsServiceImpl(
     }
 
     @TestOnly
-    fun setRustcInfo(rustcInfo: RustcInfo, parentDisposable: Disposable) {
+    fun setRustcVersion(rustcVersion: RustcVersion, parentDisposable: Disposable) {
         val oldValues = mutableMapOf<Path, RustcInfo?>()
 
         modifyProjectsSync { projects ->
             projects.forEach { oldValues[it.manifest] = it.rustcInfo }
             val updatedProjects = projects.map {
+                val oldRustcInfo = it.rustcInfo ?: RustcInfo("", null)
+                val rustcInfo = oldRustcInfo.copy(version = rustcVersion)
                 it.copy(rustcInfo = rustcInfo, rustcInfoStatus = CargoProject.UpdateStatus.UpToDate)
             }
             CompletableFuture.completedFuture(updatedProjects)

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1199,13 +1199,9 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         }
 
         if (realCount == expectedCount && fixes.isNotEmpty()) {
-            val builder = holder.holder.newSilentAnnotation(HighlightSeverity.ERROR)
-                .textAttributes(TextAttributesKey.createTextAttributesKey("DEFAULT_TEXT_ATTRIBUTES"))
-                .range(args.textRange)
-            for (fix in fixes) {
-                builder.withFix(fix)
-            }
-            builder.create()
+            holder.newAnnotation(args, HighlightSeverity.ERROR, null, *fixes.toTypedArray())
+                ?.textAttributes(TextAttributesKey.createTextAttributesKey("DEFAULT_TEXT_ATTRIBUTES"))
+                ?.create()
         }
     }
 
@@ -1587,9 +1583,11 @@ private fun checkConstGenerics(holder: RsAnnotationHolder, constParameter: RsCon
     }
 
     val lookup = ImplLookup.relativeTo(constParameter)
-    if (ProcMacroApplicationService.isFullyEnabled() && !(lookup.isPartialEq(ty) && lookup.isEq(ty))) {
-        RsDiagnostic.NonStructuralMatchTypeAsConstGenericParameter(typeReference, ty.shortPresentableText)
-            .addToHolder(holder)
+    if (ProcMacroApplicationService.isFullyEnabled()) {
+        if (lookup.isPartialEq(ty).isFalse || lookup.isEq(ty).isFalse) {
+            RsDiagnostic.NonStructuralMatchTypeAsConstGenericParameter(typeReference, ty.shortPresentableText)
+                .addToHolder(holder)
+        }
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -280,6 +280,7 @@ private fun checkConstant(holder: AnnotationHolder, const: RsConstant) {
 
 private fun checkConstantType(holder: AnnotationHolder, element: RsConstant) {
     if (element.colon == null && element.typeReference == null) {
+        val nameElement = element.nameLikeElement
         val typeText = if (element.isConst) {
             "const"
         } else {
@@ -288,11 +289,11 @@ private fun checkConstantType(holder: AnnotationHolder, element: RsConstant) {
         val message = "Missing type for `$typeText` item"
 
         val annotation = holder.newAnnotation(HighlightSeverity.ERROR, message)
-            .range(element.textRange)
+            .range(nameElement)
 
         val expr = element.expr
         if (expr != null) {
-            annotation.withFix(AddTypeFix(element.nameLikeElement, expr.type))
+            annotation.withFix(AddTypeFix(nameElement, expr.type))
         }
 
         annotation.create()

--- a/src/main/kotlin/org/rust/ide/fixes/DeriveCopyFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/DeriveCopyFix.kt
@@ -28,7 +28,7 @@ class DeriveCopyFix(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiEl
         val item = type.item.findPreviewCopyIfNeeded(file)
 
         val implLookup = ImplLookup.relativeTo(item)
-        val isCloneImplemented = implLookup.isClone(type)
+        val isCloneImplemented = implLookup.isClone(type).isTrue
 
         val psiFactory = RsPsiFactory(project)
         val existingDeriveAttr = item.findOuterAttr("derive")

--- a/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.cargo.util.AutoInjectedCrates.CORE
 import org.rust.cargo.util.AutoInjectedCrates.STD
+import org.rust.ide.utils.import.stdlibAttributes
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsFile.Attributes
 import org.rust.lang.core.types.ty.TyFloat
@@ -24,10 +25,10 @@ class RsApproxConstantInspection : RsLocalInspectionTool() {
             if (literal is RsLiteralKind.Float) {
                 val value = literal.value ?: return
                 val constant = KNOWN_CONSTS.find { it.matches(value) } ?: return
-                val lib = when (o.containingFile.rustFile?.getStdlibAttributes(o.containingCrate)) {
+                val lib = when (o.stdlibAttributes) {
                     Attributes.NONE -> STD
                     Attributes.NO_STD -> CORE
-                    else -> return
+                    Attributes.NO_CORE -> return
                 }
                 val type = when (val type = o.type) {
                     is TyFloat -> type.name

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
@@ -48,13 +48,13 @@ class RsAssertEqualInspection : RsLocalInspectionTool() {
 
             val lookup = ImplLookup.relativeTo(expr)
             // The `assert_eq!` macro, as opposed to `assert!`, requires both arguments to implement `core::fmt::Debug`.
-            if (!lookup.isDebug(leftType) || !lookup.isDebug(rightType)) {
+            if (!lookup.isDebug(leftType).isTrue || !lookup.isDebug(rightType).isTrue) {
                 Testmarks.DebugTraitIsNotImplemented.hit()
                 return false
             }
             // Don't try to convert `assert!` macro into `assert_eq!/assert_ne!`
             // if expressions can't be compared at all
-            if (!lookup.isPartialEq(leftType, rightType)) {
+            if (!lookup.isPartialEq(leftType, rightType).isTrue) {
                 Testmarks.PartialEqTraitIsNotImplemented.hit()
                 return false
             }

--- a/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import org.rust.ide.fixes.RemoveMutableFix
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.contextStrict
 import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.lang.core.psi.ext.mutability
 import org.rust.lang.core.psi.ext.selfParameter
@@ -22,8 +22,8 @@ class RsVariableMutableInspection : RsLocalInspectionTool() {
         object : RsWithMacrosInspectionVisitor() {
             override fun visitPatBinding(o: RsPatBinding) {
                 if (!o.mutability.isMut) return
-                val block = o.ancestorStrict<RsBlock>() ?: o.ancestorStrict<RsFunction>() ?: return
-                if (ReferencesSearch.search(o, LocalSearchScope(block))
+                val block = o.contextStrict<RsBlock>() ?: o.contextStrict<RsFunction>() ?: return
+                if (ReferencesSearch.search(o, LocalSearchScope(block), /*ignoreAccessScope=*/true)
                         .any { checkOccurrenceNeedMutable(it.element.parent) }) return
                 if (block.descendantsOfType<RsMacroCall>().any { checkExprPosition(o, it) }) return
                 holder.registerProblem(

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -62,13 +62,13 @@ sealed class RsLint(
      */
     fun levelFor(el: PsiElement): RsLintLevel = explicitLevel(el) ?: superModsLevel(el) ?: defaultLevel
 
-    fun explicitLevel(el: PsiElement): RsLintLevel? = el.ancestors
+    fun explicitLevel(el: PsiElement): RsLintLevel? = el.contexts
         .filterIsInstance<RsDocAndAttributeOwner>()
         .flatMap { it.queryAttributes.metaItems.toList().asReversed().asSequence() }
         .filter { it.metaItemArgs?.metaItemList.orEmpty().any { item -> item.id == id || item.id in groupIds } }
         .firstNotNullOfOrNull { it.name?.let { name -> RsLintLevel.valueForId(name) } }
 
-    private fun superModsLevel(el: PsiElement): RsLintLevel? = el.ancestors
+    private fun superModsLevel(el: PsiElement): RsLintLevel? = el.contexts
         .filterIsInstance<RsMod>()
         .lastOrNull()
         ?.superMods

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsPathStatementsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsPathStatementsInspection.kt
@@ -9,9 +9,9 @@ import com.intellij.psi.PsiElement
 import org.rust.RsBundle
 import org.rust.ide.fixes.RemoveElementFix
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.RsExprStmt
 import org.rust.lang.core.psi.RsPathExpr
-import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.isTailStmt
 
 // TODO: Future improvements: https://github.com/intellij-rust/intellij-rust/issues/9555
@@ -20,7 +20,7 @@ import org.rust.lang.core.psi.ext.isTailStmt
 class RsPathStatementsInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.PathStatements
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
         override fun visitExprStmt(exprStmt: RsExprStmt) {
             super.visitExprStmt(exprStmt)
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspection.kt
@@ -49,7 +49,7 @@ class RsSelfConventionInspection : RsLintInspection() {
                 if (selfSignature == SelfSignature.BY_VAL) {
                     val selfType = traitOrImpl.selfType
                     val implLookup = ImplLookup.relativeTo(traitOrImpl)
-                    if (selfType is TyUnknown || implLookup.isCopy(selfType)) return
+                    if (selfType is TyUnknown || !implLookup.isCopy(selfType).isFalse) return
                 }
 
                 holder.registerProblem(m.selfParameter ?: m.identifier, convention)

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -146,7 +146,7 @@ class Parameter private constructor(
                 operatorType == UnaryOperator.REF || operatorType == UnaryOperator.REF_MUT
             }
             val requiredBorrowing = hasRefOperator ||
-                (isUsedAfterEnd && binding.type !is TyReference && !implLookup.isCopy(binding.type))
+                (isUsedAfterEnd && binding.type !is TyReference && !implLookup.isCopy(binding.type).isTrue)
 
             val requiredMutableValue = binding.mutability.isMut && references.any {
                 if (it.element.ancestorStrict<RsValueArgumentList>() == null) return@any false

--- a/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
@@ -123,7 +123,7 @@ class OkPostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostfix
 class ErrPostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostfixTemplate("err", "Err(expr)", provider)
 
 private val RsExpr.isIntoIterator: Boolean
-    get() = implLookup.isIntoIterator(type)
+    get() = implLookup.isIntoIterator(type).isTrue
 
 private val RsExpr.implementsDeref: Boolean
-    get() = implLookup.isDeref(this.type)
+    get() = implLookup.isDeref(this.type).isTrue

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -341,7 +341,7 @@ fun RsPossibleMacroCall.mapRangeFromExpansionToCallBodyStrict(range: TextRange):
     return mapRangeFromExpansionToCallBody(range).singleOrNull()?.takeIf { it.length == range.length }
 }
 
-private fun RsPossibleMacroCall.mapRangeFromExpansionToCallBody(range: TextRange): List<TextRange> {
+fun RsPossibleMacroCall.mapRangeFromExpansionToCallBody(range: TextRange): List<TextRange> {
     val expansion = expansion ?: return emptyList()
     return mapRangeFromExpansionToCallBody(expansion, this, range)
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -23,6 +23,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
 import org.rust.lang.core.psi.ext.childrenWithLeaves
 import org.rust.lang.core.psi.ext.getNextNonCommentSibling
+import org.rust.lang.core.psi.ext.needsSemicolon
 import org.rust.openapiext.RsPathManager.INTELLIJ_RUST_NATIVE_HELPER
 import org.rust.openapiext.isUnitTestMode
 import org.rust.stdext.RsResult
@@ -184,7 +185,7 @@ class ProcMacroExpander private constructor(
 
             override fun visitExprStmt(o: RsExprStmt) {
                 super.visitStmt(o)
-                if (o.semicolon == null && o.getNextNonCommentSibling() is RsStmt) {
+                if (o.semicolon == null && o.needsSemicolon() && o.getNextNonCommentSibling() is RsStmt) {
                     sb.appendUnmapped(";")
                 }
             }
@@ -209,7 +210,7 @@ class ProcMacroExpander private constructor(
         psi !is RsDotExpr && psi.childrenWithLeaves.any { it is PsiErrorElement || it !is RsExpr && hasErrorToHandle(it) }
 
     companion object {
-        const val EXPANDER_VERSION: Int = 9
+        const val EXPANDER_VERSION: Int = 10
 
         fun forCrate(crate: Crate): ProcMacroExpander {
             val project = crate.project

--- a/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
@@ -57,7 +57,7 @@ class RsDefaultValueBuilder(
 
                 var default = this.defaultValue
                 val implLookup = mod.implLookup
-                if (implLookup.isDefault(ty)) {
+                if (implLookup.isDefault(ty).isTrue) {
                     default = psiFactory.createAssocFunctionCall("Default", "default", emptyList())
                 }
 
@@ -67,7 +67,7 @@ class RsDefaultValueBuilder(
                     items.String -> psiFactory.createExpression("\"\".to_string()")
                     items.Vec -> psiFactory.createExpression("vec![]")
                     is RsStructItem -> if (item.kind == RsStructKind.STRUCT && item.canBeInstantiatedIn(mod)) {
-                        if (implLookup.isDefault(ty)) {
+                        if (implLookup.isDefault(ty).isTrue) {
                             return default
                         }
 
@@ -100,7 +100,7 @@ class RsDefaultValueBuilder(
                         default
                     }
                     is RsEnumItem -> {
-                        if (implLookup.isDefault(ty)) {
+                        if (implLookup.isDefault(ty).isTrue) {
                             return default
                         }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -398,9 +398,9 @@ class QueryAttributes<out T: RsMetaItemPsiOrStub>(
     val reprAttributes: Sequence<T>
         get() = attrsByName("repr")
 
-    // #[deprecated(since, note)], #[rustc_deprecated(since, reason)]
+    // #[deprecated(since, note)]
     val deprecatedAttribute: T?
-        get() = (attrsByName("deprecated") + attrsByName("rustc_deprecated")).firstOrNull()
+        get() = attrsByName("deprecated").firstOrNull()
 
     val cfgAttributes: Sequence<T>
         get() = attrsByName("cfg")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabelDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabelDecl.kt
@@ -10,6 +10,10 @@ import com.intellij.psi.tree.IElementType
 import org.rust.lang.core.psi.RsLabelDecl
 import org.rust.lang.core.psi.RsPsiFactory
 
+// Guaranteed by the grammar
+val RsLabelDecl.owner: RsLabeledExpression
+    get() = parent as RsLabeledExpression
+
 abstract class RsLabelDeclImplMixin(type: IElementType) : RsNamedElementImpl(type), RsLabelDecl {
     override fun getNameIdentifier(): PsiElement? = quoteIdentifier
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStmt.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStmt.kt
@@ -34,10 +34,13 @@ fun RsExprStmt.addSemicolon() {
 }
 
 fun RsExprStmt.addSemicolonIfNeeded() {
-    if (expr.needsSemicolon()) {
+    if (needsSemicolon()) {
         addSemicolon()
     }
 }
+
+fun RsExprStmt.needsSemicolon(): Boolean =
+    expr.needsSemicolon()
 
 private fun RsExpr.needsSemicolon(): Boolean =
     this !is RsWhileExpr && this !is RsIfExpr && this !is RsForExpr && this !is RsLoopExpr && this !is RsMatchExpr

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -190,8 +190,8 @@ fun Ty.isMovesByDefault(lookup: ImplLookup): Boolean =
         is TyTuple -> types.any { it.isMovesByDefault(lookup) }
         is TyArray -> base.isMovesByDefault(lookup)
         is TySlice -> elementType.isMovesByDefault(lookup)
-        is TyTypeParameter -> !(parameter == TyTypeParameter.Self || lookup.isCopy(this))
-        else -> !lookup.isCopy(this)
+        is TyTypeParameter -> parameter != TyTypeParameter.Self && lookup.isCopy(this).isFalse
+        else -> lookup.isCopy(this).isFalse
     }
 
 val Ty.isBox: Boolean

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
@@ -38,6 +38,9 @@ import org.rust.openapiext.Testmark
 enum class ThreeValuedLogic {
     True, False, Unknown;
 
+    val isTrue: Boolean get() = this == True
+    val isFalse: Boolean get() = this == False
+
     companion object {
         fun fromBoolean(value: Boolean) = when (value) {
             true -> True

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -26,7 +26,6 @@ import junit.framework.AssertionFailedError
 import org.intellij.lang.annotations.Language
 import org.junit.runner.RunWith
 import org.rust.cargo.CfgOptions
-import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.impl.DEFAULT_EDITION_FOR_TESTS
 import org.rust.cargo.project.model.impl.testCargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
@@ -134,8 +133,7 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
     private fun setupMockRustcVersion() {
         val annotation = findAnnotationInstance<MockRustcVersion>() ?: return
         val (semVer, channel) = parse(annotation.rustcVersion)
-        val rustcInfo = RustcInfo("", RustcVersion(semVer, "", channel))
-        project.testCargoProjects.setRustcInfo(rustcInfo, testRootDisposable)
+        project.testCargoProjects.setRustcVersion(RustcVersion(semVer, "", channel), testRootDisposable)
     }
 
     private fun setupMockEdition() {

--- a/src/test/kotlin/org/rust/ide/annotator/AnnotationTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/AnnotationTestFixtureBase.kt
@@ -180,7 +180,7 @@ abstract class AnnotationTestFixtureBase(
         preview = preview,
     )
 
-    fun checkFixAvailableInSelectionOnly(
+    open fun checkFixAvailableInSelectionOnly(
         fixName: String,
         before: String,
         checkWarn: Boolean = true,
@@ -256,7 +256,7 @@ abstract class AnnotationTestFixtureBase(
         return unwrapped is SuppressIntentionActionFromFix
     }
 
-    fun registerSeverities(severities: List<HighlightSeverity>) {
+    open fun registerSeverities(severities: List<HighlightSeverity>) {
         val testSeverityProvider = TestSeverityProvider(severities)
         SeveritiesProvider.EP_NAME.point.registerExtension(testSeverityProvider, testRootDisposable)
     }

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
@@ -6,15 +6,14 @@
 package org.rust.ide.annotator
 
 import com.intellij.codeInspection.InspectionProfileEntry
+import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture.*
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
 import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
-import org.rust.TestProject
-import org.rust.createAndOpenFileWithCaretMarker
-import org.rust.fileTreeFromText
+import org.rust.*
 import org.rust.lang.core.macros.MacroExpansionManager
 import kotlin.reflect.KClass
 
@@ -25,6 +24,9 @@ open class RsAnnotationTestFixture<C>(
     inspectionClasses: List<KClass<out InspectionProfileEntry>> = emptyList(),
     override val baseFileName: String = "main.rs"
 ) : AnnotationTestFixtureBase(testCase, codeInsightFixture, annotatorClasses, inspectionClasses) {
+
+    private val extraSeverities: MutableSet<String> = mutableSetOf()
+    private val testWrapping: TestWrapping = (testCase as? RsTestBase)?.testWrapping ?: TestWrapping.NONE
 
     fun checkByFileTree(
         @Language("Rust") text: String,
@@ -111,12 +113,52 @@ open class RsAnnotationTestFixture<C>(
         configure = { configureByFile(file, context) },
     )
 
+    override fun checkFixAvailableInSelectionOnly(
+        fixName: String,
+        before: String,
+        checkWarn: Boolean,
+        checkInfo: Boolean,
+        checkWeakWarn: Boolean,
+    ) {
+        if (testWrapping == TestWrapping.NONE) {
+            super.checkFixAvailableInSelectionOnly(fixName, before, checkWarn, checkInfo, checkWeakWarn)
+        } else {
+            // Pass
+        }
+    }
+
+    // TODO remove after supporting quick-fixes in macros
+    override fun checkFix(
+        fixName: String,
+        before: String,
+        after: String,
+        configure: (String) -> Unit,
+        checkBefore: () -> Unit,
+        checkAfter: (String) -> Unit,
+        preview: Preview?,
+    ) {
+        if (testWrapping == TestWrapping.NONE) {
+            super.checkFix(fixName, before, after, configure, checkBefore, checkAfter, preview)
+        } else {
+            configure(before)
+            checkBefore()
+        }
+    }
+
     private fun checkByFileTree(text: String) {
         fileTreeFromText(replaceCaretMarker(text)).check(codeInsightFixture)
     }
 
     override fun configureByText(text: String) {
-        super.configureByText(text.replaceHighlightingComments())
+        if (testWrapping == TestWrapping.NONE) {
+            super.configureByText(text.replaceHighlightingCommentsWithXmlTags())
+        } else {
+            val (text2, _) = testWrapping.wrapCode(
+                project,
+                text.trimIndent().replaceHighlightingXmlTagsWithRustComments()
+            )
+            super.configureByText(text2.replaceHighlightingCommentsWithXmlTags())
+        }
     }
 
     private fun configureByFileTree(text: String, stubOnly: Boolean) {
@@ -134,17 +176,50 @@ open class RsAnnotationTestFixture<C>(
     }
 
     private fun configureByFileTree(text: String): TestProject {
-        return fileTreeFromText(text.replaceHighlightingComments()).createAndOpenFileWithCaretMarker(codeInsightFixture)
+        return fileTreeFromText(text.replaceHighlightingCommentsWithXmlTags())
+            .createAndOpenFileWithCaretMarker(codeInsightFixture)
     }
 
-    private fun String.replaceHighlightingComments(): String {
-        return replace(HIGHLIGHTING_TAG_RE) {
+    override fun registerSeverities(severities: List<HighlightSeverity>) {
+        severities.mapTo(extraSeverities) { it.name }
+        super.registerSeverities(severities)
+    }
+
+    private fun String.replaceHighlightingCommentsWithXmlTags(): String {
+        return replace(commentHighlightingTagRegex()) {
             if (it.groups[3] == null) "<${it.groupValues[1]}>" else "</${it.groupValues[1]}>"
         }
     }
 
-    companion object {
-        private val HIGHLIGHTING_TAG_RE =
-            """/\*(($ERROR_MARKER|$WARNING_MARKER|$WEAK_WARNING_MARKER|$INFO_MARKER).*?)(\*)?\*/""".toRegex()
+    private fun String.replaceHighlightingXmlTagsWithRustComments(): String {
+        return replace(xmlHighlightingOpenTagRegex()) {
+            "/*" + it.groupValues[2] + (if (it.groups[1] == null) "*/" else "**/")
+        }
     }
+
+    private fun buildSeveritiesList(): String {
+        val severities = listOf(ERROR_MARKER, WARNING_MARKER, WEAK_WARNING_MARKER, INFO_MARKER) +
+            extraSeverities
+        return severities.joinToString(separator = "|")
+    }
+
+    /** A regex that matches highlighting tags in XML style like `<error=...>` and `</error>` */
+    private fun xmlHighlightingOpenTagRegex(): Regex {
+        return ("<(/)?((${buildSeveritiesList()})" +
+            "(?:\\s+descr=\"((?:[^\"]|\\\\\"|\\\\\\\\\"|\\\\\\[|\\\\])*)\")?" +
+            "(?:\\s+type=\"([0-9A-Z_]+)\")?" +
+            "(?:\\s+foreground=\"([0-9xa-f]+)\")?" +
+            "(?:\\s+background=\"([0-9xa-f]+)\")?" +
+            "(?:\\s+effectcolor=\"([0-9xa-f]+)\")?" +
+            "(?:\\s+effecttype=\"([A-Z]+)\")?" +
+            "(?:\\s+fonttype=\"([0-9]+)\")?" +
+            "(?:\\s+textAttributesKey=\"((?:[^\"]|\\\\\"|\\\\\\\\\"|\\\\\\[|\\\\])*)\")?" +
+            "(?:\\s+bundleMsg=\"((?:[^\"]|\\\\\"|\\\\\\\\\")*)\")?" +
+            "(?:\\s+tooltip=\"((?:[^\"]|\\\\\"|\\\\\\\\\")*)\")?" +
+            "?)(/)?>").toRegex(RegexOption.MULTILINE)
+    }
+
+    /** A regex that matches highlighting tags in rust comment style like `/*error=...*/` and `/*error**/` */
+    private fun commentHighlightingTagRegex(): Regex =
+        """/\*((${buildSeveritiesList()}).*?)(\*)?\*/""".toRegex(RegexOption.MULTILINE)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt
@@ -5,9 +5,35 @@
 
 package org.rust.ide.annotator
 
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.rust.RsJUnit4ParameterizedTestRunner
+import org.rust.SkipTestWrapping
+import org.rust.TestWrapping
 import kotlin.reflect.KClass
 
+/**
+ * A base test class for [annotator][AnnotatorBase] tests.
+ *
+ * By default, each test declared in a subclass of this class will run several times - one per each
+ * [TestWrapping] value returned from [RsAnnotatorTestBase.data] method. This allows us to test annotators
+ * under different circumstances, e.g. inside a procedural macro call. Use [SkipTestWrapping]
+ * annotation to skip test run with a specific (or all) [TestWrapping] (s).
+ */
+@RunWith(RsJUnit4ParameterizedTestRunner::class)
+@Parameterized.UseParametersRunnerFactory(RsJUnit4ParameterizedTestRunner.RsRunnerForParameters.Factory::class)
 abstract class RsAnnotatorTestBase(private vararg val annotatorClasses: KClass<out AnnotatorBase>) : RsAnnotationTestBase() {
+
+    @field:Parameterized.Parameter(0)
+    override lateinit var testWrapping: TestWrapping
+
+    companion object {
+        @Parameterized.Parameters(name = "{index}: {0}")
+        @JvmStatic fun data(): Iterable<TestWrapping> = listOf(
+            TestWrapping.NONE,
+            TestWrapping.ATTR_MACRO_AS_IS_ALL_ITEMS,
+        )
+    }
 
     override fun createAnnotationFixture(): RsAnnotationTestFixture<Unit> =
         RsAnnotationTestFixture(this, myFixture, annotatorClasses = annotatorClasses.toList())

--- a/src/test/kotlin/org/rust/ide/annotator/RsAttrErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAttrErrorAnnotatorTest.kt
@@ -5,11 +5,9 @@
 
 package org.rust.ide.annotator
 
-import org.rust.MockAdditionalCfgOptions
-import org.rust.MockRustcVersion
-import org.rust.ProjectDescriptor
-import org.rust.WithDependencyRustProjectDescriptor
+import org.rust.*
 
+@SkipTestWrapping // TODO RsAttrErrorAnnotator in macros
 class RsAttrErrorAnnotatorTest : RsAnnotatorTestBase(RsAttrErrorAnnotator::class) {
 
     fun `test attributes wrong delimiter`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
@@ -6,8 +6,10 @@
 package org.rust.ide.annotator
 
 import org.rust.MockAdditionalCfgOptions
+import org.rust.SkipTestWrapping
 import org.rust.ide.colors.RsColor
 
+@SkipTestWrapping
 class RsCfgDisabledCodeAnnotatorTest : RsAnnotatorTestBase(RsCfgDisabledCodeAnnotator::class) {
     override fun setUp() {
         super.setUp()

--- a/src/test/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotatorTest.kt
@@ -7,8 +7,10 @@ package org.rust.ide.annotator
 
 import org.intellij.lang.annotations.Language
 import org.rust.MockAdditionalCfgOptions
+import org.rust.SkipTestWrapping
 import org.rust.ide.colors.RsColor
 
+@SkipTestWrapping
 class RsDocHighlightingAnnotatorTest : RsAnnotatorTestBase(RsDocHighlightingAnnotator::class, RsHighlightingAnnotator::class) {
     override fun setUp() {
         super.setUp()

--- a/src/test/kotlin/org/rust/ide/annotator/RsDuplicateDefinitionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDuplicateDefinitionAnnotatorTest.kt
@@ -5,10 +5,7 @@
 
 package org.rust.ide.annotator
 
-import org.rust.MockAdditionalCfgOptions
-import org.rust.MockRustcVersion
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+import org.rust.*
 
 class RsDuplicateDefinitionAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
@@ -267,7 +264,10 @@ class RsDuplicateDefinitionAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator:
         }
     """)
 
+    @MockRustcVersion("1.0.0-nightly")
     fun `test respects namespaces E0428`() = checkErrors("""
+        #![feature(decl_macro)]
+
         mod m {
             // Consts and types are in different namespaces
             type  NO_C_DUP = bool;
@@ -451,6 +451,7 @@ class RsDuplicateDefinitionAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator:
         struct foo2 {}
     """)
 
+    @SkipTestWrapping
     fun `test duplicates item vs extern crate E0260`() = checkErrors("""
         <error descr="The name `foo1` is defined multiple times [E0260]">extern crate std as foo1;</error>
         struct <error descr="The name `foo1` is defined multiple times [E0260]">foo1</error> {}
@@ -459,6 +460,7 @@ class RsDuplicateDefinitionAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator:
         fn foo2() {}
     """)
 
+    @SkipTestWrapping
     @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
     fun `test E0260 respects crate aliases`() = checkErrors("""
         extern crate core as core_alias;
@@ -468,6 +470,7 @@ class RsDuplicateDefinitionAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator:
         mod <error descr="The name `alloc` is defined multiple times [E0260]">alloc</error> {}
     """)
 
+    @SkipTestWrapping
     fun `test duplicates import vs extern crate E0254`() = checkErrors("""
         mod inner {
             pub struct foo1 {}
@@ -481,6 +484,7 @@ class RsDuplicateDefinitionAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator:
         use inner::foo2;
     """)
 
+    @SkipTestWrapping
     fun `test duplicates extern crate vs extern crate E0259`() = checkErrors("""
         <error descr="The name `std` is defined multiple times [E0259]">extern crate std;</error>
         <error descr="The name `std` is defined multiple times [E0259]">extern crate core as std;</error>

--- a/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
@@ -6,9 +6,11 @@
 package org.rust.ide.annotator
 
 import org.rust.MockEdition
+import org.rust.SkipTestWrapping
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.colors.RsColor
 
+@SkipTestWrapping
 class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018KeywordsAnnotator::class) {
 
     override fun setUp() {

--- a/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.annotator
 
+import org.rust.SkipTestWrapping
+
+@SkipTestWrapping
 class RsExpressionAnnotatorTest : RsAnnotatorTestBase(RsExpressionAnnotator::class) {
 
     fun `test unnecessary parens`() = checkWarnings("""

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -10,6 +10,7 @@ import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.annotator.format.RsFormatMacroAnnotator
 import org.rust.ide.colors.RsColor
 
+@SkipTestWrapping // TODO investigate what doesn't work in macros
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::class) {
     override fun setUp() {

--- a/src/test/kotlin/org/rust/ide/annotator/RsFunctionSignatureSyntaxTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFunctionSignatureSyntaxTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.annotator
 
+import org.rust.MockRustcVersion
+
 class RsFunctionSignatureSyntaxTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
     fun `test E0045 error when use variadic parameter on non-C ABI`() = checkErrors("""
         extern "Rust" {
@@ -30,7 +32,9 @@ class RsFunctionSignatureSyntaxTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotato
         }
     """)
 
+    @MockRustcVersion("1.60.0-nightly")
     fun `test E0045 no error when use variadic parameter in extern function declaration`() = checkErrors("""
+        #![feature(c_variadic)]
         unsafe extern fn foo(x: u8, ...) -> bool {
             x == 1
         }

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -12,6 +12,7 @@ import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.colors.RsColor
 
+@SkipTestWrapping
 class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator::class, RsAttrHighlightingAnnotator::class) {
 
     override fun setUp() {

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.annotator
 
 import org.rust.ProjectDescriptor
+import org.rust.SkipTestWrapping
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.colors.RsColor.MUT_BINDING
 import org.rust.ide.colors.RsColor.MUT_PARAMETER
@@ -43,6 +44,7 @@ class RsHighlightingMutableAnnotatorTest : RsAnnotatorTestBase(RsHighlightingMut
     """)
 
     @BatchMode
+    @SkipTestWrapping
     fun `test no highlighting in batch mode`() = checkHighlighting("""
         struct Foo {}
         impl Foo {

--- a/src/test/kotlin/org/rust/ide/annotator/RsReservedKeywordAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsReservedKeywordAnnotatorTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.annotator
 
+import org.rust.SkipTestWrapping
+
+@SkipTestWrapping
 class RsReservedKeywordAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
 
     fun `test annotate reserved keyword 1`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
@@ -6,7 +6,9 @@
 package org.rust.ide.annotator
 
 import org.rust.MockRustcVersion
+import org.rust.SkipTestWrapping
 
+@SkipTestWrapping
 class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
     fun `test E0379 const trait function`() = checkErrors("""
         trait Foo {
@@ -397,8 +399,8 @@ class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator:
     """)
 
     fun `test constants without a type`() = checkErrors("""
-        <error descr="Missing type for `const` item">const MY_CONST = 1;</error>
-        <error descr="Missing type for `static` item">static MY_STATIC = 1;</error>
+        const <error descr="Missing type for `const` item">MY_CONST</error> = 1;
+        static <error descr="Missing type for `static` item">MY_STATIC</error> = 1;
         const PARTIAL_TYPE:<error descr="<type> expected, got '='"> </error> = 1;
     """)
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionHighlightingAnnotatorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.colors.RsColor
 
 class RsUnsafeExpressionHighlightingAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class) {
@@ -86,6 +87,7 @@ class RsUnsafeExpressionHighlightingAnnotatorTest : RsAnnotatorTestBase(RsUnsafe
     """)
 
     @BatchMode
+    @SkipTestWrapping
     fun `test no highlighting in batch mode`() = checkHighlighting("""
         struct S;
         impl S {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
@@ -7,10 +7,12 @@ package org.rust.ide.annotator.fixes
 
 import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
+import org.rust.SkipTestWrapping
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsExpressionAnnotator
 
+@SkipTestWrapping
 class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class) {
     fun `test no named fields`() = checkBothQuickFix("""
         struct S { foo: i32, bar: f64 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddTypeFixTest.kt
@@ -5,30 +5,31 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsSyntaxErrorsAnnotator
 
 class AddTypeFixTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
     fun `test const`() = checkFixByText("Add type i32", """
-        <error>const CONST/*caret*/ = 1;</error>
+        const <error>CONST/*caret*/</error> = 1;
     """, """
         const CONST: i32/*caret*/ = 1;
     """)
 
     fun `test static`() = checkFixByText("Add type i32", """
-        <error>static STATIC/*caret*/ = 1;</error>
+        static <error>STATIC/*caret*/</error> = 1;
     """, """
         static STATIC: i32/*caret*/ = 1;
     """)
 
     fun `test unknown type`() = checkFixByText("Add type _", """
-        <error>const CONST/*caret*/ = S;</error>
+        const <error>CONST/*caret*/</error> = S;
     """, """
         const CONST: _/*caret*/ = S;
     """)
 
     fun `test partially unknown type`() = checkFixByText("Add type (_, _)", """
-        <error>const CONST/*caret*/ = (S, S);</error>
+        const <error>CONST/*caret*/</error> = (S, S);
     """, """
         const CONST: (_, _)/*caret*/ = (S, S);
     """)
@@ -38,7 +39,7 @@ class AddTypeFixTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
 
         const fn foo() -> Foo { 0 }
 
-        <error>const CONST/*caret*/ = foo();</error>
+        const <error>CONST/*caret*/</error> = foo();
     """, """
         type Foo = u32;
 
@@ -50,14 +51,15 @@ class AddTypeFixTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class) {
     fun `test skip default type argument`() = checkFixByText("Add type Foo", """
         struct Foo<T = u32>(T);
 
-        <error>const CONST/*caret*/ = Foo(0u32);</error>
+        const <error>CONST/*caret*/</error> = Foo(0u32);
     """, """
         struct Foo<T = u32>(T);
 
         const CONST: Foo = Foo(0u32);
     """)
 
+    @SkipTestWrapping
     fun `test missing expr`() = checkFixIsUnavailable("Add type", """
-        <error>const CONST/*caret*/;</error>
+        <error>const <error>CONST/*caret*/</error>;</error>
     """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFixTest.kt
@@ -5,9 +5,11 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsExpressionAnnotator
 
+@SkipTestWrapping
 class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class) {
 
     fun `test basic`() = checkFixByText("Create field", """

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/DoctestFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/DoctestFixTest.kt
@@ -11,7 +11,7 @@ import org.rust.ide.annotator.*
 class DoctestFixTest : RsAnnotationTestBase() {
     // Issue https://github.com/intellij-rust/intellij-rust/issues/6790
     fun `test in doctest fix const`() = doTest("Add type i32", """
-        <error descr="Missing type for `const` item">const CONST/*caret*/ = 1;</error>
+        const <error descr="Missing type for `const` item">CONST/*caret*/</error> = 1;
     """, """
         const CONST:i32/*caret*/ = 1;
     """)

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/EncloseExprInBracesFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/EncloseExprInBracesFixTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.MockRustcVersion
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
@@ -16,10 +17,12 @@ class EncloseExprInBracesFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) 
         struct S<const N: usize = { 1 + 1 }>;
     """)
 
+    @MockRustcVersion("1.70.0")
     fun `test const generic default unavailable 1`() = checkFixIsUnavailable("Enclose the expression in braces", """
         struct S<const N: usize = /*caret*/1>;
     """)
 
+    @MockRustcVersion("1.70.0")
     fun `test const generic default unavailable 2`() = checkFixIsUnavailable("Enclose the expression in braces", """
         struct S<const N: usize = /*caret*/{ 1 + 1 }>;
     """)
@@ -50,8 +53,10 @@ class EncloseExprInBracesFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) 
         }
     """)
 
+    @MockRustcVersion("1.60.0-nightly")
     fun `test const generic all expressions`() = checkErrors("""
-        #![feature(const_generics)]
+        #![feature(min_const_generics)]
+        #![feature(adt_const_params)]
         #![feature(const_generics_defaults)]
 
         use std::ops::Neg;

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
@@ -221,6 +222,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
         }
     """)
 
+    @SkipTestWrapping // TODO better syntax recovery for function arguments
     fun `test empty argument in the middle`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: u32) {}
         fn main() {
@@ -233,6 +235,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
         }
     """)
 
+    @SkipTestWrapping // TODO better syntax recovery for function arguments
     fun `test empty arguments in the middle`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
         fn main() {
@@ -257,6 +260,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
         }
     """)
 
+    @SkipTestWrapping // TODO better syntax recovery for function arguments
     fun `test empty arguments at the end 1`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
         fn main() {
@@ -269,6 +273,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
         }
     """)
 
+    @SkipTestWrapping // TODO better syntax recovery for function arguments
     fun `test empty arguments at the end 2`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
         fn main() {
@@ -281,6 +286,7 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
         }
     """)
 
+    @SkipTestWrapping // TODO better syntax recovery for function arguments
     fun `test interleaved empty arguments`() = checkFixByText("Fill missing arguments", """
         fn foo(a: u32, b: &str, c: bool, d: u32) {}
         fn main() {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveAttrElementFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveAttrElementFixTest.kt
@@ -5,10 +5,11 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsAttrErrorAnnotator
-import org.rust.ide.annotator.RsErrorAnnotator
 
+@SkipTestWrapping // TODO RsAttrErrorAnnotator in macros
 class RemoveAttrElementFixTest : RsAnnotatorTestBase(RsAttrErrorAnnotator::class) {
     fun `test repr on empty enum`() = checkFixByText("Remove attribute `repr`", """
         #[<error descr="Enum with no variants can't have `repr` attribute [E0084]">repr/*caret*/</error>(u8)]

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveElementFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveElementFixTest.kt
@@ -67,7 +67,7 @@ class RemoveElementFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
     fun `test remove visibility qualifier impl`() = checkFixByText("Remove visibility qualifier", """
         struct S;
-        <error descr="Unnecessary visibility qualifier [E0449]">pub/*caret*/</error> impl S {
+        /*error descr="Unnecessary visibility qualifier [E0449]"*/pub/*caret*//*error**/ impl S {
             fn foo() {}
         }
     """, """

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
@@ -106,6 +107,7 @@ class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnot
     """)
 
     // https://github.com/intellij-rust/intellij-rust/issues/7830
+    @SkipTestWrapping
     fun `test avoid infinite loop with syntax error`() = checkFixByText("Remove redundant arguments", """
         fn foo(a: &u32) {}
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveReprValueFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveReprValueFixTest.kt
@@ -5,10 +5,11 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsAttrErrorAnnotator
-import org.rust.ide.annotator.RsErrorAnnotator
 
+@SkipTestWrapping // TODO RsAttrErrorAnnotator in macros
 class RemoveReprValueFixTest : RsAnnotatorTestBase(RsAttrErrorAnnotator::class) {
 
     fun `test fix E0517 remove wrong repr value`() = checkFixByText("Remove", """

--- a/src/test/kotlin/org/rust/ide/inspections/RsApproxConstantInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsApproxConstantInspectionTest.kt
@@ -36,7 +36,7 @@ class RsApproxConstantInspectionTest : RsInspectionsTestBase(RsApproxConstantIns
     fun `test unavailable when no core lib`() = checkByText("""
         #![no_core]
         const PI: f64 = 3.1415;
-    """.trimIndent())
+    """)
 
     fun `test replace with predefined fix`() = checkFixByText("Replace with `std::f64::consts::PI`", """
         const PI: f64 = <warning descr="Approximate value of `std::f64::consts::PI` found. Consider using it directly.">3.1415<caret></warning>;
@@ -44,4 +44,13 @@ class RsApproxConstantInspectionTest : RsInspectionsTestBase(RsApproxConstantIns
         const PI: f64 = std::f64::consts::PI;
     """)
 
+    fun `test use core when no std in other file`() = checkFixByFileTree("Replace with `core::f64::consts::PI`", """
+    //- main.rs
+        #![no_std]
+        mod foo;
+    //- foo.rs
+        const PI: f64 = /*warning descr="Approximate value of `core::f64::consts::PI` found. Consider using it directly."*//*caret*/3.1415/*warning**/;
+    """, """
+
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
@@ -304,6 +304,7 @@ class RsDetachedFileInspectionTest : RsInspectionsTestBase(RsDetachedFileInspect
         //- macro.rs
     """, preview = null)
 
+    @SkipTestWrapping // Investigate after enabling file-tree with wrapping
     fun `test code insight after attach`() = checkFixByFileTreeWithoutHighlighting("Attach file to lib.rs", """
     //- lib.rs
         fn func() {}

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionSuppressorTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionSuppressorTest.kt
@@ -5,11 +5,14 @@
 
 package org.rust.ide.inspections
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.lints.RsSelfConventionInspection
 
 /**
  * Tests for inspections suppression
  */
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsInspectionSuppressorTest : RsInspectionsTestBase(RsSelfConventionInspection::class) {
 
     fun `test without suppression`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
@@ -6,14 +6,43 @@
 package org.rust.ide.inspections
 
 import com.intellij.codeInspection.InspectionProfileEntry
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.rust.RsJUnit4ParameterizedTestRunner
+import org.rust.SkipTestWrapping
 import org.rust.TestProject
+import org.rust.TestWrapping
 import org.rust.ide.annotator.RsAnnotationTestBase
 import org.rust.ide.annotator.RsAnnotationTestFixture
 import kotlin.reflect.KClass
 
+/**
+ * A base test class for [inspection][RsLocalInspectionTool] tests.
+ *
+ * By default, each test declared in a subclass of this class will run several times - one per each
+ * [TestWrapping] value returned from [RsInspectionsTestBase.data] method. This allows us to test inspections
+ * under different circumstances, e.g. inside a procedural macro call. Use [SkipTestWrapping]
+ * annotation to skip test run with a specific (or all) [TestWrapping] (s).
+ */
+@RunWith(RsJUnit4ParameterizedTestRunner::class)
+@Parameterized.UseParametersRunnerFactory(RsJUnit4ParameterizedTestRunner.RsRunnerForParameters.Factory::class)
 abstract class RsInspectionsTestBase(
     protected val inspectionClass: KClass<out InspectionProfileEntry>
 ) : RsAnnotationTestBase() {
+
+    @JvmField
+    @field:Parameterized.Parameter(0)
+    var testWrappingField: TestWrapping = TestWrapping.NONE
+
+    override val testWrapping: TestWrapping get() = testWrappingField
+
+    companion object {
+        @Parameterized.Parameters(name = "{index}: {0}")
+        @JvmStatic fun data(): Iterable<TestWrapping> = listOf(
+            TestWrapping.NONE,
+            TestWrapping.ATTR_MACRO_AS_IS_ALL_ITEMS,
+        )
+    }
 
     override fun createAnnotationFixture(): RsAnnotationTestFixture<Unit> =
         RsAnnotationTestFixture(this, myFixture, inspectionClasses = listOf(inspectionClass))

--- a/src/test/kotlin/org/rust/ide/inspections/RsLiftInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsLiftInspectionTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.inspections
 
 import org.rust.CheckTestmarkHit
+import org.rust.SkipTestWrapping
 
 class RsLiftInspectionTest : RsInspectionsTestBase(RsLiftInspection::class) {
 
@@ -58,6 +59,7 @@ class RsLiftInspectionTest : RsInspectionsTestBase(RsLiftInspection::class) {
         }
     """, checkWeakWarn = true)
 
+    @SkipTestWrapping // TODO remove after enabling quick-fixes
     @CheckTestmarkHit(RsLiftInspection.Testmarks.InsideRetExpr::class)
     fun `test lift return in if with return`() = checkFixByText("Lift return out of 'if'", """
         fn foo(x: bool) -> i32 {

--- a/src/test/kotlin/org/rust/ide/inspections/RsMissingElseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMissingElseInspectionTest.kt
@@ -5,9 +5,12 @@
 
 package org.rust.ide.inspections
 
+import org.rust.SkipTestWrapping
+
 /**
  * Tests for Missing Else inspection.
  */
+@SkipTestWrapping // TODO adjust `fixupRustSyntaxErrors`
 class RsMissingElseInspectionTest : RsInspectionsTestBase(RsMissingElseInspection::class) {
 
     fun `test simple`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
@@ -108,7 +108,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             fn test3(&self) -> i32;
         }
 
-        <weak_warning descr="Different impl member order from the trait">/*caret*/impl Trait for Struct</weak_warning> {
+        /*weak_warning descr="Different impl member order from the trait"*//*caret*/impl Trait for Struct/*weak_warning**/ {
             type T2 = T;
             const ID2: i32 = 2;
             fn test3(&self) -> i32 {
@@ -164,7 +164,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             fn bar();
         }
 
-        <weak_warning descr="Different impl member order from the trait">/*caret*/impl Foo for ()</weak_warning> {
+        /*weak_warning descr="Different impl member order from the trait"*//*caret*/impl Foo for ()/*weak_warning**/ {
             fn bar() {
             }
             type bar = ();
@@ -188,7 +188,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             fn bar();
         }
 
-        <weak_warning descr="Different impl member order from the trait">/*caret*/unsafe impl Foo for ()</weak_warning> {
+        /*weak_warning descr="Different impl member order from the trait"*//*caret*/unsafe impl Foo for ()/*weak_warning**/ {
             fn bar() {
             }
             fn foo() {
@@ -202,7 +202,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             fn bar();
         }
 
-        <weak_warning descr="Different impl member order from the trait">/*caret*/default unsafe impl Foo for ()</weak_warning> {
+        /*weak_warning descr="Different impl member order from the trait"*//*caret*/default unsafe impl Foo for ()/*weak_warning**/ {
             fn bar() {
             }
             fn foo() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -199,6 +199,7 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         use foo::<error descr="identifier expected, got '::'">:</error>:bar;
     """, false)
 
+    @SkipTestWrapping // TODO remove after enabling expansion for extern crates
     @MockAdditionalCfgOptions("intellij_rust")
     @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
     fun `test unknown crate E0463`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerFixesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerFixesTest.kt
@@ -10,6 +10,7 @@ import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsBorrowCheckerFixesTest : RsInspectionsTestBase(RsBorrowCheckerInspection::class) {
 
     fun `test derive copy on struct`() = checkFixByText("Derive Copy trait", """
@@ -92,7 +93,6 @@ class RsBorrowCheckerFixesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
         }
     """, checkWarn = false)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test derive copy on struct with impl clone`() = checkFixByText("Derive Copy trait", """
         struct S;
         impl Clone for S { fn clone(&self) -> S { unimplemented!() } }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -9,6 +9,7 @@ import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ide.utils.import.Testmarks
 
+@SkipTestWrapping // TODO remove after enabling quick-fixes in macros
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
 class AutoImportFixStdTest : AutoImportFixTestBase() {
     @CheckTestmarkHit(Testmarks.AutoInjectedStdCrate::class)

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -11,6 +11,7 @@ import org.rust.ide.experiments.RsExperiments.EVALUATE_BUILD_SCRIPTS
 import org.rust.ide.experiments.RsExperiments.PROC_MACROS
 import org.rust.ide.utils.import.Testmarks
 
+@SkipTestWrapping // TODO remove after enabling quick-fixes in macros
 class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import struct`() = checkAutoImportFixByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/import/RsReferenceImporterTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/RsReferenceImporterTest.kt
@@ -8,10 +8,12 @@ package org.rust.ide.inspections.import
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
 import org.intellij.lang.annotations.Language
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsUnresolvedReferenceInspection
 import org.rust.ide.settings.RsCodeInsightSettings
 
+@SkipTestWrapping // TODO remove after enabling quick-fixes in macros
 class RsReferenceImporterTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
 
     fun `test single item`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspectionTest.kt
@@ -64,26 +64,6 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
     """)
 
-    fun `test rustc_deprecated attribute`() = checkByText("""
-        #[rustc_deprecated(since="0.0.1", reason="here could be your reason")]
-        pub fn foo() {
-        }
-
-        fn main() {
-            <warning descr="`foo` is deprecated since 0.0.1: here could be your reason">foo</warning>();
-        }
-    """)
-
-    fun `test future rustc_deprecated attribute`() = checkByText("""
-        #[rustc_deprecated(since="1.0.0", reason="here could be your reason")]
-        pub fn foo() {
-        }
-
-        fn main() {
-            <weak_warning descr="`foo` will be deprecated from 1.0.0: here could be your reason">foo</weak_warning>();
-        }
-    """)
-
     fun `test deprecated struct`() = checkByText("""
         #[deprecated]
         struct Foo;

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 
 /**
@@ -264,6 +265,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         pub fn bar() {}
     """)
 
+    @SkipTestWrapping // TODO remove after enabling quick-fixes in macros
     fun `test suppression quick fix for statement 1`() = expect<AssertionError> {
         checkFixByText("Suppress `deprecated` for statement", """
             #[deprecated]

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
@@ -118,11 +118,11 @@ class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifeti
     fun `test output trait type`() = doTest("""
         trait T<'a> {}
         impl <'a> T<'a> for () {}
-        <weak_warning>fn <caret>foo<'a>(a: &'a str) -> impl T<'a></weak_warning> { unimplemented!() }
+        /*weak_warning*/fn /*caret*/foo<'a>(a: &'a str) -> impl T<'a>/*weak_warning**/ { unimplemented!() }
     """, """
         trait T<'a> {}
         impl <'a> T<'a> for () {}
-        fn <caret>foo(a: &str) -> impl T { unimplemented!() }
+        fn /*caret*/foo(a: &str) -> impl T { unimplemented!() }
     """)
 
     fun `test input struct with implicit lifetime`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsSelfConventionInspectionTest.kt
@@ -10,6 +10,7 @@ import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsSelfConventionInspection
 
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionInspection::class) {
     fun `test from`() = checkByText("""
         struct Foo;
@@ -64,7 +65,6 @@ class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionIns
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test is suppressed for copyable`() = checkByText("""
         #[derive(Copy)]
         struct Copyable;
@@ -73,7 +73,6 @@ class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionIns
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test is suppressed for copyable on trait`() = checkByText("""
         use std::marker::Copy;
         trait Copyable: Copy {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMustUseInspectionTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.inspections.lints
 
 import org.rust.ProjectDescriptor
+import org.rust.SkipTestWrapping
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsInspectionsTestBase
 
@@ -122,6 +123,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         }
     """)
 
+    @SkipTestWrapping // TODO test live templates
     fun `test fixing by adding assigning to _ with template`() = checkFixByTextWithLiveTemplate("Add `let _ =`","""
         #[must_use]
         fn foo() -> bool { false }
@@ -168,6 +170,7 @@ class RsUnusedMustUseInspectionTest : RsInspectionsTestBase(RsUnusedMustUseInspe
         }
     """)
 
+    @SkipTestWrapping // TODO test live templates
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test fixing unused result by adding expect with template`() = checkFixByTextWithLiveTemplate("Add `.expect(\"\")`","""
         fn foo() -> Result<bool, ()> { false }

--- a/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.inspections.match
 
 import org.rust.ProjectDescriptor
+import org.rust.SkipTestWrapping
 import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.annotator.ExplicitPreview
@@ -525,6 +526,7 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
         }
     """)
 
+    @SkipTestWrapping // TODO adjust `fixupRustSyntaxErrors`
     fun `test add _ pattern for no expression in match`() = checkFixByText("Add _ pattern", """
         fn main() {
             let test = true;
@@ -631,6 +633,7 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
         }
     """)
 
+    @SkipTestWrapping // TODO adjust `fixupRustSyntaxErrors`
     fun `test add remaining patterns for no expression in match`() = checkFixByText("Add remaining patterns", """
         fn main() {
             let test = true;
@@ -993,6 +996,7 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
         }
     """))
 
+    @SkipTestWrapping // TODO adjust `fixupRustSyntaxErrors`
     fun `test no match body with enum expr`() = checkFixByText("Add remaining patterns", """
         enum E { A, B, C }
 
@@ -1011,6 +1015,7 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
         }
     """)
 
+    @SkipTestWrapping // TODO adjust `fixupRustSyntaxErrors`
     fun `test no match body with i32 expr`() = checkFixByText("Add remaining patterns", """
         fn test(i: i32) {
             <error descr="Match must be exhaustive [E0004]">match/*caret*/</error> i<EOLError descr="'!', '(', '::', <operator>, '[' or '{' expected, got '}'"></EOLError>
@@ -1021,6 +1026,7 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
         }
     """)
 
+    @SkipTestWrapping // TODO adjust `fixupRustSyntaxErrors`
     fun `test no match body with {} expr`() = checkFixByText("Add remaining patterns", """
         fn test() {
             <error descr="Match must be exhaustive [E0004]">match/*caret*/</error> {}<EOLError descr="'(', <operator>, '[' or '{' expected, got '}'"></EOLError>

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -41,7 +41,7 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
         @Parameterized.Parameters(name = "{index}: {0}")
         @JvmStatic fun data(): Iterable<TestWrapping> = listOf(
             TestWrapping.NONE,
-            TestWrapping.ATTR_MACRO_AS_IS,
+            TestWrapping.ATTR_MACRO_AS_IS_AT_CARET,
         )
     }
 

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -8,6 +8,7 @@ package org.rust.ide.refactoring.generate
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class GenerateGetterActionTest : RsGenerateBaseTest() {
     override val generateId: String = "Rust.GenerateGetter"
 
@@ -106,7 +107,6 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test copy impl`() = doTest("""
         #[derive(Copy, Clone)]
         struct Copyable {
@@ -137,7 +137,6 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test string`() = doTest("""
         struct S {
             a: String
@@ -158,7 +157,6 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test enum and struct fields`() = doTest("""
         enum E {
             E1, E2
@@ -218,7 +216,6 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test tuple copy`() = doTest("""
         struct S {
             a: (u32, u32)
@@ -237,7 +234,6 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test tuple move`() = doTest("""
         struct NoCopy;
         struct S {
@@ -410,7 +406,6 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test type alias 2`() = doTest("""
         type Alias = (u32, u32);
         struct S {

--- a/src/test/kotlin/org/rust/ide/ssr/RsSSRTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/ssr/RsSSRTestBase.kt
@@ -9,11 +9,14 @@ import com.intellij.structuralsearch.inspection.SSBasedInspection
 import com.intellij.structuralsearch.inspection.StructuralSearchProfileActionProvider
 import com.intellij.structuralsearch.plugin.ui.SearchConfiguration
 import org.intellij.lang.annotations.Language
+import org.junit.runner.RunWith
+import org.rust.RsJUnit4TestRunner
 import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.lang.RsFileType
 import org.rust.openapiext.runWithEnabledFeatures
 
+@RunWith(RsJUnit4TestRunner::class)
 abstract class RsSSRTestBase : RsInspectionsTestBase(SSBasedInspection::class) {
     protected fun doTest(@Language("Rust") code: String, pattern: String) {
         runWithEnabledFeatures(RsExperiments.SSR) {

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroSyntaxFixupTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroSyntaxFixupTest.kt
@@ -104,6 +104,20 @@ class RsProcMacroSyntaxFixupTest : RsTestBase() {
         }
     """)
 
+    fun `test no extra semicolon for if statement`() = checkSyntaxFixup("""
+        fn main() {
+            let a = 1;
+            if true { 1; } else { 2; }
+            let c = 2;
+        }
+    """, """
+        fn main() {
+            let a = 1;
+            if true { 1; } else { 2; }
+            let c = 2;
+        }
+    """)
+
     private fun checkSyntaxFixup(input: String, @Language("Rust") expectedOutput: String) {
         InlineFile("""
             |use test_proc_macros::attr_as_is;

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCrateInspectionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCrateInspectionTestBase.kt
@@ -7,6 +7,8 @@ package org.rust.toml.inspections
 
 import com.intellij.codeInspection.InspectionProfileEntry
 import org.intellij.lang.annotations.Language
+import org.junit.runner.RunWith
+import org.rust.RsJUnit4TestRunner
 import org.rust.cargo.CargoConstants
 import org.rust.ide.annotator.RsAnnotationTestFixture
 import org.rust.ide.experiments.RsExperiments
@@ -16,6 +18,7 @@ import org.rust.toml.crates.local.CargoRegistryCrate
 import org.rust.toml.crates.local.withMockedCrates
 import kotlin.reflect.KClass
 
+@RunWith(RsJUnit4TestRunner::class)
 abstract class CargoTomlCrateInspectionTestBase(
     inspectionClass: KClass<out InspectionProfileEntry>
 ) : RsInspectionsTestBase(inspectionClass) {

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspectionTest.kt
@@ -6,9 +6,12 @@
 package org.rust.toml.inspections
 
 import org.intellij.lang.annotations.Language
+import org.junit.runner.RunWith
+import org.rust.RsJUnit4TestRunner
 import org.rust.cargo.CargoConstants.MANIFEST_FILE
 import org.rust.ide.inspections.RsInspectionsTestBase
 
+@RunWith(RsJUnit4TestRunner::class)
 class CargoTomlCyclicFeatureInspectionTest : RsInspectionsTestBase(CargoTomlCyclicFeatureInspection::class) {
     fun `test feature depending on itself`() = doTest("""
         [features]

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlUnresolvedPathReferenceInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlUnresolvedPathReferenceInspectionTest.kt
@@ -5,9 +5,12 @@
 
 package org.rust.toml.inspections
 
+import org.junit.runner.RunWith
+import org.rust.RsJUnit4TestRunner
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.toml.ide.inspections.TomlUnresolvedReferenceInspection
 
+@RunWith(RsJUnit4TestRunner::class)
 class CargoTomlUnresolvedPathReferenceInspectionTest : RsInspectionsTestBase(TomlUnresolvedReferenceInspection::class) {
     fun `test build script found`() = checkByFileTree("""
         //- main.rs

--- a/toml/src/test/kotlin/org/rust/toml/inspections/MissingFeaturesInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/MissingFeaturesInspectionTest.kt
@@ -7,6 +7,7 @@ package org.rust.toml.inspections
 
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.vfs.VirtualFile
+import org.junit.runner.RunWith
 import org.rust.*
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.FeatureState
@@ -15,6 +16,7 @@ import org.rust.ide.annotator.RsAnnotationTestFixture
 import org.rust.ide.inspections.RsWithToolchainInspectionTestBase
 import org.rust.toml.inspections.MissingFeaturesInspectionTest.Context
 
+@RunWith(RsJUnit4TestRunner::class)
 class MissingFeaturesInspectionTest : RsWithToolchainInspectionTestBase<Context>(MissingFeaturesInspection::class) {
 
     fun `test missing dependency feature`() = doTest(


### PR DESCRIPTION
From now, each test declared in a subclass of `RsAnnotatorTestBase` and `RsInspectionsTestBase` will run 2 times:
1. as usual
2. with all items in the test snipped wrapped to an attribute macro invocation (`#[attr_as_is]` added)

Some tests are skipped for now (with `@SkipTestWrapping`). Quick fixes are not yet tested in the wrapped mode.

See https://github.com/intellij-rust/intellij-rust/pull/10277 for more details.

In this PR, quick fixes are still not tested (because they don't work inside macros). Also, some tests are skipped in the wrapped mode for different reasons.

This MR also fixes many issues with inspections and annotators w.r.t. attribute macros