### PR TITLE
Adjust intellisense file size limit for Rust files

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFileViewProviderFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFileViewProviderFactory.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.lang.Language
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.FileViewProviderFactory
+import com.intellij.psi.PsiManager
+import com.intellij.psi.SingleRootFileViewProvider
+
+/**
+ * Hacky adjust the file limit for Rust file.
+ * Coupled with [org.rust.lang.core.resolve.indexes.RsAliasIndex.getFileTypesWithSizeLimitNotApplicable].
+ *
+ * @see SingleRootFileViewProvider.isTooLargeForIntelligence
+ */
+class RsFileViewProviderFactory : FileViewProviderFactory {
+    override fun createFileViewProvider(
+        file: VirtualFile,
+        language: Language,
+        manager: PsiManager,
+        eventSystemEnabled: Boolean
+    ): FileViewProvider {
+        val shouldAdjustFileLimit = SingleRootFileViewProvider.isTooLargeForIntelligence(file)
+            && file.length <= RUST_FILE_SIZE_LIMIT_FOR_INTELLISENSE
+
+        if (shouldAdjustFileLimit) {
+            SingleRootFileViewProvider.doNotCheckFileSizeLimit(file)
+        }
+
+        return SingleRootFileViewProvider(manager, file, eventSystemEnabled)
+    }
+}
+
+// Experimentally verified that 8Mb works with the default IDEA -Xmx768M. Larger values may
+// lead to OOM, please verify before adjusting
+private const val RUST_FILE_SIZE_LIMIT_FOR_INTELLISENSE: Int = 8 * 1024 * 1024

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsAliasIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsAliasIndex.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.resolve.indexes
 
+import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.project.Project
 import com.intellij.psi.stubs.StubTree
 import com.intellij.psi.stubs.StubTreeBuilder
@@ -75,6 +76,14 @@ class RsAliasIndex : FileBasedIndexExtension<TyFingerprint, List<String>>() {
     override fun getInputFilter(): FileBasedIndex.InputFilter = DefaultFileTypeSpecificInputFilter(RsFileType)
 
     override fun dependsOnFileContent(): Boolean = true
+
+    /**
+     * Hacky adjust the file limit for Rust file.
+     * Coupled with [org.rust.lang.core.psi.RsFileViewProviderFactory]
+     */
+    override fun getFileTypesWithSizeLimitNotApplicable(): Collection<FileType> {
+        return listOf(RsFileType)
+    }
 
     companion object {
         fun findPotentialAliases(

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -43,6 +43,7 @@
 
         <!-- PSI managing -->
 
+        <lang.fileViewProviderFactory language="Rust" implementationClass="org.rust.lang.core.psi.RsFileViewProviderFactory"/>
         <projectService serviceInterface="org.rust.lang.core.psi.RsPsiManager"
                         serviceImplementation="org.rust.lang.core.psi.RsPsiManagerImpl"/>
 


### PR DESCRIPTION
I finally figured out how to increase the file limit for Rust files. Now the limit for Rust files is 8MB. Previous attempt was #8699.

Fixes #10624

changelog: Adjust intellisense file size limit for Rust files
