### PR TITLE
INSP: respect lint level by `Unused mut` inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMutInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedMutInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections.lints
 
-import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
 import org.rust.ide.fixes.RemoveElementFix
 import org.rust.ide.injected.isDoctestInjection
@@ -33,11 +32,11 @@ class RsUnusedMutInspection : RsLintInspection() {
                         .any { checkOccurrenceNeedMutable(it.element.parent) }) return
 
                 val mut = o.mut ?: return
-                holder.registerProblem(
+                holder.registerLintProblem(
                     mut,
                     "Unused `mut`",
-                    ProblemHighlightType.LIKE_UNUSED_SYMBOL,
-                    RemoveElementFix(mut),
+                    RsLintHighlightingType.UNUSED_SYMBOL,
+                    listOf(RemoveElementFix(mut)),
                 )
             }
         }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMutInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedMutInspectionTest.kt
@@ -266,4 +266,11 @@ class RsUnusedMutInspectionTest : RsInspectionsTestBase(RsUnusedMutInspection::c
             let mut f = 10;
         }
     """)
+
+    fun `test use error highlighting with deny unused_mut`() = checkWarnings("""
+        #[deny(unused_mut)]
+        fn main() {
+            let /*error descr="Unused `mut`"*/mut/*error**/ f = 10;
+        }
+    """)
 }


### PR DESCRIPTION
changelog: Take into account lint level by `Unused mut` inspection during highlighting
