### PR TITLE
MACRO: match negative literals with `$l:literal` macro fragment spec

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
@@ -323,7 +323,7 @@ class DeclMacroExpander(val project: Project): MacroExpander<RsDeclMacroData, De
     }
 
     companion object {
-        const val EXPANDER_VERSION = 19
+        const val EXPANDER_VERSION = 20
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR, BLOCK_EXPR
         )

--- a/src/main/kotlin/org/rust/lang/core/parser/util.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/util.kt
@@ -43,6 +43,16 @@ inline fun <T> PsiBuilder.probe(action: () -> T): T {
     }
 }
 
+inline fun PsiBuilder.rollbackIfFalse(action: () -> Boolean): Boolean {
+    val mark = mark()
+    return if (action()) {
+        true
+    } else {
+        mark.rollbackTo()
+        false
+    }
+}
+
 fun PsiBuilder.Marker.close(result: Boolean): Boolean {
     if (result) {
         drop()

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
@@ -284,6 +284,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         foo!(f64 0.);
         foo!(f32 0.0f32);
         foo!(f32 0.1e-3f32);
+        foo!(i32 -123);
+        foo!(f64 -123.456);
     """, """
         const VALUE: u8 = 0;
     """, """
@@ -296,6 +298,10 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         const VALUE: f32 = 0.0f32;
     """, """
         const VALUE: f32 = 0.1e-3f32;
+    """, """
+        const VALUE: i32 = -123;
+    """, """
+        const VALUE: f64 = -123.456;
     """)
 
     fun `test tt group`() = doTest("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -752,4 +752,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
             Box::new(S(0i32)).foo();
         }                    //^
     """)
+
+    @MinRustcVersion("1.70.0")
+    fun `test i32 checked_ilog`() = stubOnlyResolve("""
+    //- main.rs
+        fn foo(i: i32) {
+            let _ = i.checked_ilog(i);
+        }           //^ ...core/src/num/mod.rs
+    """)
 }


### PR DESCRIPTION
This also fixes `i32` methods name resolution and completion.

changelog: match negative numeric literals with `$l:literal` macro fragment spec
