### PR TITLE
GRD: try to avoid OOM during building

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ showStandardStreams=false
 enableBuildSearchableOptions=false
 compileNativeCode=true
 
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx3g
 
 # Enable Gradle Build Cache. It is also configured in settings.gradle.kts.
 org.gradle.caching=true
@@ -30,3 +30,7 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 # But we don't need it because all necessary kotlin libraries are already bundled into IDE.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for more details
 kotlin.stdlib.default.dependency=false
+# Since kotlin 1.8.20, Gradle Kotlin plugin may produce OOM during compilation
+# See https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#incremental-compilation
+# and https://youtrack.jetbrains.com/issue/KT-57757 for more details
+kotlin.incremental.useClasspathSnapshot=false


### PR DESCRIPTION
- increase heap for Gradle daemon
- don't use kotlin classpath snapshot