### PR TITLE
Fix bug for printing of structs w/o display & debug traits quick fixes

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/format/impl.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/format/impl.kt
@@ -448,7 +448,7 @@ private fun createParameterTraitMismatchFixesForDisplayWithNoTraits(
     parameter: FormatParameter.Value,
 ): List<LocalQuickFix> {
     val adt = expr.type.baseType() ?: return emptyList()
-    if (expr.containingCrate.origin != WORKSPACE) return emptyList()
+    if (adt.containingCrate.origin != WORKSPACE) return emptyList()
     return listOf(
         DeriveDebugAndChangeFormatToDebugFix(expr, parameter),
         ImplementDisplayFix(adt)

--- a/src/main/kotlin/org/rust/ide/fixes/ImplementDisplayFix.kt
+++ b/src/main/kotlin/org/rust/ide/fixes/ImplementDisplayFix.kt
@@ -46,6 +46,8 @@ class ImplementDisplayFix(adt: RsStructOrEnumItemElement) : RsQuickFixBase<RsStr
         val createdImpl = psiFactory.createTraitImplItem(
             type = element.name ?: return,
             trait = displayName,
+            typeParameterList = element.typeParameterList,
+            whereClause = element.whereClause,
         )
         val insertedImpl = placeForImpl.insert(createdImpl)
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -825,4 +825,24 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
             println!("{:?}", my_struct/*caret*/);
         }
     """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no derive Debug for external dependency`() = checkFixIsUnavailable("Derive `Debug` for `Vec` and replace `{}` with `{:?}`", """
+        struct S2 { a: i32, b: u8, }
+
+        fn main() {
+            let v = vec![S2 { a: 0, b: 0 }];
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", /*error descr="`Vec<S2>` doesn't implement `Display` (required by {}) [E0277]"*/v/*error**//*caret*/);
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no implement Display for external dependency`() = checkFixIsUnavailable("Implement `Display` trait for `Vec`", """
+        struct S2 { a: i32, b: u8, }
+
+        fn main() {
+            let v = vec![S2 { a: 0, b: 0 }];
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", /*error descr="`Vec<S2>` doesn't implement `Display` (required by {}) [E0277]"*/v/*error**//*caret*/);
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -734,6 +734,31 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
     """, preview = null)
 
+    fun `test implement Display with generics`() = checkFixByTextWithoutHighlighting("Implement `Display` trait for `S`", """
+        trait Iterator {}
+        trait Clone {}
+        struct S<Iter: Iterator, C> where C: Clone { iter: Iter, c: C }
+        fn foo<A: Iterator, B: Clone>(s: S<A, B>) {
+            println!("{}", s/*caret*/)
+        }
+    """, """
+        use std::fmt::{Display, Formatter};
+
+        trait Iterator {}
+        trait Clone {}
+        struct S<Iter: Iterator, C> where C: Clone { iter: Iter, c: C }
+
+        impl<Iter: Iterator, C> Display for S<Iter, C> where C: Clone {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                <selection><caret>todo!()</selection>
+            }
+        }
+
+        fn foo<A: Iterator, B: Clone>(s: S<A, B>) {
+            println!("{}", s)
+        }
+    """, preview = null)
+
     fun `test implement Display with Display structs in scope`() = checkFixByTextWithoutHighlighting(
         "Implement `Display` trait for `S2`", """
         struct Display;


### PR DESCRIPTION
changelog: Fix bugs related to quick fixes of printing of structs with neither display nor debug trait implemented
