### PR TITLE
T&PERF: slightly speed up tests

### DIFF
--- a/src/test/kotlin/org/rust/RsJUnit4TestRunner.kt
+++ b/src/test/kotlin/org/rust/RsJUnit4TestRunner.kt
@@ -33,7 +33,7 @@ class RsJUnit4TestRunner(testClass: Class<*>) : BlockJUnit4ClassRunner(testClass
                 val all = junit4Methods.toMutableList()
                 junit3Methods.mapTo(all) { FrameworkMethod(it) }
                 Collections.unmodifiableList(all)
-            }
+            }.sortTests()
         }
 
         private fun computeJUnit3TestMethods(testClass: TestClass): List<Method> {
@@ -62,5 +62,15 @@ class RsJUnit4TestRunner(testClass: Class<*>) : BlockJUnit4ClassRunner(testClass
                 && Modifier.isPublic(m.modifiers)
                 && m.getAnnotation(org.junit.Test::class.java) == null
         }
+
+        private fun List<FrameworkMethod>.sortTests(): List<FrameworkMethod> {
+            // Switching between project descriptors is expensive, so let's group tests by project descriptor
+            return map { it to it.projectDescriptorName }
+                .sortedBy { it.second }
+                .map { it.first }
+        }
+
+        private val FrameworkMethod.projectDescriptorName: String
+            get() = method.getAnnotation(ProjectDescriptor::class.java)?.descriptor?.simpleName ?: ""
     }
 }

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -271,6 +271,9 @@ open class WithProcMacros(
     override val rustcInfo: RustcInfo?
         get() = delegate.rustcInfo ?: ProcMacroPackageHolder.rustcInfo
 
+    override val macroExpansionCachingKey: String?
+        get() = delegate.macroExpansionCachingKey
+
     override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
         val procMacroPackage = ProcMacroPackageHolder.getOrFetchMacroPackage(module.project)
         check(procMacroPackage != null) { "Proc macro crate is not compiled successfully" }


### PR DESCRIPTION
1. Sort tests by project descriptor
 Switching between project descriptors is expensive, so let's group tests by project descriptor
2. Pass `macroExpansionCachingKey` through `WithProcMacros`
3. Use proper ForkJoinPool threadFactory in tests
 The factory should be set up automatically in `IdeaForkJoinWorkerThreadFactory.setupForkJoinCommonPool`,
 but when tests are launched by Gradle this may not happen because Gradle can use the pool earlier.
 Setting this factory is critical for `ReadMostlyRWLock` performance, so ensure it is properly set