### PR TITLE
MACRO: Implement proc macro expander version check

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -140,7 +140,13 @@ data class RustcInfo(
     val sysroot: String,
     val version: RustcVersion?,
     val rustupActiveToolchain: String? = null,
-    val targets: List<String>? = null
+    val targets: List<String>? = null,
+
+    /**
+     * In production environments it is always equal to [version].
+     * In unit tests it is real, non-mocked toolchain version
+     */
+    val realVersion: RustcVersion? = version,
 )
 
 fun guessAndSetupRustProject(project: Project, explicitRequest: Boolean = false): Boolean {

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
@@ -73,6 +73,10 @@ sealed class GetMacroExpansionError {
                 "macro definition pattern(s)"
             is ProcMacroExpansionError.ServerSideError -> "a procedural macro error occurred:\n${e.message}"
             is ProcMacroExpansionError.Timeout -> "procedural macro expansion timeout exceeded (${e.timeout} ms)"
+            is ProcMacroExpansionError.UnsupportedExpanderVersion -> "IntelliJ Rust can't expand procedural macros using " +
+                "your Rust toolchain version. It looks like the version is too recent. " +
+                "Consider downgrading your Rust toolchain to a previous version or try to update IntelliJ Rust plugin. " +
+                "(unsupported macro expander version ${e.version})"
             is ProcMacroExpansionError.ProcessAborted -> "the procedural macro expander process unexpectedly exited " +
                 "with code ${e.exitCode}"
             is ProcMacroExpansionError.IOExceptionThrown -> "an exception thrown during communicating with proc " +

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
@@ -86,6 +86,7 @@ sealed class ProcMacroExpansionError : MacroExpansionError() {
     object IOExceptionThrown : ProcMacroExpansionError()
 
     data class Timeout(val timeout: Long) : ProcMacroExpansionError()
+    data class UnsupportedExpanderVersion(val version: Int) : ProcMacroExpansionError()
     object CantRunExpander : ProcMacroExpansionError()
     object ExecutableNotFound : ProcMacroExpansionError()
     object ProcMacroExpansionIsDisabled : ProcMacroExpansionError()
@@ -104,11 +105,12 @@ fun DataOutput.writeMacroExpansionError(err: MacroExpansionError) {
         is ProcMacroExpansionError.ProcessAborted -> 3
         is ProcMacroExpansionError.IOExceptionThrown -> 4
         is ProcMacroExpansionError.Timeout -> 5
-        ProcMacroExpansionError.CantRunExpander -> 6
-        ProcMacroExpansionError.ExecutableNotFound -> 7
-        ProcMacroExpansionError.ProcMacroExpansionIsDisabled -> 8
-        BuiltinMacroExpansionError -> 9
-        DeclMacroExpansionError.TooLargeExpansion -> 10
+        is ProcMacroExpansionError.UnsupportedExpanderVersion -> 6
+        ProcMacroExpansionError.CantRunExpander -> 7
+        ProcMacroExpansionError.ExecutableNotFound -> 8
+        ProcMacroExpansionError.ProcMacroExpansionIsDisabled -> 9
+        BuiltinMacroExpansionError -> 10
+        DeclMacroExpansionError.TooLargeExpansion -> 11
     }
     writeByte(ordinal)
 
@@ -122,6 +124,7 @@ fun DataOutput.writeMacroExpansionError(err: MacroExpansionError) {
         is ProcMacroExpansionError.ServerSideError -> IOUtil.writeUTF(this, err.message)
         is ProcMacroExpansionError.ProcessAborted -> writeInt(err.exitCode)
         is ProcMacroExpansionError.Timeout -> writeLong(err.timeout)
+        is ProcMacroExpansionError.UnsupportedExpanderVersion -> writeInt(err.version)
         else -> Unit
     }
 }
@@ -137,11 +140,12 @@ fun DataInput.readMacroExpansionError(): MacroExpansionError = when (val ordinal
     3 -> ProcMacroExpansionError.ProcessAborted(readInt())
     4 -> ProcMacroExpansionError.IOExceptionThrown
     5 -> ProcMacroExpansionError.Timeout(readLong())
-    6 -> ProcMacroExpansionError.CantRunExpander
-    7 -> ProcMacroExpansionError.ExecutableNotFound
-    8 -> ProcMacroExpansionError.ProcMacroExpansionIsDisabled
-    9 -> BuiltinMacroExpansionError
-    10 -> DeclMacroExpansionError.TooLargeExpansion
+    6 -> ProcMacroExpansionError.UnsupportedExpanderVersion(readInt())
+    7 -> ProcMacroExpansionError.CantRunExpander
+    8 -> ProcMacroExpansionError.ExecutableNotFound
+    9 -> ProcMacroExpansionError.ProcMacroExpansionIsDisabled
+    10 -> BuiltinMacroExpansionError
+    11 -> DeclMacroExpansionError.TooLargeExpansion
     else -> throw IOException("Unknown expansion error code $ordinal")
 }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProMacroExpanderVersion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProMacroExpanderVersion.kt
@@ -1,0 +1,18 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.proc
+
+enum class ProMacroExpanderVersion {
+    NO_VERSION_CHECK_VERSION,
+    VERSION_CHECK_VERSION,
+//    ENCODE_CLOSE_SPAN_VERSION,
+    ;
+
+    companion object {
+        fun from(i: Int): ProMacroExpanderVersion? =
+            values().getOrNull(i)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroApplicationService.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroApplicationService.kt
@@ -48,14 +48,18 @@ class ProcMacroApplicationService : Disposable {
     }
 
     @Synchronized
-    fun getServer(toolchain: RsToolchainBase, procMacroExpanderPath: Path): ProcMacroServerPool? {
+    fun getServer(
+        toolchain: RsToolchainBase,
+        needsVersionCheck: Boolean,
+        procMacroExpanderPath: Path
+    ): ProcMacroServerPool? {
         if (!isAnyEnabled()) return null
 
         val id = toolchain.distributionId
-        val key = DistributionIdAndExpanderPath(id, procMacroExpanderPath)
+        val key = DistributionIdAndExpanderPath(id, needsVersionCheck, procMacroExpanderPath)
         var server = servers[key]
         if (server == null) {
-            server = ProcMacroServerPool.new(toolchain, procMacroExpanderPath, this)
+            server = ProcMacroServerPool.new(toolchain, needsVersionCheck, procMacroExpanderPath, this)
             servers[key] = server
         }
         return server
@@ -81,6 +85,7 @@ class ProcMacroApplicationService : Disposable {
 
     private data class DistributionIdAndExpanderPath(
         val distributionId: String,
+        val needsVersionCheck: Boolean,
         val procMacroExpanderPath: Path,
     )
 

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/Request.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/Request.kt
@@ -22,6 +22,8 @@ sealed class Request {
         val env: List<List<String>>,
         val currentDir: String?,
     ) : Request()
+
+    object ApiVersionCheck : Request()
 }
 
 class RequestJsonSerializer : RsJacksonSerializer<Request>(Request::class.java) {
@@ -40,6 +42,10 @@ class RequestJsonSerializer : RsJacksonSerializer<Request>(Request::class.java) 
                     }
                     writeStringField("current_dir", request.currentDir)
                 }
+            }
+
+            Request.ApiVersionCheck -> gen.writeJsonObjectWithSingleField("ApiVersionCheck") {
+                writeJsonObject {}
             }
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/Response.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/Response.kt
@@ -17,6 +17,7 @@ import java.io.IOException
 sealed class Response {
     // data class ListMacros(...)
     data class ExpandMacro(val expansion: RsResult<FlatTree, PanicMessage>) : Response()
+    data class ApiVersionCheck(val version: Long) : Response()
 }
 
 data class PanicMessage(val message: String)
@@ -35,6 +36,9 @@ class ResponseJsonDeserializer : RsJacksonDeserializer<Response>(Response::class
                         }
                     }
                     Response.ExpandMacro(r)
+                }
+                "ApiVersionCheck" -> {
+                    Response.ApiVersionCheck(context.readLong())
                 }
                 else -> context.reportInputMismatch("Unknown response kind `$key`")
             }

--- a/src/main/kotlin/org/rust/stdext/SynchronizedCancellableLazy.kt
+++ b/src/main/kotlin/org/rust/stdext/SynchronizedCancellableLazy.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.stdext
+
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * Similar to [lazy], but uses cancellable locking
+ */
+fun <T> cancelableLazy(initializer: () -> T): Lazy<T> = SynchronizedCancellableLazyImpl(initializer)
+
+/**
+ * Mimics [SynchronizedLazyImpl], but uses cancellable locking
+ */
+private class SynchronizedCancellableLazyImpl<out T>(initializer: () -> T) : Lazy<T> {
+    private var initializer: (() -> T)? = initializer
+    @Volatile private var _value: Any? = UninitializedValue
+    private val lock = ReentrantLock()
+
+    @Suppress("UNCHECKED_CAST")
+    override val value: T
+        get() {
+            val v1 = _value
+            if (v1 !== UninitializedValue) {
+                return v1 as T
+            }
+
+            return lock.withLockAndCheckingCancelled() {
+                val v2 = _value
+                if (v2 !== UninitializedValue) {
+                    v2 as T
+                } else {
+                    val typedValue = initializer!!()
+                    _value = typedValue
+                    initializer = null
+                    typedValue
+                }
+            }
+        }
+
+    override fun isInitialized(): Boolean = _value !== UninitializedValue
+
+    override fun toString(): String {
+        return if (isInitialized()) value.toString() else "Lazy value not initialized yet."
+    }
+}
+
+private object UninitializedValue


### PR DESCRIPTION
From the user perspective the PR is about the error message in the case when proc macro expander from user's toolchain has too recent version.

Before:
![image](https://github.com/intellij-rust/intellij-rust/assets/3221931/1d7d3fcf-0658-41c7-899f-0aa2d51431e3)

After:
![image](https://github.com/intellij-rust/intellij-rust/assets/3221931/25687c7d-c093-4814-becb-ee5c8c119966)

Part of #10566

changelog: Implement proc macro expander version check