### PR TITLE
Highlight `compile_error!()` usage as an error

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsCompileErrorMacroInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsCompileErrorMacroInspection.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.psi.RsLiteralKind
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.ext.resolveToMacro
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.lang.core.psi.kind
+
+class RsCompileErrorMacroInspection : RsLocalInspectionTool() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsWithMacrosInspectionVisitor() {
+        override fun visitMacroCall2(o: RsMacroCall) {
+            val resolvedTo = o.resolveToMacro() ?: return
+            if (resolvedTo.name != "compile_error" || resolvedTo.containingCrate.origin != PackageOrigin.STDLIB) return
+            val macroArgument = o.macroArgument ?: return
+            val messageLiteral = macroArgument.litExprList.singleOrNull() ?: return
+            val message = (messageLiteral.kind as? RsLiteralKind.String)?.value ?: return
+            val errorRange = o.path.textRange.union(macroArgument.textRange).shiftLeft(o.startOffset)
+            holder.registerProblem(o, errorRange, message, alwaysShowInMacros = true)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsWithMacrosInspectionVisitor.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWithMacrosInspectionVisitor.kt
@@ -162,7 +162,7 @@ abstract class RsWithMacrosInspectionVisitor : RsVisitor() {
 
         while (macros.isNotEmpty()) {
             val macro = macros.removeLast()
-            for (element in macro.elementsForHighlighting) {
+            for (element in macro.elementsForErrorHighlighting) {
                 element.accept(this)
                 if (element is RsAttrProcMacroOwner) {
                     macros += element.procMacroAttribute?.attr?.prepareForExpansionHighlighting(macro) ?: continue

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroHighlightingUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroHighlightingUtil.kt
@@ -31,6 +31,11 @@ data class MacroCallPreparedForHighlighting(
     val elementsForHighlighting: List<PsiElement>
         get() {
             if (expansion.ranges.isEmpty()) return emptyList()
+            return elementsForErrorHighlighting
+        }
+
+    val elementsForErrorHighlighting: List<PsiElement>
+        get() {
             // Don't try to restrict range by `getElementsInRange`: it does not return all ancestors
             // even if `includeAllParents = true`
             return CollectHighlightsUtil.getElementsInRange(expansion.file, 0, expansion.file.textLength)

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -698,6 +698,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsUnusedLabelsInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Compile Error macro"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.RsCompileErrorMacroInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsCompileErrorMacro.html
+++ b/src/main/resources/inspectionDescriptions/RsCompileErrorMacro.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Highlights `compile_error!()` macro invocation.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -62,6 +62,7 @@ object WithStdlibWithSymlinkRustProjectDescriptor : WithCustomStdlibRustProjectD
  */
 object WithProcMacroRustProjectDescriptor : WithProcMacros(DefaultDescriptor)
 object WithProcMacroAndDependencyRustProjectDescriptor : WithProcMacros(WithDependencyRustProjectDescriptor)
+object WithProcMacroAndStdlibRustProjectDescriptor : WithProcMacros(WithStdlibRustProjectDescriptor)
 
 open class RustProjectDescriptorBase {
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsCompileErrorMacroInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsCompileErrorMacroInspectionTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.rust.*
+import org.rust.ide.experiments.RsExperiments
+
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+class RsCompileErrorMacroInspectionTest : RsInspectionsTestBase(RsCompileErrorMacroInspection::class) {
+    fun `test with semicolon`() = checkErrors("""
+        /*error descr="the error message 1"*/compile_error!("the error message 1")/*error**/;
+    """)
+
+    fun `test with braces`() = checkErrors("""
+        /*error descr="the error message 2"*/compile_error! { "the error message 2" }/*error**/
+    """)
+
+    fun `test with qualified path`() = checkErrors("""
+        /*error descr="the error message 3"*/std::compile_error!("the error message 3")/*error**/;
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test with attribute`() = checkErrors("""
+        #[cfg(intellij_rust)]
+        /*error descr="the error message"*/std::compile_error!("the error message")/*error**/;
+    """)
+
+    fun `test as expression`() = checkErrors("""
+        fn main() {
+            let _ = /*error descr="the error message"*/compile_error!("the error message")/*error**/;
+        }
+    """)
+
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroAndStdlibRustProjectDescriptor::class)
+    fun `test expanded from a macro`() = checkErrors("""
+        #[/*error descr="the error message"*/test_proc_macros::attr_err_at_3_first_tokens/*error**/]
+        pub fn foo() { }
+    """)
+
+    @WithExperimentalFeatures(RsExperiments.PROC_MACROS)
+    @ProjectDescriptor(WithProcMacroAndStdlibRustProjectDescriptor::class)
+    fun `test expanded from a nested macro`() = checkErrors("""
+        #[test_proc_macros::attr_as_is]
+        #[/*error descr="the error message"*/test_proc_macros::attr_err_at_3_first_tokens/*error**/]
+        pub fn foo() { }
+    """)
+}


### PR DESCRIPTION
This is mostly useful for procedural macros that use `compile_error!()` to show custom errors

changelog: Highlight `compile_error!()` usage as an error
