### PR TITLE
COMP: Provide postfix completion items `.sublist` and `.slice` on indexable expressions that will complete into `[]`

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
@@ -49,7 +49,9 @@ class RsPostfixTemplateProvider : PostfixTemplateProvider {
         OkPostfixTemplate(this),
         SomePostfixTemplate(this),
         ErrPostfixTemplate(this),
-        WrapTypePathPostfixTemplate(this)
+        WrapTypePathPostfixTemplate(this),
+        SlicePostfixTemplate("slice", this),
+        SlicePostfixTemplate("sublist", this)
     )
 
     override fun getTemplates(): Set<PostfixTemplate> = templates

--- a/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
@@ -12,11 +12,16 @@ import com.intellij.codeInsight.template.postfix.templates.StringBasedPostfixTem
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsBinaryExpr
 import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsUnaryExpr
 import org.rust.lang.core.psi.ext.EqualityOp
+import org.rust.lang.core.psi.ext.UnaryOperator
 import org.rust.lang.core.psi.ext.operatorType
+import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.implLookup
-import org.rust.lang.core.types.ty.TyPointer
-import org.rust.lang.core.types.ty.TyReference
+import org.rust.lang.core.types.infer.substitute
+import org.rust.lang.core.types.toTypeSubst
+import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
 abstract class AssertPostfixTemplateBase(
@@ -121,6 +126,42 @@ class DbgrPostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostf
 class SomePostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostfixTemplate("some", "Some(expr)", provider)
 class OkPostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostfixTemplate("ok", "Ok(expr)", provider)
 class ErrPostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostfixTemplate("err", "Err(expr)", provider)
+
+class SlicePostfixTemplate(name: String, provider: RsPostfixTemplateProvider) :
+    StringBasedPostfixTemplate(
+        name,
+        "&list[i..j]",
+        RsExprParentsSelector {
+            val rangeType = it.knownItems.Range?.declaredType ?: return@RsExprParentsSelector false
+            val idx = rangeType.getTypeParameter("Idx") ?: return@RsExprParentsSelector false
+            val subst = mapOf(idx to TyInteger.USize.INSTANCE).toTypeSubst()
+            pred(it.type, rangeType.substitute(subst), it.implLookup)
+        },
+        provider
+    ) {
+
+    override fun getTemplateString(element: PsiElement): String {
+        val isRef = element is RsUnaryExpr && element.operatorType in listOf(UnaryOperator.REF, UnaryOperator.REF_MUT)
+        val prefix = if (isRef) "" else "&"
+        return "$prefix${element.text}[\$from\$..\$to\$]\$END\$"
+    }
+
+    override fun setVariables(template: Template, element: PsiElement) {
+        template.addVariable("from", TextExpression("i"), true)
+        template.addVariable("to", TextExpression("j"), true)
+    }
+
+    override fun getElementToRemove(expr: PsiElement): PsiElement = expr
+
+    companion object {
+        private fun pred(ty: Ty, indexTy: Ty, implLookup: ImplLookup): Boolean =
+            when (ty) {
+                is TyStr, is TySlice -> true
+                is TyReference -> pred(ty.referenced, indexTy, implLookup)
+                else -> implLookup.isIndex(ty, indexTy).isTrue
+            }
+    }
+}
 
 private val RsExpr.isIntoIterator: Boolean
     get() = implLookup.isIntoIterator(type).isTrue

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -1359,6 +1359,8 @@ class ImplLookup(
     fun isEq(ty: Ty): ThreeValuedLogic = ty.isTraitImplemented(items.Eq)
     fun isPartialEq(ty: Ty, rhsType: Ty = ty): ThreeValuedLogic = ty.isTraitImplemented(items.PartialEq, rhsType)
     fun isIntoIterator(ty: Ty): ThreeValuedLogic = ty.isTraitImplemented(items.IntoIterator)
+    fun isDrop(ty: Ty): ThreeValuedLogic = ty.isTraitImplemented(items.Drop)
+    fun isIndex(ty: Ty, indexType: Ty): ThreeValuedLogic = ty.isTraitImplemented(items.Index, indexType)
 
     private fun Ty.isTraitImplemented(trait: RsTraitItem?, vararg subst: Ty): ThreeValuedLogic {
         if (trait == null) return ThreeValuedLogic.Unknown

--- a/src/main/resources/postfixTemplates/SlicePostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/SlicePostfixTemplate/after.rs.template
@@ -1,0 +1,4 @@
+pub fn main() {
+    let list = vec![1, 2, 3];
+    let sublist = &list[<spot>i</spot>..<spot>j</spot>]
+}

--- a/src/main/resources/postfixTemplates/SlicePostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/SlicePostfixTemplate/before.rs.template
@@ -1,0 +1,4 @@
+pub fn main() {
+    let list = vec![1, 2, 3];
+    let sublist = <spot>list</spot>$key
+}

--- a/src/main/resources/postfixTemplates/SlicePostfixTemplate/description.html
+++ b/src/main/resources/postfixTemplates/SlicePostfixTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Converts to a slice.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/template/postfix/SlicePostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/SlicePostfixTemplateTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+abstract class SlicePostfixTemplateTestBase(private val key: String) :
+    RsPostfixTemplateTest(SlicePostfixTemplate::class, key) {
+
+    fun `test non index expr`() = doTestNotApplicable("""
+            let v = 0;
+            v.$key/*caret*/
+    """)
+
+    fun `test vec`() = doTest("""
+        fn main() {
+            let v = vec![1, 2, 3];
+            v.$key/*caret*/
+        }
+    """, """
+        fn main() {
+            let v = vec![1, 2, 3];
+            &v[i..j]/*caret*/
+        }
+    """)
+
+    fun `test array`() = doTest("""
+        fn main() {
+            let v = [1, 2, 3];
+            v.$key/*caret*/
+        }
+    """, """
+        fn main() {
+            let v = [1, 2, 3];
+            &v[i..j]/*caret*/
+        }
+    """)
+
+    fun `test str`() = doTest("""
+        fn main() {
+            let v = "123";
+            v.$key/*caret*/
+        }
+    """, """
+        fn main() {
+            let v = "123";
+            &v[i..j]/*caret*/
+        }
+    """)
+
+    fun `test slice`() = doTest("""
+        fn main() {
+            let v = vec![1, 2, 3];
+            let vs = &v[0..2];
+            vs.$key/*caret*/
+        }
+    """, """
+        fn main() {
+            let v = vec![1, 2, 3];
+            let vs = &v[0..2];
+            &vs[i..j]/*caret*/
+        }
+    """)
+
+    fun `test refs`() = doTest("""
+        fn main() {
+            let v = "123";
+            let vrrr = &&&v;
+            vrrr.$key/*caret*/
+        }
+    """, """
+        fn main() {
+            let v = "123";
+            let vrrr = &&&v;
+            &vrrr[i..j]/*caret*/
+        }
+    """)
+
+    fun `test indexable 1`() = doTest("""
+        use std::ops::{Index, Range};
+        struct S;
+        impl Index<Range<usize>> for S {
+            type Output = ();
+            fn index(&self, index: Range<usize>) -> &Self::Output { todo!() }
+        }
+        fn main() {
+            let v = S;
+            v.$key/*caret*/
+        }
+    """, """
+        use std::ops::{Index, Range};
+        struct S;
+        impl Index<Range<usize>> for S {
+            type Output = ();
+            fn index(&self, index: Range<usize>) -> &Self::Output { todo!() }
+        }
+        fn main() {
+            let v = S;
+            &v[i..j]/*caret*/
+        }
+    """)
+
+    fun `test indexable 2`() = doTestNotApplicable("""
+        use std::ops::{Index, Range};
+        struct S;
+        impl Index<usize> for S {
+            type Output = ();
+            fn index(&self, index: usize) -> &Self::Output { todo!() }
+        }
+        fn main() {
+            let v = S;
+            v.$key/*caret*/
+        }
+    """)
+}
+
+class SlicePostfixTemplateTest : SlicePostfixTemplateTestBase("slice")
+class SublistPostfixTemplateTest : SlicePostfixTemplateTestBase("sublist")


### PR DESCRIPTION
changelog: Provide postfix completion items `.sublist` and `.slice` on indexable expressions that will complete into `[]`
