### PR TITLE
HINT: Render lifetimes in generic parameter info

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsGenericParameterInfoHandler.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsGenericParameterInfoHandler.kt
@@ -31,7 +31,7 @@ class RsGenericParameterInfoHandler : RsAsyncParameterInfoHandler<RsTypeArgument
         } else {
             return null
         }
-        val paramsWithBounds = genericDeclaration.getGenericParameters(includeLifetimes = false)
+        val paramsWithBounds = genericDeclaration.getGenericParameters()
         if (paramsWithBounds.isEmpty()) return null
         return listOfNotNull(firstLine(paramsWithBounds), secondLine(paramsWithBounds)).toTypedArray()
     }
@@ -88,6 +88,13 @@ private fun firstLine(params: List<RsGenericParameter>): HintLine {
     val renderer = RsPsiRenderer(PsiRenderingOptions(renderLifetimes = false))
     val splited = params.map { param ->
         when (param) {
+            is RsLifetimeParameter -> {
+                val bounds = param.bounds
+                    .filter { it.name?.equals(param.name) == false }
+                    .mapNotNull { it.name }
+                    .nullize()?.joinToString(prefix = ": ", separator = " + ") ?: ""
+                "${param.name ?: "'_"}$bounds"
+            }
             is RsTypeParameter -> {
                 param.name ?: return@map ""
                 val qSizedBound = if (!param.isSized) listOf("?Sized") else emptyList()

--- a/src/test/kotlin/org/rust/ide/hints/parameter/RsGenericParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/parameter/RsGenericParameterInfoHandlerTest.kt
@@ -128,6 +128,27 @@ class RsGenericParameterInfoHandlerTest
         fn main() { foo::</*caret*/>(); }
     """, "T: OtherTrait + Trait", "", 0)
 
+    fun `test fn with lifetime`() = checkByText("""
+        fn a<'b, C, D, E>() {}
+        fn f<'d>() {
+            a::</*caret*/>()
+        }
+    """, "'b, C, D, E", "", 0)
+
+    fun `test fn with multiple lifetimes`() = checkByText("""
+        fn a<'a, 'b, C, D, E>() {}
+        fn f<'d, 'e>() {
+            a::<'d, /*caret*/>()
+        }
+    """, "'a, 'b, C, D, E", "", 1)
+
+    fun `test fn with multiple lifetimes and bounds`() = checkByText("""
+        fn a<'a: 'a + 'b, 'b: 'b, C, D, E>() {}
+        fn f<'d, 'e>() {
+            a::</*caret*/>()
+        }
+    """, "'a: 'b, 'b, C, D, E", "", 0)
+
     fun `test enum`() = checkByText("""
         enum E<T> { Foo(T) }
         fn main() { E::</*caret*/>::Foo(); }


### PR DESCRIPTION
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->
Fixes #7091 

I really don't have much experience with Kotlin nor this project (this is my first time!) so I just copied the surrounding code; hope I lucked out and didn't break anything! Not too sure about comparing the lifetime name (in order to exclude a lifetime bound to itself), there probably exists a better way to do that. (should I even exclude it anyways..?) (not sure if this is the right approach either)

changelog: Render lifetimes in generic parameter info
