### PR TITLE
INSP: Fix false-positive `Use of moved value` for lambda expressions in `for` loops

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/regions/Scope.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/regions/Scope.kt
@@ -266,14 +266,8 @@ private data class Context(
     var varParent: ScopeInfo? = null,
 
     /** Region parent of expressions, etc., plus its depth in the scope tree. */
-    var _parent: ScopeInfo? = null
-) {
-    var parent: ScopeInfo?
-        get() = _parent
-        set(value) {
-            _parent = value
-        }
-}
+    var parent: ScopeInfo? = null
+)
 
 private class RegionResolutionVisitor {
     /** The generated scope tree. */

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -1015,4 +1015,14 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
             let c = a;
         }
     """, checkWarn = false)
+
+    fun `test no move for lambda inside for loop`() = checkByText("""
+        struct Move;
+
+        fn main() {
+            for i in 0..3 {
+                let a = |x: Move| drop(x);
+            }
+        }
+    """, checkWarn = false)
 }


### PR DESCRIPTION
changelog: Fix false-positive `Use of moved value` for lambda expressions in `for` loops
