### PR TITLE
move '--stacktrace' into `gradle.properties`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,6 @@ import org.jsoup.Jsoup
 import java.io.Writer
 import kotlin.concurrent.thread
 
-// The same as `--stacktrace` param
-gradle.startParameter.showStacktrace = ShowStacktrace.ALWAYS
-
 val isCI = System.getenv("CI") != null
 val isTeamcity = System.getenv("TEAMCITY_VERSION") != null
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ org.gradle.jvmargs=-Xmx3g
 
 # Enable Gradle Build Cache. It is also configured in settings.gradle.kts.
 org.gradle.caching=true
+org.gradle.logging.stacktrace=all
 
 systemProp.org.gradle.internal.repository.max.tentatives=10
 systemProp.org.gradle.internal.http.connectionTimeout=120000


### PR DESCRIPTION
Move the `--stacktrace` option into `gradle.properties`, which was added in Gradle 7.4.

changelog: [build config] move '--stacktrace' option into `gradle.properties`