### PR TITLE
Enable attribute procedural macro expansion by default

### DIFF
--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -15,7 +15,7 @@
         <experimentalFeature id="org.rust.macros.proc.derive" percentOfUsers="100">
             <description>Enables derive procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.macros.proc.attr" percentOfUsers="0">
+        <experimentalFeature id="org.rust.macros.proc.attr" percentOfUsers="100">
             <description>Enables attribute procedural macro expansion</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="100">

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -15,7 +15,7 @@
         <experimentalFeature id="org.rust.macros.proc.derive" percentOfUsers="100">
             <description>Enables derive procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.macros.proc.attr" percentOfUsers="0">
+        <experimentalFeature id="org.rust.macros.proc.attr" percentOfUsers="100">
             <description>Enables attribute procedural macro expansion</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="100">

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -21,8 +21,7 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
     }
 
     fun `test attributes`() = checkHighlighting("""
-        <ATTRIBUTE>#[foo(foo)]</ATTRIBUTE>
-        <ATTRIBUTE>#[foo(<STRING>"bar"</STRING>)]</ATTRIBUTE>
+        <ATTRIBUTE>#[doc = <STRING>"bar"</STRING>]</ATTRIBUTE>
         fn <FUNCTION>main</FUNCTION>() {
             <ATTRIBUTE>#![crate_type = <STRING>"lib"</STRING>]</ATTRIBUTE>
         }

--- a/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.macros.MacroExpansionManager
 class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
 
     fun `test attributes inside macro call`() = checkHighlightingInsideMacro("""
-        <ATTRIBUTE>#[foo(foo)]</ATTRIBUTE>
+        <ATTRIBUTE>#[doc = ""]</ATTRIBUTE>
         fn <FUNCTION>main</FUNCTION>() {
             <ATTRIBUTE>#![crate_type = <STRING>"lib"</STRING>]</ATTRIBUTE>
         }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -2329,7 +2329,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test group imports only if the other import doesn't have an attribute`() = checkAutoImportFixByText("""
-        #[attribute = "value"]
+        #[doc = "value"]
         use crate::foo::Foo;
 
         mod foo {
@@ -2342,7 +2342,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """, """
         use crate::foo::Bar;
-        #[attribute = "value"]
+        #[doc = "value"]
         use crate::foo::Foo;
 
         mod foo {

--- a/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
@@ -6,18 +6,17 @@
 package org.rust.ide.intentions
 
 import org.intellij.lang.annotations.Language
-import org.rust.MockCargoFeatures
-import org.rust.SkipTestWrapping
+import org.rust.*
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.FeatureState
 import org.rust.cargo.project.workspace.PackageOrigin
-import org.rust.singleProject
-import org.rust.workspaceOrFail
+import org.rust.ide.experiments.RsExperiments
 
 class ToggleFeatureIntentionTest : RsIntentionTestBase(ToggleFeatureIntention::class) {
 
     override val previewExpected: Boolean get() = false
 
+    @WithoutExperimentalFeatures(RsExperiments.PROC_MACROS, RsExperiments.ATTR_PROC_MACROS)
     @SkipTestWrapping // TODO fix `PsiElement.findExpansionElementsNonRecursive` for `cfg_attr` condition
     @MockCargoFeatures("foo")
     fun `test availability range`() = checkAvailableInSelectionOnly("""

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
@@ -7,6 +7,8 @@ package org.rust.lang.core.completion
 
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
+import org.rust.WithoutExperimentalFeatures
+import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsFieldDecl
 import kotlin.reflect.KClass
@@ -499,6 +501,7 @@ class RsCompletionSortingTest : RsTestBase() {
         Int::class to "1"
     ))
 
+    @WithoutExperimentalFeatures(RsExperiments.PROC_MACROS, RsExperiments.ATTR_PROC_MACROS)
     fun `test expected types priority (vec macro)`() = doTest("""
         #[lang = "alloc::vec::Vec"]
         struct Vec<T>(T);

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroErrorTest.kt
@@ -23,7 +23,7 @@ import org.rust.lang.core.macros.errors.GetMacroExpansionError
 @ProjectDescriptor(WithProcMacroRustProjectDescriptor::class)
 @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS, PROC_MACROS)
 class RsProcMacroErrorTest : RsMacroExpansionErrorTestBase() {
-    @WithExperimentalFeatures()
+    @WithoutExperimentalFeatures(PROC_MACROS, ATTR_PROC_MACROS)
     fun `test macro expansion is disabled`() = checkError<GetMacroExpansionError.ExpansionError>("""
         use test_proc_macros::attr_as_is;
 
@@ -62,7 +62,7 @@ class RsProcMacroErrorTest : RsMacroExpansionErrorTestBase() {
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    @WithExperimentalFeatures()
+    @WithoutExperimentalFeatures(PROC_MACROS, ATTR_PROC_MACROS)
     fun `test macro expansion is disabled with unsuccessfully compiled proc macro crate`() = checkErrorByTree<GetMacroExpansionError.ExpansionError>("""
     //- dep-proc-macro-unsuccessfully-compiled/lib.rs
         extern crate proc_macro;

--- a/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/ProcMacroAttributeTest.kt
@@ -397,15 +397,13 @@ class ProcMacroAttributeTest : RsTestBase() {
     """, Attr("attr_hardcoded_not_a_macro", 0))
 
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
-    fun `test not a macro if proc macro expansion is disabled`() {
-        setExperimentalFeatureEnabled(PROC_MACROS, false, testRootDisposable)
-        doTest("""
-            use test_proc_macros::attr_as_is;
+    @WithoutExperimentalFeatures(PROC_MACROS, ATTR_PROC_MACROS)
+    fun `test not a macro if proc macro expansion is disabled`() = doTest("""
+        use test_proc_macros::attr_as_is;
 
-            #[attr_as_is]
-            mod foo {}
-        """, None)
-    }
+        #[attr_as_is]
+        mod foo {}
+    """, None)
 
     @WithExperimentalFeatures(EVALUATE_BUILD_SCRIPTS)
     fun `test not a macro if attr macro expansion is disabled 1`() {


### PR DESCRIPTION
It looks like most of the issues with attribute macros are fixed now, so we can enable their expansion by default.

Part of #6908

Fixes #5104
Fixes #5239
Fixes #5748
Fixes #5896
Fixes #6006
Fixes #6091
Fixes #6093
Fixes #6482
Fixes #6938
Fixes #7610
Fixes #7863
Fixes #8350
Fixes #8407
Fixes #8640
Fixes #9128
Fixes #9384
Fixes #9534
Fixes #9918
Fixes #9973

changelog: Enable [attribute](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros) procedural macro expansion by default.
