### PR TITLE
Fix Completion window shows `self::`, but writes `self`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -301,14 +301,7 @@ open class RsDefaultInsertHandler : InsertHandler<LookupElement> {
         when (element) {
             is RsMod -> {
                 when (scopeName) {
-                    "self",
-                    "super" -> {
-                        val inSelfParam = context.getElementOfType<RsSelfParameter>() != null
-                        if (!(context.isInUseGroup || inSelfParam)) {
-                            context.addSuffix("::")
-                        }
-                    }
-                    "crate" -> context.addSuffix("::")
+                    "self", "super", "crate" -> context.addSuffix("::")
                 }
             }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -27,6 +27,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, RsPrimitiveTypeCompletionProvider)
         extend(CompletionType.BASIC, RsLiteralSuffixCompletionProvider)
         extend(CompletionType.BASIC, RsBoolCompletionProvider)
+        extend(CompletionType.BASIC, RsSelfParameterCompletionProvider)
         extend(CompletionType.BASIC, RsFragmentSpecifierCompletionProvider)
         extend(CompletionType.BASIC, RsCommonCompletionProvider)
         extend(CompletionType.BASIC, RsTupleFieldCompletionProvider)

--- a/src/main/kotlin/org/rust/lang/core/completion/RsSelfParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsSelfParameterCompletionProvider.kt
@@ -1,0 +1,49 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.patterns.ElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.ide.icons.RsIcons
+import org.rust.lang.core.RsPsiPattern
+import org.rust.lang.core.or
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
+import org.rust.lang.core.psi.ext.owner
+import org.rust.lang.core.psiElement
+import org.rust.lang.core.with
+
+object RsSelfParameterCompletionProvider : RsCompletionProvider() {
+    override val elementPattern: ElementPattern<PsiElement>
+        get() {
+            val firstParam = psiElement<RsValueParameter>()
+                .with("isImplFirstParam") { param, _ ->
+                    val paramList = param.context as? RsValueParameterList ?: return@with false
+                    val function = paramList.context as? RsFunction ?: return@with false
+                    param.pat == null
+                        && function.owner is RsAbstractableOwner.Impl
+                        && paramList.selfParameter== null
+                        && paramList.valueParameterList.firstOrNull() == param
+                }
+            return RsPsiPattern.simplePathPattern.withParent(
+                psiElement<RsPath>().withParent(
+                    psiElement<RsPathType>().withParent(firstParam) or
+                            psiElement<RsPathType>().withParent(psiElement<RsRefLikeType>().withParent(firstParam)))
+            )
+        }
+
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        val element = LookupElementBuilder.create("self")
+            .bold()
+            .withIcon(RsIcons.BINDING)
+            .toKeywordElement()
+        result.addElement(element)
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -156,7 +156,7 @@ class RsCompletionTest : RsCompletionTestBase() {
     """, """
         mod foo { }
 
-        use self::foo::{self/*caret*/};
+        use self::foo::{self::/*caret*/};
     """)
 
     fun `test use glob global`() = doSingleCompletion("""
@@ -307,7 +307,7 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test complete self method`() = doSingleCompletion("""
+    fun `test complete self method`() = doFirstCompletion("""
         struct S;
         impl S { fn foo(&se/*caret*/) {}}
     """, """

--- a/src/test/kotlin/org/rust/lang/core/completion/RsSelfParameterCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsSelfParameterCompletionProviderTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+class RsSelfParameterCompletionProviderTest: RsCompletionTestBase() {
+    fun `test complete self in method`() = doFirstCompletion("""
+        impl Foo {
+            fn f(se/*caret*/){}
+        }
+    """, """
+        impl Foo {
+            fn f(self/*caret*/){}
+        }
+    """)
+
+    fun `test complete self as path in non-self parameter`() = doFirstCompletion("""
+        impl Foo {
+            fn f(foo: u8, se/*caret*/){}
+        }
+    """, """
+        impl Foo {
+            fn f(foo: u8, self::/*caret*/){}
+        }
+    """)
+
+    fun `test complete self as path in nested function`() = doFirstCompletion("""
+        impl Foo {
+            fn f(){
+                fn nested(se/*caret*/){}
+            }
+        }
+    """, """
+        impl Foo {
+            fn f(){
+                fn nested(self::/*caret*/){}
+            }
+        }
+    """)
+
+    fun `test complete self as path in generic argument`() = doFirstCompletion("""
+        impl Foo {
+            fn f(x: Box<se/*caret*/>){}
+        }
+    """, """
+        impl Foo {
+            fn f(x: Box<self::/*caret*/>){}
+        }
+    """)
+
+    fun `test complete self as path in pat generic argument`() = doFirstCompletion("""
+        impl Foo {
+            fn f(Box<se/*caret*/>){}
+        }
+    """, """
+        impl Foo {
+            fn f(Box<self::/*caret*/>){}
+        }
+    """)
+
+    fun `test complete self in reference`() = doFirstCompletion("""
+        impl Foo {
+            fn f(&se/*caret*/){}
+        }
+    """, """
+        impl Foo {
+            fn f(&self/*caret*/){}
+        }
+    """)
+
+    fun `test complete self in mut reference`() = doFirstCompletion("""
+        impl Foo {
+            fn f(&mut se/*caret*/){}
+        }
+    """, """
+        impl Foo {
+            fn f(&mut self/*caret*/){}
+        }
+    """)
+
+    fun `test complete self as path if self exists`() = doFirstCompletion("""
+        impl Foo {
+            fn f(self, se/*caret*/){}
+        }
+    """, """
+        impl Foo {
+            fn f(self, self::/*caret*/){}
+        }
+    """)
+
+    fun `test complete self as path in regular function`() = doFirstCompletion("""
+        fn f(se/*caret*/){}
+    """, """
+        fn f(self::/*caret*/){}
+    """)
+}


### PR DESCRIPTION
changelog: Fix Completion window shows `self::`, but writes `self`
