### PR TITLE
MACRO&ANN: Don't mishighlight cfg-disabled code in macro calls

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/AnnotatorBase.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/AnnotatorBase.kt
@@ -17,7 +17,7 @@ import org.rust.openapiext.isUnitTestMode
 abstract class AnnotatorBase : Annotator {
 
     final override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        if (!isUnitTestMode || javaClass in enabledAnnotators) {
+        if (isEnabled(javaClass)) {
             annotateInternal(element, holder)
         }
     }
@@ -31,6 +31,10 @@ abstract class AnnotatorBase : Annotator {
         fun enableAnnotator(annotatorClass: Class<out AnnotatorBase>, parentDisposable: Disposable) {
             enabledAnnotators += annotatorClass
             Disposer.register(parentDisposable) { enabledAnnotators -= annotatorClass }
+        }
+
+        fun isEnabled(annotatorClass: Class<out AnnotatorBase>): Boolean {
+            return !isUnitTestMode || annotatorClass in enabledAnnotators
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
@@ -16,16 +16,7 @@ class RsCfgDisabledCodeAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         if (holder.isBatchMode) return
 
-        val crate = holder.currentCrate() ?: return
-
-        if (element is RsDocAndAttributeOwner && !element.isEnabledByCfgSelfOrInAttrProcMacroBody(crate)) {
-            holder.createCondDisabledAnnotation()
-        }
-
-        val isAttrDisabled = element is RsAttr
-            && element.isDisabledCfgAttrAttribute(crate)
-            && element.owner?.isEnabledByCfgSelfOrInAttrProcMacroBody(crate) == true
-        if (isAttrDisabled) {
+        if (shouldHighlightAsCfsDisabled(element, holder)) {
             holder.createCondDisabledAnnotation()
         }
     }
@@ -40,7 +31,19 @@ class RsCfgDisabledCodeAnnotator : AnnotatorBase() {
     }
 
     companion object {
-        private val CONDITIONALLY_DISABLED_CODE_SEVERITY = HighlightSeverity(
+        fun shouldHighlightAsCfsDisabled(element: PsiElement, holder: AnnotationHolder) : Boolean {
+            val crate = holder.currentCrate() ?: return false
+
+            if (element is RsDocAndAttributeOwner && !element.isEnabledByCfgSelfOrInAttrProcMacroBody(crate)) {
+                return true
+            }
+
+            return element is RsAttr
+                && element.isDisabledCfgAttrAttribute(crate)
+                && element.owner?.isEnabledByCfgSelfOrInAttrProcMacroBody(crate) == true
+        }
+
+        val CONDITIONALLY_DISABLED_CODE_SEVERITY = HighlightSeverity(
             "CONDITIONALLY_DISABLED_CODE",
             HighlightSeverity.INFORMATION.myVal + 1
         )

--- a/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
@@ -100,4 +100,30 @@ class RsCfgDisabledCodeAnnotatorTest : RsAnnotatorTestBase(RsCfgDisabledCodeAnno
             let x = 1;
         }</CFG_DISABLED_CODE>
     """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test disabled code in a macro call`() = checkHighlighting("""
+        macro_rules! foo {
+            ($ e:expr) => {
+                #[cfg(disabled)]
+                fn foo() {$ e;}
+            };
+        }
+        fn main() {
+            foo!(/*CFG_DISABLED_CODE*/2 + 2/*CFG_DISABLED_CODE**/);
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test disabled code is not highlighted in a macro call if the same code is used as enabled`() = checkHighlighting("""
+        macro_rules! foo {
+            ($ e:expr) => {
+                #[cfg(disabled)]
+                fn foo() {$ e;}
+            };
+        }
+        fn main() {
+            foo!(2 + 2);
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #9712

changelog: Don't mishighlight cfg-disabled code in macro calls