### PR TITLE
MACRO: fix error message for non-expanded macro inside an impl

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -190,7 +190,7 @@ private fun <T : RsMacroData, E : MacroExpansionError> MacroExpander<T, E>.expan
     val mixHash = def.mixHash(callDataWithHash) ?: return Err(MacroCallSyntaxError)
     val (stub, expansionResult) = MacroExpansionSharedCache.getInstance()
         .createExpansionStub(call.project, this, def.data, callData, mixHash)
-        .unwrapOrElse { return Err(MacroCallSyntaxError) }
+        .unwrapOrElse { return Err(ExpansionError(it)) }
     val expandedText = expansionResult.text
 
     val factory = RsPsiFactory(call.project, markGenerated = false, eventSystemEnabled = stub != null)

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroErrorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroErrorTest.kt
@@ -26,4 +26,15 @@ class RsMacroErrorTest : RsMacroExpansionErrorTestBase() {
         #[cfg(not(intellij_rust))]
         foo! {}
     """)
+
+    fun `test macro inside an impl`() = checkError<GetMacroExpansionError.ExpansionError>("""
+        macro_rules! foo {
+            (bar) => { fn foo() {} };
+        }
+
+        struct S;
+        impl S {
+            foo! {}
+        }
+    """)
 }


### PR DESCRIPTION
changelog: Improve error message for a non-expanded macro inside an impl block