### PR TITLE
#10125: Support multiple build targets in .cargo/config.toml

### DIFF
--- a/src/main/kotlin/org/rust/cargo/CargoConfig.kt
+++ b/src/main/kotlin/org/rust/cargo/CargoConfig.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * https://doc.rust-lang.org/cargo/reference/config.html
  */
 data class CargoConfig(
-    val buildTarget: String?,
+    val buildTargets: List<String>,
     val env: Map<String, EnvValue>,
 
 ) {
@@ -27,6 +27,6 @@ data class CargoConfig(
     )
 
     companion object {
-        val DEFAULT = CargoConfig(null, emptyMap())
+        val DEFAULT = CargoConfig(emptyList(), emptyMap())
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -131,7 +131,9 @@ interface CargoProject : UserDataHolderEx {
     sealed class UpdateStatus(private val priority: Int) {
         object UpToDate : UpdateStatus(0)
         object NeedsUpdate : UpdateStatus(1)
-        class UpdateFailed(@Suppress("UnstableApiUsage") @Tooltip val reason: String) : UpdateStatus(2)
+        class UpdateFailed(@Suppress("UnstableApiUsage") @Tooltip val reason: String) : UpdateStatus(2) {
+            override fun toString(): String = reason
+        }
 
         fun merge(status: UpdateStatus): UpdateStatus = if (priority >= status.priority) this else status
     }

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -361,10 +361,11 @@ private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext, rustcInfo: R
         }
 
         CargoEventService.getInstance(childContext.project).onMetadataCall(projectDirectory)
+        val buildTargets = cargoConfig.buildTargets.ifEmpty { listOfNotNull(rustcInfo?.version?.host) }
         val (projectDescriptionData, status) = cargo.fullProjectDescription(
             childContext.project,
             projectDirectory,
-            cargoConfig.buildTarget ?: rustcInfo?.version?.host,
+            buildTargets,
             rustcInfo?.version,
         ) {
             when (it) {

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoConfigTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoConfigTest.kt
@@ -38,9 +38,27 @@ class CargoConfigTest : RsWithToolchainTestBase() {
             dir("src") { file("main.rs") }
         }
 
-        val buildTarget = project.cargoProjects.singleWorkspace().cargoConfig.buildTarget
+        val buildTargets = project.cargoProjects.singleWorkspace().cargoConfig.buildTargets
 
-        assertEquals("wasm32-unknown-unknown", buildTarget)
+        assertEquals(listOf("wasm32-unknown-unknown"), buildTargets)
+    }
+
+    @MinRustcVersion("1.64.0")
+    fun `test multiple build targets`() {
+        buildProject {
+            dir(".cargo") {
+                toml("config.toml", """
+                    [build]
+                    target = ["wasm32-unknown-unknown", "aarch64-apple-darwin"]
+                """)
+            }
+            file("Cargo.toml", CARGO_TOML)
+            dir("src") { file("main.rs") }
+        }
+
+        val buildTargets = project.cargoProjects.singleWorkspace().cargoConfig.buildTargets
+
+        assertEquals(listOf("wasm32-unknown-unknown", "aarch64-apple-darwin"), buildTargets)
     }
 
     fun `test custom build target`() {
@@ -72,9 +90,82 @@ class CargoConfigTest : RsWithToolchainTestBase() {
             dir("src") { file("main.rs") }
         }
 
-        val buildTarget = project.cargoProjects.singleWorkspace().cargoConfig.buildTarget
+        val buildTargets = project.cargoProjects.singleWorkspace().cargoConfig.buildTargets
 
-        assertEquals(testProject.root.findChild("custom-target.json")!!.path, buildTarget)
+        assertEquals(1, buildTargets.size)
+        assertEquals(testProject.root.findChild("custom-target.json")!!.path, buildTargets.first())
+    }
+
+    @MinRustcVersion("1.64.0")
+    fun `test multiple custom build targets`() {
+        val testProject = buildProject {
+            dir(".cargo") {
+                toml("config", """
+                    [build]
+                    target = ["custom-aarch64.json", "custom-wasm32.json"]
+                """)
+            }
+            file("custom-aarch64.json", """
+                {
+                    "llvm-target": "aarch64-unknown-none",
+                    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                    "arch": "aarch64",
+                    "target-endian": "little",
+                    "target-pointer-width": "64",
+                    "target-c-int-width": "32",
+                    "os": "none",
+                    "executables": true,
+                    "linker-flavor": "ld.lld",
+                    "linker": "rust-lld",
+                    "panic-strategy": "abort",
+                    "disable-redzone": true,
+                    "features": "-mmx,-sse,+soft-float"
+                }
+            """)
+            file("custom-wasm32.json", """
+                {
+                  "arch": "wasm32",
+                  "crt-objects-fallback": "true",
+                  "data-layout": "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20",
+                  "default-adjusted-cabi": "wasm",
+                  "default-hidden-visibility": true,
+                  "dll-prefix": "",
+                  "dll-suffix": ".wasm",
+                  "dynamic-linking": true,
+                  "eh-frame-header": false,
+                  "emit-debug-gdb-scripts": false,
+                  "exe-suffix": ".wasm",
+                  "generate-arange-section": false,
+                  "has-thread-local": true,
+                  "is-like-wasm": true,
+                  "limit-rdylib-exports": false,
+                  "linker": "rust-lld",
+                  "linker-flavor": "wasm-ld",
+                  "linker-is-gnu": false,
+                  "lld-flavor": "wasm",
+                  "llvm-target": "wasm32-unknown-unknown",
+                  "max-atomic-width": 64,
+                  "only-cdylib": true,
+                  "os": "unknown",
+                  "panic-strategy": "abort",
+                  "relocation-model": "static",
+                  "singlethread": true,
+                  "target-family": [
+                    "wasm"
+                  ],
+                  "target-pointer-width": "32",
+                  "tls-model": "local-exec"
+                }
+            """)
+            file("Cargo.toml", CARGO_TOML)
+            dir("src") { file("main.rs") }
+        }
+
+        val buildTargets = project.cargoProjects.singleWorkspace().cargoConfig.buildTargets
+
+        assertEquals(2, buildTargets.size)
+        assertEquals(testProject.root.findChild("custom-aarch64.json")!!.path, buildTargets.first())
+        assertEquals(testProject.root.findChild("custom-wasm32.json")!!.path, buildTargets.last())
     }
 
     fun `test env`() {


### PR DESCRIPTION
changelog: support multiple build.target values in .cargo/config.toml

This is a fix for #10125, where the `cargo metadata` execution fails when multiple build targets are specified in `.cargo/config.toml`. Multiple build targets in config.toml were stabilized in Rust 1.64.0, as part of rust-lang/cargo#8176.

As described in [my comment on the issue](https://github.com/intellij-rust/intellij-rust/issues/10125#issuecomment-1630091562), I have changed `buildTarget: String?` into `buildTargets: List<String>` in the `CargoConfig`, as returned by `Cargo.getConfig()`, and used in various places which calls that function. Instead of being `null`, `buildTargets` is an empty list if build.target is not specified, which is still correctly handled (defaulted to the host triple) by the calling code.

As a result, `Cargo.fetchMetadata()` now passes `--filter-platform` multiple times to the `cargo metadata` call, rather than an empty string, which will correctly filter the dependencies for multiple target platforms, fixing the implementation originally added in #7185.

Tests have been added and updated to exercise this functionality.

This is my first time working on this project, so please feel free to adjust whatever is needed to take this forward.
