### PR TITLE
Fixed bug causing false positives during checking literal value overflow

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/RsLiteralOutOfRangeInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsLiteralOutOfRangeInspectionTest.kt
@@ -20,6 +20,13 @@ class RsLiteralOutOfRangeInspectionTest: RsInspectionsTestBase(RsLiteralOutOfRan
         }
     """)
 
+    fun `test declaration good i8`() = checkByText(
+        """
+        fn main() {
+            let x: i8 = -128;
+        }
+    """)
+
     fun `test declaration fix type`() = checkFixByText("Change type of `x` to `u16`",
         """
         fn main() {
@@ -49,10 +56,10 @@ class RsLiteralOutOfRangeInspectionTest: RsInspectionsTestBase(RsLiteralOutOfRan
         }
     """)
 
-    fun `test declaration good u16`() = checkByText(
+    fun `test declaration good i16`() = checkByText(
         """
         fn main() {
-            let x: u16 = 65_535;
+            let x: i16 = -32_768;
         }
     """)
 
@@ -67,6 +74,13 @@ class RsLiteralOutOfRangeInspectionTest: RsInspectionsTestBase(RsLiteralOutOfRan
         """
         fn main() {
             let x: u32 = 4_294_967_295;
+        }
+    """)
+
+    fun `test declaration good i32`() = checkByText(
+        """
+        fn main() {
+            let x: i16 = -32_768;
         }
     """)
 


### PR DESCRIPTION
Fixes bug introduced with #10709

On one side negated values are now taken into account. Using a simple strategy of checking for unary minus, similarly to what the compiler does.

On the other side, we're not checking i32 because of type inference issues.

changelog: Fixes bug introduced with #10709 causing negative values to be marked as overflown
