### PR TITLE
Fix live templates suggestion in loop labels and other positions

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/RsContextType.kt
+++ b/src/main/kotlin/org/rust/ide/template/RsContextType.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.template
 
-import com.intellij.codeInsight.template.EverywhereContextType
 import com.intellij.codeInsight.template.TemplateActionContext
 import com.intellij.codeInsight.template.TemplateContextType
 import com.intellij.openapi.fileTypes.SyntaxHighlighter
@@ -22,13 +21,8 @@ import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.doc.psi.RsDocComment
-import kotlin.reflect.KClass
 
-sealed class RsContextType(
-    id: String,
-    presentableName: String,
-    baseContextType: KClass<out TemplateContextType>
-) : TemplateContextType(id, presentableName, baseContextType.java) {
+sealed class RsContextType(presentableName: String) : TemplateContextType(presentableName) {
 
     final override fun isInContext(context: TemplateActionContext): Boolean {
         if (!PsiUtilCore.getLanguageAtOffset(context.file, context.startOffset).isKindOf(RsLanguage)) {
@@ -47,11 +41,11 @@ sealed class RsContextType(
 
     override fun createHighlighter(): SyntaxHighlighter = RsHighlighter()
 
-    class Generic : RsContextType("RUST_FILE", "Rust", EverywhereContextType::class) {
+    class Generic : RsContextType("Rust") {
         override fun isInContext(element: PsiElement): Boolean = true
     }
 
-    class Statement : RsContextType("RUST_STATEMENT", "Statement", Generic::class) {
+    class Statement : RsContextType("Statement") {
         override fun isInContext(element: PsiElement): Boolean {
             // We are inside block but there is no item nor attr between
             if (owner(element) !is RsBlock) return false
@@ -70,26 +64,26 @@ sealed class RsContextType(
         }
     }
 
-    class Item : RsContextType("RUST_ITEM", "Item", Generic::class) {
+    class Item : RsContextType("Item") {
         override fun isInContext(element: PsiElement): Boolean =
             // We are inside item but there is no block between
             owner(element) is RsItemElement
     }
 
-    class Struct : RsContextType("RUST_STRUCT", "Structure", Item::class) {
+    class Struct : RsContextType("Structure") {
         override fun isInContext(element: PsiElement): Boolean =
             // Structs can't be nested or contain other expressions,
             // so it is ok to look for any Struct ancestor.
             element.ancestorStrict<RsStructItem>() != null
     }
 
-    class Mod : RsContextType("RUST_MOD", "Module", Item::class) {
+    class Mod : RsContextType("Module") {
         override fun isInContext(element: PsiElement): Boolean
             // We are inside RsMod
             = owner(element) is RsMod
     }
 
-    class Attribute : RsContextType("RUST_ATTRIBUTE", "Attribute", Item::class) {
+    class Attribute : RsContextType("Attribute") {
         override fun isInContext(element: PsiElement): Boolean =
             element.ancestorStrict<RsAttr>() != null
     }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -733,6 +733,8 @@
         <liveTemplateContext contextId="RUST_FILE" implementation="org.rust.ide.template.RsContextType$Generic"/>
         <liveTemplateContext contextId="RUST_STATEMENT" baseContextId="RUST_FILE"
                              implementation="org.rust.ide.template.RsContextType$Statement"/>
+        <liveTemplateContext contextId="RUST_EXPRESSION" baseContextId="RUST_FILE"
+                             implementation="org.rust.ide.template.RsContextType$Expression"/>
         <liveTemplateContext contextId="RUST_ITEM" baseContextId="RUST_FILE"
                              implementation="org.rust.ide.template.RsContextType$Item"/>
         <liveTemplateContext contextId="RUST_STRUCT" baseContextId="RUST_ITEM"

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -730,12 +730,17 @@
         <defaultLiveTemplates file="org/rust/ide/liveTemplates/test"/>
         <defaultLiveTemplates file="org/rust/ide/liveTemplates/other"/>
 
-        <liveTemplateContext implementation="org.rust.ide.template.RsContextType$Generic"/>
-        <liveTemplateContext implementation="org.rust.ide.template.RsContextType$Statement"/>
-        <liveTemplateContext implementation="org.rust.ide.template.RsContextType$Item"/>
-        <liveTemplateContext implementation="org.rust.ide.template.RsContextType$Struct"/>
-        <liveTemplateContext implementation="org.rust.ide.template.RsContextType$Mod"/>
-        <liveTemplateContext implementation="org.rust.ide.template.RsContextType$Attribute"/>
+        <liveTemplateContext contextId="RUST_FILE" implementation="org.rust.ide.template.RsContextType$Generic"/>
+        <liveTemplateContext contextId="RUST_STATEMENT" baseContextId="RUST_FILE"
+                             implementation="org.rust.ide.template.RsContextType$Statement"/>
+        <liveTemplateContext contextId="RUST_ITEM" baseContextId="RUST_FILE"
+                             implementation="org.rust.ide.template.RsContextType$Item"/>
+        <liveTemplateContext contextId="RUST_STRUCT" baseContextId="RUST_ITEM"
+                             implementation="org.rust.ide.template.RsContextType$Struct"/>
+        <liveTemplateContext contextId="RUST_MOD" baseContextId="RUST_ITEM"
+                             implementation="org.rust.ide.template.RsContextType$Mod"/>
+        <liveTemplateContext contextId="RUST_ATTRIBUTE" baseContextId="RUST_ITEM"
+                             implementation="org.rust.ide.template.RsContextType$Attribute"/>
 
         <liveTemplateMacro implementation="org.rust.ide.template.macros.RsSuggestIndexNameMacro"/>
         <liveTemplateMacro implementation="org.rust.ide.template.macros.RsCollectionElementNameMacro"/>

--- a/src/main/resources/org/rust/ide/liveTemplates/iterations.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/iterations.xml
@@ -4,7 +4,7 @@
     <template name="loop" description="infinite loop" toReformat="true" toShortenFQNames="true"
               value="loop {&#10;    $END$&#10;}">
         <context>
-            <option name="RUST_STATEMENT" value="true"/>
+            <option name="RUST_EXPRESSION" value="true"/>
         </context>
     </template>
 

--- a/src/main/resources/org/rust/ide/liveTemplates/other.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/other.xml
@@ -42,7 +42,7 @@
         <variable name="EXPRESSION" expression="" defaultValue="" alwaysStopAt="true"/>
         <variable name="PATTERN" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
-            <option name="RUST_STATEMENT" value="true"/>
+            <option name="RUST_EXPRESSION" value="true"/>
         </context>
     </template>
 
@@ -51,7 +51,7 @@
         <variable name="EXPRESSION" expression="" defaultValue="" alwaysStopAt="true"/>
         <variable name="VAR" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
-            <option name="RUST_STATEMENT" value="true"/>
+            <option name="RUST_EXPRESSION" value="true"/>
         </context>
     </template>
 
@@ -60,7 +60,7 @@
         <variable name="PARAM" expression="" defaultValue="&quot;x&quot;" alwaysStopAt="true"/>
         <variable name="PARAM_COPY" expression="PARAM" defaultValue="" alwaysStopAt="true"/>
         <context>
-            <option name="RUST_STATEMENT" value="true"/>
+            <option name="RUST_EXPRESSION" value="true"/>
         </context>
     </template>
 

--- a/src/main/resources/org/rust/ide/liveTemplates/output.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/output.xml
@@ -36,7 +36,7 @@
     <template name="fmt" description="format!" toReformat="true" toShortenFQNames="true"
               value="format!(&quot;$END$&quot;);">
         <context>
-            <option name="RUST_STATEMENT" value="true"/>
+            <option name="RUST_EXPRESSION" value="true"/>
         </context>
     </template>
 

--- a/src/main/resources/org/rust/ide/liveTemplates/test.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/test.xml
@@ -22,9 +22,8 @@
               value="#[test]&#10;fn $NAME$() {&#10;    $END$&#10;}">
         <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
-            <option name="RUST_STATEMENT" value="false"/>
+            <option name="RUST_EXPRESSION" value="false"/>
             <option name="RUST_ITEM" value="false"/>
-            <option name="RUST_STATEMENT" value="false"/>
             <option name="RUST_MOD" value="true"/>
         </context>
     </template>
@@ -34,9 +33,8 @@
               value="#[bench]&#10;fn $NAME$(b: &amp;mut test::Bencher) {&#10;    b.iter(||);$END$&#10;}">
         <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
-            <option name="RUST_STATEMENT" value="false"/>
+            <option name="RUST_EXPRESSION" value="false"/>
             <option name="RUST_ITEM" value="false"/>
-            <option name="RUST_STATEMENT" value="false"/>
             <option name="RUST_MOD" value="true"/>
         </context>
     </template>
@@ -45,9 +43,8 @@
     <template name="tmod" description="test module" toReformat="false" toShortenFQNames="true"
               value="#[cfg(test)]&#10;mod tests {&#10;    use super::*;&#10;    &#10;    $END$&#10;}">
         <context>
-            <option name="RUST_STATEMENT" value="false"/>
+            <option name="RUST_EXPRESSION" value="false"/>
             <option name="RUST_ITEM" value="false"/>
-            <option name="RUST_STATEMENT" value="false"/>
             <option name="RUST_MOD" value="true"/>
         </context>
     </template>

--- a/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
@@ -21,13 +21,37 @@ class RsLiveTemplatesTest : RsTestBase() {
         }
     """)
 
-    fun `test print`() = expandSnippet("""
+    fun `test println`() = expandSnippet("""
         fn main() {
             p/*caret*/
         }
     """, """
         fn main() {
             println!("");
+        }
+    """)
+
+    fun `test println before absolute path`() = expandSnippet("""
+        fn main() {
+            p/*caret*/
+            ::foo();
+        }
+    """, """
+        fn main() {
+            println!("");
+            ::foo();
+        }
+    """)
+
+    fun `test println before block expr`() = expandSnippet("""
+        fn main() {
+            p/*caret*/
+            { 0 }
+        }
+    """, """
+        fn main() {
+            println!("");
+            { 0 }
         }
     """)
 
@@ -88,6 +112,14 @@ class RsLiveTemplatesTest : RsTestBase() {
     fun `test pattern binding`() = noSnippet("""
         fn main() {
             let p/*caret*/
+        }
+    """)
+
+    fun `test loop label`() = noSnippet("""
+        fn main() {
+            loop {
+                break '/*caret*/
+            }
         }
     """)
 


### PR DESCRIPTION
Currently we have `RsContextType.Statement` which accepts wide range of contexts, e.g. those locations:
```
let x = /*caret*/
func(/*caret*/);
break '/*caret*/
```
Thus live templates such as `assert!();` are incorrectly suggested in those locations. This PR changes `RsContextType.Statement` to accept only top-level statements inside RsBlock, and introduces `RsContextType.Expression` which equals to current `RsContextType.Statement`.