### PR TITLE
Show `Unresolved Reference` error for type-independent paths

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1369,6 +1369,9 @@
         <registryKey key="org.rust.code.vision.usage"
                      defaultValue="false"
                      description="Enable reference usage Code Vision hints for Rust" />
+        <registryKey key="org.rust.insp.unresolved.reference.type.independent"
+                     defaultValue="true"
+                     description="Enable Unresolved Reference inspection for type-independent paths" />
 
         <!-- Move refactoring -->
 


### PR DESCRIPTION
After enabling attribute macro expansion I think it's time to enable `Unresolved Reference` inspection in the case of a type-independent path.


What should be highlighted:

1. Unresolved reference in a `use`:

```rust
use foo:bar;
```

2. Unresolved 1-segment path:

```rust
fn main() {
    let b = a + 1;
}
```

3. Unresolved multi-segment path if the penultimate segment is a module:

```rust
mod foo {}
fn main () {
    let a = foo::bar;
}
```

4. Unresolved multi-segment path if the penultimate segment is a enum and the last segment starts with an uppercase letter:

```rust
enum Foo { A, B }
fn main() {
    let a = Foo::C;
}
```

What should NOT be highlighted:

1. A non-path, e.g. a method call:

```rust
struct S;
fn foo() {
    S.unresolved(); // NOT highlighted
}
```

2. A multi-segment path if the penultimate segment is not a module

```rust
struct S;
fn foo() {
    let a = S::foo; // NOT highlighted
}
```

3. An explicit type-qualified path

```rust
struct S;
fn foo() {
    let a = <S>::foo; // NOT highlighted
    let a = <S as Default>::foo; // NOT highlighted
}
```


changelog: Show `Unresolved Reference` error for type-independent paths
