### PR TITLE
ANN: Use E0403 instead of deprecated E0263

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1553,7 +1553,7 @@ private fun checkDuplicates(
     val message = when {
         element is RsNamedFieldDecl -> RsDiagnostic.DuplicateFieldError(identifier, name)
         element is RsEnumVariant -> RsDiagnostic.DuplicateDefinitionError(identifier, Namespace.Types, name, owner, E0428)
-        element is RsLifetimeParameter -> RsDiagnostic.DuplicateLifetimeError(identifier, name)
+        element is RsLifetimeParameter -> RsDiagnostic.DuplicateGenericParameterError(identifier, name)
         element is RsTypeParameter -> RsDiagnostic.DuplicateGenericParameterError(identifier, name)
         element is RsConstParameter -> RsDiagnostic.DuplicateGenericParameterError(identifier, name)
         element is RsPatBinding && owner is RsValueParameterList -> {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -749,21 +749,6 @@ sealed class RsDiagnostic(
         }
     }
 
-    class DuplicateLifetimeError(
-        element: PsiElement,
-        private val fieldName: String
-    ) : RsDiagnostic(element) {
-        override fun prepare() = PreparedAnnotation(
-            ERROR,
-            E0263,
-            errorText()
-        )
-
-        private fun errorText(): String {
-            return "Lifetime name `$fieldName` declared twice in the same scope"
-        }
-    }
-
     class LoopOnlyKeywordUsedInClosureError(
         element: PsiElement
     ) : RsDiagnostic(element) {
@@ -2123,7 +2108,7 @@ sealed class RsDiagnostic(
 enum class RsErrorCode {
     E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0044, E0045, E0046, E0049, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0130, E0131, E0132, E0133, E0183, E0184, E0185, E0186, E0191, E0197, E0198,
-    E0199, E0200, E0201, E0203, E0206, E0220, E0224, E0225, E0226, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0263, E0267, E0268, E0277,
+    E0199, E0200, E0201, E0203, E0206, E0220, E0224, E0225, E0226, E0252, E0254, E0255, E0259, E0260, E0261, E0262, E0267, E0268, E0277,
     E0308, E0316, E0322, E0323, E0324, E0325, E0328, E0364, E0365, E0379, E0381, E0382, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0437, E0438, E0449, E0451, E0463,
     E0505, E0517, E0518, E0536, E0537, E0538, E0541, E0551, E0552, E0554, E0557, E0561, E0562, E0569, E0571, E0583, E0586, E0589, E0590, E0594,

--- a/src/test/kotlin/org/rust/ide/annotator/RsDuplicateDefinitionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDuplicateDefinitionAnnotatorTest.kt
@@ -52,14 +52,14 @@ class RsDuplicateDefinitionAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator:
         }
     """)
 
-    fun `test lifetime name duplication in generic params E0263`() = checkErrors("""
+    fun `test lifetime name duplication in generic params E0403`() = checkErrors("""
         fn foo<'a, 'b>(x: &'a str, y: &'b str) { }
         struct Str<'a, 'b> { a: &'a u32, b: &'b f64 }
         impl<'a, 'b> Str<'a, 'b> {}
         enum Direction<'a, 'b> { LEFT(&'a str), RIGHT(&'b str) }
         trait Trait<'a, 'b> {}
 
-        fn bar<<error descr="Lifetime name `'a` declared twice in the same scope [E0263]">'a</error>, 'b, <error>'a</error>>(x: &'a str, y: &'b str) { }
+        fn bar<<error descr="The name `'a` is already used for a generic parameter in this item's generic parameters [E0403]">'a</error>, 'b, <error>'a</error>>(x: &'a str, y: &'b str) { }
         struct St<<error>'a</error>, 'b, <error>'a</error>> { a: &'a u32, b: &'b f64 }
         impl<<error>'a</error>, 'b, <error>'a</error>> Str<'a, 'b> {}
         enum Dir<<error>'a</error>, 'b, <error>'a</error>> { LEFT(&'a str), RIGHT(&'b str) }


### PR DESCRIPTION
changelog: Use [E0403](https://doc.rust-lang.org/error_codes/E0403.html) instead of deprecated [E0263](https://doc.rust-lang.org/error_codes/E0263.html)
