### PR TITLE
Enable `RsReferenceCodeVisionProvider` for top-level items

### DIFF
--- a/src/232/test/kotlin/org/rust/ide/hints/codeVision/RsReferenceCodeVisionTest.kt
+++ b/src/232/test/kotlin/org/rust/ide/hints/codeVision/RsReferenceCodeVisionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.hints.codeVision
 
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.testFramework.utils.codeVision.CodeVisionTestCase
 import org.intellij.lang.annotations.Language
 
@@ -143,6 +144,7 @@ class RsReferenceCodeVisionTest : CodeVisionTestCase() {
     """)
 
     private fun doTest(@Language("Rust") text: String) {
+        Registry.get("org.rust.code.vision.usage.slow").setValue(true, testRootDisposable)
         testProviders(text.trimIndent(), "main.rs", RsReferenceCodeVisionProvider().groupId)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -154,7 +154,8 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
                 processPathResolveVariants(
                     lookup,
                     element,
-                    true,
+                    isCompletion = true,
+                    processAssocItems = true,
                     filtered
                 )
             }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -327,8 +327,14 @@ fun findDependencyCrateByName(context: RsElement, name: String): RsFile? {
     } as? RsFile
 }
 
-fun processPathResolveVariants(lookup: ImplLookup?, path: RsPath, isCompletion: Boolean, processor: RsResolveProcessor): Boolean {
-    val ctx = PathResolutionContext(path, isCompletion, lookup)
+fun processPathResolveVariants(
+    lookup: ImplLookup?,
+    path: RsPath,
+    isCompletion: Boolean,
+    processAssocItems: Boolean,
+    processor: RsResolveProcessor,
+): Boolean {
+    val ctx = PathResolutionContext(path, isCompletion, processAssocItems, lookup)
     val pathKind = ctx.classifyPath(path)
     return processPathResolveVariants(ctx, pathKind, processor)
 }
@@ -559,6 +565,8 @@ private fun processQualifiedPathResolveVariants1(
         }
 
         if (processEnumVariantsWithShadowing(baseTy, prevScope, ns, processor)) return true
+
+        if (!ctx.processAssocItems) return false
 
         val result2 = processWithShadowing(prevScope, ns, processor) {
             if (restrictedTraits != null) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/PathResolutionContext.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/PathResolutionContext.kt
@@ -19,6 +19,7 @@ import kotlin.LazyThreadSafetyMode.NONE
 class PathResolutionContext(
     val context: RsElement,
     val isCompletion: Boolean,
+    val processAssocItems: Boolean,
     private val givenImplLookup: ImplLookup?,
 ) {
     val crateRoot: RsMod? = context.crateRoot

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt
@@ -24,8 +24,7 @@ class RsPatBindingReferenceImpl(
 
     override fun isReferenceTo(element: PsiElement): Boolean {
         if (element !is RsElement || !element.isConstantLike && element !is RsNamedFieldDecl) return false
-        val target = resolve()
-        return element.manager.areElementsEquivalent(target, element)
+        return super.isReferenceTo(element)
     }
 
     override fun handleElementRename(newName: String): PsiElement {

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt
@@ -10,8 +10,12 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructLiteralField
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsFieldDecl
+import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.isShorthand
+import org.rust.lang.core.resolve.Namespace
 import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.namespaces
 import org.rust.lang.core.resolve.processStructLiteralFieldResolveVariants
 
 class RsStructLiteralFieldReferenceImpl(
@@ -24,6 +28,12 @@ class RsStructLiteralFieldReferenceImpl(
 
     override fun resolveInner(): List<RsElement> =
         collectResolveVariants(element.referenceName) { processStructLiteralFieldResolveVariants(element, false, it) }
+
+    override fun isReferenceTo(target: PsiElement): Boolean {
+        val canBeReferenceTo = target is RsFieldDecl
+            || element.isShorthand && target is RsNamedElement && Namespace.Values in target.namespaces
+        return canBeReferenceTo && super.isReferenceTo(target)
+    }
 
     override fun handleElementRename(newName: String): PsiElement {
         return if (!element.isShorthand) {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1385,8 +1385,11 @@
                      defaultValue="true"
                      description="Enable version control author Code Vision hints for Rust" />
         <registryKey key="org.rust.code.vision.usage"
-                     defaultValue="false"
+                     defaultValue="true"
                      description="Enable reference usage Code Vision hints for Rust" />
+        <registryKey key="org.rust.code.vision.usage.slow"
+                     defaultValue="false"
+                     description="Enable reference usage Code Vision hints for Rust elements which can work slowly" />
         <registryKey key="org.rust.code.vision.implementation"
                      defaultValue="false"
                      description="Enable implementation Code Vision hints for rust"/>

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
@@ -159,9 +159,16 @@ class RsMultiResolveTest : RsResolveTestBase() {
     private fun doTest(@Language("Rust") code: String) {
         InlineFile(code)
         val element = findElementInEditor<RsReferenceElement>()
-        val ref = element.reference ?: error("Failed to get reference for `${element.text}`")
-        check(ref.multiResolve().size == 2) {
-            "Expected 2 variants, got ${ref.multiResolve()}"
+        val reference = element.reference ?: error("Failed to get reference for `${element.text}`")
+        val multiResolved = reference.multiResolve()
+        check(multiResolved.size == 2) {
+            "Expected 2 variants, got $multiResolved"
+        }
+
+        for (resolved in multiResolved) {
+            check(reference.isReferenceTo(resolved)) {
+                "Incorrect `isReferenceTo` implementation in `${reference.javaClass.name}`"
+            }
         }
     }
 }


### PR DESCRIPTION
The provider was initially added in #9927.

Here I enable usages Code Vision for Rust items except:
- an associated item (an impl/trait member)
- a struct field
- a macro declaration
- an enum variant

Usage code vision can be enabled for these elements using `org.rust.code.vision.usage.slow` registry option.

For other items Reference Search does not use type inference and hence it should work fast.
I additionally adjusted `RsReferenceImpl.isReferenceTo()` to ensure it does not touch type inference in such cases.

changelog:  Enable Usages Code Vision hints for some top-level items