### PR TITLE
Fix scope for `macro` template

### DIFF
--- a/src/main/resources/org/rust/ide/liveTemplates/other.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/other.xml
@@ -32,12 +32,12 @@
         <variable name="MATCHER" expression="" defaultValue="" alwaysStopAt="true"/>
         <variable name="TRANSCRIBER" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
-            <option name="RUST_FILE" value="true"/>
-            <option name="RUST_ATTRIBUTE" value="false"/>
+            <option name="RUST_MOD" value="true"/>
+            <option name="RUST_STATEMENT" value="true"/>
         </context>
     </template>
 
-        <template name="ifl" description="if let ... statement" toReformat="true" toShortenFQNames="true"
+    <template name="ifl" description="if let ... statement" toReformat="true" toShortenFQNames="true"
               value="if let $PATTERN$ = $EXPRESSION$ {&#10;    $END$&#10;}">
         <variable name="EXPRESSION" expression="" defaultValue="" alwaysStopAt="true"/>
         <variable name="PATTERN" expression="" defaultValue="" alwaysStopAt="true"/>

--- a/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
@@ -211,6 +211,30 @@ class RsLiveTemplatesTest : RsTestBase() {
         }
     """)
 
+    fun `test macro 1`() = expandSnippet("""
+        macro/*caret*/
+    """, """
+        macro_rules! /*caret*/ {
+            () => {};
+        }
+    """)
+
+    fun `test macro 2`() = expandSnippet("""
+        fn main() {
+            macro/*caret*/
+        }
+    """, """
+        fn main() {
+            macro_rules! /*caret*/ {
+                () => {};
+            }
+        }
+    """)
+
+    fun `test macro 3`() = noSnippet("""
+        fn macro/*caret*/
+    """)
+
     private fun expandSnippet(@Language("Rust") before: String, @Language("Rust") after: String) =
         checkEditorAction(before, after, IdeActions.ACTION_EXPAND_LIVE_TEMPLATE_BY_TAB)
 


### PR DESCRIPTION
changelog: Complete `macro` live template only in item context