### PR TITLE
GDB: Initial support for gdb debugging outside CLion

### DIFF
--- a/debugger/src/231/main/kotlin/org/rust/debugger/RsDebuggerUrlProvider.kt
+++ b/debugger/src/231/main/kotlin/org/rust/debugger/RsDebuggerUrlProvider.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger
+
+import com.intellij.util.system.CpuArch
+import com.intellij.util.system.OS
+import com.jetbrains.cidr.execution.debugger.backend.lldb.LLDBBinUrlProvider
+import com.jetbrains.cidr.execution.debugger.backend.lldb.LLDBBinUrlProvider.Bin
+import java.net.URL
+
+object RsDebuggerUrlProvider {
+    fun lldbFrontend(os: OS, arch: CpuArch): URL? = LLDBBinUrlProvider.lldbFrontend.url(os, arch)
+    fun lldb(os: OS, arch: CpuArch): URL? = LLDBBinUrlProvider.lldb.url(os, arch)
+    @Suppress("UNUSED_PARAMETER")
+    fun gdb(os: OS, arch: CpuArch): URL? = null
+
+    private fun Bin.url(os: OS, arch: CpuArch): URL? {
+        return when (os) {
+            // Binaries for macos are universal, i.e. they may work on x86 and arm
+            OS.macOS -> macX64
+            OS.Linux -> {
+                when (arch) {
+                    CpuArch.X86_64 -> linuxX64
+                    CpuArch.ARM64 -> linuxAarch64
+                    else -> null
+                }
+            }
+            OS.Windows -> {
+                when (arch) {
+                    CpuArch.X86_64 -> winX64
+                    CpuArch.ARM64 -> winAarch64
+                    else -> null
+                }
+            }
+            else -> null
+        }
+    }
+}

--- a/debugger/src/232/main/kotlin/org/rust/debugger/RsDebuggerUrlProvider.kt
+++ b/debugger/src/232/main/kotlin/org/rust/debugger/RsDebuggerUrlProvider.kt
@@ -1,0 +1,18 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger
+
+import com.intellij.util.system.CpuArch
+import com.intellij.util.system.OS
+import com.jetbrains.cidr.execution.debugger.backend.bin.UrlProvider
+import java.net.URL
+
+// BACKCOMPAT: 2023.1. Use `UrlProvider` directly
+object RsDebuggerUrlProvider {
+    fun lldbFrontend(os: OS, arch: CpuArch): URL? = UrlProvider.lldbFrontend(os, arch)
+    fun lldb(os: OS, arch: CpuArch): URL? = UrlProvider.lldb(os, arch)
+    fun gdb(os: OS, arch: CpuArch): URL? = UrlProvider.gdb(os, arch)
+}

--- a/debugger/src/main/kotlin/org/rust/debugger/DebuggerAvailability.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/DebuggerAvailability.kt
@@ -5,7 +5,7 @@
 
 package org.rust.debugger
 
-import java.io.File
+import java.nio.file.Path
 
 sealed class DebuggerAvailability<out T> {
     object Unavailable : DebuggerAvailability<Nothing>()
@@ -15,5 +15,5 @@ sealed class DebuggerAvailability<out T> {
     data class Binaries<T>(val binaries: T) : DebuggerAvailability<T>()
 }
 
-data class LLDBBinaries(val frameworkFile: File, val frontendFile: File)
-data class GDBBinaries(val gdbFile: File)
+data class LLDBBinaries(val frameworkFile: Path, val frontendFile: Path)
+data class GDBBinaries(val gdbFile: Path)

--- a/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerToolchainService.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerToolchainService.kt
@@ -18,16 +18,14 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.ThrowableComputable
-import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.download.DownloadableFileDescription
 import com.intellij.util.download.DownloadableFileService
 import com.intellij.util.io.Decompressor
 import com.intellij.util.system.CpuArch
+import com.intellij.util.system.OS
 import com.jetbrains.cidr.execution.debugger.CidrDebuggerPathManager
-import com.jetbrains.cidr.execution.debugger.backend.lldb.LLDBBinUrlProvider
 import com.jetbrains.cidr.execution.debugger.backend.lldb.LLDBDriverConfiguration
 import org.rust.RsBundle
-import org.rust.debugger.settings.RsDebuggerSettings
 import org.rust.openapiext.RsPathManager
 import java.io.File
 import java.io.IOException
@@ -35,17 +33,21 @@ import java.net.URL
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
+import kotlin.io.path.exists
+import kotlin.io.path.name
 
 @Service
 class RsDebuggerToolchainService {
 
-    fun lldbAvailability(): DebuggerAvailability<LLDBBinaries> {
-        if (LLDBDriverConfiguration.hasBundledLLDB()) return DebuggerAvailability.Bundled
-        return lldbAvailability(RsDebuggerSettings.getInstance().lldbPath)
+    fun debuggerAvailability(kind: DebuggerKind): DebuggerAvailability<*> {
+        return when (kind) {
+            DebuggerKind.LLDB -> lldbAvailability()
+            DebuggerKind.GDB -> gdbAvailability()
+        }
     }
 
-    fun lldbAvailability(lldbPath: String?, checkVersions: Boolean = true): DebuggerAvailability<LLDBBinaries> {
-        if (lldbPath.isNullOrEmpty()) return DebuggerAvailability.NeedToDownload
+    fun lldbAvailability(): DebuggerAvailability<LLDBBinaries> {
+        if (LLDBDriverConfiguration.hasBundledLLDB()) return DebuggerAvailability.Bundled
 
         val (frameworkPath, frontendPath) = when {
             SystemInfo.isMac -> "LLDB.framework" to "LLDBFrontend"
@@ -54,20 +56,19 @@ class RsDebuggerToolchainService {
             else -> return DebuggerAvailability.Unavailable
         }
 
-        val frameworkFile = File(FileUtil.join(lldbPath, frameworkPath))
-        val frontendFile = File(FileUtil.join(lldbPath, frontendPath))
+        val lldbPath = lldbPath()
+        val frameworkFile = lldbPath.resolve(frameworkPath)
+        val frontendFile = lldbPath.resolve(frontendPath)
         if (!frameworkFile.exists() || !frontendFile.exists()) return DebuggerAvailability.NeedToDownload
 
-        if (checkVersions) {
-            val versions = loadLLDBVersions()
-            val (lldbFrameworkUrl, lldbFrontendUrl) = lldbUrls ?: return DebuggerAvailability.Unavailable
+        val versions = loadDebuggerVersions(DebuggerKind.LLDB)
+        val (lldbFrameworkUrl, lldbFrontendUrl) = lldbUrls() ?: return DebuggerAvailability.Unavailable
 
-            val lldbFrameworkVersion = fileNameWithoutExtension(lldbFrameworkUrl.toString())
-            val lldbFrontendVersion = fileNameWithoutExtension(lldbFrontendUrl.toString())
+        val lldbFrameworkVersion = fileNameWithoutExtension(lldbFrameworkUrl.toString())
+        val lldbFrontendVersion = fileNameWithoutExtension(lldbFrontendUrl.toString())
 
-            if (versions[LLDB_FRAMEWORK_PROPERTY_NAME] != lldbFrameworkVersion ||
-                versions[LLDB_FRONTEND_PROPERTY_NAME] != lldbFrontendVersion) return DebuggerAvailability.NeedToUpdate
-        }
+        if (versions[LLDB_FRAMEWORK_PROPERTY_NAME] != lldbFrameworkVersion ||
+            versions[LLDB_FRONTEND_PROPERTY_NAME] != lldbFrontendVersion) return DebuggerAvailability.NeedToUpdate
 
         return DebuggerAvailability.Binaries(LLDBBinaries(frameworkFile, frontendFile))
     }
@@ -77,12 +78,29 @@ class RsDebuggerToolchainService {
         // Even if we have bundled GDB, it still doesn't work on macOS for local runs
         if (SystemInfo.isMac) return DebuggerAvailability.Unavailable
         if (CidrDebuggerPathManager.getBundledGDBBinary().exists()) return DebuggerAvailability.Bundled
-        return DebuggerAvailability.Unavailable
+
+        val gdbBinaryPath = when {
+            SystemInfo.isUnix -> "bin/gdb"
+            SystemInfo.isWindows -> "bin/gdb.exe"
+            else -> return DebuggerAvailability.Unavailable
+        }
+
+        val gdbFile = gdbPath().resolve(gdbBinaryPath)
+        if (!gdbFile.exists()) return DebuggerAvailability.NeedToDownload
+
+        val versions = loadDebuggerVersions(DebuggerKind.GDB)
+        val gdbUrl = gdbUrl() ?: return DebuggerAvailability.Unavailable
+
+        val gdbVersion = fileNameWithoutExtension(gdbUrl.toString())
+
+        if (versions[GDB_PROPERTY_NAME] != gdbVersion) return DebuggerAvailability.NeedToUpdate
+
+        return DebuggerAvailability.Binaries(GDBBinaries(gdbFile))
     }
 
-    fun downloadDebugger(project: Project? = null): DownloadResult {
+    fun downloadDebugger(project: Project? = null, debuggerKind: DebuggerKind): DownloadResult {
         val result = ProgressManager.getInstance().runProcessWithProgressSynchronously(ThrowableComputable<DownloadResult, Nothing> {
-            downloadDebuggerSynchronously()
+            downloadDebuggerSynchronously(debuggerKind)
         }, RsBundle.message("dialog.title.download.debugger"), true, project)
 
         when (result) {
@@ -108,44 +126,49 @@ class RsDebuggerToolchainService {
         return result
     }
 
-    private fun downloadDebuggerSynchronously(): DownloadResult {
-        val (lldbFrameworkUrl, lldbFrontendUrl) = lldbUrls ?: return DownloadResult.NoUrls
+    private fun downloadDebuggerSynchronously(kind: DebuggerKind): DownloadResult {
+        val baseDir = kind.basePath()
+        val downloadableBinaries = when (kind) {
+            DebuggerKind.LLDB -> {
+                val (lldbFrameworkUrl, lldbFrontendUrl) = lldbUrls() ?: return DownloadResult.NoUrls
+                listOf(
+                    DownloadableDebuggerBinary(lldbFrameworkUrl.toString(), LLDB_FRAMEWORK_PROPERTY_NAME),
+                    DownloadableDebuggerBinary(lldbFrontendUrl.toString(), LLDB_FRONTEND_PROPERTY_NAME)
+                )
+            }
+            DebuggerKind.GDB -> {
+                val gdbUrl = gdbUrl() ?: return DownloadResult.NoUrls
+                listOf(DownloadableDebuggerBinary(gdbUrl.toString(), GDB_PROPERTY_NAME))
+            }
+        }
+
         return try {
-            val lldbDir = downloadAndUnarchive(lldbFrameworkUrl.toString(), lldbFrontendUrl.toString())
-            DownloadResult.Ok(lldbDir)
+            downloadAndUnarchive(baseDir, downloadableBinaries)
+            DownloadResult.Ok(baseDir)
         } catch (e: IOException) {
             LOG.warn("Can't download debugger", e)
             DownloadResult.Failed(e.message)
         }
     }
 
-    private val lldbUrls: Pair<URL, URL>?
-        get() {
-            return when {
-                SystemInfo.isMac -> LLDBBinUrlProvider.lldb.macX64 to LLDBBinUrlProvider.lldbFrontend.macX64
-                SystemInfo.isLinux -> LLDBBinUrlProvider.lldb.linuxX64 to LLDBBinUrlProvider.lldbFrontend.linuxX64
-                SystemInfo.isWindows -> {
-                    if (CpuArch.isIntel64()) {
-                        LLDBBinUrlProvider.lldb.winX64 to LLDBBinUrlProvider.lldbFrontend.winX64
-                    } else {
-                        LLDBBinUrlProvider.lldb.winX86 to LLDBBinUrlProvider.lldbFrontend.winX86
-                    }
-                }
-                else -> return null
-            }
-        }
+    private fun lldbUrls(): Pair<URL, URL>? {
+        val lldb = RsDebuggerUrlProvider.lldb(OS.CURRENT, CpuArch.CURRENT) ?: return null
+        val lldbFrontend = RsDebuggerUrlProvider.lldbFrontend(OS.CURRENT, CpuArch.CURRENT) ?: return null
+        return lldb to lldbFrontend
+    }
+
+    private fun gdbUrl(): URL? = RsDebuggerUrlProvider.gdb(OS.CURRENT, CpuArch.CURRENT)
 
     @Throws(IOException::class)
-    private fun downloadAndUnarchive(lldbFrameworkUrl: String, lldbFrontendUrl: String): File {
+    private fun downloadAndUnarchive(baseDir: Path, binariesToDownload: List<DownloadableDebuggerBinary>) {
         val service = DownloadableFileService.getInstance()
 
-        val lldbDir = lldbPath().toFile()
-        lldbDir.deleteRecursively()
+        val downloadDir = baseDir.toFile()
+        downloadDir.deleteRecursively()
 
-        val descriptions = listOf(
-            service.createFileDescription(lldbFrameworkUrl),
-            service.createFileDescription(lldbFrontendUrl)
-        )
+        val descriptions = binariesToDownload.map {
+            service.createFileDescription(it.url)
+        }
 
         val downloader = service.createDownloader(descriptions, "Debugger downloading")
         val downloadDirectory = downloadPath().toFile()
@@ -154,16 +177,15 @@ class RsDebuggerToolchainService {
         val versions = Properties()
         for (result in downloadResults) {
             val downloadUrl = result.second.downloadUrl
-            val propertyName = if (downloadUrl == lldbFrameworkUrl) LLDB_FRAMEWORK_PROPERTY_NAME else LLDB_FRONTEND_PROPERTY_NAME
+            val binaryToDownload = binariesToDownload.first { it.url == downloadUrl }
+            val propertyName = binaryToDownload.propertyName
             val archiveFile = result.first
-            Unarchiver.unarchive(archiveFile, lldbDir)
+            Unarchiver.unarchive(archiveFile, downloadDir)
             archiveFile.delete()
             versions[propertyName] = fileNameWithoutExtension(downloadUrl)
         }
 
-        saveLLDBVersions(versions)
-
-        return lldbDir
+        saveVersionsFile(baseDir, versions)
     }
 
     private fun DownloadableFileService.createFileDescription(url: String): DownloadableFileDescription {
@@ -176,42 +198,59 @@ class RsDebuggerToolchainService {
     }
 
     @VisibleForTesting
-    fun loadLLDBVersions(): Properties {
+    fun loadDebuggerVersions(kind: DebuggerKind): Properties = loadVersions(kind.basePath())
+
+    @VisibleForTesting
+    fun saveDebuggerVersions(kind: DebuggerKind, versions: Properties) {
+        saveVersionsFile(kind.basePath(), versions)
+    }
+
+    private fun saveVersionsFile(basePath: Path, versions: Properties) {
+        val file = basePath.resolve(DEBUGGER_VERSIONS).toFile()
+        try {
+            versions.store(file.bufferedWriter(), "")
+        } catch (e: IOException) {
+            LOG.warn("Failed to save `${basePath.name}/${file.name}`", e)
+        }
+    }
+
+    private fun loadVersions(basePath: Path): Properties {
         val versions = Properties()
-        val versionsFile = lldbPath().resolve(LLDB_VERSIONS).toFile()
+        val versionsFile = basePath.resolve(DEBUGGER_VERSIONS).toFile()
 
         if (versionsFile.exists()) {
             try {
                 versionsFile.bufferedReader().use { versions.load(it) }
             } catch (e: IOException) {
-                LOG.warn("Failed to load `$LLDB_VERSIONS`", e)
+                LOG.warn("Failed to load `${basePath.name}/${versionsFile.name}`", e)
             }
         }
 
         return versions
     }
 
-    @VisibleForTesting
-    fun saveLLDBVersions(versions: Properties) {
-        try {
-            versions.store(lldbPath().resolve(LLDB_VERSIONS).toFile().bufferedWriter(), "")
-        } catch (e: IOException) {
-            LOG.warn("Failed to save `$LLDB_VERSIONS`")
+    private fun DebuggerKind.basePath(): Path {
+        val basePath = when (this) {
+            DebuggerKind.LLDB -> lldbPath()
+            DebuggerKind.GDB -> gdbPath()
         }
+        return basePath
     }
 
     companion object {
         private val LOG: Logger = logger<RsDebuggerToolchainService>()
 
-        private const val LLDB_VERSIONS: String = "versions.properties"
+        private const val DEBUGGER_VERSIONS: String = "versions.properties"
 
-        const val LLDB_FRONTEND_PROPERTY_NAME = "lldbFrontend"
-        const val LLDB_FRAMEWORK_PROPERTY_NAME = "lldbFramework"
+        private const val LLDB_FRONTEND_PROPERTY_NAME = "lldbFrontend"
+        private const val LLDB_FRAMEWORK_PROPERTY_NAME = "lldbFramework"
+        private const val GDB_PROPERTY_NAME = "gdb"
 
         const val RUST_DEBUGGER_GROUP_ID = "Rust Debugger"
 
         private fun downloadPath(): Path = Paths.get(PathManager.getTempPath())
         private fun lldbPath(): Path = RsPathManager.pluginDirInSystem().resolve("lldb")
+        private fun gdbPath(): Path = RsPathManager.pluginDirInSystem().resolve("gdb")
 
         fun getInstance(): RsDebuggerToolchainService = service()
     }
@@ -241,8 +280,13 @@ class RsDebuggerToolchainService {
     }
 
     sealed class DownloadResult {
-        class Ok(val lldbDir: File) : DownloadResult()
+        class Ok(val baseDir: Path) : DownloadResult()
         object NoUrls : DownloadResult()
         class Failed(val message: String?) : DownloadResult()
     }
+
+    private class DownloadableDebuggerBinary(
+        val url: String,
+        val propertyName: String,
+    )
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/RsDefaultDebuggerDriverConfigurationProvider.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsDefaultDebuggerDriverConfigurationProvider.kt
@@ -37,6 +37,7 @@ class RsDefaultDebuggerDriverConfigurationProvider : RsDebuggerDriverConfigurati
                 val gdbAvailability = RsDebuggerToolchainService.getInstance().gdbAvailability()
                 return when (gdbAvailability) {
                     DebuggerAvailability.Bundled -> RsGDBDriverConfiguration(isElevated, emulateTerminal)
+                    is DebuggerAvailability.Binaries -> RsCustomBinariesGDBDriverConfiguration(gdbAvailability.binaries, isElevated, emulateTerminal)
                     else -> null
                 }
             }
@@ -44,7 +45,7 @@ class RsDefaultDebuggerDriverConfigurationProvider : RsDebuggerDriverConfigurati
     }
 }
 
-class RsGDBDriverConfiguration(
+open class RsGDBDriverConfiguration(
     private val isElevated: Boolean,
     private val emulateTerminal: Boolean
 ) : GDBDriverConfiguration() {
@@ -54,6 +55,14 @@ class RsGDBDriverConfiguration(
     override fun isAttachSupported(): Boolean = false
     override fun isElevated(): Boolean = isElevated
     override fun emulateTerminal(): Boolean = emulateTerminal
+}
+
+private class RsCustomBinariesGDBDriverConfiguration(
+    private val binaries: GDBBinaries,
+    isElevated: Boolean,
+    emulateTerminal: Boolean
+) : RsGDBDriverConfiguration(isElevated, emulateTerminal) {
+    override fun getGDBExecutablePath(): String = binaries.gdbFile.toString()
 }
 
 open class RsLLDBDriverConfiguration(
@@ -73,6 +82,6 @@ private class RsCustomBinariesLLDBDriverConfiguration(
 ) : RsLLDBDriverConfiguration(isElevated, emulateTerminal) {
     override fun getDriverName(): String = "Rust LLDB"
     override fun useSTLRenderers(): Boolean = false
-    override fun getLLDBFrameworkFile(architectureType: ArchitectureType): File = binaries.frameworkFile
-    override fun getLLDBFrontendFile(architectureType: ArchitectureType): File = binaries.frontendFile
+    override fun getLLDBFrameworkFile(architectureType: ArchitectureType): File = binaries.frameworkFile.toFile()
+    override fun getLLDBFrontendFile(architectureType: ArchitectureType): File = binaries.frontendFile.toFile()
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/RsDefaultDebuggerDriverConfigurationProvider.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsDefaultDebuggerDriverConfigurationProvider.kt
@@ -5,11 +5,15 @@
 
 package org.rust.debugger
 
+import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.removeUserData
 import com.jetbrains.cidr.ArchitectureType
+import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriver
 import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriverConfiguration
+import com.jetbrains.cidr.execution.debugger.backend.gdb.GDBDriver
 import com.jetbrains.cidr.execution.debugger.backend.gdb.GDBDriverConfiguration
 import com.jetbrains.cidr.execution.debugger.backend.lldb.LLDBDriverConfiguration
 import org.rust.debugger.settings.RsDebuggerSettings
@@ -63,6 +67,19 @@ private class RsCustomBinariesGDBDriverConfiguration(
     emulateTerminal: Boolean
 ) : RsGDBDriverConfiguration(isElevated, emulateTerminal) {
     override fun getGDBExecutablePath(): String = binaries.gdbFile.toString()
+
+    override fun createDriverCommandLine(driver: DebuggerDriver, architectureType: ArchitectureType): GeneralCommandLine {
+        val cmd = super.createDriverCommandLine(driver, architectureType)
+        // `GDBDriverConfiguration` assumes that there are bundled C++ pretty-printers.
+        // It's not true in the case of Native Debugging Support plugin outside CLion,
+        // and gdb throws an exception `Error while executing Python code`.
+        // As a result, Rust pretty printers are not loaded as well.
+        // As a temporary workaround, just remove paths to C++ pretty printers.
+        // See https://youtrack.jetbrains.com/issue/CPP-34231
+        cmd.removeUserData(GDBDriver.PRETTY_PRINTERS_PATH)
+        cmd.removeUserData(GDBDriver.ENABLE_STL_PRETTY_PRINTERS)
+        return cmd
+    }
 }
 
 open class RsLLDBDriverConfiguration(

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
@@ -84,10 +84,8 @@ object RsDebugRunnerUtils {
     }
 
     fun checkToolchainConfigured(project: Project): Boolean {
-        val debuggerAvailability = when (RsDebuggerSettings.getInstance().debuggerKind) {
-            DebuggerKind.LLDB -> RsDebuggerToolchainService.getInstance().lldbAvailability()
-            DebuggerKind.GDB -> RsDebuggerToolchainService.getInstance().gdbAvailability()
-        }
+        val debuggerKind = RsDebuggerSettings.getInstance().debuggerKind
+        val debuggerAvailability = RsDebuggerToolchainService.getInstance().debuggerAvailability(debuggerKind)
 
         val (message, action) = when (debuggerAvailability) {
             DebuggerAvailability.Unavailable -> return false
@@ -104,9 +102,8 @@ object RsDebugRunnerUtils {
         }
 
         if (downloadDebugger) {
-            val result = RsDebuggerToolchainService.getInstance().downloadDebugger(project)
+            val result = RsDebuggerToolchainService.getInstance().downloadDebugger(project, debuggerKind)
             if (result is RsDebuggerToolchainService.DownloadResult.Ok) {
-                RsDebuggerSettings.getInstance().lldbPath = result.lldbDir.absolutePath
                 return true
             }
         }

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
@@ -23,7 +23,6 @@ class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
 
     var debuggerKind: DebuggerKind = DebuggerKind.LLDB
 
-    var lldbPath: String? = null
     var downloadAutomatically: Boolean = false
 
     var breakOnPanic: Boolean = true

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerToolchainConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerToolchainConfigurableUi.kt
@@ -11,8 +11,8 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.COLUMNS_SHORT
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.columns
-import org.rust.debugger.DebuggerKind
 import org.rust.debugger.DebuggerAvailability
+import org.rust.debugger.DebuggerKind
 import org.rust.debugger.RsDebuggerBundle
 import org.rust.debugger.RsDebuggerToolchainService
 import java.util.*
@@ -27,6 +27,8 @@ class RsDebuggerToolchainConfigurableUi : RsDebuggerUiComponent() {
         JBCheckBox(RsDebuggerBundle.message("settings.rust.debugger.toolchain.download.debugger.automatically.checkbox"), RsDebuggerSettings.getInstance().downloadAutomatically)
 
     private var comment: JEditorPane? = null
+
+    private val currentDebuggerKind: DebuggerKind get() = debuggerKindCombobox.item
 
     override fun isModified(settings: RsDebuggerSettings): Boolean {
         return settings.debuggerKind != debuggerKindCombobox.item ||
@@ -78,16 +80,14 @@ class RsDebuggerToolchainConfigurableUi : RsDebuggerUiComponent() {
     }
 
     private fun downloadDebugger() {
-        val result = RsDebuggerToolchainService.getInstance().downloadDebugger()
+        val result = RsDebuggerToolchainService.getInstance().downloadDebugger(debuggerKind = currentDebuggerKind)
         if (result is RsDebuggerToolchainService.DownloadResult.Ok) {
-            RsDebuggerSettings.getInstance().lldbPath = result.lldbDir.absolutePath
             update()
         }
     }
 
     private fun update() {
-        @Suppress("MoveVariableDeclarationIntoWhen")
-        val availability = RsDebuggerToolchainService.getInstance().lldbAvailability()
+        val availability = RsDebuggerToolchainService.getInstance().debuggerAvailability(currentDebuggerKind)
         val text = when (availability) {
             DebuggerAvailability.NeedToDownload -> RsDebuggerBundle.message("settings.rust.debugger.toolchain.download.comment")
             DebuggerAvailability.NeedToUpdate -> RsDebuggerBundle.message("settings.rust.debugger.toolchain.update.comment")

--- a/debugger/src/test/kotlin/org/rust/debugger/RsDebuggerToolchainServiceTest.kt
+++ b/debugger/src/test/kotlin/org/rust/debugger/RsDebuggerToolchainServiceTest.kt
@@ -5,14 +5,21 @@
 
 package org.rust.debugger
 
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.util.BuildNumber
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.util.PlatformUtils
 import com.intellij.util.ThrowableRunnable
 import org.rust.RsTestBase
-import java.io.File
+import org.rust.setRegistryOptionEnabled
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.exists
 
 class RsDebuggerToolchainServiceTest : RsTestBase() {
 
-    private var lldbDir: File? = null
+    private var debuggerDir: Path? = null
 
     override fun runTestRunnable(testRunnable: ThrowableRunnable<Throwable>) {
         @Suppress("UnstableApiUsage")
@@ -21,44 +28,77 @@ class RsDebuggerToolchainServiceTest : RsTestBase() {
         }
     }
 
+    override fun setUp() {
+        super.setUp()
+        setRegistryOptionEnabled(Registry.get("org.rust.debugger.gdb.setup.v2"), true, testRootDisposable)
+    }
+
     override fun tearDown() {
-        lldbDir?.deleteRecursively()
-        lldbDir = null
+        debuggerDir?.toFile()?.deleteRecursively()
+        debuggerDir = null
         super.tearDown()
     }
 
     fun `test lldb loading and update`() {
-        val toolchainService = RsDebuggerToolchainService.getInstance()
-        assertEquals(DebuggerAvailability.NeedToDownload, toolchainService.lldbAvailability())
-
-        downloadDebugger()
-
-        val version = toolchainService.loadLLDBVersions()
-        version[RsDebuggerToolchainService.LLDB_FRONTEND_PROPERTY_NAME] = "lldbfrontend-1234567890-mac-x64"
-        toolchainService.saveLLDBVersions(version)
-
-        assertEquals(DebuggerAvailability.NeedToUpdate, toolchainService.lldbAvailability(lldbDir?.absolutePath))
-
-        downloadDebugger()
+        checkDebuggerLoadingAndUpdate(DebuggerKind.LLDB)
     }
 
-    private fun downloadDebugger() {
+    fun `test gdb loading and update`() {
+        if (ApplicationInfo.getInstance().build < BUILD_232 || SystemInfo.isMac) return
+        checkDebuggerLoadingAndUpdate(DebuggerKind.GDB)
+    }
+
+    private fun checkDebuggerLoadingAndUpdate(kind: DebuggerKind) {
         val toolchainService = RsDebuggerToolchainService.getInstance()
-        val result = toolchainService.downloadDebugger()
+        assertEquals(DebuggerAvailability.NeedToDownload, toolchainService.debuggerAvailability(kind))
+
+        downloadDebugger(kind)
+
+        // Emulate an outdated version
+        val version = toolchainService.loadDebuggerVersions(kind)
+        val propertyName = version.stringPropertyNames().first()
+        val value = version.getProperty(propertyName)
+        version[propertyName] = "$value!"
+        toolchainService.saveDebuggerVersions(kind, version)
+
+        assertEquals(DebuggerAvailability.NeedToUpdate, toolchainService.debuggerAvailability(kind))
+
+        downloadDebugger(kind)
+    }
+
+    private fun downloadDebugger(kind: DebuggerKind) {
+        val result = RsDebuggerToolchainService.getInstance().downloadDebugger(null, kind)
         check(result is RsDebuggerToolchainService.DownloadResult.Ok) {
             val message = (result as? RsDebuggerToolchainService.DownloadResult.Failed)?.message.orEmpty()
             "Failed to load debugger\n$message"
         }
-        lldbDir = result.lldbDir
-        val lldbAvailability = toolchainService.lldbAvailability(result.lldbDir.absolutePath)
-        check(lldbAvailability is DebuggerAvailability.Binaries) {
-            "Unexpected lldb availability after downloading: $lldbAvailability"
+        debuggerDir = result.baseDir
+        checkAvailability(kind)
+    }
+
+    private fun checkAvailability(kind: DebuggerKind) {
+        val availability = RsDebuggerToolchainService.getInstance().debuggerAvailability(kind)
+        check(availability is DebuggerAvailability.Binaries) {
+            "Unexpected ${kind.name.lowercase()} availability after downloading: $availability"
         }
 
-        fun checkFileExist(file: File) {
-            check(file.exists()) { "Failed to find `${file.absoluteFile}`" }
+        val binaries = availability.binaries
+        val expectedFiles = when (kind) {
+            DebuggerKind.LLDB -> listOf((binaries as LLDBBinaries).frameworkFile, binaries.frontendFile)
+            DebuggerKind.GDB -> listOf((binaries as GDBBinaries).gdbFile)
         }
-        checkFileExist(lldbAvailability.binaries.frontendFile)
-        checkFileExist(lldbAvailability.binaries.frameworkFile)
+
+        fun Path.checkExistence() {
+            check(exists()) { "Failed to find `${absolutePathString()}`" }
+        }
+
+        for (expectedFile in expectedFiles) {
+            expectedFile.checkExistence()
+        }
+    }
+
+    companion object {
+        // BACKCOMPAT: 2023.1
+        private val BUILD_232 = BuildNumber.fromString("232")!!
     }
 }


### PR DESCRIPTION
- the feature is still under `org.rust.debugger.gdb.setup.v2` registry option
- works only since 232.8296
- works only on Linux local debugging. Windows doesn't work because of `winbreak` binaries are expected to be present in Native Debugging plugin but it doesn't contain them. I think it will be fixed on Native Debugging plugin side and won't require any changes from the Rust plugin
- WSL debugging is not supported

changelog: Implement initial support for gdb debugging outside of CLion. Right now it's disabled by default and works only on Linux
