### PR TITLE
Make parameter info available inside struct literal

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsAsyncParameterInfoHandler.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsAsyncParameterInfoHandler.kt
@@ -7,9 +7,11 @@ package org.rust.ide.hints.parameter
 
 import com.intellij.lang.parameterInfo.CreateParameterInfoContext
 import com.intellij.lang.parameterInfo.ParameterInfoHandler
+import com.intellij.lang.parameterInfo.ParameterInfoUIContext
 import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.util.concurrency.AppExecutorUtil
@@ -64,8 +66,26 @@ abstract class RsAsyncParameterInfoHandler<ParameterOwner : PsiElement, Paramete
         context.showHint(element, element.startOffset, this)
     }
 
-    private companion object {
+    companion object {
         private val executor: Executor =
             AppExecutorUtil.createBoundedApplicationPoolExecutor("Rust async parameter info handler", 1)
+
+        fun updateUI(text: String, range: TextRange, context: ParameterInfoUIContext) {
+            context.setupUIComponentPresentation(
+                text,
+                range.startOffset,
+                range.endOffset,
+                !context.isUIComponentEnabled,
+                false,
+                false,
+                context.defaultParameterColor
+            )
+        }
+
+        fun getArgumentRange(arguments: Array<String>, index: Int): TextRange {
+            if (index < 0 || index >= arguments.size) return TextRange.EMPTY_RANGE
+            val start = arguments.take(index).sumOf { it.length + 2 }
+            return TextRange(start, start + arguments[index].length)
+        }
     }
 }

--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsParameterInfoHandler.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsParameterInfoHandler.kt
@@ -8,7 +8,6 @@ package org.rust.ide.hints.parameter
 import com.intellij.lang.parameterInfo.ParameterInfoUIContext
 import com.intellij.lang.parameterInfo.ParameterInfoUtils
 import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import org.rust.ide.utils.CallInfo
 import org.rust.lang.core.psi.RsCallExpr
@@ -44,15 +43,8 @@ class RsParameterInfoHandler : RsAsyncParameterInfoHandler<RsValueArgumentList, 
     }
 
     override fun updateUI(p: RsArgumentsDescription, context: ParameterInfoUIContext) {
-        val range = p.getArgumentRange(context.currentParameterIndex)
-        context.setupUIComponentPresentation(
-            p.presentText,
-            range.startOffset,
-            range.endOffset,
-            !context.isUIComponentEnabled,
-            false,
-            false,
-            context.defaultParameterColor)
+        val range = getArgumentRange(p.arguments, context.currentParameterIndex)
+        updateUI(p.presentText, range, context)
     }
 }
 
@@ -62,12 +54,6 @@ class RsParameterInfoHandler : RsAsyncParameterInfoHandler<RsValueArgumentList, 
 class RsArgumentsDescription(
     val arguments: Array<String>
 ) {
-    fun getArgumentRange(index: Int): TextRange {
-        if (index < 0 || index >= arguments.size) return TextRange.EMPTY_RANGE
-        val start = arguments.take(index).sumOf { it.length + 2 }
-        return TextRange(start, start + arguments[index].length)
-    }
-
     val presentText = if (arguments.isEmpty()) "<no arguments>" else arguments.joinToString(", ")
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsStructLiteralParameterInfoHandler.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsStructLiteralParameterInfoHandler.kt
@@ -1,0 +1,78 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.parameter
+
+import com.intellij.lang.parameterInfo.ParameterInfoUIContext
+import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
+import com.intellij.psi.PsiFile
+import com.intellij.util.containers.map2Array
+import org.rust.ide.hints.parameter.RsStructLiteralParameterInfoHandler.Description
+import org.rust.ide.utils.findElementAtIgnoreWhitespaceBefore
+import org.rust.lang.core.psi.RsStructLiteral
+import org.rust.lang.core.psi.RsStructLiteralBody
+import org.rust.lang.core.psi.RsStructLiteralField
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.substAndGetText
+import org.rust.lang.core.resolve.ref.deepResolve
+import org.rust.lang.core.types.emptySubstitution
+import org.rust.lang.core.types.ty.TyAdt
+import org.rust.lang.core.types.type
+import org.rust.stdext.mapNotNullToSet
+
+class RsStructLiteralParameterInfoHandler : RsAsyncParameterInfoHandler<RsStructLiteralBody, Description>() {
+
+    class Description(val fields: Array<Field>)
+    class Field(val name: String, val type: String)
+
+    override fun findTargetElement(file: PsiFile, offset: Int): RsStructLiteralBody? =
+        file.findElementAt(offset)?.ancestorStrict()
+
+    override fun calculateParameterInfo(element: RsStructLiteralBody): Array<Description>? {
+        val structLiteral = element.parent as? RsStructLiteral ?: return null
+        val struct = structLiteral.path.reference?.deepResolve() as? RsFieldsOwner ?: return null
+        if (struct.blockFields == null) return null
+        val subst = (structLiteral.type as? TyAdt)?.typeParameterValues ?: emptySubstitution
+        val fields = struct.namedFields.map2Array {
+            val name = it.name ?: ""
+            val type = it.typeReference?.substAndGetText(subst) ?: "_"
+            Field(name, type)
+        }
+        return arrayOf(Description(fields))
+    }
+
+    override fun updateParameterInfo(parameterOwner: RsStructLiteralBody, context: UpdateParameterInfoContext) {
+        val description = context.objectsToView.singleOrNull() as? Description ?: return
+        val declaredFields = description.fields.map { it.name }
+
+        val fields = parameterOwner.structLiteralFieldList.mapNotNullToSet { it.referenceName }
+        val currentField = findCurrentFieldName(parameterOwner, context.offset)
+
+        val index = when {
+            currentField != null -> declaredFields.indexOf(currentField)
+            declaredFields.size == fields.size -> 0
+            else -> declaredFields.indexOfFirst { it !in fields }
+        }
+        context.setCurrentParameter(index)
+    }
+
+    private fun findCurrentFieldName(structLiteral: RsStructLiteralBody, offset: Int): String? {
+        val file = structLiteral.containingFile
+        val element1 = file.findElementAtIgnoreWhitespaceBefore(offset)
+        val element2 = element1?.getPrevNonWhitespaceSibling()
+        val field = element1?.ancestorOrSelf<RsStructLiteralField>()
+            ?: element2?.ancestorOrSelf<RsStructLiteralField>()
+            ?: return null
+        return field.referenceName
+    }
+
+    override fun updateUI(p: Description, context: ParameterInfoUIContext) {
+        val fields = p.fields
+        val fieldsText = fields.map2Array { "${it.name}: ${it.type}" }
+        val text = fieldsText.joinToString(", ").ifEmpty { "<no fields>" }
+        val range = getArgumentRange(fieldsText, context.currentParameterIndex)
+        updateUI(text, range, context)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/typing/RsTypedHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsTypedHandler.kt
@@ -76,6 +76,12 @@ class RsTypedHandler : TypedHandlerDelegate() {
             }
         }
 
+        // struct literal `Foo {/*caret*/}`
+        if (charTyped == '{') {
+            AutoPopupController.getInstance(project).autoPopupParameterInfo(editor, null)
+            return Result.STOP
+        }
+
         return Result.CONTINUE
     }
 }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -178,6 +178,7 @@
 
         <codeInsight.typeInfo language="Rust" implementationClass="org.rust.ide.hints.type.RsExpressionTypeProvider"/>
         <codeInsight.parameterInfo language="Rust" implementationClass="org.rust.ide.hints.parameter.RsParameterInfoHandler"/>
+        <codeInsight.parameterInfo language="Rust" implementationClass="org.rust.ide.hints.parameter.RsStructLiteralParameterInfoHandler"/>
         <codeInsight.parameterInfo language="Rust"
                                    implementationClass="org.rust.ide.hints.parameter.RsGenericParameterInfoHandler"/>
         <codeInsight.parameterNameHints language="Rust"

--- a/src/test/kotlin/org/rust/ide/hints/parameter/RsParameterInfoHandlerTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/hints/parameter/RsParameterInfoHandlerTestBase.kt
@@ -37,7 +37,7 @@ abstract class RsParameterInfoHandlerTestBase<A : PsiElement, B>(
                 assertEquals(hint, context.text)
 
                 // Check parameter index
-                val updateContext = MockUpdateParameterInfoContext(myFixture.editor, myFixture.file)
+                val updateContext = MockUpdateParameterInfoContext(myFixture.editor, myFixture.file, createContext.itemsToShow)
                 updateContext.parameterOwner = elt
                 val element = handler.findElementForUpdatingParameterInfo(updateContext) ?: error("Parameter not found")
                 handler.updateParameterInfo(element, updateContext)

--- a/src/test/kotlin/org/rust/ide/hints/parameter/RsStructLiteralParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/parameter/RsStructLiteralParameterInfoHandlerTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints.parameter
+
+import org.rust.ide.hints.parameter.RsStructLiteralParameterInfoHandler.Description
+import org.rust.lang.core.psi.RsStructLiteralBody
+
+class RsStructLiteralParameterInfoHandlerTest
+    : RsParameterInfoHandlerTestBase<RsStructLiteralBody, Description>(RsStructLiteralParameterInfoHandler()) {
+
+    fun `test no fields`() = checkByText("""
+        struct Foo {}
+        fn main() {
+            Foo { /*caret*/ };
+        }
+    """, "<no fields>", 0)
+
+    fun `test one field, zero present`() = checkByText("""
+        struct Foo { a: i32 }
+        fn main() {
+            Foo { /*caret*/ };
+        }
+    """, "a: i32", 0)
+
+    fun `test one field, one present`() = checkByText("""
+        struct Foo { a: i32 }
+        fn main() {
+            Foo { a: 1/*caret*/ };
+        }
+    """, "a: i32", 0)
+
+    fun `test two fields, first present`() = checkByText("""
+        struct Foo { a: i32, b: i32 }
+        fn main() {
+            Foo { a: 1/*caret*/ };
+        }
+    """, "a: i32, b: i32", 0)
+
+    fun `test two fields, second present 1`() = checkByText("""
+        struct Foo { a: i32, b: i32 }
+        fn main() {
+            Foo { /*caret*/b: 1 };
+        }
+    """, "a: i32, b: i32", 1)
+
+    fun `test two fields, second present 2`() = checkByText("""
+        struct Foo { a: i32, b: i32 }
+        fn main() {
+            Foo { b:/*caret*/ 1 };
+        }
+    """, "a: i32, b: i32", 1)
+
+    fun `test two fields, second present 3`() = checkByText("""
+        struct Foo { a: i32, b: i32 }
+        fn main() {
+            Foo { b: 1/*caret*/ };
+        }
+    """, "a: i32, b: i32", 1)
+
+    fun `test three fields, first and third present`() = checkByText("""
+        struct Foo { a: i32, b: i32, c: i32 }
+        fn main() {
+            Foo { a: 1, c: 1/*caret*/ };
+        }
+    """, "a: i32, b: i32, c: i32", 2)
+
+    fun `test missing field`() = checkByText("""
+        struct Foo { a: i32, b: i32, c: i32 }
+        fn main() {
+            Foo { a: 1, /*caret*/, c: 1 };
+        }
+    """, "a: i32, b: i32, c: i32", 1)
+
+    fun `test field without value`() = checkByText("""
+        struct Foo { a: i32, b: i32 }
+        fn main() {
+            Foo { b/*caret*/ };
+        }
+    """, "a: i32, b: i32", 1)
+
+    fun `test enum variant`() = checkByText("""
+        enum E {
+            Foo { a: i32, b: i32 },
+        }
+        fn main() {
+            E::Foo { b: 1/*caret*/ };
+        }
+    """, "a: i32, b: i32", 1)
+
+    fun `test generics`() = checkByText("""
+        struct Foo<T> { a: T, b: T }
+        fn main() {
+            Foo { a: 1, /*caret*/ };
+        }
+    """, "a: i32, b: i32", 1)
+
+    fun `test generics (enum variant)`() = checkByText("""
+        enum E<T> {
+            Foo { a: T, b: T },
+        }
+        fn main() {
+            E::Foo { a: 1, /*caret*/ };
+        }
+    """, "a: i32, b: i32", 1)
+
+    fun `test raw identifier`() = checkByText("""
+        struct Foo { r#let: i32 }
+        fn main() {
+            Foo { /*caret*/ };
+        }
+    """, "let: i32", 0)
+}


### PR DESCRIPTION
Note that hint should be shown automatically after typing `{`