### PR TITLE
T&PERF: use single `LightProjectDescriptor` in most tests

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
@@ -39,6 +39,11 @@ class TestCargoProjectsServiceImpl(project: Project) : CargoProjectsServiceImpl(
     }
 
     @TestOnly
+    fun removeAllProjects() {
+        modifyProjectsSync { CompletableFuture.completedFuture(emptyList()) }
+    }
+
+    @TestOnly
     fun setRustcVersion(rustcVersion: RustcVersion, parentDisposable: Disposable) {
         val oldValues = mutableMapOf<Path, RustcInfo?>()
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.RootsChangeRescanningInfo
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx
 import com.intellij.openapi.util.*
 import com.intellij.openapi.util.io.BufferExposingByteArrayOutputStream
@@ -292,14 +293,14 @@ class MacroExpansionManagerImpl(
         check(isUnitTestMode)
         val dir = updateDirs(cacheDirectory.ifEmpty { null })
         val impl = MacroExpansionServiceBuilder.build(project, dir)
-        this.dirs = dir
-        this.inner = impl
         impl.macroExpansionMode = mode
         impl.enabledInUnitTests = true
 
         runWriteAction {
+            this.dirs = dir
+            this.inner = impl
             ProjectRootManagerEx.getInstanceEx(project)
-                .makeRootsChange(EmptyRunnable.getInstance(), false, true)
+                .makeRootsChange(EmptyRunnable.getInstance(), RootsChangeRescanningInfo.TOTAL_RESCAN)
         }
 
         val saveCacheOnDispose = cacheDirectory.isNotEmpty()

--- a/src/test/kotlin/org/rust/ProjectDescriptor.kt
+++ b/src/test/kotlin/org/rust/ProjectDescriptor.kt
@@ -5,13 +5,12 @@
 
 package org.rust
 
-import com.intellij.testFramework.LightProjectDescriptor
 import java.lang.annotation.Inherited
 import kotlin.reflect.KClass
 
 /**
- * Allows to set [LightProjectDescriptor] for a specific test.
- * The [descriptor] class must be a kotlin object (`object Foo : LightProjectDescriptor`).
+ * Allows to set [RustProjectDescriptorBase] for a specific test.
+ * The [descriptor] class must be a kotlin object (`object Foo : RustProjectDescriptorBase`).
  *
  * Example values:
  * - [WithStdlibRustProjectDescriptor]
@@ -24,4 +23,4 @@ import kotlin.reflect.KClass
 @Inherited
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class ProjectDescriptor(val descriptor: KClass<out LightProjectDescriptor>)
+annotation class ProjectDescriptor(val descriptor: KClass<out RustProjectDescriptorBase>)

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -6,9 +6,16 @@
 package org.rust
 
 import com.intellij.codeInsight.template.impl.TemplateManagerImpl
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.application.invokeAndWaitIfNeeded
 import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.RootsChangeRescanningInfo
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ex.ProjectRootManagerEx
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.EmptyRunnable
 import com.intellij.openapi.util.RecursionManager
 import com.intellij.openapi.vcs.ex.ProjectLevelVcsManagerEx
 import com.intellij.openapi.vcs.impl.ProjectLevelVcsManagerImpl
@@ -37,6 +44,7 @@ import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.settings.ExcludedPath
 import org.rust.ide.settings.ExclusionType
 import org.rust.ide.settings.RsCodeInsightSettings
+import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.openapiext.document
 import org.rust.openapiext.saveAllDocuments
@@ -52,25 +60,7 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
     private var tempDirRootUrl: String? = null
     private var tempDirRoot: VirtualFile? = null
 
-    override fun getProjectDescriptor(): LightProjectDescriptor {
-        val baseDesc = run {
-            val annotation = findAnnotationInstance<ProjectDescriptor>() ?: return@run DefaultDescriptor
-            return@run (annotation.descriptor.objectInstance
-                ?: error("Only Kotlin objects defined with `object` keyword are allowed"))
-        }
-        val testWrapping = testWrapping
-        if (shouldSkipTestWrapping(testWrapping)) {
-            shouldSkipTestWithCurrentWrapping = true
-            return baseDesc
-        }
-        val wrappedDesc = (baseDesc as? RustProjectDescriptorBase)?.let { testWrapping.wrapProjectDescriptor(it) }
-        return if (wrappedDesc == null) {
-            shouldSkipTestWithCurrentWrapping = true
-            baseDesc
-        } else {
-            wrappedDesc
-        }
-    }
+    override fun getProjectDescriptor(): LightProjectDescriptor = RustLightProjectDescriptor
 
     open val testWrapping: TestWrapping get() = TestWrapping.NONE
     private var shouldSkipTestWithCurrentWrapping: Boolean = false
@@ -85,8 +75,7 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
     override fun setUp() {
         super.setUp()
 
-        (projectDescriptor as? RustProjectDescriptorBase)?.setUp(myFixture)
-
+        invokeAndWaitIfNeeded { setupRustProject() }
         setupMockRustcVersion()
         setupMockEdition()
         setupMockCfgOptions()
@@ -128,6 +117,66 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
             }
             error("Root directory has been renamed from `$oldTempDirRootUrl` to `$newTempDirRootUrl`; This should not happens")
         }
+    }
+
+    private val rustProjectDescriptor: RustProjectDescriptorBase
+        get() {
+            val baseDesc = run {
+                val annotation = findAnnotationInstance<ProjectDescriptor>() ?: return@run DefaultDescriptor
+                return@run (annotation.descriptor.objectInstance
+                    ?: error("Only Kotlin objects defined with `object` keyword are allowed"))
+            }
+            val testWrapping = testWrapping
+            if (shouldSkipTestWrapping(testWrapping)) {
+                shouldSkipTestWithCurrentWrapping = true
+                return baseDesc
+            }
+            val wrappedDesc = (baseDesc as? RustProjectDescriptorBase)?.let { testWrapping.wrapProjectDescriptor(it) }
+            return if (wrappedDesc == null) {
+                shouldSkipTestWithCurrentWrapping = true
+                baseDesc
+            } else {
+                wrappedDesc
+            }
+        }
+
+    private fun setupRustProject() {
+        if (projectDescriptor != RustLightProjectDescriptor) {
+            RustProjectDescriptorHolder.disposePreviousDescriptor()
+            return
+        }
+
+        val descriptor = rustProjectDescriptor
+        val projectDir = ModuleRootManager.getInstance(myFixture.module).contentEntries.single().file!!
+
+        val key = RustProjectDescriptorKey(project, projectDir, descriptor)
+
+        if (RustProjectDescriptorHolder.previousDescriptorKey != key) {
+            RustProjectDescriptorHolder.disposePreviousDescriptor()
+
+            val ws = descriptor.createTestCargoWorkspace(project, projectDir.url)
+            if (ws != null) {
+                project.testCargoProjects.createTestProject(projectDir, ws, descriptor.rustcInfo)
+            } else {
+                project.testCargoProjects.removeAllProjects()
+            }
+
+            val disposable = module.project.macroExpansionManager.setUnitTestExpansionModeAndDirectory(
+                MacroExpansionScope.ALL,
+                descriptor.macroExpansionCachingKey.orEmpty()
+            )
+            @Suppress("IncorrectParentDisposable") // It's fine for a unit test
+            Disposer.register(module, disposable)
+            RustProjectDescriptorHolder.disposable = disposable
+
+            runWriteAction {
+                ProjectRootManagerEx.getInstanceEx(project)
+                    .makeRootsChange(EmptyRunnable.getInstance(), RootsChangeRescanningInfo.TOTAL_RESCAN)
+            }
+
+            RustProjectDescriptorHolder.previousDescriptorKey = key
+        }
+        descriptor.setUp(myFixture)
     }
 
     private fun setupMockRustcVersion() {
@@ -285,16 +334,20 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
 
     protected open val skipTestReason: String?
         get() {
-            val projectDescriptor = projectDescriptor as? RustProjectDescriptorBase
-            return projectDescriptor?.skipTestReason ?: run {
+            val projectDescriptor = rustProjectDescriptor
+
+            fun getMinRustVersionReason(): String? {
                 if (shouldSkipTestWithCurrentWrapping) {
                     return "this test is marked to skip the wrapping `${testWrapping.name}`"
                 }
-                checkRustcVersionRequirements {
+                return checkRustcVersionRequirements {
                     val rustcVersion = projectDescriptor?.rustcInfo?.version?.semver
                     if (rustcVersion != null) RsResult.Ok(rustcVersion) else RsResult.Err(null)
                 }
             }
+
+            return projectDescriptor.skipTestReason
+                ?: getMinRustVersionReason()
         }
 
     private fun shouldSkipTestWrapping(testWrapping: TestWrapping): Boolean {
@@ -526,6 +579,35 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
             optionProperty.set(oldValue)
         }
     }
+
+    /**
+     * Holds a static instance of [RustProjectDescriptorBase] between tests in order to speed up tests.
+     *
+     * (This is similar to [com.intellij.testFramework.LightPlatformTestCase.ourProject], see
+     * [com.intellij.testFramework.LightPlatformTestCase.doSetup])
+     */
+    private object RustProjectDescriptorHolder {
+        var previousDescriptorKey: RustProjectDescriptorKey? = null
+        var disposable: Disposable? = null
+
+        fun disposePreviousDescriptor() {
+            previousDescriptorKey = null
+            val disposable = disposable
+            if (disposable != null) {
+                Disposer.dispose(disposable)
+                this.disposable = null
+                checkMacroExpansionFileSystemAfterTest()
+            }
+        }
+    }
+
+    private data class RustProjectDescriptorKey(
+        val project: Project,
+        val projectDir: VirtualFile,
+        val descriptor: RustProjectDescriptorBase,
+    )
+
+    private object RustLightProjectDescriptor : LightProjectDescriptor()
 
     companion object {
         // XXX: hides `Assert.fail`

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionTest.kt
@@ -5,11 +5,12 @@
 
 package org.rust.lang.core.completion
 
-import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
 import com.intellij.util.Urls
 import org.rust.ProjectDescriptor
 import org.rust.RustProjectDescriptorBase
 import org.rust.WithRustup
+import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import java.nio.file.Paths
@@ -273,7 +274,7 @@ class RsPathCompletionTest : RsCompletionTestBase() {
 }
 
 private object WithWorkspaceProjectDescriptor : RustProjectDescriptorBase() {
-    override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
+    override fun createTestCargoWorkspace(project: Project, contentRoot: String): CargoWorkspace {
         val crateA = testCargoPackage("$contentRoot/crate-a", name="crate-a")
         val crateB = testCargoPackage("$contentRoot/crate-b", name="crate-b")
 

--- a/src/test/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystemTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystemTest.kt
@@ -9,10 +9,15 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileSystem
 import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.LightProjectDescriptor
+import org.rust.EmptyDescriptor
+import org.rust.ProjectDescriptor
+import org.rust.RsTestBase
 import org.rust.checkMacroExpansionFileSystemAfterTest
 
-class MacroExpansionFileSystemTest : BasePlatformTestCase() {
+class MacroExpansionFileSystemTest : RsTestBase() {
+    override fun getProjectDescriptor(): LightProjectDescriptor = LightProjectDescriptor.EMPTY_PROJECT_DESCRIPTOR
+
     fun `test simple`() {
         batch {
             createFile("/foo/bar.txt", "bar content")

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
@@ -117,7 +117,7 @@ class RsMultipleDefMapsUpdateTest : RsTestBase() {
 }
 
 /**
- * See [WithDependencyRustProjectDescriptor.testCargoProject]
+ * See [WithDependencyRustProjectDescriptor.createTestCargoWorkspace]
  *
  * BIN -> LIB -> DEP_LIB -> TRANS_LIB -> TRANS_LIB2
  *                  |

--- a/src/test/kotlin/org/rustPerformanceTests/RsParsingPerfTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsParsingPerfTest.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.SyntaxTraverser
 import com.intellij.psi.impl.source.tree.TreeUtil
 import com.intellij.psi.tree.ILazyParseableElementTypeBase
 import com.intellij.util.LocalTimeCounter
+import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.RsFileType
@@ -22,8 +23,8 @@ import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.doc.psi.RsDocComment
 import org.rust.stdext.repeatBenchmark
 
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsParsingPerfTest : RsTestBase() {
-    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
 
     fun `test stdlib source`() {
         val sources = rustSrcDir()
@@ -101,5 +102,5 @@ class RsParsingPerfTest : RsTestBase() {
         )
     }
 
-    private fun rustSrcDir(): VirtualFile = projectDescriptor.stdlib!!
+    private fun rustSrcDir(): VirtualFile = WithStdlibRustProjectDescriptor.stdlib!!
 }

--- a/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesLazyBlockStubCreationTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesLazyBlockStubCreationTest.kt
@@ -6,11 +6,12 @@
 package org.rustSlowTests
 
 import com.intellij.openapi.vfs.VirtualFile
+import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.stubs.RsLazyBlockStubCreationTestBase
 
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsCompilerSourcesLazyBlockStubCreationTest : RsLazyBlockStubCreationTestBase() {
-    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
 
     fun `test stdlib source`() {
         val sources = rustSrcDir()
@@ -20,5 +21,5 @@ class RsCompilerSourcesLazyBlockStubCreationTest : RsLazyBlockStubCreationTestBa
         )
     }
 
-    private fun rustSrcDir(): VirtualFile = projectDescriptor.stdlib!!
+    private fun rustSrcDir(): VirtualFile = WithStdlibRustProjectDescriptor.stdlib!!
 }

--- a/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesPerfTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesPerfTest.kt
@@ -14,15 +14,14 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.impl.DebugUtil
 import com.intellij.psi.util.PsiTreeUtil
+import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.RsFileType
 import kotlin.system.measureTimeMillis
 
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsCompilerSourcesPerfTest : RsTestBase() {
-    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
-
-
     // Use this function to check that some code does not blow up
     // on some strange real-world PSI.
 //    fun `test anything`() = forAllPsiElements { element ->
@@ -115,7 +114,7 @@ class RsCompilerSourcesPerfTest : RsTestBase() {
         })
     }
 
-    private fun rustSrcDir(): VirtualFile = projectDescriptor.stdlib!!
+    private fun rustSrcDir(): VirtualFile = WithStdlibRustProjectDescriptor.stdlib!!
 
     private fun VirtualFile.loadText(): CharSequence = LoadTextUtil.loadText(this)
 }


### PR DESCRIPTION
Use one `LightProjectDescriptor` in almost all tests. The test framework caches `com.intellij.openapi.project.Project`
 instance between tests if these tests have the same `LightProjectDescriptor` instance. If not, the framework initializes a new `Project`. Previously we used different `LightProjectDescriptor` instances in order to make different `CargoWorkspace`
 setups (For example, with, or without stdlib). But we could change this setup without creating a new `Project`. So I've introduced `RustLightProjectDescriptor` which is now used in almost all tests. The Cargo workspace setup is done by `RustProjectDescriptorBase` as before (but now `RustProjectDescriptorBase` does not extend `LightProjectDescriptor` and works in parallel with it)
