### PR TITLE
COMP: Add `iter` alias for `for` live template

### DIFF
--- a/src/main/resources/org/rust/ide/liveTemplates/iterations.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/iterations.xml
@@ -34,6 +34,15 @@
         </context>
     </template>
 
+    <template name="iter" description="iterate (for ... in ...)" toReformat="true" toShortenFQNames="true"
+              value="for $VAR$ in $ITERABLE$ {&#10;    $END$&#10;}">
+        <variable name="ITERABLE" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="VAR" expression="rustCollectionElementName(ITERABLE)" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="RUST_STATEMENT" value="true"/>
+        </context>
+    </template>
+
     <template name="for" description="iterate (for ... in ...)" toReformat="true" toShortenFQNames="true"
               value="for $VAR$ in $ITERABLE$ {&#10;    $END$&#10;}">
         <variable name="ITERABLE" expression="" defaultValue="" alwaysStopAt="true"/>

--- a/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
@@ -187,6 +187,30 @@ class RsLiveTemplatesTest : RsTestBase() {
         }
     """)
 
+    fun `test iter`() = expandSnippet("""
+        fn main() {
+            iter/*caret*/
+        }
+    """, """
+        fn main() {
+            for  in /*caret*/ {
+            $indent
+            }
+        }
+    """)
+
+    fun `test for`() = expandSnippet("""
+        fn main() {
+            for/*caret*/
+        }
+    """, """
+        fn main() {
+            for  in /*caret*/ {
+            $indent
+            }
+        }
+    """)
+
     private fun expandSnippet(@Language("Rust") before: String, @Language("Rust") after: String) =
         checkEditorAction(before, after, IdeActions.ACTION_EXPAND_LIVE_TEMPLATE_BY_TAB)
 


### PR DESCRIPTION
changelog: Add `iter` alias for `for` live template
