### PR TITLE
RUN: Don't run `cargo clean` on `Build` action

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskRunner.kt
@@ -150,7 +150,7 @@ class CargoBuildTaskRunner : ProjectTaskRunner() {
             val configuration = settings.configuration as? CargoCommandConfiguration ?: return@mapNotNull null
             configuration.emulateTerminal = false
             val buildableElement = CargoBuildConfiguration(configuration, environment)
-            ProjectModelBuildTaskImpl(buildableElement, false)
+            ProjectModelBuildTaskImpl(buildableElement, task.isIncrementalBuild)
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/10346.

changelog: Don't run `cargo clean` on `Build` action
