### PR TITLE
INSP: Implement `as` cast can be replaced with literal suffix inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/fixes/ReplaceCastWithLiteralSuffixFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ReplaceCastWithLiteralSuffixFix.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsCastExpr
+import org.rust.lang.core.psi.RsPsiFactory
+
+open class ReplaceCastWithLiteralSuffixFix(
+    element: RsCastExpr
+) : RsQuickFixBase<RsCastExpr>(element) {
+    private val fixText: String = "Replace with `${element.expr.text}${element.typeReference.text}`"
+    override fun getFamilyName(): String = "Replace cast with literal suffix"
+    override fun getText(): String = fixText
+    override fun invoke(project: Project, editor: Editor?, element: RsCastExpr) {
+        val psiFactory = RsPsiFactory(project)
+        element.replace(psiFactory.createExpression(element.expr.text + element.typeReference.text))
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsReplaceCastWithSuffixInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsReplaceCastWithSuffixInspection.kt
@@ -1,0 +1,78 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.psi.PsiElement
+import org.rust.ide.fixes.ReplaceCastWithLiteralSuffixFix
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.RsWithMacrosInspectionVisitor
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.types.rawType
+import org.rust.lang.core.types.ty.TyFloat
+import org.rust.lang.core.types.ty.TyInteger
+
+class RsReplaceCastWithSuffixInspection : RsLintInspection() {
+
+    override fun getLint(element: PsiElement): RsLint = RsLint.UnnecessaryCast
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsWithMacrosInspectionVisitor() {
+        override fun visitCastExpr(castExpr: RsCastExpr) {
+            val expr = castExpr.expr
+
+            val typeReference = castExpr.typeReference
+            val typeReferenceType = typeReference.rawType
+            if (typeReferenceType !is TyInteger && typeReferenceType !is TyFloat) {
+                return
+            }
+            if (typeReferenceType.aliasedBy != null) {
+                return
+            }
+
+            if (!isValidSuffix(expr, typeReference.text)) {
+                return
+            }
+
+            holder.registerLintProblem(
+                castExpr,
+                "Can be replaced with literal suffix",
+                RsLintHighlightingType.WEAK_WARNING,
+                fixes = listOf(ReplaceCastWithLiteralSuffixFix(castExpr))
+            )
+        }
+    }
+
+    private fun isValidSuffix(expr: RsExpr, suffix: String): Boolean {
+        val kind = when (expr) {
+            is RsLitExpr -> expr
+            // -1 is an unary expression
+            is RsUnaryExpr -> {
+                if (expr.minus == null) return false
+                val lit = expr.expr
+                if (lit is RsLitExpr) lit else return false
+            }
+
+            else -> return false
+        }.kind
+        if (kind !is RsLiteralWithSuffix) return false
+
+        return kind.suffix == null && isValidSuffix(kind, suffix)
+    }
+
+    private fun isValidSuffix(kind: RsLiteralWithSuffix, suffix: String): Boolean {
+        // Special case for `1f32`, which is allowed even though f32 is not a valid integer suffix
+        if (kind is RsLiteralKind.Integer && TyFloat.NAMES.contains(suffix)
+            // But `0b11f32` is not allowed
+            && !startsWithRadixPrefix(kind)) return true
+
+        return kind.validSuffixes.contains(suffix)
+    }
+
+    private fun startsWithRadixPrefix(kind: RsLiteralKind.Integer): Boolean {
+        return radixPrefixes.any { kind.node.text.startsWith(it) }
+    }
+
+    private val radixPrefixes = listOf("0x", "0b", "0o")
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -494,6 +494,11 @@
                          implementationClass="org.rust.ide.inspections.lints.RsUnnecessaryCastInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Cast can be replaced with literal suffix"
+                         enabledByDefault="true" level="WEAK WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsReplaceCastWithSuffixInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="While true loop"
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsWhileTrueLoopInspection"/>

--- a/src/main/resources/inspectionDescriptions/RsReplaceCastWithSuffix.html
+++ b/src/main/resources/inspectionDescriptions/RsReplaceCastWithSuffix.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects <code>as</code> casts that can be replaced with literal suffixes.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/ReplaceCastWithSuffixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/ReplaceCastWithSuffixTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.*
+import org.rust.ide.inspections.lints.RsReplaceCastWithSuffixInspection
+
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)// for arithmetic type inference
+class ReplaceCastWithSuffixTest : RsInspectionsTestBase(RsReplaceCastWithSuffixInspection::class) {
+    fun `test integer cast`() = checkFixByText("Replace with `1i32`", """
+        fn foo() {
+            let a = /*weak_warning*/1 /*caret*/as i32/*weak_warning**/;
+        }
+    """, """
+        fn foo() {
+            let a = 1i32;
+        }
+    """)
+
+    fun `test negative integer cast`() = checkFixByText("Replace with `-1i32`", """
+        fn foo() {
+            let a = /*weak_warning*/-1 /*caret*/as i32/*weak_warning**/;
+        }
+    """, """
+        fn foo() {
+            let a = -1i32;
+        }
+    """)
+
+    fun `test float cast`() = checkFixByText("Replace with `1.0f64`", """
+        fn foo() {
+            let a = /*weak_warning*/1.0 /*caret*/as f64/*weak_warning**/;
+        }
+    """, """
+        fn foo() {
+            let a = 1.0f64;
+        }
+    """)
+
+    fun `test negative float cast`() = checkFixByText("Replace with `-1.0f32`", """
+        fn foo() {
+            let a = /*weak_warning*/-1.0 /*caret*/as f32/*weak_warning**/;
+        }
+    """, """
+        fn foo() {
+            let a = -1.0f32;
+        }
+    """)
+
+    fun `test isize cast`() = checkFixByText("Replace with `1isize`", """
+        fn foo() {
+            let a = /*weak_warning*/1 /*caret*/as isize/*weak_warning**/;
+        }
+    """, """
+        fn foo() {
+            let a = 1isize;
+        }
+    """)
+
+    fun `test hex cast`() = checkFixByText("Replace with `0xffi32`", """
+        fn foo() {
+            let a = /*weak_warning*/0xff /*caret*/as i32/*weak_warning**/;
+        }
+    """, """
+        fn foo() {
+            let a = 0xffi32;
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsReplaceCastWithSuffixInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsReplaceCastWithSuffixInspectionTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)// for arithmetic type inference
+class RsReplaceCastWithSuffixInspectionTest : RsInspectionsTestBase(RsReplaceCastWithSuffixInspection::class) {
+
+    fun `test integer cast`() = checkWarnings("""
+        fn main() {
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/1 as i8/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/1 as i16/*weak_warning**/;
+            let c = /*weak_warning descr="Can be replaced with literal suffix"*/1 as i32/*weak_warning**/;
+            let d = /*weak_warning descr="Can be replaced with literal suffix"*/1 as i64/*weak_warning**/;
+            let e = /*weak_warning descr="Can be replaced with literal suffix"*/1 as i128/*weak_warning**/;
+
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/1 as u8/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/1 as u16/*weak_warning**/;
+            let c = /*weak_warning descr="Can be replaced with literal suffix"*/1 as u32/*weak_warning**/;
+            let d = /*weak_warning descr="Can be replaced with literal suffix"*/1 as u64/*weak_warning**/;
+            let e = /*weak_warning descr="Can be replaced with literal suffix"*/1 as u128/*weak_warning**/;
+
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/1 as isize/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/1 as usize/*weak_warning**/;
+        }
+    """)
+
+    fun `test negative integer cast`() = checkWarnings("""
+        fn main() {
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as i8/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as i16/*weak_warning**/;
+            let c = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as i32/*weak_warning**/;
+            let d = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as i64/*weak_warning**/;
+            let e = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as i128/*weak_warning**/;
+            let f = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as isize/*weak_warning**/;
+
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as u8/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as u16/*weak_warning**/;
+            let c = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as u32/*weak_warning**/;
+            let d = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as u64/*weak_warning**/;
+            let e = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as u128/*weak_warning**/;
+
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as isize/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as usize/*weak_warning**/;
+        }
+    """)
+
+    fun `test float cast`() = checkWarnings("""
+        fn main() {
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/1.0 as f32/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/1.0 as f64/*weak_warning**/;
+        }
+    """)
+
+    fun `test negative float cast`() = checkWarnings("""
+        fn main() {
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/-1.0 as f32/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/-1.0 as f64/*weak_warning**/;
+        }
+    """)
+
+
+    fun `test integer as float cast`() = checkWarnings("""
+        fn main() {
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/1 as f32/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/1 as f64/*weak_warning**/;
+            let c = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as f32/*weak_warning**/;
+            let d = /*weak_warning descr="Can be replaced with literal suffix"*/-1 as f64/*weak_warning**/;
+        }
+    """)
+
+
+    fun `test non-decimal numbers`() = checkWarnings("""
+        fn main() {
+            let a = /*weak_warning descr="Can be replaced with literal suffix"*/0b111 as i8/*weak_warning**/;
+            let b = /*weak_warning descr="Can be replaced with literal suffix"*/0xff as i32/*weak_warning**/;
+            let c = /*weak_warning descr="Can be replaced with literal suffix"*/0o77 as i64/*weak_warning**/;
+        }
+    """)
+
+    fun `test with suffix cast`() = checkWarnings("""
+        fn main() {
+            let a = 1.0f32 as f32;
+            let b = 1.0f64 as f64;
+            let c = 1.0f64 as f32;
+            let d = 1.0f32 as f64;
+
+            let a = 1i32 as i32;
+            let b = 1i16 as i32;
+            let c = 1i64 as i16;
+            let d = 1u64 as u64;
+            let e = 1usize as usize;
+            let f = 1usize as isize;
+            let g = 1isize as isize;
+            let h = 1isize as usize;
+
+            let a = -1.0f32 as f32;
+            let b = -1.0f64 as f64;
+            let c = -1.0f64 as f32;
+            let d = -1.0f32 as f64;
+
+            let a = -1i32 as i32;
+            let b = -1i16 as i32;
+            let c = -1i64 as i16;
+            let d = -1u64 as u64;
+            let e = -1usize as usize;
+            let f = -1usize as isize;
+            let g = -1isize as isize;
+            let h = -1isize as usize;
+        }
+    """)
+
+    fun `test non-number primitives`() = checkWarnings("""
+        fn main() {
+            let a = true as bool;
+            let b = 1 as bool;
+            let c = 1 as char;
+            let d = &1 as &i32;
+            let e = b'A' as u8;
+            let f = "1" as u32;
+        }
+    """)
+
+    fun `test type alias`() = checkWarnings("""
+        type A = i32;
+        fn main() {
+            let a = 1 as A;
+        }
+    """)
+
+    fun `test associated type`() = checkWarnings("""
+        pub trait T {
+            type Item;
+        }
+
+        struct S;
+
+        impl T for S {
+            type Item = i32;
+        }
+
+        fn main() {
+            let a = 1 as <S as T>::Item;
+        }
+    """)
+
+    fun `test non-primitive expr`() = checkWarnings("""
+        fn main() {
+            let a = if 1 + 1 == 2 { 1 } else { 2i32 } as i64;
+        }
+    """)
+
+    fun `test not allowed suffixes`() = checkWarnings("""
+        fn main() {
+            let a = 0o73 as f64;
+            let b = 11.0 as i32;
+            let c = 11.0 as i64;
+            let d = 11.0 as usize;
+            let e = 0b11 as f32;
+            let f = 0xff as f64;
+        }
+    """)
+}


### PR DESCRIPTION
changelog: Implement `as` cast can be replaced with literal suffix inspection
