### PR TITLE
INSP: remove `unused_qualifications` lint from `unused` group, change level to `WEAK WARNING` 

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -32,7 +32,7 @@ sealed class RsLint(
     object UnreachableCode : RsLint("unreachable_code")
     object BareTraitObjects : RsLint("bare_trait_objects", listOf("rust_2018_idioms"))
     object NonShorthandFieldPatterns : RsLint("non_shorthand_field_patterns")
-    object UnusedQualifications : RsLint("unused_qualifications", listOf("unused"))
+    object UnusedQualifications : RsLint("unused_qualifications")
     object UnusedMustUse : RsLint("unused_must_use", listOf("unused"))
     object RedundantSemicolons : RsLint("redundant_semicolons", listOf("unused"))
     object UnusedLabels : RsLint("unused_labels", listOf("unused"))

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -701,7 +701,7 @@
                          key="inspection.rs.unused.import.display.name"/>
 
         <localInspection language="Rust" groupPath="Rust" groupKey="lints"
-                         enabledByDefault="true" level="WARNING"
+                         enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsUnnecessaryQualificationsInspection"
                          key="inspection.rs.unnecessary.qualifications.display.name"/>
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspectionTest.kt
@@ -385,4 +385,18 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
             let _: <error descr="Unnecessary qualification">bar::/*caret*/</error>S;
         }
     """)
+
+    fun `test deny 'unused' does not make the unused_qualifications a hard error`() = checkWarnings("""
+        #![deny(unused)]
+
+        mod bar {
+            pub struct S;
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _: <warning descr="Unnecessary qualification">bar::/*caret*/</warning>S;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspectionTest.kt
@@ -28,7 +28,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::S;
 
         fn foo() {
-            let _: <warning descr="Unnecessary qualification">bar::/*caret*/</warning>S;
+            let _: <weak_warning descr="Unnecessary qualification">bar::/*caret*/</weak_warning>S;
         }
     """, """
         mod bar {
@@ -40,7 +40,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: /*caret*/S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test multiple path necessary qualified`() = checkFixIsUnavailable("Remove unnecessary path prefix", """
         mod bar {
@@ -52,7 +52,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: bar::baz::/*caret*/S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test multiple segments whole path`() = checkFixByText("Remove unnecessary path prefix", """
         mod bar {
@@ -64,7 +64,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::baz::S;
 
         fn foo() {
-            let _: <warning descr="Unnecessary qualification">bar::baz::/*caret*/</warning>S;
+            let _: <weak_warning descr="Unnecessary qualification">bar::baz::/*caret*/</weak_warning>S;
         }
     """, """
         mod bar {
@@ -78,7 +78,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: /*caret*/S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test multiple segments partial path`() = checkFixByText("Remove unnecessary path prefix", """
         mod bar {
@@ -90,7 +90,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::baz;
 
         fn foo() {
-            let _: <warning descr="Unnecessary qualification">bar::/*caret*/</warning>baz::S;
+            let _: <weak_warning descr="Unnecessary qualification">bar::/*caret*/</weak_warning>baz::S;
         }
     """, """
         mod bar {
@@ -104,7 +104,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: /*caret*/baz::S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test associated method`() = checkFixByText("Remove unnecessary path prefix", """
         mod bar {
@@ -117,7 +117,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::S;
 
         fn foo() {
-            let _ = <warning descr="Unnecessary qualification">bar::/*caret*/</warning>S::new();
+            let _ = <weak_warning descr="Unnecessary qualification">bar::/*caret*/</weak_warning>S::new();
         }
     """, """
         mod bar {
@@ -132,7 +132,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _ = /*caret*/S::new();
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test expression context with generics`() = checkFixByText("Remove unnecessary path prefix", """
         mod bar {
@@ -145,7 +145,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::S;
 
         fn foo() {
-            let _ = <warning descr="Unnecessary qualification">bar::/*caret*/</warning>S::<u32>::new(0);
+            let _ = <weak_warning descr="Unnecessary qualification">bar::/*caret*/</weak_warning>S::<u32>::new(0);
         }
     """, """
         mod bar {
@@ -160,7 +160,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _ = /*caret*/S::<u32>::new(0);
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test crate prefix`() = checkFixByText("Remove unnecessary path prefix", """
         mod bar {
@@ -170,7 +170,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::S;
 
         fn foo() {
-            let _: <warning descr="Unnecessary qualification">crate::/*caret*/</warning>S;
+            let _: <weak_warning descr="Unnecessary qualification">crate::/*caret*/</weak_warning>S;
         }
     """, """
         mod bar {
@@ -182,7 +182,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: /*caret*/S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2015)
     fun `test bare colon colon`() = checkFixByText("Remove unnecessary path prefix", """
@@ -193,7 +193,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::S;
 
         fn foo() {
-            let _: <warning descr="Unnecessary qualification">::/*caret*/</warning>S;
+            let _: <weak_warning descr="Unnecessary qualification">::/*caret*/</weak_warning>S;
         }
     """, """
         mod bar {
@@ -205,7 +205,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: /*caret*/S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2015)
     fun `test bare colon colon with nested path`() = checkFixByText("Remove unnecessary path prefix", """
@@ -216,7 +216,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::S;
 
         fn foo() {
-            let _: <warning descr="Unnecessary qualification">::bar::/*caret*/</warning>S;
+            let _: <weak_warning descr="Unnecessary qualification">::bar::/*caret*/</weak_warning>S;
         }
     """, """
         mod bar {
@@ -228,7 +228,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: /*caret*/S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test bare colon colon necessary qualification`() = checkFixIsUnavailableByFileTree("Remove unnecessary path prefix", """
@@ -247,7 +247,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: ::dep_lib::bar::/*caret*/S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test spaces in path`() = checkFixByText("Remove unnecessary path prefix", """
         mod bar {
@@ -257,7 +257,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::S;
 
         fn foo() {
-            let _: <warning descr="Unnecessary qualification">bar ::   /*caret*/</warning>S;
+            let _: <weak_warning descr="Unnecessary qualification">bar ::   /*caret*/</weak_warning>S;
         }
     """, """
         mod bar {
@@ -269,7 +269,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: /*caret*/S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test comments in path`() = checkFixByText("Remove unnecessary path prefix", """
         mod bar {
@@ -279,7 +279,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::S;
 
         fn foo() {
-            let _: <warning descr="Unnecessary qualification">bar/*foo*/ :: /*bar*//*caret*/</warning>S;
+            let _: <weak_warning descr="Unnecessary qualification">bar/*foo*/ :: /*bar*//*caret*/</weak_warning>S;
         }
     """, """
         mod bar {
@@ -291,7 +291,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _: /*caret*/S;
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test path in value namespace`() = checkFixByText("Remove unnecessary path prefix", """
         enum Foo {
@@ -302,7 +302,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use Foo::B;
 
         fn foo() {
-            let _ = <warning descr="Unnecessary qualification">Foo::/*caret*/</warning>B;
+            let _ = <weak_warning descr="Unnecessary qualification">Foo::/*caret*/</weak_warning>B;
         }
     """, """
         enum Foo {
@@ -315,7 +315,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _ = /*caret*/B;
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test path with type arguments 1`() = checkWarnings("""
         enum Foo<T> {
@@ -341,7 +341,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::Foo;
 
         fn foo() {
-            let _ = <warning descr="Unnecessary qualification">bar::/*caret*/</warning>Foo::<()>::B;
+            let _ = <weak_warning descr="Unnecessary qualification">bar::/*caret*/</weak_warning>Foo::<()>::B;
         }
     """, """
         mod bar {
@@ -356,7 +356,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         fn foo() {
             let _ = /*caret*/Foo::<()>::B;
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test allow`() = checkWarnings("""
         #![allow(unused_qualifications)]
@@ -396,7 +396,7 @@ class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnece
         use bar::S;
 
         fn foo() {
-            let _: <warning descr="Unnecessary qualification">bar::/*caret*/</warning>S;
+            let _: <weak_warning descr="Unnecessary qualification">bar::/*caret*/</weak_warning>S;
         }
     """)
 }


### PR DESCRIPTION
changelog: remove `unused_qualifications` lint from `unused` group, change level to `WEAK WARNING` 
