### PR TITLE
Support quick fixes in attribute macros

### DIFF
--- a/src/main/kotlin/org/rust/ide/fixes/AddAsTyFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddAsTyFix.kt
@@ -6,11 +6,8 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.presentation.shortPresentableText
 import org.rust.lang.core.psi.RsExpr
@@ -24,14 +21,11 @@ class AddAsTyFix(
     expr: RsExpr,
     @SafeFieldForPreview
     private val ty: Ty,
-) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
-
+) : RsQuickFixBase<RsExpr>(expr) {
     override fun getFamilyName(): String = "Add safe cast"
-
     override fun getText(): String = "Add safe cast to ${ty.shortPresentableText}"
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsExpr) return
-        startElement.replace(RsPsiFactory(project).createCastExpr(startElement, ty.renderInsertionSafe(startElement)))
+    override fun invoke(project: Project, editor: Editor?, element: RsExpr) {
+        element.replace(RsPsiFactory(project).createCastExpr(element, ty.renderInsertionSafe(element)))
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/AddAssocTypeBindingsFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddAssocTypeBindingsFix.kt
@@ -6,11 +6,8 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.RsPathType
 import org.rust.lang.core.psi.RsPsiFactory
@@ -19,21 +16,14 @@ import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.startOffset
 
 class AddAssocTypeBindingsFix(
-    element: PsiElement,
+    element: RsElement,
     @SafeFieldForPreview
     private val missingTypes: List<String>
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+) : RsQuickFixBase<RsElement>(element) {
     override fun getText(): String = "Add missing associated types"
     override fun getFamilyName() = text
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val element = startElement as? RsElement ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsElement) {
         val path = when (element) {
             is RsTraitRef -> element.path
             is RsPathType -> element.path

--- a/src/main/kotlin/org/rust/ide/fixes/AddAsyncAttributeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddAsyncAttributeFix.kt
@@ -5,11 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.utils.import.RsImportHelper
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPsiFactory
@@ -17,24 +14,16 @@ import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.containingCrate
 import org.rust.lang.core.resolve.knownItems
 
-class AddAsyncRecursionAttributeFix(function: RsFunction): LocalQuickFixAndIntentionActionOnPsiElement(function) {
-
+class AddAsyncRecursionAttributeFix(function: RsFunction): RsQuickFixBase<RsFunction>(function) {
     override fun getText(): String = "Add `async_recursion` attribute"
     override fun getFamilyName(): String = text
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val function = startElement as? RsFunction ?: return
-        val procMacro = function.knownItems
+    override fun invoke(project: Project, editor: Editor?, element: RsFunction) {
+        val procMacro = element.knownItems
             .findItem<RsFunction>("async_recursion::async_recursion", isStd = false) ?: return
-        RsImportHelper.importElement(function, procMacro)
+        RsImportHelper.importElement(element, procMacro)
         val attr = RsPsiFactory(project).createOuterAttr("async_recursion")
-        function.addAfter(attr, null)
+        element.addAfter(attr, null)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/fixes/AddAttrParenthesesFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddAttrParenthesesFix.kt
@@ -5,23 +5,18 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsPsiFactory
 
-class AddAttrParenthesesFix(element: RsMetaItem, private val attrName: String) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class AddAttrParenthesesFix(element: RsMetaItem, private val attrName: String) : RsQuickFixBase<RsMetaItem>(element) {
     override fun getFamilyName(): String = "Add parentheses"
     override fun getText(): String = "Add parentheses to `$attrName`"
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsMetaItem) return
-
+    override fun invoke(project: Project, editor: Editor?, element: RsMetaItem) {
         val newItem = RsPsiFactory(project).createOuterAttr("$attrName()").metaItem
-        val replaced = startElement.replace(newItem) as? RsMetaItem ?: return
+        val replaced = element.replace(newItem) as? RsMetaItem ?: return
 
         // Place caret between parentheses, so the user can immediately start typing
         val offset = replaced.metaItemArgs?.lparen?.textOffset ?: return

--- a/src/main/kotlin/org/rust/ide/fixes/AddFeatureAttributeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddFeatureAttributeFix.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
@@ -21,20 +20,18 @@ import org.rust.lang.core.psi.ext.name
 class AddFeatureAttributeFix(
     private val featureName: String,
     element: PsiElement
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
-
+) : RsQuickFixBase<PsiElement>(element) {
     override fun getFamilyName(): String = "Add feature attribute"
     override fun getText(): String = "Add `$featureName` feature"
 
     // TODO: Add intention preview
     override fun getFileModifierForPreview(target: PsiFile): FileModifier? = null
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        addFeatureAttribute(project, startElement, featureName)
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        addFeatureAttribute(project, element, featureName)
     }
 
     companion object {
-
         fun addFeatureAttribute(project: Project, context: PsiElement, featureName: String) {
             val mod = context.ancestorOrSelf<RsElement>()?.crateRoot ?: return
             val lastFeatureAttribute = mod.childrenOfType<RsInnerAttr>()

--- a/src/main/kotlin/org/rust/ide/fixes/AddGenericArguments.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddGenericArguments.kt
@@ -6,11 +6,9 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPsiElementPointer
 import org.rust.ide.inspections.getTypeArgumentsAndDeclaration
 import org.rust.ide.utils.template.buildAndRunTemplate
@@ -24,19 +22,12 @@ import org.rust.lang.core.psi.ext.*
 class AddGenericArguments(
     @SafeFieldForPreview
     private val declaration: SmartPsiElementPointer<RsGenericDeclaration>,
-    element: RsElement
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    element: RsMethodOrPath
+) : RsQuickFixBase<RsMethodOrPath>(element) {
     override fun getText(): String = "Add missing $argumentsName"
     override fun getFamilyName() = "Add missing generic arguments"
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val element = startElement as? RsMethodOrPath ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsMethodOrPath) {
         val inserted = insertGenericArgumentsIfNeeded(element) ?: return
         editor?.buildAndRunTemplate(element, inserted.map { it })
     }

--- a/src/main/kotlin/org/rust/ide/fixes/AddMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddMutableFix.kt
@@ -5,11 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.ext.RsBindingModeKind.BindByReference
@@ -18,14 +15,14 @@ import org.rust.lang.core.types.declaration
 import org.rust.lang.core.types.ty.TyReference
 import org.rust.lang.core.types.type
 
-class AddMutableFix(binding: RsNamedElement) : LocalQuickFixAndIntentionActionOnPsiElement(binding) {
+class AddMutableFix(binding: RsNamedElement) : RsQuickFixBase<RsNamedElement>(binding) {
     private val _text = "Make `${binding.name}` mutable"
     override fun getFamilyName(): String = "Make mutable"
     override fun getText(): String = _text
     val mutable = true
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        updateMutable(project, startElement as RsNamedElement, mutable)
+    override fun invoke(project: Project, editor: Editor?, element: RsNamedElement) {
+        updateMutable(project, element, mutable)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/fixes/AddPatRestFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddPatRestFix.kt
@@ -5,11 +5,9 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsPatStruct
 import org.rust.lang.core.psi.RsPatTupleStruct
@@ -17,21 +15,15 @@ import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
 
-class AddPatRestFix(element: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class AddPatRestFix(element: PsiElement) : RsQuickFixBase<PsiElement>(element) {
     override fun getText() = "Add '..'"
 
     override fun getFamilyName() = text
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val (pat, lBraceOrParen, rBraceOrParen) = when (startElement) {
-            is RsPatStruct -> Triple(startElement, startElement.lbrace, startElement.rbrace)
-            is RsPatTupleStruct -> Triple(startElement, startElement.lparen, startElement.rparen)
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        val (pat, lBraceOrParen, rBraceOrParen) = when (element) {
+            is RsPatStruct -> Triple(element, element.lbrace, element.rbrace)
+            is RsPatTupleStruct -> Triple(element, element.lparen, element.rparen)
             else -> return
         }
         val lastSibling = rBraceOrParen.getPrevNonCommentSibling() ?: return

--- a/src/main/kotlin/org/rust/ide/fixes/AddRemainingArmsFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddRemainingArmsFix.kt
@@ -6,10 +6,8 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.utils.PsiInsertionPlace
 import org.rust.ide.utils.checkMatch.Pattern
 import org.rust.ide.utils.import.RsImportHelper.importTypeReferencesFromTy
@@ -21,15 +19,14 @@ open class AddRemainingArmsFix(
     match: RsMatchExpr,
     @SafeFieldForPreview
     private val patterns: List<Pattern>,
-) : LocalQuickFixOnPsiElement(match) {
+) : RsQuickFixBase<RsMatchExpr>(match) {
     override fun getFamilyName(): String = NAME
     override fun getText(): String = familyName
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsMatchExpr) return
-        val expr = startElement.expr ?: return
-        val place = findArmsInsertionPlaceIn(startElement) ?: return
-        invoke(project, startElement, expr, place)
+    override fun invoke(project: Project, editor: Editor?, element: RsMatchExpr) {
+        val expr = element.expr ?: return
+        val place = findArmsInsertionPlaceIn(element) ?: return
+        invoke(project, element, expr, place)
     }
 
     fun invoke(project: Project, match: RsMatchExpr, expr: RsExpr, place: ArmsInsertionPlace) {

--- a/src/main/kotlin/org/rust/ide/fixes/AddSelfFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddSelfFix.kt
@@ -5,33 +5,28 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.rawValueParameters
 
-class AddSelfFix(function: RsFunction) : LocalQuickFixAndIntentionActionOnPsiElement(function) {
+class AddSelfFix(function: RsFunction) : RsQuickFixBase<RsFunction>(function) {
     override fun getFamilyName() = "Add self to function"
 
     override fun getText() = "Add self to function"
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        val function = startElement as RsFunction
-        val hasParameters = function.rawValueParameters.isNotEmpty()
+    override fun invoke(project: Project, editor: Editor?, element: RsFunction) {
+        val hasParameters = element.rawValueParameters.isNotEmpty()
         val psiFactory = RsPsiFactory(project)
 
-        val valueParameterList = function.valueParameterList
+        val valueParameterList = element.valueParameterList
         val lparen = valueParameterList?.firstChild
 
         val self = psiFactory.createSelfReference()
 
         valueParameterList?.addAfter(self, lparen)
         if (hasParameters) {
-            // IDE error if use addAfter(comma, self)
             val parent = lparen?.parent
             parent?.addAfter(psiFactory.createComma(), parent.firstChild.nextSibling)
         }

--- a/src/main/kotlin/org/rust/ide/fixes/AddStructFieldsFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddStructFieldsFix.kt
@@ -5,11 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.utils.addMissingFieldsToStructLiteral
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructLiteral
@@ -20,7 +17,7 @@ import org.rust.lang.core.psi.RsStructLiteral
 class AddStructFieldsFix(
     structBody: RsStructLiteral,
     private val recursive: Boolean = false
-) : LocalQuickFixAndIntentionActionOnPsiElement(structBody) {
+) : RsQuickFixBase<RsStructLiteral>(structBody) {
     override fun getText(): String {
         return if (recursive) {
             "Recursively add missing fields"
@@ -31,13 +28,7 @@ class AddStructFieldsFix(
 
     override fun getFamilyName(): String = text
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        addMissingFieldsToStructLiteral(RsPsiFactory(project), editor, startElement as RsStructLiteral, recursive)
+    override fun invoke(project: Project, editor: Editor?, element: RsStructLiteral) {
+        addMissingFieldsToStructLiteral(RsPsiFactory(project), editor, element, recursive)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/AddStructFieldsPatFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddStructFieldsPatFix.kt
@@ -5,11 +5,9 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.utils.expandStructFields
 import org.rust.ide.utils.expandTupleStructFields
 import org.rust.lang.core.psi.RsPatStruct
@@ -18,17 +16,17 @@ import org.rust.lang.core.psi.RsPsiFactory
 
 class AddStructFieldsPatFix(
     element: PsiElement
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+) : RsQuickFixBase<PsiElement>(element) {
     override fun getText() = "Add missing fields"
 
     override fun getFamilyName() = text
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, pat: PsiElement, endElement: PsiElement) {
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
         val factory = RsPsiFactory(project)
-        if (pat is RsPatStruct) {
-            expandStructFields(factory, pat)
-        } else if (pat is RsPatTupleStruct) {
-            expandTupleStructFields(factory, editor, pat)
+        if (element is RsPatStruct) {
+            expandStructFields(factory, element)
+        } else if (element is RsPatTupleStruct) {
+            expandTupleStructFields(factory, editor, element)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/AddTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddTypeFix.kt
@@ -5,11 +5,9 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.RsPsiFactory
@@ -18,24 +16,18 @@ import org.rust.lang.core.types.ty.Ty
 /**
  * Adds type ascription after the given element.
  */
-class AddTypeFix(anchor: PsiElement, ty: Ty) : LocalQuickFixAndIntentionActionOnPsiElement(anchor) {
+class AddTypeFix(anchor: PsiElement, ty: Ty) : RsQuickFixBase<PsiElement>(anchor) {
     private val typeText: String = ty.renderInsertionSafe()
 
     override fun getFamilyName(): String = "Add type"
     override fun getText(): String = "Add type $typeText"
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
         val factory = RsPsiFactory(project)
-        val parent = startElement.parent
+        val parent = element.parent
 
         val colon = factory.createColon()
-        val anchor = parent.addAfter(colon, startElement)
+        val anchor = parent.addAfter(colon, element)
 
         val type = factory.createType(typeText)
         val insertedType = parent.addAfter(type, anchor)

--- a/src/main/kotlin/org/rust/ide/fixes/AddUnsafeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddUnsafeFix.kt
@@ -5,11 +5,9 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.psi.RsBlockExpr
 import org.rust.lang.core.psi.RsFunction
@@ -17,7 +15,7 @@ import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.isMain
 
-class AddUnsafeFix private constructor(element: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class AddUnsafeFix private constructor(element: PsiElement) : RsQuickFixBase<PsiElement>(element) {
     private val _text = run {
         val item = when (element) {
             is RsBlockExpr -> "block"
@@ -30,7 +28,7 @@ class AddUnsafeFix private constructor(element: PsiElement) : LocalQuickFixAndIn
     override fun getFamilyName() = text
     override fun getText() = _text
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, element: PsiElement, endElement: PsiElement) {
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
         val unsafe = RsPsiFactory(project).createUnsafeKeyword()
 
         when (element) {

--- a/src/main/kotlin/org/rust/ide/fixes/ChangeRefToMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ChangeRefToMutableFix.kt
@@ -5,13 +5,10 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsUnaryExpr
-import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.UnaryOperator
 import org.rust.lang.core.psi.ext.operatorType
 
@@ -20,16 +17,15 @@ import org.rust.lang.core.psi.ext.operatorType
  * Fix that converts the given immutable reference to a mutable reference.
  * @param expr An element, that represents an immutable reference.
  */
-class ChangeRefToMutableFix(expr: RsElement) : LocalQuickFixOnPsiElement(expr) {
+class ChangeRefToMutableFix(expr: RsUnaryExpr) : RsQuickFixBase<RsUnaryExpr>(expr) {
     override fun getText() = "Change reference to mutable"
     override fun getFamilyName() = text
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        val ref = startElement as? RsUnaryExpr ?: return
-        if (ref.operatorType != UnaryOperator.REF) return
-        val innerExpr = ref.expr ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsUnaryExpr) {
+        if (element.operatorType != UnaryOperator.REF) return
+        val innerExpr = element.expr ?: return
 
         val mutableExpr = RsPsiFactory(project).tryCreateExpression("&mut ${innerExpr.text}") ?: return
-        startElement.replace(mutableExpr)
+        element.replace(mutableExpr)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/ChangeReprAttributeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ChangeReprAttributeFix.kt
@@ -5,11 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.psi.RsExpr
@@ -39,7 +36,7 @@ class ChangeReprAttributeFix(
     element: RsElement,
     enumName: String,
     private val actualTy: String
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+) : RsQuickFixBase<RsElement>(element) {
     private val _text: String = run {
         "Change representation of enum `$enumName` to `#[repr($actualTy)]`"
     }
@@ -47,14 +44,8 @@ class ChangeReprAttributeFix(
     override fun getText(): String = _text
     override fun getFamilyName(): String = "Change `repr` attribute"
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val owner = findEnumOwner(startElement) as? RsDocAndAttributeOwner ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsElement) {
+        val owner = findEnumOwner(element) as? RsDocAndAttributeOwner ?: return
         val reprAttributes = owner.queryAttributes.reprAttributes.toList()
         val newOuterAttribute = RsPsiFactory(project).createOuterAttr("repr($actualTy)")
 
@@ -69,7 +60,7 @@ class ChangeReprAttributeFix(
     }
 
     companion object {
-        private fun findEnumOwner(element: PsiElement): RsEnumItem? {
+        private fun findEnumOwner(element: RsElement): RsEnumItem? {
             return if (element is RsExpr && element.context is RsVariantDiscriminant) {
                 element.contextStrict()
             } else {

--- a/src/main/kotlin/org/rust/ide/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ChangeReturnTypeFix.kt
@@ -6,11 +6,9 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.presentation.render
 import org.rust.ide.presentation.renderInsertionSafe
@@ -30,7 +28,7 @@ class ChangeReturnTypeFix(
     element: RsElement,
     @SafeFieldForPreview
     private val actualTy: Ty
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+) : RsQuickFixBase<RsElement>(element) {
     private val _text: String = run {
         val callable = findCallableOwner(startElement)
 
@@ -60,14 +58,8 @@ class ChangeReturnTypeFix(
     override fun getText(): String = _text
     override fun getFamilyName(): String = "Change return type"
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val owner = findCallableOwner(startElement) ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsElement) {
+        val owner = findCallableOwner(element) ?: return
         val oldRetType = owner.retType
 
         if (actualTy is TyUnit) {
@@ -78,7 +70,7 @@ class ChangeReturnTypeFix(
         val oldTy = oldRetType?.typeReference?.rawType ?: TyUnknown
         val (_, useQualifiedName) = getTypeReferencesInfoFromTys(owner, actualTy, oldTy)
         val text = actualTy.renderInsertionSafe(
-            context = startElement as? RsElement,
+            context = element,
             useQualifiedName = useQualifiedName,
             includeLifetimeArguments = true
         )

--- a/src/main/kotlin/org/rust/ide/fixes/ChangeToFieldShorthandFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ChangeToFieldShorthandFix.kt
@@ -5,16 +5,16 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.RsStructLiteralField
 
-class ChangeToFieldShorthandFix : LocalQuickFix {
-    override fun getFamilyName(): String = "Use initialization shorthand"
+class ChangeToFieldShorthandFix(element: RsStructLiteralField) : RsQuickFixBase<RsStructLiteralField>(element) {
+    override fun getText(): String = "Use initialization shorthand"
+    override fun getFamilyName(): String = text
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        applyShorthandInit(descriptor.psiElement as RsStructLiteralField)
+    override fun invoke(project: Project, editor: Editor?, element: RsStructLiteralField) {
+        applyShorthandInit(element)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/fixes/ChangeTryMacroToTryOperator.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ChangeTryMacroToTryOperator.kt
@@ -5,8 +5,7 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsPsiFactory
@@ -14,18 +13,16 @@ import org.rust.lang.core.psi.RsTryExpr
 import org.rust.lang.core.psi.ext.macroBody
 import org.rust.lang.core.psi.ext.replaceWithExpr
 
-class ChangeTryMacroToTryOperator : LocalQuickFix {
-    override fun getName() = "Change try! to ?"
+class ChangeTryMacroToTryOperator(element: RsMacroCall) : RsQuickFixBase<RsMacroCall>(element) {
+    override fun getText(): String = "Change try! to ?"
+    override fun getFamilyName(): String = name
 
-    override fun getFamilyName() = name
-
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val macro = descriptor.psiElement as? RsMacroCall ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsMacroCall) {
         val factory = RsPsiFactory(project)
-        val body = macro.macroBody ?: return
+        val body = element.macroBody ?: return
         val expr = factory.tryCreateExpression(body) ?: return
         val tryExpr = factory.createExpression("()?") as RsTryExpr
         tryExpr.expr.replace(expr)
-        macro.replaceWithExpr(tryExpr)
+        element.replaceWithExpr(tryExpr)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/CompareWithZeroFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/CompareWithZeroFix.kt
@@ -5,24 +5,20 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsCastExpr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.types.ty.TyNumeric
 import org.rust.lang.core.types.type
 
-class CompareWithZeroFix private constructor(expr: RsCastExpr) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+class CompareWithZeroFix private constructor(expr: RsCastExpr) : RsQuickFixBase<RsCastExpr>(expr) {
     override fun getFamilyName(): String = "Compare with zero"
 
     override fun getText(): String = familyName
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsCastExpr) return
-        startElement.replace(RsPsiFactory(project).createExpression("${startElement.expr.text} != 0"))
+    override fun invoke(project: Project, editor: Editor?, element: RsCastExpr) {
+        element.replace(RsPsiFactory(project).createExpression("${element.expr.text} != 0"))
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertFunctionToClosureFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertFunctionToClosureFix.kt
@@ -5,27 +5,17 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.intentions.ConvertFunctionToClosureIntention
 import org.rust.lang.core.psi.RsFunction
 
-class ConvertFunctionToClosureFix(function: RsFunction) : LocalQuickFixAndIntentionActionOnPsiElement(function) {
+class ConvertFunctionToClosureFix(function: RsFunction) : RsQuickFixBase<RsFunction>(function) {
 
     override fun getText(): String = "Convert function to closure"
     override fun getFamilyName(): String = text
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val function = startElement as? RsFunction ?: return
-        ConvertFunctionToClosureIntention().doInvoke(project, editor, function)
+    override fun invoke(project: Project, editor: Editor?, element: RsFunction) {
+        ConvertFunctionToClosureIntention().doInvoke(project, editor, element)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertLetDeclTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertLetDeclTypeFix.kt
@@ -6,11 +6,8 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.lang.core.psi.RsLetDecl
 import org.rust.lang.core.psi.RsPsiFactory
@@ -24,21 +21,14 @@ class ConvertLetDeclTypeFix(
     private val fixText: String,
     @SafeFieldForPreview
     private val ty: Ty
-) : LocalQuickFixAndIntentionActionOnPsiElement(decl) {
+) : RsQuickFixBase<RsLetDecl>(decl) {
     override fun getFamilyName(): String = "Convert type of local variable"
     override fun getText(): String = fixText
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val decl = startElement as? RsLetDecl ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsLetDecl) {
         val factory = RsPsiFactory(project)
         val type = factory.tryCreateType(ty.renderInsertionSafe()) ?: return
 
-        decl.typeReference?.replace(type)
+        element.typeReference?.replace(type)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertMalformedCfgNotPatternToCfgAllPatternFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertMalformedCfgNotPatternToCfgAllPatternFix.kt
@@ -5,16 +5,14 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsMetaItemArgs
 import org.rust.lang.core.psi.RsPsiFactory
 
-class ConvertMalformedCfgNotPatternToCfgAllPatternFix(element: RsMetaItem) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class ConvertMalformedCfgNotPatternToCfgAllPatternFix(element: RsMetaItem) : RsQuickFixBase<RsMetaItem>(element) {
     private val fixText = run {
         val metaItemList = element.metaItemArgs ?: return@run ""
         val negatedArguments = convertToAllPatternWithNegatedArguments(metaItemList)
@@ -25,13 +23,12 @@ class ConvertMalformedCfgNotPatternToCfgAllPatternFix(element: RsMetaItem) : Loc
     override fun getFamilyName(): String = "Convert `not(a, b)` cfg-pattern to `all(not(a), not(b))`"
     override fun getText(): String = fixText
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsMetaItem) return
-        val metaItemList = startElement.metaItemArgs ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsMetaItem) {
+        val metaItemList = element.metaItemArgs ?: return
 
         val factory = RsPsiFactory(project)
         val newItem = factory.createMetaItem(convertToAllPatternWithNegatedArguments(metaItemList))
-        val replaced = startElement.replace(newItem) as? RsMetaItem ?: return
+        val replaced = element.replace(newItem) as? RsMetaItem ?: return
 
         val offset = replaced.metaItemArgs?.lparen?.textOffset ?: return
         editor?.caretModel?.moveToOffset(offset + 1)

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertToSizedTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertToSizedTypeFix.kt
@@ -5,25 +5,23 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsTypeReference
 
 private const val FAMILY_NAME: String = "Convert to Sized type"
 
-abstract class ConvertToSizedTypeFix(element: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+abstract class ConvertToSizedTypeFix(element: PsiElement) : RsQuickFixBase<PsiElement>(element) {
 
     override fun getFamilyName(): String = FAMILY_NAME
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, typeReference: PsiElement, endElement: PsiElement) {
-        if (typeReference !is RsTypeReference) return
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        if (element !is RsTypeReference) return
         val factory = RsPsiFactory(project)
-        val newTypeReference = newTypeReference(factory, typeReference)
-        typeReference.replace(newTypeReference)
+        val newTypeReference = newTypeReference(factory, element)
+        element.replace(newTypeReference)
     }
 
     protected abstract fun newTypeReference(factory: RsPsiFactory, typeReference: RsTypeReference): RsTypeReference

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertToStrFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertToStrFix.kt
@@ -7,8 +7,6 @@ package org.rust.ide.fixes
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsPsiFactory
 
@@ -19,9 +17,8 @@ import org.rust.lang.core.psi.RsPsiFactory
 abstract class ConvertToStrFix(expr: RsExpr, strTypeName: String, private val strMethodName: String) :
     ConvertToTyFix(expr, strTypeName, "`$strMethodName` method") {
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsExpr) return
-        startElement.replace(RsPsiFactory(project).createNoArgsMethodCall(startElement, strMethodName))
+    override fun invoke(project: Project, editor: Editor?, element: RsExpr) {
+        element.replace(RsPsiFactory(project).createNoArgsMethodCall(element, strMethodName))
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertToTyFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertToTyFix.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import org.rust.ide.presentation.render
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.types.ty.Ty
@@ -14,7 +13,7 @@ abstract class ConvertToTyFix(
     expr: RsExpr,
     private val tyName: String,
     private val convertSubject: String
-) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+) : RsQuickFixBase<RsExpr>(expr) {
 
     constructor(expr: RsExpr, ty: Ty, convertSubject: String) :
         this(expr, ty.render(), convertSubject)

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertToTyUsingFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertToTyUsingFromTraitFix.kt
@@ -8,8 +8,6 @@ package org.rust.ide.fixes
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.presentation.render
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsPsiFactory
@@ -23,20 +21,12 @@ class ConvertToTyUsingFromTraitFix(
     @SafeFieldForPreview
     private val ty: Ty,
 ) : ConvertToTyUsingTraitFix(expr, ty, "From") {
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        if (startElement !is RsExpr) return
-
+    override fun invoke(project: Project, editor: Editor?, element: RsExpr) {
         val newElement = RsPsiFactory(project).createAssocFunctionCall(
             ty.render(includeTypeArguments = false),
             "from",
-            listOf(startElement)
+            listOf(element)
         )
-        startElement.replace(newElement)
+        element.replace(newElement)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertToTyUsingTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertToTyUsingTraitFix.kt
@@ -7,8 +7,6 @@ package org.rust.ide.fixes
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.types.ty.Ty
@@ -36,9 +34,8 @@ abstract class ConvertToTyUsingTraitMethodFix : ConvertToTyUsingTraitFix {
         this.methodName = methodName
     }
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsExpr) return
-        startElement.replace(RsPsiFactory(project).createNoArgsMethodCall(startElement, methodName))
+    override fun invoke(project: Project, editor: Editor?, element: RsExpr) {
+        element.replace(RsPsiFactory(project).createNoArgsMethodCall(element, methodName))
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertToTyUsingTryFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertToTyUsingTryFromTraitFix.kt
@@ -8,8 +8,6 @@ package org.rust.ide.fixes
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.presentation.render
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsFunctionOrLambda
@@ -34,11 +32,10 @@ abstract class ConvertToTyUsingTryTraitFix(
     private val fromCallMaker: ConvertToTyUsingTryTraitFix.(RsPsiFactory, RsExpr, Ty) -> RsExpr
 ) : ConvertToTyUsingTraitFix(expr, ty, traitName) {
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsExpr) return
+    override fun invoke(project: Project, editor: Editor?, element: RsExpr) {
         val psiFactory = RsPsiFactory(project)
-        val fromCall = fromCallMaker(psiFactory, startElement, ty)
-        addFromCall(psiFactory, startElement, fromCall)
+        val fromCall = fromCallMaker(psiFactory, element, ty)
+        addFromCall(psiFactory, element, fromCall)
     }
 
     open fun addFromCall(psiFactory: RsPsiFactory, expr: RsExpr, fromCall: RsExpr) {

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertToTyWithDerefsRefsFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertToTyWithDerefsRefsFix.kt
@@ -8,8 +8,6 @@ package org.rust.ide.fixes
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.types.ty.Mutability
@@ -32,16 +30,9 @@ class ConvertToTyWithDerefsRefsFix(
     @SafeFieldForPreview
     private val path: DerefRefPath
 ) : ConvertToTyFix(expr, ty, formatRefs(path)) {
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        if (startElement !is RsExpr) return
+    override fun invoke(project: Project, editor: Editor?, element: RsExpr) {
         val psiFactory = RsPsiFactory(project)
-        startElement.replace(psiFactory.createRefExpr(psiFactory.createDerefExpr(startElement, path.derefs), path.refs))
+        element.replace(psiFactory.createRefExpr(psiFactory.createDerefExpr(element, path.derefs), path.refs))
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/fixes/ConvertToUnsuffixedIntegerFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ConvertToUnsuffixedIntegerFix.kt
@@ -5,17 +5,18 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsLitExpr
 import org.rust.lang.core.psi.RsLiteralKind
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.kind
 
-class ConvertToUnsuffixedIntegerFix private constructor(element: RsLitExpr, private val textTemplate: String): LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class ConvertToUnsuffixedIntegerFix private constructor(
+    element: RsLitExpr,
+    private val textTemplate: String
+): RsQuickFixBase<RsLitExpr>(element) {
     override fun getFamilyName(): String = "Convert to unsuffixed integer"
 
     override fun getText(): String {
@@ -23,10 +24,10 @@ class ConvertToUnsuffixedIntegerFix private constructor(element: RsLitExpr, priv
     }
 
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        val integer = convertToUnsuffixedInteger(startElement) ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsLitExpr) {
+        val integer = convertToUnsuffixedInteger(element) ?: return
         val psiFactory = RsPsiFactory(project)
-        startElement.replace(psiFactory.createExpression(integer))
+        element.replace(psiFactory.createExpression(integer))
     }
 
 

--- a/src/main/kotlin/org/rust/ide/fixes/CreateLifetimeParameterFromUsageFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/CreateLifetimeParameterFromUsageFix.kt
@@ -5,22 +5,19 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsLifetime
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.*
 
-class CreateLifetimeParameterFromUsageFix(lifetime: RsLifetime) : LocalQuickFixAndIntentionActionOnPsiElement(lifetime) {
+class CreateLifetimeParameterFromUsageFix(lifetime: RsLifetime) : RsQuickFixBase<RsLifetime>(lifetime) {
 
     override fun getFamilyName(): String = "Create lifetime parameter"
     override fun getText(): String = familyName
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        val context = gatherContext(startElement) ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsLifetime) {
+        val context = gatherContext(element) ?: return
         insertLifetime(context.declaration, project, context.lifetime)
     }
 
@@ -55,8 +52,7 @@ private class Context(
     val declaration: RsGenericDeclaration
 )
 
-private fun gatherContext(element: PsiElement): Context? {
-    if (element !is RsLifetime) return null
+private fun gatherContext(element: RsLifetime): Context? {
     val genericDeclaration = element.ancestorOrSelf<RsGenericDeclaration>()
     if (genericDeclaration !is RsNameIdentifierOwner) return null
     return Context(element, genericDeclaration)

--- a/src/main/kotlin/org/rust/ide/fixes/DeriveCopyFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/DeriveCopyFix.kt
@@ -5,11 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.psi.RsPathExpr
@@ -23,14 +20,13 @@ import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.ty.isMovesByDefault
 import org.rust.lang.core.types.type
 
-class DeriveCopyFix(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class DeriveCopyFix(element: RsPathExpr) : RsQuickFixBase<RsPathExpr>(element) {
     override fun getFamilyName(): String = name
     override fun getText(): String = "Derive Copy trait"
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        val pathExpr = startElement as? RsPathExpr ?: return
-        val type = pathExpr.type as? TyAdt ?: return
-        val item = type.item.findPreviewCopyIfNeeded(file)
+    override fun invoke(project: Project, editor: Editor?, element: RsPathExpr) {
+        val type = element.type as? TyAdt ?: return
+        val item = type.item.findPreviewCopyIfNeeded()
 
         val implLookup = ImplLookup.relativeTo(item)
         val isCloneImplemented = implLookup.isClone(type).isTrue

--- a/src/main/kotlin/org/rust/ide/fixes/DeriveTraitsFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/DeriveTraitsFix.kt
@@ -5,11 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsOuterAttr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
@@ -19,22 +16,15 @@ import org.rust.lang.core.psi.ext.firstKeyword
 class DeriveTraitsFix(
     item: RsStructOrEnumItemElement,
     private val traits: String,  // comma separated
-) : LocalQuickFixAndIntentionActionOnPsiElement(item) {
+) : RsQuickFixBase<RsStructOrEnumItemElement>(item) {
 
     private val itemName: String? = item.name
 
     override fun getText(): String = "Add #[derive($traits)] to `$itemName`"
     override fun getFamilyName(): String = "Derive trait"
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val item = startElement as? RsStructOrEnumItemElement ?: return
-        invoke(item, traits)
+    override fun invoke(project: Project, editor: Editor?, element: RsStructOrEnumItemElement) {
+        invoke(element, traits)
     }
 
     companion object {
@@ -50,11 +40,11 @@ class DeriveTraitsFix(
         }
 
         private fun updateDeriveAttr(psiFactory: RsPsiFactory, deriveAttr: RsOuterAttr, traits: String) {
-            val oldAttrText = deriveAttr.text
+            val oldAttrText = deriveAttr.metaItem.text
             val newAttrText = oldAttrText.substringBeforeLast(")") + ", $traits)"
 
-            val newDeriveAttr = psiFactory.createOuterAttr(newAttrText)
-            deriveAttr.replace(newDeriveAttr)
+            val newDeriveAttr = psiFactory.createMetaItem(newAttrText)
+            deriveAttr.metaItem.replace(newDeriveAttr)
         }
 
         private fun createDeriveAttr(psiFactory: RsPsiFactory, item: RsStructOrEnumItemElement, traits: String) {

--- a/src/main/kotlin/org/rust/ide/fixes/ElideLifetimesFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ElideLifetimesFix.kt
@@ -5,19 +5,17 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 
-class ElideLifetimesFix : LocalQuickFix {
-    override fun getName() = "Elide lifetimes"
-    override fun getFamilyName() = name
+class ElideLifetimesFix(element: RsFunction) : RsQuickFixBase<RsFunction>(element) {
+    override fun getText() = "Elide lifetimes"
+    override fun getFamilyName() = text
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val fn = descriptor.psiElement as? RsFunction ?: return
-        LifetimeRemover().visitFunction(fn)
+    override fun invoke(project: Project, editor: Editor?, element: RsFunction) {
+        LifetimeRemover().visitFunction(element)
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/fixes/EncloseExprInBracesFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/EncloseExprInBracesFix.kt
@@ -5,26 +5,18 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.RsElement
 
-class EncloseExprInBracesFix(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class EncloseExprInBracesFix(element: RsElement) : RsQuickFixBase<PsiElement>(element) {
     override fun getFamilyName(): String = text
     override fun getText(): String = "Enclose the expression in braces"
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val enclosed = RsPsiFactory(project).createExpression("{ ${startElement.text} }")
-        startElement.replace(enclosed)
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        val enclosed = RsPsiFactory(project).createExpression("{ ${element.text} }")
+        element.replace(enclosed)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/EscapeKeywordFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/EscapeKeywordFix.kt
@@ -5,23 +5,21 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsPsiFactory
 
 class EscapeKeywordFix(
     element: PsiElement,
     private val isKeyword: Boolean
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+) : RsQuickFixBase<PsiElement>(element) {
 
     override fun getFamilyName(): String = "Escape keyword"
     override fun getText(): String = if (isKeyword) "Escape keyword" else "Escape reserved keyword"
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        val name = startElement.text
-        startElement.replace(RsPsiFactory(project).createIdentifier("r#${name}"))
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        val name = element.text
+        element.replace(RsPsiFactory(project).createIdentifier("r#${name}"))
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/FixVisRestriction.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/FixVisRestriction.kt
@@ -5,21 +5,17 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsVisRestriction
 
-class FixVisRestriction(visRestriction: RsVisRestriction) : LocalQuickFixAndIntentionActionOnPsiElement(visRestriction) {
+class FixVisRestriction(visRestriction: RsVisRestriction) : RsQuickFixBase<RsVisRestriction>(visRestriction) {
 
     override fun getText(): String = "Fix visibility restriction"
     override fun getFamilyName(): String = text
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsVisRestriction) return
-        startElement.addBefore(RsPsiFactory(project).createIn(), startElement.path)
+    override fun invoke(project: Project, editor: Editor?, element: RsVisRestriction) {
+        element.addBefore(RsPsiFactory(project).createIn(), element.path)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/InitializeWithDefaultValueFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/InitializeWithDefaultValueFix.kt
@@ -5,11 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.utils.template.buildAndRunTemplate
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
@@ -19,18 +16,18 @@ import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.declaration
 import org.rust.lang.core.types.type
 
-class InitializeWithDefaultValueFix(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class InitializeWithDefaultValueFix(element: RsElement) : RsQuickFixBase<RsElement>(element) {
     override fun getText() = "Initialize with a default value"
     override fun getFamilyName() = name
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        val variable = startElement.ancestorOrSelf<RsExpr>() ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsElement) {
+        val variable = element.ancestorOrSelf<RsExpr>() ?: return
         val patBinding = variable.declaration as? RsPatBinding ?: return
         val declaration = patBinding.ancestorOrSelf<RsLetDecl>() ?: return
         val semicolon = declaration.semicolon ?: return
         val psiFactory = RsPsiFactory(project)
         val initExpr = RsDefaultValueBuilder(declaration.knownItems, declaration.containingMod, psiFactory, true)
-            .buildFor(patBinding.type, (startElement as RsElement).getLocalVariableVisibleBindings())
+            .buildFor(patBinding.type, element.getLocalVariableVisibleBindings())
 
         if (declaration.eq == null) {
             declaration.addBefore(psiFactory.createEq(), semicolon)

--- a/src/main/kotlin/org/rust/ide/fixes/MakeAsyncFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/MakeAsyncFix.kt
@@ -5,18 +5,15 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsLambdaExpr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.RsFunctionOrLambda
 import org.rust.lang.core.psi.ext.isAsync
 
-class MakeAsyncFix(function: RsFunctionOrLambda) : LocalQuickFixAndIntentionActionOnPsiElement(function) {
+class MakeAsyncFix(function: RsFunctionOrLambda) : RsQuickFixBase<RsFunctionOrLambda>(function) {
 
     private val isFunction: Boolean = function is RsFunction
 
@@ -27,20 +24,13 @@ class MakeAsyncFix(function: RsFunctionOrLambda) : LocalQuickFixAndIntentionActi
 
     override fun getFamilyName(): String = "Make async"
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val function = startElement as? RsFunctionOrLambda ?: return
-        if (function.isAsync) return
-        val anchor = when (function) {
-            is RsFunction -> function.unsafe ?: function.externAbi ?: function.fn
-            is RsLambdaExpr -> function.move ?: function.valueParameterList
+    override fun invoke(project: Project, editor: Editor?, element: RsFunctionOrLambda) {
+        if (element.isAsync) return
+        val anchor = when (element) {
+            is RsFunction -> element.unsafe ?: element.externAbi ?: element.fn
+            is RsLambdaExpr -> element.move ?: element.valueParameterList
             else -> error("unreachable")
         }
-        function.addBefore(RsPsiFactory(project).createAsyncKeyword(), anchor)
+        element.addBefore(RsPsiFactory(project).createAsyncKeyword(), anchor)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/MakePublicFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/MakePublicFix.kt
@@ -5,11 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.intentions.visibility.ChangeVisibilityIntention
 import org.rust.lang.core.psi.ext.RsVisibilityOwner
 
@@ -17,23 +14,13 @@ class MakePublicFix private constructor(
     element: RsVisibilityOwner,
     elementName: String?,
     private val withinOneCrate: Boolean
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
-
+) : RsQuickFixBase<RsVisibilityOwner>(element) {
     private val _text = "Make `$elementName` public"
-
     override fun getFamilyName(): String = "Make public"
-
     override fun getText(): String = _text
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val visibilityOwner = startElement as? RsVisibilityOwner ?: return
-        ChangeVisibilityIntention.makePublic(visibilityOwner, withinOneCrate)
+    override fun invoke(project: Project, editor: Editor?, element: RsVisibilityOwner) {
+        ChangeVisibilityIntention.makePublic(element, withinOneCrate)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/fixes/NameSuggestionFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/NameSuggestionFix.kt
@@ -6,10 +6,9 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.util.text.EditDistance
 
 /**
@@ -20,13 +19,13 @@ class NameSuggestionFix<T : PsiElement>(
     private val newName: String,
     @SafeFieldForPreview
     private val elementFactory: (name: String) -> T
-): LocalQuickFixOnPsiElement(element) {
+): RsQuickFixBase<T>(element) {
     override fun getFamilyName(): String = "Change name of element"
     override fun getText(): String = "Change to `$newName`"
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+    override fun invoke(project: Project, editor: Editor?, element: T) {
         val newElement = elementFactory(newName)
-        startElement.replace(newElement)
+        element.replace(newElement)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/fixes/QualifyPathFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/QualifyPathFix.kt
@@ -6,10 +6,8 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.utils.import.ImportInfo
 import org.rust.ide.utils.import.insertExternCrateIfNeeded
 import org.rust.lang.core.psi.RsPath
@@ -23,13 +21,12 @@ class QualifyPathFix(
     path: RsPath,
     @SafeFieldForPreview
     private val importInfo: ImportInfo
-) : LocalQuickFixOnPsiElement(path) {
+) : RsQuickFixBase<RsPath>(path) {
     override fun getText(): String = "Qualify path to `${importInfo.usePath}`"
     override fun getFamilyName(): String = "Qualify path"
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        val path = startElement as? RsPath ?: return
-        qualify(path, importInfo)
+    override fun invoke(project: Project, editor: Editor?, element: RsPath) {
+        qualify(element, importInfo)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveAssocTypeBindingFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveAssocTypeBindingFix.kt
@@ -5,22 +5,21 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsAssocTypeBinding
 import org.rust.lang.core.psi.RsTypeArgumentList
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.childOfType
 import org.rust.lang.core.psi.ext.deleteWithSurroundingCommaAndWhitespace
 
-class RemoveAssocTypeBindingFix(binding: PsiElement) : LocalQuickFixOnPsiElement(binding) {
+class RemoveAssocTypeBindingFix(binding: PsiElement) : RsQuickFixBase<PsiElement>(binding) {
     override fun getFamilyName(): String = text
     override fun getText(): String = "Remove redundant associated type"
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        val binding = startElement as? RsAssocTypeBinding ?: return
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        val binding = element as? RsAssocTypeBinding ?: return
         val parent = binding.parent as? RsTypeArgumentList
 
         binding.deleteWithSurroundingCommaAndWhitespace()

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveCastFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveCastFix.kt
@@ -5,22 +5,17 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsCastExpr
 
 open class RemoveCastFix(
     element: RsCastExpr
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+) : RsQuickFixBase<RsCastExpr>(element) {
     private val fixText: String = "Remove `as ${element.typeReference.text}`"
     override fun getFamilyName(): String = "Remove unnecessary cast"
     override fun getText(): String = fixText
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement !is RsCastExpr) return
-
-        startElement.replace(startElement.expr)
+    override fun invoke(project: Project, editor: Editor?, element: RsCastExpr) {
+        element.replace(element.expr)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveElementFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveElementFix.kt
@@ -5,19 +5,17 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 
 open class RemoveElementFix(
     element: PsiElement,
     private val removingElementName: String = "`${element.text}`"
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+) : RsQuickFixBase<PsiElement>(element) {
     override fun getFamilyName(): String = "Remove"
     override fun getText(): String = "Remove $removingElementName"
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        startElement.delete()
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        element.delete()
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveGenericArguments.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveGenericArguments.kt
@@ -5,8 +5,7 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import org.rust.ide.inspections.getTypeArgumentsAndDeclaration
 import org.rust.lang.core.psi.RsTypeArgumentList
@@ -16,13 +15,14 @@ import org.rust.lang.core.psi.ext.getNextNonCommentSibling
 import org.rust.lang.core.psi.ext.startOffset
 
 class RemoveGenericArguments(
+    element: RsMethodOrPath,
     private val startIndex: Int,
     private val endIndex: Int
-) : LocalQuickFix {
-    override fun getFamilyName() = "Remove redundant generic arguments"
+) : RsQuickFixBase<RsMethodOrPath>(element) {
+    override fun getText(): String = "Remove redundant generic arguments"
+    override fun getFamilyName(): String = text
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val element = descriptor.psiElement as? RsMethodOrPath ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsMethodOrPath) {
         val (typeArguments) = getTypeArgumentsAndDeclaration(element) ?: return
         typeArguments?.removeTypeParameters()
     }

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveImportFix.kt
@@ -5,10 +5,9 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.intentions.RemoveCurlyBracesIntention
 import org.rust.lang.core.psi.RsUseGroup
 import org.rust.lang.core.psi.RsUseItem
@@ -21,12 +20,12 @@ import org.rust.lang.core.psi.ext.parentUseSpeck
 /**
  * Fix that removes a use speck or a whole use item.
  */
-class RemoveImportFix(element: PsiElement) : LocalQuickFixOnPsiElement(element) {
+class RemoveImportFix(element: PsiElement) : RsQuickFixBase<PsiElement>(element) {
     override fun getText() = "Remove unused import"
     override fun getFamilyName() = text
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        val element = startElement as? RsElement ?: return
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        if (element !is RsElement) return
         deleteUseSpeckOrUseItem(element)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RemovePolyBoundFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemovePolyBoundFix.kt
@@ -5,22 +5,19 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsPolybound
 import org.rust.lang.core.psi.ext.deleteWithSurroundingPlus
 
 class RemovePolyBoundFix(
     bound: RsPolybound,
     private val boundName: String = "`${bound.text}`"
-) : LocalQuickFixOnPsiElement(bound) {
+) : RsQuickFixBase<RsPolybound>(bound) {
     override fun getText() = "Remove $boundName bound"
     override fun getFamilyName() = "Remove bound"
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        val bound = (startElement as? RsPolybound) ?: return
+    override fun invoke(project: Project, editor: Editor?, bound: RsPolybound) {
         bound.deleteWithSurroundingPlus()
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveRedundantFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveRedundantFunctionArgumentsFix.kt
@@ -5,30 +5,20 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsValueArgumentList
 import org.rust.lang.core.psi.ext.deleteWithSurroundingCommaAndWhitespace
 
 class RemoveRedundantFunctionArgumentsFix(
     element: RsValueArgumentList,
     private val expectedCount: Int
-) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+) : RsQuickFixBase<RsValueArgumentList>(element) {
     override fun getText(): String = "Remove redundant arguments"
     override fun getFamilyName(): String = text
 
-    override fun invoke(
-        project: Project,
-        file: PsiFile,
-        editor: Editor?,
-        startElement: PsiElement,
-        endElement: PsiElement
-    ) {
-        val args = startElement as? RsValueArgumentList ?: return
-        val extraArgs = args.exprList.drop(expectedCount)
+    override fun invoke(project: Project, editor: Editor?, element: RsValueArgumentList) {
+        val extraArgs = element.exprList.drop(expectedCount)
         for (arg in extraArgs) {
             arg.deleteWithSurroundingCommaAndWhitespace()
         }

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveRedundantParenthesesFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveRedundantParenthesesFix.kt
@@ -5,22 +5,17 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsParenExpr
 
-class RemoveRedundantParenthesesFix(element: RsParenExpr) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class RemoveRedundantParenthesesFix(element: RsParenExpr) : RsQuickFixBase<RsParenExpr>(element) {
     override fun getText(): String = "Remove parentheses from expression"
 
     override fun getFamilyName(): String = text
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement is RsParenExpr) {
-            val wrapped = startElement.expr ?: return
-            startElement.replace(wrapped)
-        }
+    override fun invoke(project: Project, editor: Editor?, element: RsParenExpr) {
+        val wrapped = element.expr ?: return
+        element.replace(wrapped)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveRefFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveRefFix.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsUnaryExpr
 import org.rust.lang.core.psi.ext.UnaryOperator
@@ -22,7 +20,7 @@ import org.rust.lang.core.psi.ext.operatorType
  */
 class RemoveRefFix private constructor(
     expr: RsUnaryExpr
-) : LocalQuickFixOnPsiElement(expr) {
+) : RsQuickFixBase<RsUnaryExpr>(expr) {
     private val _text: String = when (val operatorType = expr.operatorType) {
         UnaryOperator.REF -> "Remove &"
         UnaryOperator.REF_MUT -> "Remove &mut"
@@ -32,8 +30,8 @@ class RemoveRefFix private constructor(
     override fun getText() = _text
     override fun getFamilyName() = "Remove reference"
 
-    override fun invoke(project: Project, file: PsiFile, expr: PsiElement, endElement: PsiElement) {
-        (expr as RsUnaryExpr).expr?.let { expr.replace(it) }
+    override fun invoke(project: Project, editor: Editor?, element: RsUnaryExpr) {
+        element.expr?.let { element.replace(it) }
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveSemicolonFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveSemicolonFix.kt
@@ -5,18 +5,17 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.RsExprStmt
 
-class RemoveSemicolonFix : LocalQuickFix {
-    override fun getName() = "Remove semicolon"
+open class RemoveSemicolonFix(
+    element: RsExprStmt,
+) : RsQuickFixBase<RsExprStmt>(element) {
+    override fun getText(): String = "Remove semicolon"
+    override fun getFamilyName(): String = text
 
-    override fun getFamilyName() = name
-
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val statement = (descriptor.psiElement as RsExprStmt)
-        statement.semicolon?.delete()
+    override fun invoke(project: Project, editor: Editor?, element: RsExprStmt) {
+        element.semicolon?.delete()
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveStructLiteralFieldFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveStructLiteralFieldFix.kt
@@ -5,23 +5,21 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsStructLiteralField
 import org.rust.lang.core.psi.ext.deleteWithSurroundingCommaAndWhitespace
 
 class RemoveStructLiteralFieldFix(
     field: RsStructLiteralField,
     private val removingFieldName: String = "`${field.text}`"
-) : LocalQuickFixAndIntentionActionOnPsiElement(field) {
+) : RsQuickFixBase<PsiElement>(field) {
     override fun getFamilyName() = "Remove struct literal field"
 
     override fun getText() = "Remove $removingFieldName"
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+    override fun invoke(project: Project, editor: Editor?, startElement: PsiElement) {
         val field = (startElement as? RsStructLiteralField) ?: return
         field.deleteWithSurroundingCommaAndWhitespace()
     }

--- a/src/main/kotlin/org/rust/ide/fixes/RemoveVariableFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RemoveVariableFix.kt
@@ -5,10 +5,8 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.psi.util.parentOfType
 import org.rust.lang.core.psi.RsLetDecl
 import org.rust.lang.core.psi.RsPatBinding
@@ -22,13 +20,15 @@ import org.rust.lang.core.psi.ext.topLevelPattern
  * Fix that removes a variable.
  * A heuristic is used whether to also remove its expression or not.
  */
-class RemoveVariableFix(binding: RsPatBinding, private val bindingName: String) : LocalQuickFixOnPsiElement(binding) {
+class RemoveVariableFix(
+    binding: RsPatBinding,
+    private val bindingName: String
+) : RsQuickFixBase<RsPatBinding>(binding) {
     override fun getText() = "Remove variable `${bindingName}`"
     override fun getFamilyName() = "Remove variable"
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        val binding = startElement as? RsPatBinding ?: return
-        val patIdent = binding.topLevelPattern as? RsPatIdent ?: return
+    override fun invoke(project: Project, editor: Editor?, element: RsPatBinding) {
+        val patIdent = element.topLevelPattern as? RsPatIdent ?: return
         deleteVariable(patIdent)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RenameFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RenameFix.kt
@@ -6,10 +6,9 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
 import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNamedElement
 import com.intellij.refactoring.RefactoringFactory
@@ -26,17 +25,20 @@ class RenameFix(
     element: PsiNamedElement,
     val newName: String,
     private val fixName: String = "Rename to `$newName`"
-) : LocalQuickFixOnPsiElement(element) {
+) : RsQuickFixBase<PsiNamedElement>(element) {
     override fun getText() = fixName
     override fun getFamilyName() = "Rename element"
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) =
+    override fun invoke(project: Project, editor: Editor?, element: PsiNamedElement) =
         project.nonBlocking({
-            (startElement as? RsModDeclItem)?.reference?.resolve() ?: startElement
+            (element as? RsModDeclItem)?.reference?.resolve() ?: element
         }, {
             RefactoringFactory.getInstance(project).createRename(it, newName).run()
         })
 
     override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo =
+        IntentionPreviewInfo.EMPTY
+
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo =
         IntentionPreviewInfo.EMPTY
 }

--- a/src/main/kotlin/org/rust/ide/fixes/ReplaceBoxSyntaxFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ReplaceBoxSyntaxFix.kt
@@ -5,23 +5,19 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsUnaryExpr
 
-class ReplaceBoxSyntaxFix(element: RsUnaryExpr): LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class ReplaceBoxSyntaxFix(element: RsUnaryExpr): RsQuickFixBase<RsUnaryExpr>(element) {
     override fun getFamilyName(): String = "Replace `box` with `Box::new`"
 
     override fun getText(): String = familyName
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, boxExpr: PsiElement, endElement: PsiElement) {
-        if (boxExpr !is RsUnaryExpr) return
-        if (boxExpr.box == null) return
-        val exprText = boxExpr.expr?.text ?: return
-        boxExpr.replace(RsPsiFactory(project).createBox(exprText))
+    override fun invoke(project: Project, editor: Editor?, element: RsUnaryExpr) {
+        if (element.box == null) return
+        val exprText = element.expr?.text ?: return
+        element.replace(RsPsiFactory(project).createBox(exprText))
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RsAddLabelFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RsAddLabelFix.kt
@@ -5,26 +5,23 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsWhileExpr
 import org.rust.lang.core.psi.ext.RsLabelReferenceOwner
 import org.rust.lang.core.psi.ext.ancestorStrict
 
-class RsAddLabelFix(element: RsLabelReferenceOwner): LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class RsAddLabelFix(element: RsLabelReferenceOwner): RsQuickFixBase<RsLabelReferenceOwner>(element) {
     override fun getFamilyName(): String = "Add label"
 
     override fun getText(): String = familyName
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, labelOwner: PsiElement, endElement: PsiElement) {
+    override fun invoke(project: Project, editor: Editor?, element: RsLabelReferenceOwner) {
         if (editor == null) return
-        val whileExpr = labelOwner.ancestorStrict<RsWhileExpr>() ?: return
+        val whileExpr = element.ancestorStrict<RsWhileExpr>() ?: return
         val labelDeclaration = RsPsiFactory(project).createLabelDeclaration("a")
         whileExpr.addBefore(labelDeclaration, whileExpr.firstChild)
-        labelOwner.add(RsPsiFactory(project).createLabel("a"))
+        element.add(RsPsiFactory(project).createLabel("a"))
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RsConvertBlockToLoopFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RsConvertBlockToLoopFix.kt
@@ -5,25 +5,18 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsBlockExpr
 import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.RsWhileExpr
-import org.rust.lang.core.psi.ext.RsLabelReferenceOwner
-import org.rust.lang.core.psi.ext.ancestorStrict
 
-class RsConvertBlockToLoopFix(element: RsBlockExpr): LocalQuickFixAndIntentionActionOnPsiElement(element) {
+class RsConvertBlockToLoopFix(element: RsBlockExpr): RsQuickFixBase<RsBlockExpr>(element) {
     override fun getFamilyName(): String = "Convert to loop"
 
     override fun getText(): String = familyName
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, blockExpr: PsiElement, endElement: PsiElement) {
-        val rsBlockExpr = blockExpr as RsBlockExpr
-        val labelName = rsBlockExpr.labelDecl?.name ?: return
-        rsBlockExpr.replace(RsPsiFactory(project).createLoop(rsBlockExpr.block.text, labelName))
+    override fun invoke(project: Project, editor: Editor?, element: RsBlockExpr) {
+        val labelName = element.labelDecl?.name ?: return
+        element.replace(RsPsiFactory(project).createLoop(element.block.text, labelName))
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/RsQuickFixBase.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/RsQuickFixBase.kt
@@ -1,0 +1,117 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.fixes
+
+import com.intellij.codeInsight.intention.FileModifier
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.intentions.util.macros.IntentionInMacroUtil
+import org.rust.lang.core.macros.findMacroCallExpandedFrom
+import org.rust.lang.core.macros.isExpandedFromMacro
+
+/**
+ * A base class for implementing quick fixes.
+ *
+ * [org.rust.ide.intentions.RsElementBaseIntentionAction]
+ */
+abstract class RsQuickFixBase<E: PsiElement>(element: E) : LocalQuickFixAndIntentionActionOnPsiElement(element),
+                                                           LocalQuickFix {
+    abstract override fun getFamilyName(): String
+    abstract override fun getText(): String
+
+    override fun startInWriteAction(): Boolean = true
+    override fun availableInBatchMode(): Boolean = true
+
+    abstract fun invoke(project: Project, editor: Editor?, element: E)
+
+    final override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        if (startElement.isExpandedFromMacro) {
+            invokeInsideMacroExpansion(project, editor, file, startElement)
+        } else {
+            @Suppress("UNCHECKED_CAST")
+            invoke(project, editor, startElement as E)
+        }
+    }
+
+    private fun invokeInsideMacroExpansion(
+        project: Project,
+        originalEditor: Editor?,
+        originalFile: PsiFile,
+        expandedElement: PsiElement
+    ) {
+        IntentionInMacroUtil.runActionInsideMacroExpansionCopy(
+            project,
+            originalEditor,
+            originalFile,
+            expandedElement
+        ) { editorCopy, expandedElementCopy ->
+            @Suppress("UNCHECKED_CAST")
+            invoke(project, editorCopy, expandedElementCopy as E)
+            return@runActionInsideMacroExpansionCopy true
+        }
+    }
+
+    final override fun isAvailable(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement): Boolean {
+        return super.isAvailable(project, file, startElement, endElement)
+    }
+
+    final override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        super.invoke(project, file, startElement, endElement)
+    }
+
+    final override fun isAvailable(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement): Boolean {
+        return super.isAvailable(project, file, editor, startElement, endElement)
+    }
+
+    final override fun applyFix(): Unit = super.applyFix()
+    final override fun isAvailable(): Boolean = super.isAvailable()
+
+    override fun getElementToMakeWritable(currentFile: PsiFile): PsiElement? {
+        if (!startInWriteAction()) return null
+        val element = super.getStartElement()
+        val macroCall = element.findMacroCallExpandedFrom()
+        val originalContainingFile = if (macroCall != null) {
+            macroCall.containingFile
+        } else {
+            element.containingFile
+        }
+
+        return if (originalContainingFile == currentFile.originalFile) {
+            // Intention preview
+            currentFile
+        } else {
+            originalContainingFile
+        }
+    }
+
+    override fun getFileModifierForPreview(target: PsiFile): FileModifier? {
+        return if (!super.getStartElement().isExpandedFromMacro) {
+            super<LocalQuickFixAndIntentionActionOnPsiElement>.getFileModifierForPreview(target)
+        } else {
+            // Check field safety in subclass
+            if (super<LocalQuickFix>.getFileModifierForPreview(target) !== this) return null
+            this
+        }
+    }
+
+    @Deprecated("In the case of a macro, this method returns a wrong PSI element", ReplaceWith("element"))
+    final override fun getStartElement(): PsiElement = super.getStartElement()
+
+    @Deprecated("It is always null", ReplaceWith("null"))
+    final override fun getEndElement(): PsiElement? = null
+}
+
+

--- a/src/main/kotlin/org/rust/ide/fixes/SimplifyBooleanExpressionFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/SimplifyBooleanExpressionFix.kt
@@ -5,23 +5,20 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.ide.utils.BooleanExprSimplifier
 import org.rust.ide.utils.isPure
 import org.rust.lang.core.psi.RsExpr
 
-class SimplifyBooleanExpressionFix(expr: RsExpr) : LocalQuickFixOnPsiElement(expr) {
+class SimplifyBooleanExpressionFix(expr: RsExpr) : RsQuickFixBase<RsExpr>(expr) {
     override fun getText(): String = "Simplify boolean expression"
     override fun getFamilyName() = text
 
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        val expr = startElement as? RsExpr ?: return
-        if (expr.isPure() == true && BooleanExprSimplifier.canBeSimplified(expr)) {
-            val simplified = BooleanExprSimplifier(project).simplify(expr) ?: return
-            expr.replace(simplified)
+    override fun invoke(project: Project, editor: Editor?, element: RsExpr) {
+        if (element.isPure() == true && BooleanExprSimplifier.canBeSimplified(element)) {
+            val simplified = BooleanExprSimplifier(project).simplify(element) ?: return
+            element.replace(simplified)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/SubstituteTextFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/SubstituteTextFix.kt
@@ -6,14 +6,13 @@
 package org.rust.ide.fixes
 
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.util.IntentionName
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPointerManager
-import org.rust.lang.core.psi.ext.findPreviewCopyIfNeeded
 import org.rust.openapiext.document
 
 /**
@@ -25,36 +24,36 @@ import org.rust.openapiext.document
  */
 class SubstituteTextFix private constructor(
     @IntentionName private val fixName: String = "Substitute",
-    file: PsiFile,
+    element: PsiElement,
     range: TextRange,
     private val substitution: String?
-) : LocalQuickFix {
+) : RsQuickFixBase<PsiElement>(element) {
 
     @SafeFieldForPreview
-    private val fileWithRange = SmartPointerManager.getInstance(file.project)
-        .createSmartPsiFileRangePointer(file, range)
+    private val fileWithRange = SmartPointerManager.getInstance(element.project)
+        .createSmartPsiFileRangePointer(element.containingFile, range)
 
-    override fun getName(): String = fixName
+    override fun getText(): String = fixName
     override fun getFamilyName() = "Substitute one text to another"
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val file = fileWithRange.containingFile?.findPreviewCopyIfNeeded(descriptor.startElement.containingFile) ?: return
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
         val range = fileWithRange.range ?: return
-        val document = file.document
-        document?.deleteString(range.startOffset, range.endOffset)
+        val document = element.containingFile.document ?: return
         if (substitution != null) {
-            document?.insertString(range.startOffset, substitution)
+            document.replaceString(range.startOffset, range.endOffset, substitution)
+        } else {
+            document.deleteString(range.startOffset, range.endOffset)
         }
     }
 
     companion object {
         fun delete(@IntentionName fixName: String, file: PsiFile, range: TextRange) =
-            SubstituteTextFix(fixName, file, range, null)
+            SubstituteTextFix(fixName, file.findElementAt(range.startOffset)!!, range, null)
 
-        fun insert(@IntentionName fixName: String, file: PsiFile, offsetInElement: Int, text: String) =
-            SubstituteTextFix(fixName, file, TextRange(offsetInElement, offsetInElement), text)
+        fun insert(@IntentionName fixName: String, file: PsiFile, offset: Int, text: String) =
+            SubstituteTextFix(fixName, file.findElementAt(offset)!!, TextRange(offset, offset), text)
 
         fun replace(@IntentionName fixName: String, file: PsiFile, range: TextRange, text: String) =
-            SubstituteTextFix(fixName, file, range, text)
+            SubstituteTextFix(fixName, file.findElementAt(range.startOffset)!!, range, text)
     }
 }

--- a/src/main/kotlin/org/rust/ide/fixes/SurroundWithUnsafeFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/SurroundWithUnsafeFix.kt
@@ -5,22 +5,19 @@
 
 package org.rust.ide.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsExprStmt
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.ancestorStrict
 
-class SurroundWithUnsafeFix(expr: RsExpr) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+class SurroundWithUnsafeFix(expr: RsExpr) : RsQuickFixBase<RsExpr>(expr) {
     override fun getFamilyName() = text
     override fun getText() = "Surround with unsafe block"
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, expr: PsiElement, endElement: PsiElement) {
-        val target = expr.ancestorStrict<RsExprStmt>() ?: expr
+    override fun invoke(project: Project, editor: Editor?, element: RsExpr) {
+        val target = element.ancestorStrict<RsExprStmt>() ?: element
         val unsafeBlockExpr = RsPsiFactory(project).createUnsafeBlockExprOrStmt(target)
         target.replace(unsafeBlockExpr)
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
@@ -5,12 +5,11 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.rust.cargo.util.AutoInjectedCrates.CORE
 import org.rust.cargo.util.AutoInjectedCrates.STD
+import org.rust.ide.fixes.RsQuickFixBase
 import org.rust.ide.utils.import.stdlibAttributes
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsFile.Attributes
@@ -42,16 +41,16 @@ class RsApproxConstantInspection : RsLocalInspectionTool() {
     }
 
     private class ReplaceWithPredefinedQuickFix(
-        element: PsiElement,
+        element: RsLitExpr,
         private val path: String
-    ) : LocalQuickFixOnPsiElement(element) {
+    ) : RsQuickFixBase<RsLitExpr>(element) {
 
         override fun getFamilyName() = "Replace with predefined constant"
         override fun getText() = "Replace with `$path`"
 
-        override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        override fun invoke(project: Project, editor: Editor?, element: RsLitExpr) {
             val pathExpr = RsPsiFactory(project).createExpression(path)
-            startElement.replace(pathExpr)
+            element.replace(pathExpr)
         }
 
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
@@ -32,7 +32,7 @@ class RsExtraSemicolonInspection : RsLocalInspectionTool() {
                         holder.registerProblem(
                             exitPoint.stmt,
                             "Function returns () instead of ${retType.text}",
-                            RemoveSemicolonFix()
+                            RemoveSemicolonFix(exitPoint.stmt)
                         )
                     }
                 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
@@ -20,7 +20,7 @@ class RsFieldInitShorthandInspection : RsLocalInspectionTool() {
                 o,
                 "Expression can be simplified",
                 ProblemHighlightType.WEAK_WARNING,
-                ChangeToFieldShorthandFix()
+                ChangeToFieldShorthandFix(o)
             )
         }
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt
@@ -5,10 +5,10 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.fixes.RsQuickFixBase
 import org.rust.lang.core.psi.RsFormatMacroArgument
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsVisitor
@@ -33,19 +33,17 @@ class RsSimplifyPrintInspection : RsLocalInspectionTool() {
             holder.registerProblem(
                 o,
                 "println! macro invocation can be simplified",
-                RemoveUnnecessaryPrintlnArgument()
+                RemoveUnnecessaryPrintlnArgument(o)
             )
         }
     }
 
-    private class RemoveUnnecessaryPrintlnArgument : LocalQuickFix {
-        override fun getName() = "Remove unnecessary argument"
-
+    private class RemoveUnnecessaryPrintlnArgument(element: RsMacroCall) : RsQuickFixBase<RsMacroCall>(element) {
+        override fun getText() = "Remove unnecessary argument"
         override fun getFamilyName() = name
 
-        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-            val macro = descriptor.psiElement as RsMacroCall
-            val arg = emptyStringArg(macro.formatMacroArgument!!) ?: return
+        override fun invoke(project: Project, editor: Editor?, element: RsMacroCall) {
+            val arg = emptyStringArg(element.formatMacroArgument!!) ?: return
             arg.delete()
         }
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -5,11 +5,11 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.tree.IElementType
+import org.rust.ide.fixes.RsQuickFixBase
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.*
@@ -27,9 +27,10 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
                 typeRef.startOffsetInParent + typeRef.textLength
             )
             holder.registerProblem(
-                impl, textRange,
+                impl,
+                textRange,
                 "Different impl member order from the trait",
-                SortImplTraitMembersFix()
+                SortImplTraitMembersFix(impl)
             )
         }
     }
@@ -47,13 +48,13 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
         }
     }
 
-    private class SortImplTraitMembersFix : LocalQuickFix {
-        override fun getFamilyName() = "Apply same member order"
+    private class SortImplTraitMembersFix(element: RsImplItem) : RsQuickFixBase<RsImplItem>(element) {
+        override fun getText() = "Apply same member order"
+        override fun getFamilyName() = text
 
-        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-            val impl = descriptor.psiElement as? RsImplItem ?: return
-            val trait = impl.traitRef?.resolveToTrait() ?: return
-            val implItems = impl.explicitMembers
+        override fun invoke(project: Project, editor: Editor?, element: RsImplItem) {
+            val trait = element.traitRef?.resolveToTrait() ?: return
+            val implItems = element.explicitMembers
             val traitItems = trait.explicitMembers
 
             // As we're applying the fix, this will be non-null.

--- a/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt
@@ -26,7 +26,7 @@ class RsTryMacroInspection : RsLocalInspectionTool() {
             holder.registerProblem(
                 o,
                 "try! macro can be replaced with ? operator",
-                ChangeTryMacroToTryOperator()
+                ChangeTryMacroToTryOperator(o)
             )
         }
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
@@ -74,11 +74,11 @@ class RsWrongGenericArgumentsNumberInspection : RsLocalInspectionTool() {
 
 private fun getFixes(
     declaration: RsGenericDeclaration,
-    element: RsElement,
+    element: RsMethodOrPath,
     actualArgs: Int,
     expectedTotalParams: Int
 ): List<LocalQuickFix> = when {
-    actualArgs > expectedTotalParams -> listOf(RemoveGenericArguments(expectedTotalParams, actualArgs))
+    actualArgs > expectedTotalParams -> listOf(RemoveGenericArguments(element, expectedTotalParams, actualArgs))
     actualArgs < expectedTotalParams -> listOf(AddGenericArguments(declaration.createSmartPointer(), element))
     else -> emptyList()
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
@@ -5,10 +5,10 @@
 
 package org.rust.ide.inspections.lints
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.fixes.RsQuickFixBase
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.*
@@ -36,20 +36,20 @@ class RsBareTraitObjectsInspection : RsLintInspection() {
                 holder.registerLintProblem(
                     typeReference,
                     "Trait objects without an explicit 'dyn' are deprecated",
-                    fixes = listOf(AddDynKeywordFix())
+                    fixes = listOf(AddDynKeywordFix(typeReference))
                 )
             }
         }
 
-    private class AddDynKeywordFix : LocalQuickFix {
-        override fun getFamilyName(): String = "Add 'dyn' keyword to trait object"
+    private class AddDynKeywordFix(element: RsTypeReference) : RsQuickFixBase<RsTypeReference>(element) {
+        override fun getText(): String = "Add 'dyn' keyword to trait object"
+        override fun getFamilyName(): String = text
 
-        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-            val target = descriptor.psiElement as RsTypeReference
-            val typeElement = target.skipParens()
+        override fun invoke(project: Project, editor: Editor?, element: RsTypeReference) {
+            val typeElement = element.skipParens()
             val traitText = (typeElement as? RsPathType)?.path?.text ?: (typeElement as RsTraitType).text
             val new = RsPsiFactory(project).createDynTraitType(traitText)
-            target.replace(new)
+            element.replace(new)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -46,7 +46,7 @@ class RsNeedlessLifetimesInspection : RsLintInspection() {
                 fn.block?.getPrevNonCommentSibling()?.endOffsetInParent ?: fn.identifier.endOffsetInParent
             ),
             RsLintHighlightingType.WEAK_WARNING,
-            listOf(ElideLifetimesFix())
+            listOf(ElideLifetimesFix(fn))
         )
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsRedundantSemicolonsInspection.kt
@@ -5,13 +5,13 @@
 
 package org.rust.ide.inspections.lints
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
 import org.rust.RsBundle
+import org.rust.ide.fixes.RsQuickFixBase
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.RsBlock
@@ -19,16 +19,16 @@ import org.rust.lang.core.psi.RsEmptyStmt
 import org.rust.lang.core.psi.RsStmt
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.endOffsetInParent
+import org.rust.lang.core.psi.ext.rightSiblings
 
-private class FixRedundantSemicolons(start: PsiElement, end: PsiElement = start)
-    : LocalQuickFixAndIntentionActionOnPsiElement(start, end) {
+private class FixRedundantSemicolons(element: PsiElement) : RsQuickFixBase<PsiElement>(element) {
+    override fun getText() = RsBundle.message("inspection.RedundantSemicolons.fix.name")
+    override fun getFamilyName() = text
 
-    override fun getFamilyName() = RsBundle.message("inspection.RedundantSemicolons.fix.name")
-    override fun getText() = familyName
-
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
-        val parent = startElement.parent as? RsBlock ?: return
-        parent.deleteChildRange(startElement, endElement)
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        val parent = element.parent as? RsBlock ?: return
+        val last = element.rightSiblings.takeWhile { it is RsEmptyStmt || it is PsiWhiteSpace }.lastOrNull()
+        parent.deleteChildRange(element, last ?: element)
     }
 }
 
@@ -50,7 +50,7 @@ class RsRedundantSemicolonsInspection : RsLintInspection() {
                 } else {
                     val description = RsBundle.message("inspection.RedundantSemicolons.description.multiple")
                     val range = TextRange.create(stmts.first().startOffsetInParent, stmts.last().endOffsetInParent)
-                    val fixes = listOf(FixRedundantSemicolons(stmts.first(), stmts.last()))
+                    val fixes = listOf(FixRedundantSemicolons(stmts.first()))
                     holder.registerLintProblem(block, description, range, highlighting, fixes)
                 }
                 stmts.clear()

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
@@ -5,11 +5,11 @@
 
 package org.rust.ide.inspections.lints
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import org.rust.ide.fixes.RsQuickFixBase
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.ide.utils.skipParenExprDown
@@ -34,7 +34,7 @@ class RsWhileTrueLoopInspection : RsLintInspection() {
                     "Denote infinite loops with `loop { ... }`",
                     TextRange.create(o.`while`.startOffsetInParent, condition.endOffsetInParent),
                     RsLintHighlightingType.WEAK_WARNING,
-                    listOf(UseLoopFix())
+                    listOf(UseLoopFix(o))
                 )
             }
         }
@@ -42,11 +42,11 @@ class RsWhileTrueLoopInspection : RsLintInspection() {
 
     override val isSyntaxOnly: Boolean = true
 
-    private class UseLoopFix : LocalQuickFix {
+    private class UseLoopFix(element: RsWhileExpr) : RsQuickFixBase<RsWhileExpr>(element) {
         override fun getFamilyName(): String = "Use `loop`"
+        override fun getText(): String = familyName
 
-        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-            val element = descriptor.psiElement as? RsWhileExpr ?: return
+        override fun invoke(project: Project, editor: Editor?, element: RsWhileExpr) {
             val block = element.block ?: return
             val label = element.labelDecl?.text ?: ""
             val loopExpr = RsPsiFactory(project).createExpression("${label}loop ${block.text}") as RsLoopExpr

--- a/src/main/kotlin/org/rust/ide/intentions/AddImplTraitIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImplTraitIntention.kt
@@ -75,7 +75,7 @@ class AddImplTraitIntention : RsElementBaseIntentionAction<AddImplTraitIntention
             null
         }
 
-        generateMissingTraitMembers(impl, editor)
+        generateMissingTraitMembers(impl, traitRef, editor)
 
         showGenericArgumentsTemplate(
             editor,

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -28,7 +28,7 @@ import kotlin.math.max
 
 fun generateTraitMembers(impl: RsImplItem, editor: Editor?) {
     checkWriteAccessNotAllowed()
-    val (implInfo, trait) = findMembersToImplement(impl) ?: run {
+    val (implInfo, trait) = findMembersToImplement(impl, impl.traitRef) ?: run {
         editor?.showErrorHint("No members to implement have been found")
         return
     }
@@ -44,18 +44,18 @@ fun generateTraitMembers(impl: RsImplItem, editor: Editor?) {
 /**
  * Generates missing trait members in a non-interactive way.
  */
-fun generateMissingTraitMembers(impl: RsImplItem, editor: Editor?) {
-    val (implInfo, trait) = findMembersToImplement(impl) ?: return
+fun generateMissingTraitMembers(impl: RsImplItem, traitRef: RsTraitRef, editor: Editor?) {
+    val (implInfo, trait) = findMembersToImplement(impl, traitRef) ?: return
 
     IntentionPreviewUtils.write<Throwable> {
         insertNewTraitMembers(implInfo.missingImplementations, impl, trait, editor)
     }
 }
 
-private fun findMembersToImplement(impl: RsImplItem): Pair<TraitImplementationInfo, BoundElement<RsTraitItem>>? {
+private fun findMembersToImplement(impl: RsImplItem, traitRef: RsTraitRef?): Pair<TraitImplementationInfo, BoundElement<RsTraitItem>>? {
     checkReadAccessAllowed()
 
-    val trait = impl.traitRef?.resolveToBoundTrait() ?: return null
+    val trait = traitRef?.resolveToBoundTrait() ?: return null
     val implInfo = TraitImplementationInfo.create(trait.element, impl) ?: return null
     if (implInfo.declared.isEmpty()) return null
     return implInfo to trait

--- a/src/main/kotlin/org/rust/ide/utils/PsiInsertionPlace.kt
+++ b/src/main/kotlin/org/rust/ide/utils/PsiInsertionPlace.kt
@@ -132,7 +132,7 @@ sealed interface PsiInsertionPlace {
             }
         }
 
-        private fun forItemBefore(context: RsElement): PsiInsertionPlace? {
+        fun forItemBefore(context: RsElement): PsiInsertionPlace? {
             val topLevelItem = context.contexts.firstOrNull {
                 it is RsItemElement && (it !is RsAbstractable || it.owner is RsAbstractableOwner.Free)
             } ?: return null

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -347,7 +347,9 @@ val PsiElement.isIntentionPreviewElement: Boolean
  * We will have an exception if we try to modify the original element.
  * Thus, we should call this function on `resolve` result to obtain element in the copy of the original file.
  */
-fun <T: PsiElement> T.findPreviewCopyIfNeeded(copyFile: PsiFile): T {
+fun <T: PsiElement> T.findPreviewCopyIfNeeded(): T {
+    val previewEditor = IntentionPreviewUtils.getPreviewEditor() ?: return this
+    val copyFile = PsiDocumentManager.getInstance(project).getPsiFile(previewEditor.document) ?: return this
     if (!copyFile.isIntentionPreviewElement) return this
     return when (containingFile) {
         copyFile -> this

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -158,7 +158,9 @@ sealed class RsDiagnostic(
                                 add(ConvertToRefTyFix(element, expectedTy))
                             }
                         } else if (expectedTy.mutability == Mutability.MUTABLE) {
-                            if (actualTy is TyReference && actualTy.mutability == Mutability.IMMUTABLE) {
+                            if (actualTy is TyReference && actualTy.mutability == Mutability.IMMUTABLE &&
+                                element is RsUnaryExpr && element.operatorType == UnaryOperator.REF
+                            ) {
                                 add(ChangeRefToMutableFix(element))
                             }
 
@@ -1706,7 +1708,7 @@ sealed class RsDiagnostic(
     }
 
     class MissingAssocTypeBindings(
-        element: PsiElement,
+        element: RsElement,
         private val missingTypes: List<RsWrongAssocTypeArgumentsInspection.MissingAssocTypeBinding>
     ) : RsDiagnostic(element) {
         private fun getText(): String {
@@ -1719,7 +1721,7 @@ sealed class RsDiagnostic(
             ERROR,
             E0191,
             getText(),
-            fixes = listOfFixes(AddAssocTypeBindingsFix(element, missingTypes.map { it.name }))
+            fixes = listOfFixes(AddAssocTypeBindingsFix(element as RsElement, missingTypes.map { it.name }))
         )
     }
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveElementFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveElementFixTest.kt
@@ -59,7 +59,7 @@ class RemoveElementFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     """, checkWeakWarn = true)
 
     fun `test derive on function`() = checkFixByText("Remove attribute `derive`","""
-        <error descr="`derive` may only be applied to structs, enums and unions [E0774]">#[derive(Debug)]</error>
+        <error descr="`derive` may only be applied to structs, enums and unions [E0774]">/*caret*/#[derive(Debug)]</error>
         fn foo() { }
     """, """
         fn foo() { }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveRedundantParenthesesFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveRedundantParenthesesFixTest.kt
@@ -5,9 +5,11 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsExpressionAnnotator
 
+@SkipTestWrapping // TODO make `RsExpressionAnnotator` work in macro expansions
 class RemoveRedundantParenthesesFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class) {
     fun `test simple parentheses`() = checkFixIsUnavailable("Remove parentheses from expression", """
         fn test() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
@@ -165,8 +165,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
         }
 
         /*weak_warning descr="Different impl member order from the trait"*//*caret*/impl Foo for ()/*weak_warning**/ {
-            fn bar() {
-            }
+            fn bar() {}
             type bar = ();
         }
     """, """
@@ -177,8 +176,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
 
         impl Foo for () {
             type bar = ();
-            fn bar() {
-            }
+            fn bar() {}
         }
     """, checkWeakWarn = true)
 

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/RemoveImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/RemoveImportFixTest.kt
@@ -90,6 +90,7 @@ class RemoveImportFixTest : RsInspectionsTestBase(RsUnusedImportInspection::clas
 
         mod foo {
             use crate::{<warning>A/*caret*/</warning>, inner::B};
+
             fn foo(b: B) {}
         }
     """, """
@@ -100,6 +101,7 @@ class RemoveImportFixTest : RsInspectionsTestBase(RsUnusedImportInspection::clas
 
         mod foo {
             use crate::inner::B;
+
             fn foo(b: B) {}
         }
     """)

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsArgumentNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsArgumentNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsArgumentNamingInspection
 
@@ -21,6 +22,7 @@ class RsArgumentNamingInspectionTest: RsInspectionsTestBase(RsArgumentNamingInsp
         fn fn_par(ParFoo: u32) {}
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test function arguments fix`() = checkFixByText("Rename to `arg_baz`", """
         fn test (<warning descr="Argument `Arg__Baz_` should have a snake case name such as `arg_baz`">Arg__<caret>Baz_</warning>: u32) {
             println!("{}", Arg__Baz_);
@@ -49,6 +51,7 @@ class RsArgumentNamingInspectionTest: RsInspectionsTestBase(RsArgumentNamingInsp
         }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test method arguments fix`() = checkFixByText("Rename to `m_arg`", """
         struct Foo;
         impl Foo {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsAssocTypeNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsAssocTypeNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsAssocTypeNamingInspection
 
@@ -23,6 +24,7 @@ class RsAssocTypeNamingInspectionTest : RsInspectionsTestBase(RsAssocTypeNamingI
         }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test associated types fix`() = checkFixByText("Rename to `AssocFoo`", """
         trait Foo {
             type <warning descr="Type `assoc_foo` should have a camel case name such as `AssocFoo`">ass<caret>oc_foo</warning>;

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsConstNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsConstNamingInspection
 
@@ -24,6 +25,7 @@ class RsConstNamingInspectionTest : RsInspectionsTestBase(RsConstNamingInspectio
         const const_foo: u32 = 12;
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test constants fix`() = checkFixByText("Rename to `CONST_FOO`", """
         const <warning descr="Constant `ConstFoo` should have an upper case name such as `CONST_FOO`">Con<caret>stFoo</warning>: u32 = 42;
         fn const_use() {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsEnumNamingInspection
 
@@ -19,6 +20,7 @@ class RsEnumNamingInspectionTest : RsInspectionsTestBase(RsEnumNamingInspection:
         enum enum_foo {}
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test enums fix`() = checkFixByText("Rename to `EnumFoo`", """
         enum <warning descr="Type `enum_foo` should have a camel case name such as `EnumFoo`">enum_f<caret>oo</warning> { Var }
         fn enum_use() {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumVariantNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumVariantNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsEnumVariantNamingInspection
 
@@ -23,6 +24,7 @@ class RsEnumVariantNamingInspectionTest : RsInspectionsTestBase(RsEnumVariantNam
         }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test enum variants fix`() = checkFixByText("Rename to `VarBar`", """
         enum ToFix {
             <warning descr="Enum variant `var_bar` should have a camel case name such as `VarBar`">var_b<caret>ar</warning>

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFieldNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFieldNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsFieldNamingInspection
 
@@ -27,6 +28,7 @@ class RsFieldNamingInspectionTest : RsInspectionsTestBase(RsFieldNamingInspectio
         }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test enum variant fields fix`() = checkFixByText("Rename to `field_foo`", """
         enum EnumToFix {
             Test {
@@ -62,6 +64,7 @@ class RsFieldNamingInspectionTest : RsInspectionsTestBase(RsFieldNamingInspectio
         }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test struct fields fix`() = checkFixByText("Rename to `is_deleted`", """
         struct Foo {
             <warning descr="Field `IsDeleted` should have a snake case name such as `is_deleted`">IsDelete<caret>d</warning>: bool

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFunctionNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFunctionNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsFunctionNamingInspection
 
@@ -23,6 +24,7 @@ class RsFunctionNamingInspectionTest : RsInspectionsTestBase(RsFunctionNamingIns
         fn FN_BAR() {}
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test functions fix`() = checkFixByText("Rename to `fun_foo`", """
         fn <warning descr="Function `FUN_FOO` should have a snake case name such as `fun_foo`">F<caret>UN_FOO</warning>() {}
         fn fun_use() {
@@ -35,6 +37,7 @@ class RsFunctionNamingInspectionTest : RsInspectionsTestBase(RsFunctionNamingIns
         }
     """, preview = null)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test function with raw identifier`() = checkFixByText("Rename to `extern`", """
         fn <warning descr="Function `Extern` should have a snake case name such as `extern`">r#Extern/*caret*/</warning>() {}
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsLifetimeNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsLifetimeNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsLifetimeNamingInspection
 
@@ -22,6 +23,7 @@ class RsLifetimeNamingInspectionTest : RsInspectionsTestBase(RsLifetimeNamingIns
         fn lifetimes<'LifetimeFoo>() {}
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test lifetimes fix`() = checkFixByText("Rename to `'lifetime_foo`", """
         fn lifetimes<
             <warning descr="Lifetime `'LifetimeFoo` should have a snake case name such as `'lifetime_foo`">'Lifetime<caret>Foo</warning>>(x: &'LifetimeFoo u32) {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMacroNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMacroNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsMacroNamingInspection
 
@@ -19,6 +20,7 @@ class RsMacroNamingInspectionTest : RsInspectionsTestBase(RsMacroNamingInspectio
         macro_rules! MacroFoo { () => {}; }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test macros fix`() = checkFixByText("Rename to `macro_foo`", """
         macro_rules! <warning descr="Macro `MacroFoo` should have a snake case name such as `macro_foo`">Macro<caret>Foo</warning> { () => {}; }
         MacroFoo!();
@@ -27,6 +29,7 @@ class RsMacroNamingInspectionTest : RsInspectionsTestBase(RsMacroNamingInspectio
         macro_foo!();
     """, preview = null)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test macros with raw identifier`() = checkFixByText("Rename to `macro_foo`", """
         macro_rules! <warning descr="Macro `MacroFoo` should have a snake case name such as `macro_foo`">r#Macro/*caret*/Foo</warning> { () => {}; }
         r#MacroFoo!();

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMethodNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMethodNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsMethodNamingInspection
 
@@ -25,6 +26,7 @@ class RsMethodNamingInspectionTest : RsInspectionsTestBase(RsMethodNamingInspect
         }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test methods fix`() = checkFixByText("Rename to `met_bar`", """
         struct Foo;
         impl Foo {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsModuleNamingInspection
 
@@ -38,6 +39,7 @@ class RsModuleNamingInspectionTest : RsInspectionsTestBase(RsModuleNamingInspect
         mod moduleA {}
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test modules fix`() = checkFixByText("Rename to `mod_foo`", """
         mod <warning descr="Module `modFoo` should have a snake case name such as `mod_foo`">modF<caret>oo</warning> {
             pub const ONE: u32 = 1;

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStaticConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStaticConstNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsStaticConstNamingInspection
 
@@ -19,6 +20,7 @@ class RsStaticConstNamingInspectionTest : RsInspectionsTestBase(RsStaticConstNam
         static static_foo: u32 = 12;
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test statics fix`() = checkFixByText("Rename to `STATIC_FOO`", """
         static <warning descr="Static constant `staticFoo` should have an upper case name such as `STATIC_FOO`">sta<caret>ticFoo</warning>: u32 = 43;
         fn static_use() {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStructNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStructNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsStructNamingInspection
 
@@ -19,6 +20,7 @@ class RsStructNamingInspectionTest : RsInspectionsTestBase(RsStructNamingInspect
         struct struct_foo {}
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test structs fix`() = checkFixByText("Rename to `StructFoo`", """
         struct <warning descr="Type `Struct_foo` should have a camel case name such as `StructFoo`">Stru<caret>ct_foo</warning> {}
         fn struct_use() {
@@ -31,6 +33,7 @@ class RsStructNamingInspectionTest : RsInspectionsTestBase(RsStructNamingInspect
         }
     """, preview = null)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test struct with raw identifier`() = checkFixByText("Rename to `FooBar`", """
         struct <warning descr="Type `foo_bar` should have a camel case name such as `FooBar`">r#foo_bar/*caret*/</warning>;
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTraitNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTraitNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsTraitNamingInspection
 
@@ -24,6 +25,7 @@ class RsTraitNamingInspectionTest : RsInspectionsTestBase(RsTraitNamingInspectio
         trait trait_foo {}
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test traits fix`() = checkFixByText("Rename to `HotFix`", """
         trait <warning descr="Trait `hot_fix` should have a camel case name such as `HotFix`">ho<caret>t_fix</warning> {}
         struct Patch {}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeAliasNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeAliasNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsTypeAliasNamingInspection
 
@@ -19,6 +20,7 @@ class RsTypeAliasNamingInspectionTest : RsInspectionsTestBase(RsTypeAliasNamingI
         type type_foo = u32;
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test type aliases fix`() = checkFixByText("Rename to `ULong`", """
         type <warning descr="Type `u_long` should have a camel case name such as `ULong`">u_<caret>long</warning> = u64;
         const ZERO: u_long = 0;

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeParameterNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeParameterNamingInspectionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections.lints.naming
 
+import org.rust.SkipTestWrapping
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsTypeParameterNamingInspection
 
@@ -34,6 +35,7 @@ class RsTypeParameterNamingInspectionTest : RsInspectionsTestBase(RsTypeParamete
         }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test type parameters with where fix`() = checkFixByText("Rename to `Base`", """
         fn type_params<<warning descr="Type parameter `base` should have a camel case name such as `Base`">b<caret>ase</warning>>(b: &base) where base: Clone {}
     """, """

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsVariableNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsVariableNamingInspectionTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.inspections.lints.naming
 
 import org.rust.ProjectDescriptor
+import org.rust.SkipTestWrapping
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.lints.RsVariableNamingInspection
@@ -32,6 +33,7 @@ class RsVariableNamingInspectionTest : RsInspectionsTestBase(RsVariableNamingIns
         }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test variables fix`() = checkFixByText("Rename to `dwarfs_count`", """
         fn test() {
             let <warning descr="Variable `DWARFS_COUNT` should have a snake case name such as `dwarfs_count`">DWARF<caret>S_COUNT</warning> = 7;
@@ -51,6 +53,7 @@ class RsVariableNamingInspectionTest : RsInspectionsTestBase(RsVariableNamingIns
         }
     """)
 
+    @SkipTestWrapping // TODO support `RenameFix` in macros
     fun `test tuple variables fix`() = checkFixByText("Rename to `real`", """
         fn test() {
             let (<warning descr="Variable `Real` should have a snake case name such as `real`">Re<caret>al</warning>, imaginary) = (7.2, 3.5);


### PR DESCRIPTION
Most quick fixes now work in attribute macros, except these:
- RenameFix
- AddTurbofishFix

The implementation is based on intention actions in macros - see #10182.

The major difference is that a quick fix will be available (and will be shown in the list of quick fixes) even if the fix actually can't be applied. This is done in order to deliver the feature faster and because I don't expect many cases where a fix can't be applied in an attribute macro

changelog: Support quick fixes in attribute proc macros