### PR TITLE
INT: Adding a quick fix to add #[tokio::main]

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -133,6 +133,17 @@ class Cargo(
         commandLine.run(cargoProject, "Install $crateName", saveConfiguration = false)
     }
 
+    fun addDependency(project: Project, crateName: String, features: List<String> = emptyList()) {
+        val cargoProject = project.cargoProjects.allProjects.firstOrNull() ?: return
+        val args = mutableListOf(crateName)
+        if (features.isNotEmpty()) {
+            args.add("--features")
+            args.add(features.joinToString(","))
+        }
+        val commandLine = CargoCommandLine.forProject(cargoProject, "add", args)
+        commandLine.run(cargoProject, "Add dependency $crateName", saveConfiguration = false)
+    }
+
     fun checkSupportForBuildCheckAllTargets(): Boolean {
         val lines = createBaseCommandLine("help", "check")
             .execute(toolchain.executionTimeoutInMilliseconds)

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1508,7 +1508,11 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     private fun checkIsAsyncContext(holder: RsAnnotationHolder, element: RsElement) {
         if (element.isInAsyncContext) return
         val function = element.ancestorStrict<RsFunctionOrLambda>() ?: return
-        val fix = MakeAsyncFix(function).takeIf { !function.returnsFuture() }
+        val fix = when {
+            function is RsFunction && !function.isAsync && function.isMain -> AddTokioMainFix(function)
+            !function.returnsFuture() -> MakeAsyncFix(function)
+            else -> null
+        }
         RsDiagnostic.AwaitOutsideAsyncContext(element, fix).addToHolder(holder)
     }
 

--- a/src/main/kotlin/org/rust/ide/fixes/AddTokioMainFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/AddTokioMainFix.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.fixes
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import org.rust.RsBundle
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.toolchain.tools.cargo
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.*
+
+class AddTokioMainFix(function: RsFunction) : RsQuickFixBase<RsFunction>(function) {
+    private val hasTokio = function.findDependencyCrateRoot("tokio") != null
+    override fun getFamilyName() = RsBundle.message("intention.name.add.tokio.main")
+    override fun getText(): String {
+        return if (hasTokio) {
+            RsBundle.message("intention.name.add.tokio.main")
+        } else {
+            RsBundle.message("intention.name.install.tokio.and.add.main")
+        }
+
+    }
+    override fun invoke(project: Project, editor: Editor?, element: RsFunction) {
+        val anchor = element.outerAttrList.firstOrNull() ?: element.firstKeyword
+
+        element.addOuterAttribute(Attribute("tokio::main"), anchor)
+
+        if (!element.isIntentionPreviewElement && !hasTokio) {
+            installTokio(project)
+        }
+    }
+    private fun installTokio(project: Project) {
+        val cargo = project.toolchain?.cargo() ?: return
+        object : Task.Backgroundable(project, RsBundle.message("progress.title.adding.dependency", "tokio")) {
+            override fun shouldStartInBackground(): Boolean = true
+            override fun run(indicator: ProgressIndicator) {
+                cargo.addDependency(project, "tokio", listOf("full"))
+            }
+            override fun onSuccess() {
+                project.cargoProjects.refreshAllProjects()
+            }
+        }.queue()
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsAsyncMainFunctionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAsyncMainFunctionInspection.kt
@@ -21,9 +21,8 @@ class RsAsyncMainFunctionInspection: RsLocalInspectionTool() {
                 if (o.isMain && async != null) {
                     val hardcodedProMacros = ProcMacroAttribute.getHardcodedProcMacroAttributes(o)
                     val hasAsyncMainMacro = hardcodedProMacros.any { it == KnownProcMacroKind.ASYNC_MAIN }
-                    val name = o.name
-                    if (!hasAsyncMainMacro && name != null) {
-                        RsDiagnostic.AsyncMainFunction(async, name).addToHolder(holder)
+                    if (!hasAsyncMainMacro) {
+                        RsDiagnostic.AsyncMainFunction(async, o).addToHolder(holder)
                     }
                 }
             }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -399,3 +399,14 @@ private fun RsMetaItem.canBeAttrProcMacro(): Boolean =
 /** See also [procMacroName] */
 val RsFunction.functionName: String?
     get() = (this as RsFunctionImplMixin).functionName
+
+val RsFunction.firstKeyword: PsiElement
+    get() = node.findChildByType(
+        tokenSetOf(
+            RsElementTypes.VIS, RsElementTypes.DEFAULT, RsElementTypes.ASYNC, RsElementTypes.CONST,
+            RsElementTypes.UNSAFE, RsElementTypes.EXTERN_ABI
+        )
+    )?.psi ?: fn
+
+val RsFunction.async: PsiElement?
+    get() = node.findChildByType(RsElementTypes.ASYNC)?.psi

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1489,13 +1489,14 @@ sealed class RsDiagnostic(
         }
     }
 
-    class AsyncMainFunction(element: PsiElement, private val entryPointName: String) : RsDiagnostic(element) {
+    class AsyncMainFunction(element: PsiElement, private val entryPoint: RsFunction) : RsDiagnostic(element) {
+        private val entryPointName = entryPoint.name
         override fun prepare(): PreparedAnnotation {
             return PreparedAnnotation(
                 ERROR,
                 E0752,
                 "`$entryPointName` function is not allowed to be `async`",
-                fixes = listOfFixes(RemoveElementFix(element))
+                fixes = listOfFixes(RemoveElementFix(element), AddTokioMainFix(entryPoint))
             )
         }
     }

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -1401,3 +1401,6 @@ tooltip.this.accepted.in.current.edition.rust.but.hard.error.in.rust=This is acc
 inspection.message.expected.trait.bound.found.impl.trait.type=Expected trait bound, found `impl Trait` type
 inspection.message.invalid.dyn.keyword=Invalid `dyn` keyword
 inspection.duplicated.key.display.name=Duplicated key
+intention.name.add.tokio.main=Add `#[tokio::main]`
+progress.title.adding.dependency=Adding {0} to dependencies
+intention.name.install.tokio.and.add.main=Add tokio to dependencies and add `#[tokio::main]`

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddTokioMainFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddTokioMainFixTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.openapi.project.Project
+import com.intellij.util.Urls
+import org.rust.ProjectDescriptor
+import org.rust.RustProjectDescriptorBase
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspaceData
+import org.rust.cargo.project.workspace.PackageId
+import org.rust.ide.inspections.RsAsyncMainFunctionInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
+import java.nio.file.Paths
+
+@ProjectDescriptor(WithTokioDependencyRustProjectDescriptor::class)
+class AddTokioMainFixTest : RsInspectionsTestBase(RsAsyncMainFunctionInspection::class) {
+    fun `test fix add tokio main`() = checkFixByFileTree("Add `#[tokio::main]`", """
+        $TOKIO_CRATE_MOCK
+    //- main.rs
+        /*error descr="`main` function is not allowed to be `async` [E0752]"*/async/*caret*//*error**/ fn main() {}
+    """, """
+    //- main.rs
+        #[tokio::main]
+        async fn main() {}
+    """)
+
+    fun `test fix add tokio with keyword`() = checkFixByFileTree("Add `#[tokio::main]`", """
+        $TOKIO_CRATE_MOCK
+    //- main.rs
+        pub /*error descr="`main` function is not allowed to be `async` [E0752]"*/async/*caret*//*error**/ fn main() {}
+    """, """
+    //- main.rs
+        #[tokio::main]
+        pub async fn main() {}
+    """)
+}
+
+private const val TOKIO_CRATE_MOCK = """
+    //- tokio/lib.rs
+        pub mod tokio {
+            pub struct Error;
+        }
+
+        pub fun main() {}
+"""
+internal object WithTokioDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
+    override fun createTestCargoWorkspace(project: Project, contentRoot: String): CargoWorkspace {
+        val tokio = externalPackage("$contentRoot/tokio", "lib.rs", "tokio")
+        val testPackage = testCargoPackage(contentRoot)
+        val packages = listOf(testPackage, tokio)
+        return CargoWorkspace.deserialize(
+            Paths.get("${Urls.newFromIdea(contentRoot).path}/workspace/Cargo.toml"),
+            CargoWorkspaceData(
+                packages,
+                mapOf(testPackage.id to setOf(dep(tokio.id))),
+                emptyMap(),
+                contentRoot
+            ),
+        )
+    }
+
+    private fun dep(id: PackageId): CargoWorkspaceData.Dependency = CargoWorkspaceData.Dependency(
+        id = id,
+        name = null,
+        depKinds = listOf(CargoWorkspace.DepKindInfo(CargoWorkspace.DepKind.Normal))
+    )
+}


### PR DESCRIPTION
When `async` main function is found, this will suggest to use `#[tokio::main]`.
If `tokio` is not a dependency of the project, it will be added via `cargo add`
This will also suggest to use `#[tokio::main]` if `await` is used inside a non-async main.

changelog: Add quick-fix to install tokio and add #[tokio::main]
