### PR TITLE
Fix user's custom LLDB commands `settings append target.source-map` be overwritten

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -98,7 +98,7 @@ class RsDebugProcessConfigurationHelper(
         val sysroot = checkSysroot(sysroot, RsBundle.message("notification.content.cannot.load.rustc.sources"))
             ?: return
         val sourceMapCommand = when (this) {
-            is LLDBDriver -> "settings set target.source-map"
+            is LLDBDriver -> "settings append target.source-map"
             is GDBDriver -> "set substitute-path"
             else -> return
         }


### PR DESCRIPTION
If users set their specific LLDB settings with `settings append target.source-map SRC_DIR DEST_DIR` in Debugger Configuration/LLDB Startup Commands , it will be overwritten by intellij-rust plugin built-in sourceMapCommand which using `settings set` instead of `settings append` right now.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

changelog: Fix user's custom LLDB commands `settings append target.source-map` be overwritten
