### PR TITLE
INSP: Add a TOML inspection for duplicated keys (in simple cases)

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/inspections/TomlDuplicatedKeyInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/TomlDuplicatedKeyInspection.kt
@@ -1,0 +1,42 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.toml.RsTomlBundle
+import org.toml.lang.psi.TomlKeyValue
+import org.toml.lang.psi.TomlKeyValueOwner
+import org.toml.lang.psi.TomlVisitor
+
+class TomlDuplicatedKeyInspection : TomlLocalInspectionToolBase() {
+    override fun buildVisitorInternal(holder: ProblemsHolder, isOnTheFly: Boolean): TomlVisitor {
+        return object : TomlVisitor() {
+            override fun visitKeyValueOwner(element: TomlKeyValueOwner) {
+                val keyValues = element.entries
+                highlightDuplicates(keyValues)
+            }
+
+            override fun visitFile(file: PsiFile) {
+                // Top-level key/values do not have a KeyValueOwner
+                val keyValues = file.childrenOfType<TomlKeyValue>()
+                highlightDuplicates(keyValues)
+            }
+
+            private fun highlightDuplicates(entries: List<TomlKeyValue>) {
+                entries
+                    .groupBy { it.key.segments.mapNotNull { segment -> segment.name }.joinToString(".") }
+                    .filter { it.value.size > 1 }
+                    .values
+                    .forEach { tomlKeyValues -> tomlKeyValues.forEach { keyValue -> holder.registerProblem(
+                        keyValue.key,
+                        RsTomlBundle.message("inspection.duplicated.key.problem")
+                    ) } }
+            }
+        }
+    }
+}

--- a/toml/src/main/resources/inspectionDescriptions/TomlDuplicatedKey.html
+++ b/toml/src/main/resources/inspectionDescriptions/TomlDuplicatedKey.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+Reports duplicated keys that are in the same array in <code>.toml</code> files.
+<p><b>Example:</b></p>
+<pre><code lang="toml">
+  [foo]
+  bar = 1 # Property redefinition is not allowed
+  bar = 2 # Property redefinition is not allowed
+</code></pre>
+<!-- tooltip end -->
+</body>
+</html>

--- a/toml/src/main/resources/messages/RsTomlBundle.properties
+++ b/toml/src/main/resources/messages/RsTomlBundle.properties
@@ -1,3 +1,4 @@
 rust.update.crates.index.progress.title=Updating crates.io index
 rust.too.many.keywords=There can be maximum 5 keywords in the section
 rust.invalid.keyword=Keyword must be ASCII text, start with a letter, and only contain letters, numbers, _ or -, and have at most 20 characters.
+inspection.duplicated.key.problem=Property redefinition is not allowed

--- a/toml/src/main/resources/org.rust.toml.xml
+++ b/toml/src/main/resources/org.rust.toml.xml
@@ -68,6 +68,14 @@
                          implementationClass="org.rust.toml.inspections.TomlInvalidKeywordSegmentInspection"/>
 
 
+        <localInspection language="TOML"
+                         displayName="Duplicated key"
+                         groupPath="Rust"
+                         groupName="Cargo.toml"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         implementationClass="org.rust.toml.inspections.TomlDuplicatedKeyInspection"/>
+
         <intentionAction>
             <className>org.rust.toml.intentions.ExpandDependencySpecificationIntention</className>
             <category>Rust/Cargo.toml</category>

--- a/toml/src/test/kotlin/org/rust/toml/inspections/TomlDuplicatedKeyInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/TomlDuplicatedKeyInspectionTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+class TomlDuplicatedKeyInspectionTest : CargoTomlCrateInspectionTestBase(TomlDuplicatedKeyInspection::class) {
+
+    fun `test top-level properties`() = doTest("""
+        <error descr="Property redefinition is not allowed">foo</error> = 1
+        <error descr="Property redefinition is not allowed">foo</error> = 2
+        bar = 3
+    """)
+
+    fun `test category properties`() = doTest("""
+        [foo]
+        <error descr="Property redefinition is not allowed">foo</error> = 1
+        <error descr="Property redefinition is not allowed">foo</error> = 2
+        bar = 3
+    """)
+
+    fun `test segments`() = doTest("""
+        <error descr="Property redefinition is not allowed">foo.bar</error> = 1
+        <error descr="Property redefinition is not allowed">"foo" . 'bar'</error> = 2
+        foobar = 3
+    """)
+
+    fun `test valid segments`() = doTest("""
+        foo."  ".bar = 1
+        foo." ".bar = 2
+        foo."".bar = 3
+        foo.bar = 4
+    """)
+
+    fun `test inline array valid`() = doTest("""
+        foo = [
+            { bar = 1 },
+            { bar = 2 },
+        ]
+        bar = 1
+    """)
+
+    fun `test no errors for arrays`() = doTest("""
+        [foo1]
+        bar = 1
+
+        [foo2]
+        bar = 2
+
+        [[foo]]
+        bar = 1
+
+        [[foo]]
+        bar = 2
+    """)
+
+    fun `test duplicated key in array`() = doTest("""
+        [[foo]]
+        <error descr="Property redefinition is not allowed">bar</error> = 1
+        <error descr="Property redefinition is not allowed">bar</error> = 1
+        baz = 2
+
+        [[foo]]
+        bar = 2
+    """)
+
+    fun `test duplicated key in inline array`() = doTest("""
+        foo = {
+            <error descr="Property redefinition is not allowed">bar</error> = 1,
+            <error descr="Property redefinition is not allowed">bar</error> = 2,
+            baz = 3
+        }
+
+        [a]
+        bar = [
+            {
+                <error descr="Property redefinition is not allowed">bar</error> = 1,
+                <error descr="Property redefinition is not allowed">bar</error> = 2,
+                baz = 3
+            },
+            {
+                <error descr="Property redefinition is not allowed">bar</error> = 1,
+                <error descr="Property redefinition is not allowed">bar</error> = 2,
+                baz = 3
+            }
+        ]
+    """)
+}


### PR DESCRIPTION
changelog: Highlight duplicated keys from the same table in TOML files.
