### PR TITLE
Mark test source files with a green color

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/RsTestSourcesFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/RsTestSourcesFilter.kt
@@ -6,12 +6,30 @@
 package org.rust.cargo.project.model
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.SourceFolder
 import com.intellij.openapi.roots.TestSourcesFilter
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.io.isAncestor
 import org.rust.ide.injected.isDoctestInjection
+import org.rust.openapiext.modules
+import org.rust.openapiext.pathAsPath
 
 class RsTestSourcesFilter : TestSourcesFilter() {
     override fun isTestSource(file: VirtualFile, project: Project): Boolean {
-        return file.isDoctestInjection(project)
+        val isInTestDir = getTestSourceFolders(project).any { it.file?.pathAsPath?.isAncestor(file.pathAsPath) == true }
+        return isInTestDir || file.isDoctestInjection(project)
     }
+}
+
+fun getTestSourceFolders(project: Project): Sequence<SourceFolder> {
+    return project.modules
+        .asSequence()
+        .flatMap { module ->
+            ModuleRootManager.getInstance(module).contentEntries
+                .asSequence()
+                .flatMap { contentEntry ->
+                    contentEntry.sourceFolders.filter { it.isTestSource }
+                }
+        }
 }

--- a/src/main/kotlin/org/rust/ide/colors/ColorProvider.kt
+++ b/src/main/kotlin/org/rust/ide/colors/ColorProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.colors
+
+import com.intellij.openapi.fileEditor.impl.EditorTabColorProvider
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.JBColor
+import com.intellij.util.io.isAncestor
+import org.rust.cargo.project.model.getTestSourceFolders
+import org.rust.openapiext.pathAsPath
+import java.awt.Color
+
+class ColorProvider : EditorTabColorProvider {
+    override fun getEditorTabColor(project: Project, file: VirtualFile): Color? {
+        return null
+    }
+
+    override fun getProjectViewColor(project: Project, file: VirtualFile): Color? {
+        val testSourceDirs = getTestSourceFolders(project)
+        val shouldBeMarked = testSourceDirs.any { it.file == file || it.file?.pathAsPath?.isAncestor(file.pathAsPath) == true }
+        if (shouldBeMarked) {
+            return JBColor(0xeffae7, 0x49544a)
+        }
+        return null
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -328,6 +328,8 @@
 
         <colorSettingsPage implementation="org.rust.ide.colors.RsColorSettingsPage"/>
 
+        <editorTabColorProvider implementation="org.rust.ide.colors.ColorProvider" />
+
         <additionalTextAttributes scheme="Default" file="org/rust/ide/colors/RustDefault.xml"/>
         <additionalTextAttributes scheme="Darcula" file="org/rust/ide/colors/RustDarcula.xml"/>
 


### PR DESCRIPTION
This PR improves how the plugin marks test source files:
- The first commit marks files under the `tests` and `benches` directories as test files, which means that they will be correctly filtered as tests e.g. in `Find in Files -> Scope -> Project Test Files`.
- The second commit marks test files with a green color in the Project view (the file list on the left) and also in `Find in Usages` etc. lists.

![test](https://github.com/intellij-rust/intellij-rust/assets/4539057/c5768ae5-1300-48bd-9b5c-324dee5f2e55)

TODO/questions:
- Should we make the color configurable/let users disable the coloring?
- The `getTestSourceFolders` approach seems that it could be slow, should I cache it or something?
- This still doesn't mark usages of tests in `Find in XXX` that are located in Rust files that are not under `tests` (like `#[cfg(test)] mod tests { ... }`. Sadly, the platform only passes the [file](https://github.com/JetBrains/intellij-community/blob/2b65709ba9b9756ed88528fb63138a6a9e56e6a3/platform/lang-impl/src/com/intellij/find/impl/uiModel.kt#L91) to the extension point, not the actual `Usage` instance, so we can't easily find if a specific usage if a test usage. I *think* that we might be able to solve this by creating some synthetic file for test usages? But it sounds like a horrible hack.

Related issue: https://github.com/intellij-rust/intellij-rust/issues/4436

changelog: Mark test source files with a green color in project view and various file lists (like Find in Path).