### PR TITLE
RES: Fix name resolution inside a nested block under cfg attribute

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -24,7 +24,7 @@ interface RsExpandedElement : RsElement {
     companion object {
         fun getContextImpl(psi: RsExpandedElement, isIndexAccessForbidden: Boolean = false): PsiElement? {
             psi.getUserData(RS_EXPANSION_CONTEXT)?.let { return it }
-            val parent = psi.stubParent
+            val parent = psi.parent
             if (parent is RsFile && !isIndexAccessForbidden) {
                 val project = parent.project
                 if (!DumbService.isDumb(project)) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.MockAdditionalCfgOptions
 import org.rust.WithoutExperimentalFeatures
 import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.psi.RsImplItem
@@ -1593,6 +1594,22 @@ class RsResolveTest : RsResolveTestBase() {
                     }
                 }
             }
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test resolve from a nested block under cfg attribute`() = checkByCode("""
+        fn main() {
+            {
+                let mut a = 1;
+                      //X
+                #[cfg(intellij_rust)]
+                {
+                    use foo::bar;
+                    a += 1;
+                } //^
+                a
+            };
         }
     """)
 }


### PR DESCRIPTION

Example:
```rust
fn main() {
    {
        let mut a = 1;
              //X
        #[cfg(intellij_rust)]
        {
            use foo::bar;
            a += 1;
        } //^
        a
    };
}
```

changelog: Fix name resolution inside a nested block under cfg attribute