### PR TITLE
leptos component + server macro -> identity

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/HardcodedProcMacroProperties.kt
@@ -56,6 +56,10 @@ private val RS_HARDCODED_PROC_MACRO_ATTRIBUTES: Map<String, Map<String, KnownPro
     "uefi_macros" to mapOf("entry" to KnownProcMacroKind.CUSTOM_MAIN),
     "async_trait" to mapOf("async_trait" to KnownProcMacroKind.ASYNC_TRAIT),
     "sqlx_macros" to mapOf("test" to KnownProcMacroKind.ASYNC_TEST),
+    "leptos_macro" to mapOf(
+        "component" to KnownProcMacroKind.IDENTITY,
+        "server" to KnownProcMacroKind.IDENTITY,
+    ),
 )
 
 fun getHardcodeProcMacroProperties(packageName: String, macroName: String): KnownProcMacroKind {


### PR DESCRIPTION
This PR adds the `component` and `server` macro from [leptos](https://github.com/leptos-rs/leptos) to the list of excluded macros for the expansion. We even suggest this for other IDE's too, since you will not get any benefit from having them expanded. Actually, it produces a lot of problems, bugs and a slow IDE. Sometimes the IDE even breaks and it can only be solved with out-commenting these macros shortly.

I have no idea about the bigger picture of the code of the `inellij-rust` plugin and this is the first time I ever took a look at its code, but as far as I can see, the solution was to just add these 2 macros with the `IDENTITY` type to the hardcoded list.  
I tested it with the `RunIDEA` run config and some issues, for instance the `Add missing fields` action for a struct inside such a function body do work with this addition in the dev IDE.

changelog: Add `leptos_macros::component` and `leptos_macros::server` to the list of excluded macro for the proc macro expansion.
