### PR TITLE
Fix `self` parameter type handling in suggested refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringStateChanges.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringStateChanges.kt
@@ -14,7 +14,9 @@ import com.intellij.refactoring.suggested.SuggestedRefactoringSupport
 import org.rust.lang.core.psi.RsElementTypes.COLON
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPatIdent
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.childrenWithLeaves
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.rawValueParameters
 
 data class RsSignatureAdditionalData(val isFunction: Boolean) : SuggestedRefactoringSupport.SignatureAdditionalData
 data class RsParameterAdditionalData(val isPatIdent: Boolean) : SuggestedRefactoringSupport.ParameterAdditionalData
@@ -24,10 +26,9 @@ class RsSuggestedRefactoringStateChanges(
 ) : SuggestedRefactoringStateChanges(support) {
     override fun parameterMarkerRanges(anchor: PsiElement): List<TextRange?> {
         val function = anchor as? RsFunction ?: return emptyList()
-        val parameterColons: List<PsiElement?> = listOf(function.selfParameter?.colon) +
-            function.rawValueParameters.map { parameter ->
-                parameter.childrenWithLeaves.firstOrNull { it.elementType == COLON }
-            }
+        val parameterColons: List<PsiElement?> = function.rawValueParameters.map { parameter ->
+            parameter.childrenWithLeaves.firstOrNull { it.elementType == COLON }
+        }
         return parameterColons.mapNotNull { it?.textRange }
     }
 

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsChangeSignatureSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsChangeSignatureSuggestedRefactoringTest.kt
@@ -538,6 +538,44 @@ New:
   ')'
     """.trimIndent())
 
+    fun `test change method impl with explicit self type`() = doTestChangeSignature("""
+        trait Trait {
+            fn foo(&self: &Self/*caret*/);
+        }
+
+        struct S;
+        impl Trait for S {
+            fn foo(&self: &Self) {}
+        }
+    """, """
+        trait Trait {
+            fn foo(&self: &Self, a: u32);
+        }
+
+        struct S;
+        impl Trait for S {
+            fn foo(&self: &Self, a: u32) {}
+        }
+    """, "foo", {
+        myFixture.type(", a: u32")
+    }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (added):
+    'a'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
     fun `test default value only parameter`() {
         val factory = RsPsiFactory(project)
         val exprs = listOf(


### PR DESCRIPTION
Previously, `change signature` refactoring was not suggested in this case:

```rust
trait Trait {
    fn foo(self: &Self/*caret*/); // Type `, a: i32`
}

struct S;
impl Trait for S {
    fn foo(self: &Self) {}
}
```

changelog: Suggest `change signature` refactoring when editing a signature of a method with explicit `self` type