### PR TITLE
Fixes add #[tokio::main] quick fix.

### DIFF
--- a/src/main/kotlin/org/rust/toml/CrateExt.kt
+++ b/src/main/kotlin/org/rust/toml/CrateExt.kt
@@ -1,0 +1,83 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import org.rust.lang.core.crate.Crate
+import org.rust.openapiext.checkWriteAccessAllowed
+import org.toml.lang.psi.*
+
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+/**
+ * Adds dependency [name] with version [version] to the corresponding `[dependencies]` section
+ * in the corresponding `Cargo.toml` file if the dependency doesn't exist already. If it does,
+ * update the features of the dependency with [features] if required.
+ *
+ * For example, if [name] = "tokio", [version] = "1.0.0" and [features] = "full", it inserts
+ * ```
+ * [dependencies]
+ * tokio = { version = "1.0.0", features = ["full"] }
+ * ```
+ */
+fun Crate.addCargoDependency(name: String, version: String, features: List<String> = emptyList()) {
+    checkWriteAccessAllowed()
+
+    val cargoToml = cargoTarget?.pkg?.getPackageCargoTomlFile(project) ?: return
+    val factory = TomlPsiFactory(project)
+
+    val featuresArray = features.joinToString(prefix = "[", separator = ", ", postfix = "]") { "\"$it\"" }
+
+    when (val existingDependency = cargoToml.findDependencyElement(name)) {
+        is TomlKeyValueOwner -> {
+            updateDependencyFeatures(factory, existingDependency, features)
+        }
+        is TomlLiteral -> {
+            val newVersion = existingDependency.stringValue ?: version
+            val newEntry = factory.createInlineTable("""version = "$newVersion", features = $featuresArray""")
+            existingDependency.replace(newEntry)
+        }
+        else -> {
+            val existingDependencies = cargoToml.tableList.find {
+                it.header.key?.stringValue == "dependencies"
+            }
+            val dependencies = existingDependencies ?: run {
+                val newDependenciesTable = factory.createTable("dependencies")
+                cargoToml.add(factory.createWhitespace("\n"))
+                cargoToml.add(newDependenciesTable) as TomlTable
+            }
+            val newDependencyKeyValue = if (features.isEmpty()) {
+                factory.createKeyValue(name, version)
+            } else {
+                factory.createKeyValue(name, """{ version = "$version", features = $featuresArray }""")
+            }
+
+            dependencies.add(factory.createWhitespace("\n"))
+            dependencies.add(newDependencyKeyValue)
+        }
+    }
+}
+
+private fun updateDependencyFeatures(factory: TomlPsiFactory, table: TomlKeyValueOwner, features: List<String>) {
+    val featuresEntry = table.entries.find { entry -> entry.key.stringValue == "features" }
+    if (featuresEntry == null) {
+        val featuresArray = features.joinToString(prefix = "[", separator = ", ", postfix = "]") { "\"$it\"" }
+        val newEntry = factory.createKeyValue("features", featuresArray)
+        val newTable = (table.entries + listOf(newEntry)).joinToString(separator=", ") {
+            """${it.key.text} = ${it.value?.text}"""
+        }
+        table.replace(factory.createInlineTable(newTable))
+    } else {
+        val existingFeatures = (featuresEntry.value as? TomlArray)?.elements
+            ?.mapNotNull { value -> value.stringValue }
+            ?: emptyList()
+        val newFeatures = (existingFeatures + features).distinct()
+        val newFeaturesArray = newFeatures.joinToString(prefix = "[", separator = ", ", postfix = "]") { "\"$it\"" }
+        featuresEntry.replace(factory.createKeyValue("features", newFeaturesArray))
+    }
+}

--- a/src/main/kotlin/org/rust/toml/completion/CargoTomlFeatureDependencyCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/toml/completion/CargoTomlFeatureDependencyCompletionProvider.kt
@@ -14,7 +14,7 @@ import com.intellij.util.ProcessingContext
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.toml.StringLiteralInsertionHandler
 import org.rust.toml.findCargoPackageForCargoToml
-import org.rust.toml.getPackageTomlFile
+import org.rust.toml.getPackageCargoTomlFile
 import org.rust.toml.resolve.allFeatures
 import org.toml.lang.psi.TomlFile
 import org.toml.lang.psi.impl.TomlKeyValueImpl
@@ -45,7 +45,7 @@ class CargoTomlFeatureDependencyCompletionProvider : CompletionProvider<Completi
         for (dep in pkg.dependencies) {
             if (dep.pkg.origin == PackageOrigin.STDLIB) continue
             // TODO avoid AST loading?
-            for (feature in dep.pkg.getPackageTomlFile(tomlFile.project)?.allFeatures().orEmpty()) {
+            for (feature in dep.pkg.getPackageCargoTomlFile(tomlFile.project)?.allFeatures().orEmpty()) {
                 result.addElement(
                     LookupElementBuilder
                         .createWithSmartPointer("${dep.pkg.name}/${feature.text}", feature)

--- a/src/main/kotlin/org/rust/toml/completion/RsCfgFeatureCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/toml/completion/RsCfgFeatureCompletionProvider.kt
@@ -23,7 +23,7 @@ import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.psi.ext.elementType
-import org.rust.toml.getPackageTomlFile
+import org.rust.toml.getPackageCargoTomlFile
 import org.rust.toml.resolve.allFeatures
 import org.toml.lang.psi.TomlKeySegment
 
@@ -39,7 +39,7 @@ import org.toml.lang.psi.TomlKeySegment
 object RsCfgFeatureCompletionProvider : RsCompletionProvider() {
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         val pkg = parameters.position.ancestorOrSelf<RsElement>()?.containingCargoPackage ?: return
-        val pkgToml = pkg.getPackageTomlFile(parameters.originalFile.project) ?: return
+        val pkgToml = pkg.getPackageCargoTomlFile(parameters.originalFile.project) ?: return
 
         for (feature in pkgToml.allFeatures()) {
             result.addElement(rustLookupElementForFeature(feature))

--- a/src/main/kotlin/org/rust/toml/resolve/CargoTomlNameResolution.kt
+++ b/src/main/kotlin/org/rust/toml/resolve/CargoTomlNameResolution.kt
@@ -7,11 +7,7 @@ package org.rust.toml.resolve
 
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.ResolveResult
-import org.rust.lang.core.psi.ext.childrenOfType
-import org.rust.toml.getValueWithKey
-import org.rust.toml.isDependencyListHeader
-import org.rust.toml.isFeatureListHeader
-import org.rust.toml.isSpecificDependencyTableHeader
+import org.rust.toml.*
 import org.toml.lang.psi.*
 import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
@@ -25,7 +21,7 @@ fun TomlFile.resolveFeature(featureName: String, depOnly: Boolean = false): Arra
 
 fun TomlFile.allFeatures(depOnly: Boolean = false): Sequence<TomlKeySegment> {
     val explicitFeatures = hashSetOf<String>()
-    return childrenOfType<TomlTable>()
+    return tableList
         .asSequence()
         .flatMap { table ->
             val header = table.header

--- a/src/main/kotlin/org/rust/toml/resolve/RsCfgFeatureReferenceProvider.kt
+++ b/src/main/kotlin/org/rust/toml/resolve/RsCfgFeatureReferenceProvider.kt
@@ -11,7 +11,7 @@ import org.rust.lang.core.psi.RsLitExpr
 import org.rust.lang.core.psi.RsLiteralKind
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.psi.kind
-import org.rust.toml.getPackageTomlFile
+import org.rust.toml.getPackageCargoTomlFile
 
 /**
  * Consider "main.rs":
@@ -31,7 +31,7 @@ class RsCfgFeatureReferenceProvider : PsiReferenceProvider() {
 private class RsCfgFeatureReferenceReference(element: RsLitExpr) : PsiPolyVariantReferenceBase<RsLitExpr>(element) {
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
         val literalValue = (element.kind as? RsLiteralKind.String)?.value ?: return ResolveResult.EMPTY_ARRAY
-        val toml = element.containingCargoPackage?.getPackageTomlFile(element.project) ?: return ResolveResult.EMPTY_ARRAY
+        val toml = element.containingCargoPackage?.getPackageCargoTomlFile(element.project) ?: return ResolveResult.EMPTY_ARRAY
         return toml.resolveFeature(literalValue)
     }
 }

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -1419,7 +1419,6 @@ inspection.message.expected.trait.bound.found.impl.trait.type=Expected trait bou
 inspection.message.invalid.dyn.keyword=Invalid `dyn` keyword
 inspection.duplicated.key.display.name=Duplicated key
 intention.name.add.tokio.main=Add `#[tokio::main]`
-progress.title.adding.dependency=Adding {0} to dependencies
 intention.name.install.tokio.and.add.main=Add tokio to dependencies and add `#[tokio::main]`
 dbg.usage=#[dbg] usage
 const.generics.defaults=const generics defaults


### PR DESCRIPTION
This changes the way we are installing tokio dependency. Instead of using `cargo add` we're editing Cargo.toml directly. This allows us to have more control over the features. New helper function to add cargo dependency is added as well.

changelog: Fixes undo not available after adding tokio dependency when using Add `#[tokio::main]` quickfix.
