### PR TITLE
Update 2023.2 IDE and plugin dependencies 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,6 +121,7 @@ allprojects {
         buildSearchableOptions { enabled = false }
 
         test {
+            systemProperty("java.awt.headless", "true")
             testLogging {
                 showStandardStreams = prop("showStandardStreams").toBoolean()
                 afterSuite(

--- a/gradle-232.properties
+++ b/gradle-232.properties
@@ -1,11 +1,11 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-232.8296-EAP-CANDIDATE-SNAPSHOT
-clionVersion=CL-232.8296-EAP-CANDIDATE-SNAPSHOT
+ideaVersion=IU-232.8660-EAP-CANDIDATE-SNAPSHOT
+clionVersion=CL-232.8660-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPlugin=com.intellij.nativeDebug:232.8296.17
+nativeDebugPlugin=com.intellij.nativeDebug:232.8660.17
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPlugin=PsiViewer:232.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
 # Supported platforms: 231, 232
-platformVersion=231
+platformVersion=232
 # Supported IDEs: idea, clion
 baseIDE=idea
 


### PR DESCRIPTION
And make 2023.2 the default platform for development

changelog: Make 2023.2 the default platform for development
