### PR TITLE
T: Check intention/quick fix preview after checking intention invocation

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
@@ -71,7 +71,7 @@ abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferen
     ) = doTest {
         checkAutoImportWithMultipleChoice(expectedElements, choice = null) {
             configureByText(before)
-            annotationFixture.applyQuickFix(AutoImportFix.NAME, preview = null)
+            annotationFixture.applyQuickFix(AutoImportFix.NAME, preview = null).checkPreview()
         }
     }
 

--- a/src/test/kotlin/org/rust/ide/intentions/AddImportForPatternIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImportForPatternIntentionTest.kt
@@ -150,8 +150,9 @@ class AddImportForPatternIntentionTest : RsIntentionTestBase(AddImportForPattern
         expectedElements: List<String>
     ) = checkAutoImportWithMultipleChoice(expectedElements, choice = null) {
         InlineFile(before.trimIndent()).withCaret()
-        launchAction()
+        val previewChecker = launchAction()
         testWrappingUnwrapper?.unwrap()
         myFixture.checkResult(replaceCaretMarker(before.trimIndent()))
+        previewChecker.checkPreview()
     }
 }

--- a/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
@@ -53,11 +53,12 @@ class ToggleFeatureIntentionTest : RsIntentionTestBase(ToggleFeatureIntention::c
         project.cargoProjects.modifyFeatures(cargoProject, setOf(feature), initialState)
 
         InlineFile(code.trimIndent()).withCaret()
-        launchAction()
+        val previewChecker = launchAction()
 
         val cargoProjectRefreshed = project.cargoProjects.singleProject()
         val pkgRefreshed = cargoProjectRefreshed.workspaceOrFail().packages.single { it.origin == PackageOrigin.WORKSPACE }
 
         assertEquals(!initialState, pkgRefreshed.featureState[featureName])
+        previewChecker.checkPreview()
     }
 }


### PR DESCRIPTION
Previously we checked intention/quick fix preview *before* checking
 a normal intention behavior (without preview) which was very unhandy
 in a TDD workflow. As a developer, first I want to make intention work,
 and only after that I should care about preview.

Now we check intention/quick invocation first, and only after its
 success we check the preview.
