### PR TITLE
INSP: move `Unused mut modifier` and `Unnecessary cast` inspections to `Rust/Lint` group

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryCastInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryCastInspection.kt
@@ -3,20 +3,18 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.rust.ide.fixes.RemoveCastFix
-import org.rust.ide.inspections.lints.RsLint
-import org.rust.ide.inspections.lints.RsLintHighlightingType
-import org.rust.ide.inspections.lints.RsLintInspection
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.infer.containsTyOfClass
 import org.rust.lang.core.types.rawType
 import org.rust.lang.core.types.ty.Ty
-import org.rust.lang.core.types.ty.TyFunctionBase
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMutInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMutInspection.kt
@@ -3,19 +3,18 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
 import org.rust.ide.fixes.RemoveElementFix
 import org.rust.ide.injected.isDoctestInjection
-import org.rust.ide.inspections.lints.RsLint
-import org.rust.ide.inspections.lints.RsLintInspection
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.mutability
 import org.rust.lang.core.psi.ext.searchReferencesAfterExpansion
 import org.rust.lang.core.psi.ext.selfParameter
-import org.rust.lang.core.psi.ext.*
 
 class RsUnusedMutInspection : RsLintInspection() {
     override fun getDisplayName(): String = "No mutable required"

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -488,10 +488,10 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.RsTryMacroInspection"/>
 
-        <localInspection language="Rust" groupName="Rust"
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Unnecessary cast"
                          enabledByDefault="true" level="WEAK WARNING"
-                         implementationClass="org.rust.ide.inspections.RsUnnecessaryCastInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsUnnecessaryCastInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="While true loop"
@@ -513,10 +513,10 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsConstantConditionIfInspection"/>
 
-        <localInspection language="Rust" groupName="Rust"
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Unused mut modifier"
                          enabledByDefault="true" level="WEAK WARNING"
-                         implementationClass="org.rust.ide.inspections.RsUnusedMutInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsUnusedMutInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
                          displayName="Wrong generic arguments number"

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryCastInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryCastInspectionTest.kt
@@ -3,12 +3,13 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import org.junit.ComparisonFailure
 import org.junit.Test
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.RsInspectionsTestBase
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)// for arithmetic type inference
 class RsUnnecessaryCastInspectionTest : RsInspectionsTestBase(RsUnnecessaryCastInspection::class) {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMutInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMutInspectionTest.kt
@@ -3,10 +3,11 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
+import org.rust.ide.inspections.RsInspectionsTestBase
 
 class RsUnusedMutInspectionTest : RsInspectionsTestBase(RsUnusedMutInspection::class) {
 


### PR DESCRIPTION
Also, move the corresponding classes into `inspections.lints` package

changelog: Move `Unused mut modifier` and `Unnecessary cast` inspections to `Rust/Lint` group in inspection settings
